### PR TITLE
Update reescraper dependecy to 2.1.0 version.

### DIFF
--- a/parsers/ES_CN.py
+++ b/parsers/ES_CN.py
@@ -6,10 +6,10 @@ import logging
 from arrow import get
 # The request library is used to fetch content through HTTP
 from requests import Session
-from reescraper import (ElHierro, GranCanaria, Gomera, LanzaroteFuerteventura,
+from ree import (ElHierro, GranCanaria, Gomera, LanzaroteFuerteventura,
                         LaPalma, Tenerife)
-from .lib.exceptions import ParserException
-from .lib.validation import validate
+from parsers.lib.exceptions import ParserException
+from parsers.lib.validation import validate
 
 
 # Minimum valid zone demand. This is used to eliminate some cases

--- a/parsers/ES_IB.py
+++ b/parsers/ES_IB.py
@@ -4,8 +4,8 @@
 from arrow import get
 # The request library is used to fetch content through HTTP
 from requests import Session
-from reescraper import BalearicIslands
-from .lib.exceptions import ParserException
+from ree import BalearicIslands
+from parsers.lib.exceptions import ParserException
 
 
 def fetch_consumption(zone_key='ES-IB', session=None, target_datetime=None, logger=None):

--- a/parsers/requirements.txt
+++ b/parsers/requirements.txt
@@ -7,7 +7,7 @@ mock==2.0.0
 pandas==0.22.0
 Pillow==4.0.0
 pytesseract==0.2.0
-reescraper==1.6.0
+ree==2.1.0
 requests==2.18.4
 requests-mock==1.3.0
 tablib==0.12.1

--- a/parsers/test/test_ES_CN.py
+++ b/parsers/test/test_ES_CN.py
@@ -3,8 +3,8 @@ import unittest
 from arrow import get
 from parsers import ES_CN
 from mock import patch
-from reescraper import Response
-from reescraper import ElHierro, GranCanaria, Gomera, LanzaroteFuerteventura, LaPalma, Tenerife
+from ree import Response
+from ree import ElHierro, GranCanaria, Gomera, LanzaroteFuerteventura, LaPalma, Tenerife
 
 
 class TestESIB(unittest.TestCase):

--- a/parsers/test/test_ES_IB.py
+++ b/parsers/test/test_ES_IB.py
@@ -3,8 +3,8 @@ import unittest
 from requests import Session
 from parsers import ES_IB
 from mock import patch
-from reescraper import BalearicIslands
-from reescraper import Response
+from ree import BalearicIslands
+from ree import Response
 
 
 class TestESIB(unittest.TestCase):


### PR DESCRIPTION
Update reescraper dependecy to 2.1.0 version. Issue https://github.com/tmrowco/electricitymap/issues/1347