### PR TITLE
GE parser: production forecast support  (and a few questions before this is ready to merge)

### DIFF
--- a/config/zones.json
+++ b/config/zones.json
@@ -2435,12 +2435,13 @@
     "contributors": [
       "alixunderplatz",
       "kruschk",
-      "tmslaine"
+      "tmslaine",
+      "q--"
     ],
     "parsers": {
       "consumption": "ENTSOE.fetch_consumption",
       "consumptionForecast": "ENTSOE.fetch_consumption_forecast",
-      "generationForecast": "ENTSOE.fetch_generation_forecast",
+      "generationForecast": "GE.fetch_generation_forecast",
       "production": "GE.fetch_production",
       "productionPerModeForecast": "ENTSOE.fetch_wind_solar_forecasts"
     },


### PR DESCRIPTION
Implements the production forecast data source mentioned in #2838

A few questions / things that might still be broken:

- Haven't tested except for syntax errors
- No logic for dealing with no target datetime given yet; I saw in the ENTSOE parser that the corresponding method there returns 'generation forecast for 48 hours ahead and previous 24 hours' in that scenario, but is that standard or ENTSOE-specific? How should this parser handle it?
- I return a `dict`, ENTSOE returns a `list` for this - are both allowed?
- I changed the forecast parser from ENTSOE to this one - is it desirable, or should this parser just exist as a fallback that can be switched to if necessary?
- The ENTSOE parser has a `@refetch_frequency` defined in a few places, should this parser? Is there any documentation on how this works?