### PR TITLE
[CI] limit Poetry to 1.1.x

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -13,7 +13,7 @@ jobs:
         uses: actions/checkout@v3
       - name: Install poetry
         run: |
-          pipx install poetry
+          pipx install poetry@1.1
       - name: Setup Python
         uses: actions/setup-python@v4
         with:
@@ -44,7 +44,7 @@ jobs:
         uses: actions/checkout@v3
       - name: Install poetry
         run: |
-          pipx install poetry
+          pipx install poetry@1.1
       - name: Setup Python
         uses: actions/setup-python@v4
         with:

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -13,7 +13,7 @@ jobs:
         uses: actions/checkout@v3
       - name: Install poetry
         run: |
-          pipx install poetry@1.1
+          pipx install poetry==1.1
       - name: Setup Python
         uses: actions/setup-python@v4
         with:
@@ -44,7 +44,7 @@ jobs:
         uses: actions/checkout@v3
       - name: Install poetry
         run: |
-          pipx install poetry@1.1
+          pipx install poetry==1.1
       - name: Setup Python
         uses: actions/setup-python@v4
         with:


### PR DESCRIPTION
## Issue

Poetry has released version 1.2 but we currently use 1.1 in the backend/locally.

## Description

This limits poetry to version 1.1.x in the CI until we can get all systems upgraded to v 1.2
