### PR TITLE
Use short month for ticks to prevent text overflow

### DIFF
--- a/web/src/helpers/formatting.js
+++ b/web/src/helpers/formatting.js
@@ -101,7 +101,7 @@ const formatDateTick = function (date, lang, timeAggregate) {
     case TIME.HOURLY:
       return new Intl.DateTimeFormat(lang, { timeStyle: 'short' }).format(date);
     case TIME.DAILY:
-      return new Intl.DateTimeFormat(lang, { month: 'long', day: 'numeric' }).format(date);
+      return new Intl.DateTimeFormat(lang, { month: 'short', day: 'numeric' }).format(date);
     case TIME.MONTHLY:
       return new Intl.DateTimeFormat(lang, { month: 'short' }).format(date);
     case TIME.YEARLY:


### PR DESCRIPTION
## Issue
The current formatting overflows when the month names are long.
![image](https://user-images.githubusercontent.com/30777521/191606819-19bf3b0a-1630-4fd0-ab04-a73882886bd0.png)

## Description

This PR simply changes the ticks to use the short form of the months so prevent this overflow.

### Preview

![image](https://user-images.githubusercontent.com/30777521/191607039-b4b2110c-aef9-4a01-811e-d6767375a143.png)

