### PR TITLE
Fixes app breaking when using URL with invalid zoneid

### DIFF
--- a/web/src/layout/map.jsx
+++ b/web/src/layout/map.jsx
@@ -56,7 +56,7 @@ export default () => {
   // Center the map initially based on the focused zone and the user geolocation.
   useEffect(() => {
     if (!hasCentered) {
-      if (zoneId) {
+      if (zoneId && zones[zoneId]) {
         console.log(`Centering on zone ${zoneId}`); // eslint-disable-line no-console
         dispatchApplication('mapViewport', getCenteredZoneViewport(zones[zoneId].geography));
         setHasCentered(true);


### PR DESCRIPTION
## Issue

https://github.com/electricitymaps/electricitymaps-contrib/issues/4172

## Description

This fixes the problem where everything broke if the zoneId does not exist (invalid or removed).

Going to https://app.electricitymaps.com/zone/GERMANY will just send you back to the map.

Fixing the lower/uppercase requires a bit more work as we consume the parameter in different ways throughout the app, so I decided to skip that for now :)

### Preview

<!-- Please add screenshots and/or gif that shows visual changes (if applicable) -->
