### PR TITLE
Add time-controller.title translation to PT-BR

### DIFF
--- a/web/public/locales/pt-BR.json
+++ b/web/public/locales/pt-BR.json
@@ -66,6 +66,9 @@
     "colorblindmode": "Modo para daltônicos",
     "carbonintensity": "Intensidade de carbono"
   },
+  "time-controller": {
+    "title": "Exibir dados do passado"
+  },
   "tooltips": {
     "carbonintensity": "Intensidade de emissões de CO₂",
     "lowcarbon": "Baixo carbono",


### PR DESCRIPTION
## Issue

Hi! I am a Portuguese speaker from Brazil and I notice a title in a component was missing from the PT-BR version of the website. So I thought of contributing.

Will probably run the `node translation-helper.js` tool to help out with other translations as well in the next few days.

## Description

* Add `time-controller.title` to pt-BR translations

### Preview

Here is the missing piece: 

<img width="520" alt="image" src="https://user-images.githubusercontent.com/4624484/194735811-fe7c31f4-aca0-467c-a3ce-7d73f51d1c7e.png">

<!-- Please add screenshots and/or gif that shows visual changes (if applicable) -->
