### PR TITLE
Catches errors with Intl.NumberFormat and adds fallback

### DIFF
--- a/web/src/helpers/formatting.js
+++ b/web/src/helpers/formatting.js
@@ -68,12 +68,20 @@ const formatDate = function (date, lang, time) {
   }
 };
 
-const getLocaleNumberFormat = (lang, { unit, unitDisplay, range }) =>
-  new Intl.NumberFormat(lang, {
-    style: 'unit',
-    unit,
-    unitDisplay: unitDisplay || 'long',
-  }).format(range);
+const getLocaleNumberFormat = (lang, { unit, unitDisplay, range }) => {
+  try {
+    return new Intl.NumberFormat(lang, {
+      style: 'unit',
+      unit,
+      unitDisplay: unitDisplay || 'long',
+    }).format(range);
+  } catch (error) {
+    // As Intl.NumberFormat with custom 'unit' is not supported in all browsers, we fallback to
+    // a simple English based implementation
+    const plural = range !== 1 ? 's' : '';
+    return `${range} ${unit}${plural}`;
+  }
+};
 
 const formatTimeRange = (lang, timeAggregate) => {
   // Note that not all browsers fully support all languages


### PR DESCRIPTION
## Issue

Closes #4630

## Description

This catches exceptions where browsers don't support Intl.NumberFormat with unit param.

I considered if we could test in a smarter way, but seeing as [formatJS also does a try-catch to check if it should polyfill](https://github.com/formatjs/formatjs/blob/main/packages/intl-numberformat/should-polyfill.ts), I reckon it should be fine to do the same :)

### Preview

_Only tested by throwing inside the try block, haven't actually tested on an older version of Safari_

![Screenshot 2022-10-13 at 16 11 01](https://user-images.githubusercontent.com/3296643/195620423-262602c5-8ec4-473f-891b-048d83d63fd9.png)


