### PR TITLE
Add config labels to labeler

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -41,3 +41,9 @@ science:
 
 mobile app 📱:
   - mobileapp/**/*
+
+exchange config:
+  - config/exchanges/**/*.yaml
+
+zone config:
+  - config/zones/**/*.yaml


### PR DESCRIPTION
Adds config lables to for zones and exchanges that matches the config structure.
