### PR TITLE
Fix date tick for months in Estonian

### DIFF
--- a/web/src/helpers/formatting.js
+++ b/web/src/helpers/formatting.js
@@ -111,7 +111,11 @@ const formatDateTick = function (date, lang, timeAggregate) {
     case TIME.DAILY:
       return new Intl.DateTimeFormat(lang, { month: 'short', day: 'numeric' }).format(date);
     case TIME.MONTHLY:
-      return new Intl.DateTimeFormat(lang, { month: 'short' }).format(date);
+      return lang === 'et'
+        ? new Intl.DateTimeFormat(lang, { month: 'short', day: 'numeric' })
+            .formatToParts(date)
+            .find((part) => part.type === 'month').value
+        : new Intl.DateTimeFormat(lang, { month: 'short' }).format(date);
     case TIME.YEARLY:
       return new Intl.DateTimeFormat(lang, { year: 'numeric' }).format(date);
     default:


### PR DESCRIPTION
## Issue
X labels (Month names) are collapsing in 'Eesti' language.

<!-- Explains the goal of this PR -->
### Preview
<img width="491" alt="Screenshot 2022-10-16 at 10 23 29 PM" src="https://user-images.githubusercontent.com/46367738/196047970-fc8d5ae6-00b0-43a5-8987-eb7a7f8f6aa8.png">

<!-- Please add screenshots and/or gif that shows visual changes (if applicable) -->
