### PR TITLE
Update minimal Slovenian production to just 140MW

### DIFF
--- a/parsers/ENTSOE.py
+++ b/parsers/ENTSOE.py
@@ -437,7 +437,7 @@ VALIDATIONS: Dict[str, Dict[str, Any]] = {
     "SI": {
         # own total generation capacity is around 4 GW
         "required": ["nuclear"],
-        "expected_range": (800, 5000),
+        "expected_range": (140, 5000),
     },
     "SK": {"required": ["nuclear"]},
 }


### PR DESCRIPTION
## Issue
Slovenia doesn't have data for most of October.

## Description
In April I reduced minimal production to 800MW see PR: https://github.com/electricitymaps/electricitymaps-contrib/pull/4043 But with Nuclear power plant in maintenance for a month of October, TEŠ was supposed to work whole month but TEŠ has problems with coal production, hence it shut down as well to build up coal storage for winter months, hence Slovenia can sometimes produce only 145MW(according to logs) its mostly just rivers at night and those conserve water for morning/evenings...