### PR TITLE
[BUGFIX]: Don't join on undefined or null

### DIFF
--- a/web/src/helpers/formatting.js
+++ b/web/src/helpers/formatting.js
@@ -144,7 +144,7 @@ function formatDataSources(dataSources, language) {
   if (typeof Intl.ListFormat !== 'undefined') {
     return new Intl.ListFormat(language, { style: 'long', type: 'conjunction' }).format(dataSources);
   } else {
-    return dataSources.join(', ');
+    return dataSources?.join(', ');
   }
 }
 


### PR DESCRIPTION
## Issue
If `dataSources` are `undefined` or `null` on a system that don't support `Intl.ListFormat` the app crashes.
## Description
This adds optional chaining to make sure we don't call `.join()` on `undefined` or `null` values wo we avoid a hard crash and simply display a ? as the source instead.

Fixes: #4705
Fixes: #4708