### PR TITLE
Update French translations

### DIFF
--- a/web/public/locales/fr.json
+++ b/web/public/locales/fr.json
@@ -6,9 +6,15 @@
     "datasources": "source des données",
     "contribute": "Contribuez en <a href=\"%s\" target=\"_blank\">ajoutant votre pays</a>"
   },
-  "mobile-main-menu": { "map": "Electricity Maps", "areas": "Zones", "about": "À propos" },
+  "mobile-main-menu": {
+    "map": "Electricity Maps",
+    "areas": "Zones",
+    "about": "À propos"
+  },
   "onboarding-modal": {
-    "view1": { "subtitle": "Cartographie de l’impact de l’électricité sur le climat" },
+    "view1": {
+      "subtitle": "Cartographie de l’impact de l’électricité sur le climat"
+    },
     "view2": {
       "header": "Visualisez la quantité de CO₂ émise pour produire votre électricité, en temps réel.",
       "text": "Les régions du monde sont colorées en fonction de l’intensité en carbone (incluant tous les gaz à effet de serre) de l’électricité qui y est consommée. Des couleurs plus vertes signifient une électricité plus respectueuse du climat."
@@ -37,7 +43,15 @@
     "noLiveData": "Données temps-réel temporairement indisponibles pour cette zone",
     "noParserInfo": "Nous n’avons pas encore d’information pour cette zone. <br/>Vous voulez corriger ça ? Vous pouvez contribuer en <a href=\"%s\" target=\"_blank\">ajoutant des données de zone</a>.",
     "now": "Maintenant",
-    "dataIsDelayed": "Les données relatives à cette région peuvent avoir jusqu'à %s heures de retard. Les données temps-réel ne peuvent pas être affichées."
+    "dataIsDelayed": "Les données relatives à cette région peuvent avoir jusqu'à %s heures de retard. Les données temps-réel ne peuvent pas être affichées.",
+    "averagebysource": "moyenne par source",
+    "estimated": "estimé",
+    "aggregated": "aggrégé",
+    "dataIsEstimated": "Certaines données de cette région sont estimées. En savoir plus sur notre méthodologie d'estimation <a href=\"https://github.com/electricityMaps/electricitymaps-contrib/wiki/Estimation-methods\" target=\"_blank\">ici</a>.",
+    "exchangesAreMissing": "Les échanges sont pris en compte dans les calculs mais ne sont pas indiqués actuellement. En savoir plus sur notre agrégation historique  <a href=\"https://github.com/electricityMaps/electricitymaps-contrib/wiki/Estimation-methods\" target=\"_blank\">ici</a>.",
+    "estimatedTooltip": "Les données en temps réel pour cette zone sont estimées sur la base des données de la source et des hypothèses du modèle.",
+    "aggregatedTooltip": "Les données pour cette zone sont agrégées sur la base des valeurs horaires historiques.",
+    "helpUs": "Aidez-nous à identifier le problème en consultant les <a href=\"%s\" target=\"_blank\">journaux d'exécution</a> ou contactez le fournisseur de données."
   },
   "left-panel": {
     "zone-list-header-title": "Impact sur le climat par zone",
@@ -46,13 +60,37 @@
   },
   "country-history": {
     "Getdata": "Obtenir l’historique et l’API de prévision + marginal",
-    "carbonintensity": { "hourly": "Intensité carbone des 24 dernières heures" },
-    "emissionsorigin": { "hourly": "Origine des émissions des 24 dernières heures" },
-    "emissionsproduction": { "hourly": "Émissions produites dans les 24 dernières heures" },
-    "electricityorigin": { "hourly": "Origine de l’électricité des 24 dernières heures" },
-    "electricityproduction": { "hourly": "Production électrique des 24 dernières heures" },
-    "electricityprices": { "hourly": "Prix de l’électricité des 24 dernières heures" },
-    "emissions": { "hourly": "Émissions des 24 dernières heures" }
+    "carbonintensity": {
+      "hourly": "Intensité carbone des 24 dernières heures",
+      "default": "Intensité en carbone dans les derniers %1$s",
+      "daily": "Intensité en carbone du dernier mois",
+      "monthly": "Intensité carbone au cours de la dernière année",
+      "yearly": "Intensité carbone au cours des 5 dernières années"
+    },
+    "emissionsorigin": {
+      "hourly": "Origine des émissions des 24 dernières heures",
+      "default": "Émissions dans les derniers %1$s"
+    },
+    "emissionsproduction": {
+      "hourly": "Émissions produites dans les 24 dernières heures",
+      "default": "Origine des émissions dans les derniers %1$s"
+    },
+    "electricityorigin": {
+      "hourly": "Origine de l’électricité des 24 dernières heures",
+      "default": "Origine de l'électricité dans les derniers %1$s"
+    },
+    "electricityproduction": {
+      "hourly": "Production électrique des 24 dernières heures",
+      "default": "Production d'électricité dans les derniers %1$s"
+    },
+    "electricityprices": {
+      "hourly": "Prix de l’électricité des 24 dernières heures",
+      "default": "Prix de l'électricité dans les derniers %1$s"
+    },
+    "emissions": {
+      "hourly": "Émissions des 24 dernières heures",
+      "default": "Émissions dans les derniers %1$s"
+    }
   },
   "footer": {
     "foundbugs": "Un bug ? Une idée ? Cliquez",
@@ -87,7 +125,13 @@
     "cpinfo": "La <b>consommation</b> tient compte des importations et des exportations, la <b>production</b> les ignore.",
     "selectLanguage": "Choisissez une langue",
     "lowCarbDescription": "Inclut les énergies renouvelables et nucléaire",
-    "dataIsDelayed": "Données en retard"
+    "dataIsDelayed": "Données en retard",
+    "representing": "représentation",
+    "ofemissions": "d'émissions",
+    "zoomIn": "Zoomer",
+    "zoomOut": "Dézoomer",
+    "weatherDisabled": "Les données météo ne sont pas disponible actuellement",
+    "aggregateinfo": "Les pays sont agrégés lorsque la capacité annuelle de la zone est supérieure à 90 % de la capacité totale."
   },
   "misc": {
     "maintitle": "Émissions CO₂ de la consommation électrique en temps réel",
@@ -98,7 +142,9 @@
     "faq": "Foire Aux Questions",
     "database-ad": "Vous recherchez des données historiques ? <a href=\"https://electricitymaps.com?utm_source=app.electricitymaps.com&utm_medium=referral\" target=\"_blank\">Jetez un œil à notre base de données.</a>",
     "api-ad": "Vous voulez des données en temps réel pour votre application ou votre appareil ? <a href=\"https://electricitymaps.com?utm_source=app.electricitymaps.com&utm_medium=referral\" target=\"_blank\">Explorez notre API !</a>",
-    "webgl-not-supported": "La carte ne peut pas être rendue car ce navigateur ne supporte pas WebGL."
+    "webgl-not-supported": "La carte ne peut pas être rendue car ce navigateur ne supporte pas WebGL.",
+    "privacyPolicy": "Politique de confidentialité",
+    "legalNotice": "Informations légales"
   },
   "wind": "éolien",
   "solar": "solaire",
@@ -189,383 +235,1627 @@
     "disclaimer-answer": "<a href=\"https://electricitymaps.com/\" target=\"_blank\">Electricity Maps</a> publie à titre informatif des données et des images sur son site <a href=\"https://www.electricitymaps.com/\" target=\"_blank\">Electricity Maps</a>.electricityMap ne répond pas de l’exactitude de ces informations, ne fournit aucune garantie sur ce point et se réserve le droit de changer le contenu de ce site à tout moment, ainsi que d’en retirer, sans avoir à informer son auditoire. Electricity Maps décline toute responsabilité et ne pourrait être tenu responsable de dommages ou dépenses qui résulteraient de l’inexactitude d’electricityMap, qu’elle soit due à une erreur, un manque de données, la présence d’information obsolète ou dépassée. Cela s’applique à electricityMap ainsi qu’à tout produit dérivé. Il est interdit d’inclure cette page web et n’importe lequel de ces éléments dans une autre page web, sans le consentement écrit préalable de Electricity Maps.<br><br> Tous les droits de propriété intellectuelle appartiennent aux propriétaires légitimes et légaux de ce site, ainsi qu’à tous les concédants. La copie, la distribution ou tout autre usage de ces documents, en particulier les données énergétiques, sont interdits sans le consentement écrit de Electricity Maps, sauf contre-indication légale (telle que le droit de mention), à moins que cela ne soit explicitement spécifié par ces documents.<br><br>Cette notice légale pourra être ponctuellement mise à jour."
   },
   "zoneShortName": {
-    "AD": { "zoneName": "Andorre" },
-    "AE": { "zoneName": "Émirats arabes unis" },
-    "AF": { "zoneName": "Afghanistan" },
-    "AG": { "zoneName": "Antigua-et-Barbuda" },
-    "AI": { "zoneName": "Anguilla" },
-    "AL": { "zoneName": "Albanie" },
-    "AM": { "zoneName": "Arménie" },
-    "AO": { "zoneName": "Angola" },
-    "AQ": { "zoneName": "Antarctique" },
-    "AS": { "zoneName": "Samoa américaines" },
-    "AT": { "zoneName": "Autriche" },
-    "AR": { "zoneName": "Argentine" },
-    "AUS-NSW": { "countryName": "Australie", "zoneName": "Nouvelle-Galles du Sud" },
-    "AUS-NT": { "countryName": "Australie", "zoneName": "Territoire du Nord" },
-    "AUS-QLD": { "countryName": "Australie", "zoneName": "Queensland" },
-    "AUS-SA": { "countryName": "Australie", "zoneName": "Australie-Méridionale" },
-    "AUS-TAS": { "countryName": "Australie", "zoneName": "Tasmanie" },
-    "AUS-TAS-KI": { "countryName": "Australie", "zoneName": "Tasmanie (Île King)" },
-    "AUS-VIC": { "countryName": "Australie", "zoneName": "Victoria" },
-    "AUS-WA": { "countryName": "Australie", "zoneName": "Australie-Occidentale" },
-    "AUS-WA-RI": { "countryName": "Australie", "zoneName": "Île Rottnest" },
-    "AW": { "zoneName": "Aruba" },
-    "AX": { "zoneName": "Åland" },
-    "AZ": { "zoneName": "Azerbaïdjan" },
-    "BA": { "zoneName": "Bosnie-Herzégovine" },
-    "BB": { "zoneName": "Barbade" },
-    "BD": { "zoneName": "Bangladesh" },
-    "BE": { "zoneName": "Belgique" },
-    "BF": { "zoneName": "Burkina Faso" },
-    "BG": { "zoneName": "Bulgarie" },
-    "BH": { "zoneName": "Bahreïn" },
-    "BI": { "zoneName": "Burundi" },
-    "BJ": { "zoneName": "Bénin" },
-    "BM": { "zoneName": "Bermudes" },
-    "BN": { "zoneName": "Brunei" },
-    "BO": { "zoneName": "Bolivie" },
-    "BQ": { "zoneName": "Pays-Bas caribéens" },
-    "BR-CS": { "countryName": "Brésil", "zoneName": "Central" },
-    "BR-N": { "countryName": "Brésil", "zoneName": "Nord" },
-    "BR-NE": { "countryName": "Brésil", "zoneName": "Nord-Est" },
-    "BR-S": { "countryName": "Brésil", "zoneName": "Sud" },
-    "BS": { "zoneName": "Bahamas" },
-    "BT": { "zoneName": "Bhoutan" },
-    "BV": { "zoneName": "Île Bouvet" },
-    "BW": { "zoneName": "Botswana" },
-    "BY": { "zoneName": "Biélorussie" },
-    "BZ": { "zoneName": "Belize" },
-    "CA-AB": { "countryName": "Canada", "zoneName": "Alberta" },
-    "CA-BC": { "countryName": "Canada", "zoneName": "Colombie-Britannique" },
-    "CA-MB": { "countryName": "Canada", "zoneName": "Manitoba" },
-    "CA-NL": { "countryName": "Canada", "zoneName": "Terre-Neuve-et-Labrador" },
-    "CA-NB": { "countryName": "Canada", "zoneName": "Nouveau-Brunswick" },
-    "CA-NT": { "countryName": "Canada", "zoneName": "Territoires du Nord-Ouest" },
-    "CA-NS": { "countryName": "Canada", "zoneName": "Nouvelle-Écosse" },
-    "CA-NU": { "countryName": "Canada", "zoneName": "Nunavut" },
-    "CA-ON": { "countryName": "Canada", "zoneName": "Ontario" },
-    "CA-PE": { "countryName": "Canada", "zoneName": "Île-du-Prince-Édouard" },
-    "CA-QC": { "countryName": "Canada", "zoneName": "Québec" },
-    "CA-SK": { "countryName": "Canada", "zoneName": "Saskatchewan" },
-    "CA-YT": { "countryName": "Canada", "zoneName": "Yukon" },
-    "CC": { "zoneName": "Îles Cocos" },
-    "CD": { "zoneName": "République démocratique du Congo" },
-    "CF": { "zoneName": "République centrafricaine" },
-    "CG": { "zoneName": "République du Congo" },
-    "CH": { "zoneName": "Suisse" },
-    "CI": { "zoneName": "Côte d’Ivoire" },
-    "CK": { "zoneName": "Îles Cook" },
-    "CL-SING": { "countryName": "Chili", "zoneName": "SING" },
-    "CL-SING-SIC": { "countryName": "Chili", "zoneName": "SING - SIC" },
-    "CL-SEM": { "countryName": "Chili", "zoneName": "SEM" },
-    "CL-SEA": { "countryName": "Chili", "zoneName": "SEA" },
-    "CL-SEN": { "countryName": "Chili", "zoneName": "SEN" },
-    "CL-CHP": { "countryName": "Chili", "zoneName": "Île de Pâques" },
-    "CM": { "zoneName": "Cameroun" },
-    "CN": { "zoneName": "Chine" },
-    "CO": { "zoneName": "Colombie" },
-    "CR": { "zoneName": "Costa Rica" },
-    "CU": { "zoneName": "Cuba" },
-    "CV": { "zoneName": "Cap-Vert" },
-    "CW": { "zoneName": "Curaçao" },
-    "CX": { "zoneName": "Île Christmas" },
-    "CY": { "zoneName": "Chypre" },
-    "CZ": { "zoneName": "Tchéquie" },
-    "DE": { "zoneName": "Allemagne" },
-    "DJ": { "zoneName": "Djibouti" },
-    "DK": { "zoneName": "Danemark" },
-    "DK-DK1": { "countryName": "Danemark", "zoneName": "Danemark ouest" },
-    "DK-DK2": { "countryName": "Danemark", "zoneName": "Danemark est" },
-    "DK-BHM": { "countryName": "Danemark", "zoneName": "Bornholm" },
-    "DM": { "zoneName": "Dominique" },
-    "DO": { "zoneName": "République Dominicaine" },
-    "DZ": { "zoneName": "Algérie" },
-    "EC": { "zoneName": "Equateur" },
-    "EE": { "zoneName": "Estonie" },
-    "EG": { "zoneName": "Egypte" },
-    "EH": { "zoneName": "Sahara Occidental" },
-    "ER": { "zoneName": "Érythrée" },
-    "ES": { "zoneName": "Espagne" },
-    "ES-CE": { "countryName": "Espagne", "zoneName": "Ceuta" },
-    "ES-IB-FO": { "countryName": "Espagne", "zoneName": "Formentera" },
-    "ES-IB-IZ": { "countryName": "Espagne", "zoneName": "Ibiza" },
-    "ES-IB-MA": { "countryName": "Espagne", "zoneName": "Majorque" },
-    "ES-IB-ME": { "countryName": "Espagne", "zoneName": "Minorque" },
-    "ES-CN-FVLZ": { "countryName": "Espagne", "zoneName": "Fuerteventura/Lanzarote" },
-    "ES-CN-GC": { "countryName": "Espagne", "zoneName": "Grande Canarie" },
-    "ES-CN-HI": { "countryName": "Espagne", "zoneName": "El Hierro" },
-    "ES-CN-IG": { "countryName": "Espagne", "zoneName": "Ile de la Gomera" },
-    "ES-CN-LP": { "countryName": "Espagne", "zoneName": "La Palma" },
-    "ES-CN-TE": { "countryName": "Espagne", "zoneName": "Tenerife" },
-    "ES-ML": { "countryName": "Espagne", "zoneName": "Melilla" },
-    "ET": { "zoneName": "Éthiopie" },
-    "FI": { "zoneName": "Finlande" },
-    "FJ": { "zoneName": "Fidji" },
-    "FK": { "zoneName": "Malouines" },
-    "FM": { "zoneName": "Micronésie" },
-    "FO": { "zoneName": "Îles Féroé" },
-    "FR": { "zoneName": "France" },
-    "FR-COR": { "countryName": "France", "zoneName": "Corse" },
-    "GA": { "zoneName": "Gabon" },
-    "GB": { "zoneName": "Grande-Bretagne" },
-    "GB-NIR": { "zoneName": "Irlande du Nord" },
-    "GB-ORK": { "countryName": "Grande Bretagne", "zoneName": "Orcades" },
-    "GB-SHI": { "countryName": "Grande Bretagne", "zoneName": "Shetland" },
-    "GB-ZET": { "countryName": "Grande Bretagne", "zoneName": "Shetland" },
-    "GD": { "zoneName": "Grenade" },
-    "GE": { "zoneName": "Géorgie" },
-    "GF": { "countryName": "France", "zoneName": "Guyane Française" },
-    "GG": { "zoneName": "Guernesey" },
-    "GH": { "zoneName": "Ghana" },
-    "GI": { "zoneName": "Gibraltar" },
-    "GL": { "zoneName": "Groenland" },
-    "GM": { "zoneName": "Gambie" },
-    "GN": { "zoneName": "Guinée" },
-    "GP": { "countryName": "France", "zoneName": "Guadeloupe" },
-    "GQ": { "zoneName": "Guinée équatoriale" },
-    "GR": { "zoneName": "Grèce" },
-    "GR-IS": { "countryName": "Grèce", "zoneName": "Îles Égéennes" },
-    "GS": { "zoneName": "Géorgie du Sud-et-les Îles Sandwich du Sud" },
-    "GT": { "zoneName": "Guatémala" },
-    "GU": { "zoneName": "Guam" },
-    "GW": { "zoneName": "Guinée-Bissau" },
-    "GY": { "zoneName": "Guyana" },
-    "HK": { "zoneName": "Hong Kong" },
-    "HM": { "zoneName": "Îles Heard-et-MacDonald" },
-    "HN": { "zoneName": "Honduras" },
-    "HR": { "zoneName": "Croatie" },
-    "HT": { "zoneName": "Haïti" },
-    "HU": { "zoneName": "Hongrie" },
-    "ID": { "zoneName": "Indonésie" },
-    "IE": { "zoneName": "Irlande" },
-    "IL": { "zoneName": "Israël" },
-    "IM": { "zoneName": "Île de Man" },
-    "IN-AN": { "countryName": "Inde", "zoneName": "Andaman and Nicobar Islands" },
-    "IN-AP": { "countryName": "Inde", "zoneName": "Andhra Pradesh" },
-    "IN-AR": { "countryName": "Inde", "zoneName": "Arunachal Pradesh" },
-    "IN-AS": { "countryName": "Inde", "zoneName": "Assam" },
-    "IN-BR": { "countryName": "Inde", "zoneName": "Bihar" },
-    "IN-CT": { "countryName": "Inde", "zoneName": "Chhattisgarh" },
-    "IN-DL": { "countryName": "Inde", "zoneName": "Delhi" },
-    "IN-DN": { "countryName": "Inde", "zoneName": "Dadra et Nagar Haveli" },
-    "IN-GA": { "countryName": "Inde", "zoneName": "Goa" },
-    "IN-GJ": { "countryName": "Inde", "zoneName": "Gujarat" },
-    "IN-HP": { "countryName": "Inde", "zoneName": "Himachal Pradesh" },
-    "IN-HR": { "countryName": "Inde", "zoneName": "Haryana" },
-    "IN-JH": { "countryName": "Inde", "zoneName": "Jharkhand" },
-    "IN-JK": { "countryName": "Inde", "zoneName": "Jammu and Kashmir" },
-    "IN-KA": { "countryName": "Inde", "zoneName": "Karnataka" },
-    "IN-KL": { "countryName": "Inde", "zoneName": "Kerala" },
-    "IN-MH": { "countryName": "Inde", "zoneName": "Maharashtra" },
-    "IN-ML": { "countryName": "Inde", "zoneName": "Meghalaya" },
-    "IN-MN": { "countryName": "Inde", "zoneName": "Manipur" },
-    "IN-MP": { "countryName": "Inde", "zoneName": "Madhya Pradesh" },
-    "IN-MZ": { "countryName": "Inde", "zoneName": "Mizoram" },
-    "IN-NL": { "countryName": "Inde", "zoneName": "Nagaland" },
-    "IN-OR": { "countryName": "Inde", "zoneName": "Orissa" },
-    "IN-PB": { "countryName": "Inde", "zoneName": "Punjab" },
-    "IN-PY": { "countryName": "Inde", "zoneName": "Pondicherry" },
-    "IN-RJ": { "countryName": "Inde", "zoneName": "Rajasthan" },
-    "IN-SK": { "countryName": "Inde", "zoneName": "Sikkim" },
-    "IN-TN": { "countryName": "Inde", "zoneName": "Tamil Nadu" },
-    "IN-TR": { "countryName": "Inde", "zoneName": "Tripura" },
-    "IN-UP": { "countryName": "Inde", "zoneName": "Uttar Pradesh" },
-    "IN-UT": { "countryName": "Inde", "zoneName": "Uttarakhand" },
-    "IN-WB": { "countryName": "Inde", "zoneName": "West Bengal" },
-    "IO": { "zoneName": "Territoire britannique de l’océan Indien" },
-    "IQ": { "zoneName": "Irak" },
-    "IQ-KUR": { "countryName": "Irak", "zoneName": "Kurdistan" },
-    "IR": { "zoneName": "Iran" },
-    "IS": { "zoneName": "Islande" },
-    "IT": { "zoneName": "Italie" },
-    "IT-CNO": { "countryName": "Italie", "zoneName": "Centre nord" },
-    "IT-CSO": { "countryName": "Italie", "zoneName": "Centre sud" },
-    "IT-NO": { "countryName": "Italie", "zoneName": "Nord" },
-    "IT-SAR": { "countryName": "Italie", "zoneName": "Sardaigne" },
-    "IT-SIC": { "countryName": "Italie", "zoneName": "Sicile" },
-    "IT-SO": { "countryName": "Italie", "zoneName": "Sud" },
-    "JE": { "zoneName": "Jersey" },
-    "JM": { "zoneName": "Jamaïque" },
-    "JO": { "zoneName": "Jordanie" },
-    "JP-CB": { "countryName": "Japon", "zoneName": "Chūbu" },
-    "JP-CG": { "countryName": "Japon", "zoneName": "Chūgoku" },
-    "JP-HKD": { "countryName": "Japon", "zoneName": "Hokkaidō" },
-    "JP-HR": { "countryName": "Japon", "zoneName": "Hokuriku" },
-    "JP-KN": { "countryName": "Japon", "zoneName": "Kansai" },
-    "JP-KY": { "countryName": "Japon", "zoneName": "Kyūshū" },
-    "JP-ON": { "countryName": "Japon", "zoneName": "Okinawa" },
-    "JP-SK": { "countryName": "Japon", "zoneName": "Shikoku" },
-    "JP-TH": { "countryName": "Japon", "zoneName": "Tōhoku" },
-    "JP-TK": { "countryName": "Japon", "zoneName": "Tokyo" },
-    "KE": { "zoneName": "Kenya" },
-    "KG": { "zoneName": "Kirghizistan" },
-    "KH": { "zoneName": "Cambodge" },
-    "KI": { "zoneName": "Kiribati" },
-    "KM": { "zoneName": "Comores" },
-    "KN": { "zoneName": "Saint-Christophe-et-Niévès" },
-    "KP": { "zoneName": "Corée du Nord" },
-    "KR": { "zoneName": "Corée du Sud" },
-    "KW": { "zoneName": "Koweït" },
-    "KY": { "zoneName": "Îles Caïmans" },
-    "KZ": { "zoneName": "Kazakhstan" },
-    "LA": { "zoneName": "Laos" },
-    "LB": { "zoneName": "Liban" },
-    "LC": { "zoneName": "Sainte-Lucie" },
-    "LI": { "zoneName": "Liechtenstein" },
-    "LK": { "zoneName": "Sri Lanka" },
-    "LR": { "zoneName": "Liberia" },
-    "LS": { "zoneName": "Lesotho" },
-    "LT": { "zoneName": "Lituanie" },
-    "LU": { "zoneName": "Luxembourg" },
-    "LV": { "zoneName": "Lettonie" },
-    "LY": { "zoneName": "Libya" },
-    "MA": { "zoneName": "Maroc" },
-    "MC": { "zoneName": "Monaco" },
-    "MD": { "zoneName": "Moldavie" },
-    "ME": { "zoneName": "Monténégro" },
-    "MF": { "countryName": "France", "zoneName": "Saint-Martin" },
-    "MG": { "zoneName": "Madagascar" },
-    "MH": { "zoneName": "Îles Marshall" },
-    "MK": { "zoneName": "Macédoine du Nord" },
-    "ML": { "zoneName": "Mali" },
-    "MM": { "zoneName": "Birmanie" },
-    "MN": { "zoneName": "Mongolia" },
-    "MO": { "zoneName": "Macao" },
-    "MP": { "zoneName": "Îles Mariannes du Nord" },
-    "MQ": { "countryName": "France", "zoneName": "Martinique" },
-    "MR": { "zoneName": "Mauritanie" },
-    "MS": { "zoneName": "Montserrat" },
-    "MT": { "zoneName": "Malte" },
-    "MU": { "zoneName": "Maurice" },
-    "MV": { "zoneName": "Maldives" },
-    "MW": { "zoneName": "Malawi" },
-    "MX": { "zoneName": "Mexique" },
-    "MX-BC": { "countryName": "Mexique", "zoneName": "Baja California" },
-    "MX-CE": { "countryName": "Mexique", "zoneName": "Centre" },
-    "MX-NE": { "countryName": "Mexique", "zoneName": "Nord-est" },
-    "MX-NO": { "countryName": "Mexique", "zoneName": "Nord" },
-    "MX-NW": { "countryName": "Mexique", "zoneName": "Nord-ouest" },
-    "MX-OC": { "countryName": "Mexique", "zoneName": "Occidental" },
-    "MX-OR": { "countryName": "Mexique", "zoneName": "Oriental" },
-    "MX-PN": { "countryName": "Mexique", "zoneName": "Péninsule" },
-    "MY-EM": { "countryName": "Malaisie", "zoneName": "Borneo" },
-    "MY-WM": { "countryName": "Malaisie", "zoneName": "Peninsule" },
-    "MZ": { "zoneName": "Mozambique" },
-    "NA": { "zoneName": "Namibie" },
-    "NC": { "zoneName": "Nouvelle-Calédonie" },
-    "NE": { "zoneName": "Niger" },
-    "NF": { "zoneName": "Île Norfolk" },
-    "NG": { "zoneName": "Nigeria" },
-    "NI": { "zoneName": "Nicaragua" },
-    "NKR": { "zoneName": "Haut-Karabagh" },
-    "NL": { "zoneName": "Pays-Bas" },
-    "NO-NO1": { "countryName": "Norvège", "zoneName": "Norvège du Sud-Est" },
-    "NO-NO2": { "countryName": "Norvège", "zoneName": "Norvège du Sud-Ouest" },
-    "NO-NO3": { "countryName": "Norvège", "zoneName": "Norvège Centre" },
-    "NO-NO4": { "countryName": "Norvège", "zoneName": "Norvège Nord" },
-    "NO-NO5": { "countryName": "Norvège", "zoneName": "Norvège Ouest" },
-    "NP": { "zoneName": "Népal" },
-    "NR": { "zoneName": "Nauru" },
-    "NU": { "zoneName": "Niue" },
-    "NZ": { "zoneName": "Nouvelle-Zélande" },
-    "NZ-NZA": { "countryName": "Nouvelle-Zélande", "zoneName": "Îles Auckland" },
-    "NZ-NZC": { "countryName": "Nouvelle-Zélande", "zoneName": "Îles Chatham" },
-    "OM": { "zoneName": "Oman" },
-    "PA": { "zoneName": "Panama" },
-    "PE": { "zoneName": "Pérou" },
-    "PF": { "zoneName": "Polynésie française" },
-    "PG": { "zoneName": "Papouasie-Nouvelle-Guinée" },
-    "PH": { "zoneName": "Philippines" },
-    "PK": { "zoneName": "Pakistan" },
-    "PL": { "zoneName": "Pologne" },
-    "PM": { "countryName": "France", "zoneName": "Saint-Pierre-et-Miquelon" },
-    "PN": { "zoneName": "Îles Pitcairn" },
-    "PR": { "zoneName": "Porto Rico" },
-    "PS": { "zoneName": "Palestine" },
-    "PT": { "zoneName": "Portugal" },
-    "PT-AC": { "countryName": "Portugal", "zoneName": "Açores" },
-    "PT-MA": { "countryName": "Portugal", "zoneName": "Madère" },
-    "PW": { "zoneName": "Palaos" },
-    "PY": { "zoneName": "Paraguay" },
-    "QA": { "zoneName": "Qatar" },
-    "RE": { "countryName": "France", "zoneName": "La Réunion" },
-    "RO": { "zoneName": "Roumanie" },
-    "RS": { "zoneName": "Serbie" },
-    "RU": { "zoneName": "Russie" },
-    "RU-1": { "countryName": "Russie", "zoneName": "Europe-Oural" },
-    "RU-2": { "countryName": "Russie", "zoneName": "Sibérie" },
-    "RU-EU": { "countryName": "Russie", "zoneName": "Arctique" },
-    "RU-AS": { "countryName": "Russie", "zoneName": "Orient" },
-    "RU-FE": { "countryName": "Russie", "zoneName": "Extrême-Orient" },
-    "RU-KGD": { "countryName": "Russie", "zoneName": "Kaliningrad" },
-    "RW": { "zoneName": "Rwanda" },
-    "SA": { "zoneName": "Arabie saoudite" },
-    "SB": { "zoneName": "Salomon" },
-    "SC": { "zoneName": "Seychelles" },
-    "SD": { "zoneName": "Soudan" },
-    "SE": { "zoneName": "Suède" },
-    "SG": { "zoneName": "Singapour" },
-    "SH": { "zoneName": "Sainte-Hélène, Ascension et Tristan da Cunha" },
-    "SI": { "zoneName": "Slovénie" },
-    "SJ": { "zoneName": "Svalbard et ile Jan Mayen" },
-    "SK": { "zoneName": "Slovaquie" },
-    "SL": { "zoneName": "Sierra Leone" },
-    "SM": { "zoneName": "Sain Marin" },
-    "SN": { "zoneName": "Sénégal" },
-    "SO": { "zoneName": "Somalie" },
-    "SR": { "zoneName": "Suriname" },
-    "SS": { "zoneName": "Soudan du Sud" },
-    "ST": { "zoneName": "Sao Tomé et Principe" },
-    "SV": { "zoneName": "Salvador" },
-    "SX": { "countryName": "Saint Martin", "zoneName": "Pays-Bas" },
-    "SY": { "zoneName": "Syrie" },
-    "SZ": { "zoneName": "Swaziland" },
-    "TC": { "zoneName": "Îles Turques-et-Caïques" },
-    "TD": { "zoneName": "Tchad" },
-    "TF": { "zoneName": "Terres australes et antarctiques françaises" },
-    "TG": { "zoneName": "Togo" },
-    "TH": { "zoneName": "Thaïlande" },
-    "TJ": { "zoneName": "Tadjikistan" },
-    "TK": { "zoneName": "Tokelau" },
-    "TL": { "zoneName": "Timor oriental" },
-    "TM": { "zoneName": "Turkménistan" },
-    "TN": { "zoneName": "Tunisie" },
-    "TO": { "zoneName": "Tonga" },
-    "TR": { "zoneName": "Turquie" },
-    "TT": { "zoneName": "Trinité et Tobago" },
-    "TV": { "zoneName": "Tuvalu" },
-    "TW": { "zoneName": "Taïwan" },
-    "TZ": { "zoneName": "Tanzanie" },
-    "UA": { "zoneName": "Ukraine" },
-    "UA-CR": { "zoneName": "Crimée", "countryName": "Ukraine" },
-    "UG": { "zoneName": "Ouganda" },
-    "UM": { "zoneName": "Îles mineures éloignées des États-Unis" },
-    "US-HI": { "countryName": "États-Unis d’Amérique", "zoneName": "Hawaï" },
-    "US-HI-HA": { "countryName": "États Unis d’Amérique", "zoneName": "Hawaï" },
-    "US-HI-KA": { "countryName": "États Unis d’Amérique", "zoneName": "Kauai" },
-    "US-HI-KH": { "countryName": "États Unis d’Amérique", "zoneName": "Kahoolawe" },
-    "US-HI-LA": { "countryName": "États Unis d’Amérique", "zoneName": "Lanai" },
-    "US-HI-MA": { "countryName": "États Unis d’Amérique", "zoneName": "Maui" },
-    "US-HI-MO": { "countryName": "États Unis d’Amérique", "zoneName": "Molokai" },
-    "US-HI-NI": { "countryName": "États Unis d’Amérique", "zoneName": "Niihau" },
-    "US-HI-OA": { "countryName": "États Unis d’Amérique", "zoneName": "Oahu" },
-    "UY": { "zoneName": "Uruguay" },
-    "UZ": { "zoneName": "Ouzbékistan" },
-    "VA": { "zoneName": "Cité du Vatican" },
-    "VC": { "zoneName": "Saint-Vincent-et-les Grenadines" },
-    "VE": { "zoneName": "Venezuela" },
-    "VG": { "countryName": "Îles Vierges", "zoneName": "Îles Vierges britanniques" },
-    "VI": { "countryName": "États-Unis d’Amérique", "zoneName": "Îles Vierges des États-Unis" },
-    "VN": { "zoneName": "Viêt Nam" },
-    "VU": { "zoneName": "Vanuatu" },
-    "WF": { "countryName": "France", "zoneName": "Wallis-et-Futuna" },
-    "WS": { "zoneName": "Samoa" },
-    "XX": { "zoneName": "Chypre du Nord" },
-    "YE": { "zoneName": "Yémen" },
-    "YT": { "countryName": "France", "zoneName": "Mayotte" },
-    "ZA": { "zoneName": "Afrique du Sud" },
-    "ZM": { "zoneName": "Zambie" },
-    "ZW": { "zoneName": "Zimbabwe" }
-  }
+    "AD": {
+      "zoneName": "Andorre"
+    },
+    "AE": {
+      "zoneName": "Émirats arabes unis"
+    },
+    "AF": {
+      "zoneName": "Afghanistan"
+    },
+    "AG": {
+      "zoneName": "Antigua-et-Barbuda"
+    },
+    "AI": {
+      "zoneName": "Anguilla"
+    },
+    "AL": {
+      "zoneName": "Albanie"
+    },
+    "AM": {
+      "zoneName": "Arménie"
+    },
+    "AO": {
+      "zoneName": "Angola"
+    },
+    "AQ": {
+      "zoneName": "Antarctique"
+    },
+    "AS": {
+      "zoneName": "Samoa américaines"
+    },
+    "AT": {
+      "zoneName": "Autriche"
+    },
+    "AR": {
+      "zoneName": "Argentine"
+    },
+    "AUS-NSW": {
+      "countryName": "Australie",
+      "zoneName": "Nouvelle-Galles du Sud"
+    },
+    "AUS-NT": {
+      "countryName": "Australie",
+      "zoneName": "Territoire du Nord"
+    },
+    "AUS-QLD": {
+      "countryName": "Australie",
+      "zoneName": "Queensland"
+    },
+    "AUS-SA": {
+      "countryName": "Australie",
+      "zoneName": "Australie-Méridionale"
+    },
+    "AUS-TAS": {
+      "countryName": "Australie",
+      "zoneName": "Tasmanie"
+    },
+    "AUS-TAS-KI": {
+      "countryName": "Australie",
+      "zoneName": "Tasmanie (Île King)"
+    },
+    "AUS-VIC": {
+      "countryName": "Australie",
+      "zoneName": "Victoria"
+    },
+    "AUS-WA": {
+      "countryName": "Australie",
+      "zoneName": "Australie-Occidentale"
+    },
+    "AUS-WA-RI": {
+      "countryName": "Australie",
+      "zoneName": "Île Rottnest"
+    },
+    "AW": {
+      "zoneName": "Aruba"
+    },
+    "AX": {
+      "zoneName": "Åland"
+    },
+    "AZ": {
+      "zoneName": "Azerbaïdjan"
+    },
+    "BA": {
+      "zoneName": "Bosnie-Herzégovine"
+    },
+    "BB": {
+      "zoneName": "Barbade"
+    },
+    "BD": {
+      "zoneName": "Bangladesh"
+    },
+    "BE": {
+      "zoneName": "Belgique"
+    },
+    "BF": {
+      "zoneName": "Burkina Faso"
+    },
+    "BG": {
+      "zoneName": "Bulgarie"
+    },
+    "BH": {
+      "zoneName": "Bahreïn"
+    },
+    "BI": {
+      "zoneName": "Burundi"
+    },
+    "BJ": {
+      "zoneName": "Bénin"
+    },
+    "BM": {
+      "zoneName": "Bermudes"
+    },
+    "BN": {
+      "zoneName": "Brunei"
+    },
+    "BO": {
+      "zoneName": "Bolivie"
+    },
+    "BQ": {
+      "zoneName": "Pays-Bas caribéens"
+    },
+    "BR-CS": {
+      "countryName": "Brésil",
+      "zoneName": "Central"
+    },
+    "BR-N": {
+      "countryName": "Brésil",
+      "zoneName": "Nord"
+    },
+    "BR-NE": {
+      "countryName": "Brésil",
+      "zoneName": "Nord-Est"
+    },
+    "BR-S": {
+      "countryName": "Brésil",
+      "zoneName": "Sud"
+    },
+    "BS": {
+      "zoneName": "Bahamas"
+    },
+    "BT": {
+      "zoneName": "Bhoutan"
+    },
+    "BV": {
+      "zoneName": "Île Bouvet"
+    },
+    "BW": {
+      "zoneName": "Botswana"
+    },
+    "BY": {
+      "zoneName": "Biélorussie"
+    },
+    "BZ": {
+      "zoneName": "Belize"
+    },
+    "CA-AB": {
+      "countryName": "Canada",
+      "zoneName": "Alberta"
+    },
+    "CA-BC": {
+      "countryName": "Canada",
+      "zoneName": "Colombie-Britannique"
+    },
+    "CA-MB": {
+      "countryName": "Canada",
+      "zoneName": "Manitoba"
+    },
+    "CA-NL": {
+      "countryName": "Canada",
+      "zoneName": "Terre-Neuve-et-Labrador"
+    },
+    "CA-NB": {
+      "countryName": "Canada",
+      "zoneName": "Nouveau-Brunswick"
+    },
+    "CA-NT": {
+      "countryName": "Canada",
+      "zoneName": "Territoires du Nord-Ouest"
+    },
+    "CA-NS": {
+      "countryName": "Canada",
+      "zoneName": "Nouvelle-Écosse"
+    },
+    "CA-NU": {
+      "countryName": "Canada",
+      "zoneName": "Nunavut"
+    },
+    "CA-ON": {
+      "countryName": "Canada",
+      "zoneName": "Ontario"
+    },
+    "CA-PE": {
+      "countryName": "Canada",
+      "zoneName": "Île-du-Prince-Édouard"
+    },
+    "CA-QC": {
+      "countryName": "Canada",
+      "zoneName": "Québec"
+    },
+    "CA-SK": {
+      "countryName": "Canada",
+      "zoneName": "Saskatchewan"
+    },
+    "CA-YT": {
+      "countryName": "Canada",
+      "zoneName": "Yukon"
+    },
+    "CC": {
+      "zoneName": "Îles Cocos"
+    },
+    "CD": {
+      "zoneName": "République démocratique du Congo"
+    },
+    "CF": {
+      "zoneName": "République centrafricaine"
+    },
+    "CG": {
+      "zoneName": "République du Congo"
+    },
+    "CH": {
+      "zoneName": "Suisse"
+    },
+    "CI": {
+      "zoneName": "Côte d’Ivoire"
+    },
+    "CK": {
+      "zoneName": "Îles Cook"
+    },
+    "CL-SING": {
+      "countryName": "Chili",
+      "zoneName": "SING"
+    },
+    "CL-SING-SIC": {
+      "countryName": "Chili",
+      "zoneName": "SING - SIC"
+    },
+    "CL-SEM": {
+      "countryName": "Chili",
+      "zoneName": "SEM"
+    },
+    "CL-SEA": {
+      "countryName": "Chili",
+      "zoneName": "SEA"
+    },
+    "CL-SEN": {
+      "countryName": "Chili",
+      "zoneName": "SEN"
+    },
+    "CL-CHP": {
+      "countryName": "Chili",
+      "zoneName": "Île de Pâques"
+    },
+    "CM": {
+      "zoneName": "Cameroun"
+    },
+    "CN": {
+      "zoneName": "Chine"
+    },
+    "CO": {
+      "zoneName": "Colombie"
+    },
+    "CR": {
+      "zoneName": "Costa Rica"
+    },
+    "CU": {
+      "zoneName": "Cuba"
+    },
+    "CV": {
+      "zoneName": "Cap-Vert"
+    },
+    "CW": {
+      "zoneName": "Curaçao"
+    },
+    "CX": {
+      "zoneName": "Île Christmas"
+    },
+    "CY": {
+      "zoneName": "Chypre"
+    },
+    "CZ": {
+      "zoneName": "Tchéquie"
+    },
+    "DE": {
+      "zoneName": "Allemagne"
+    },
+    "DJ": {
+      "zoneName": "Djibouti"
+    },
+    "DK": {
+      "zoneName": "Danemark"
+    },
+    "DK-DK1": {
+      "countryName": "Danemark",
+      "zoneName": "Danemark ouest"
+    },
+    "DK-DK2": {
+      "countryName": "Danemark",
+      "zoneName": "Danemark est"
+    },
+    "DK-BHM": {
+      "countryName": "Danemark",
+      "zoneName": "Bornholm"
+    },
+    "DM": {
+      "zoneName": "Dominique"
+    },
+    "DO": {
+      "zoneName": "République Dominicaine"
+    },
+    "DZ": {
+      "zoneName": "Algérie"
+    },
+    "EC": {
+      "zoneName": "Equateur"
+    },
+    "EE": {
+      "zoneName": "Estonie"
+    },
+    "EG": {
+      "zoneName": "Egypte"
+    },
+    "EH": {
+      "zoneName": "Sahara Occidental"
+    },
+    "ER": {
+      "zoneName": "Érythrée"
+    },
+    "ES": {
+      "zoneName": "Espagne"
+    },
+    "ES-CE": {
+      "countryName": "Espagne",
+      "zoneName": "Ceuta"
+    },
+    "ES-IB-FO": {
+      "countryName": "Espagne",
+      "zoneName": "Formentera"
+    },
+    "ES-IB-IZ": {
+      "countryName": "Espagne",
+      "zoneName": "Ibiza"
+    },
+    "ES-IB-MA": {
+      "countryName": "Espagne",
+      "zoneName": "Majorque"
+    },
+    "ES-IB-ME": {
+      "countryName": "Espagne",
+      "zoneName": "Minorque"
+    },
+    "ES-CN-FVLZ": {
+      "countryName": "Espagne",
+      "zoneName": "Fuerteventura/Lanzarote"
+    },
+    "ES-CN-GC": {
+      "countryName": "Espagne",
+      "zoneName": "Grande Canarie"
+    },
+    "ES-CN-HI": {
+      "countryName": "Espagne",
+      "zoneName": "El Hierro"
+    },
+    "ES-CN-IG": {
+      "countryName": "Espagne",
+      "zoneName": "Ile de la Gomera"
+    },
+    "ES-CN-LP": {
+      "countryName": "Espagne",
+      "zoneName": "La Palma"
+    },
+    "ES-CN-TE": {
+      "countryName": "Espagne",
+      "zoneName": "Tenerife"
+    },
+    "ES-ML": {
+      "countryName": "Espagne",
+      "zoneName": "Melilla"
+    },
+    "ET": {
+      "zoneName": "Éthiopie"
+    },
+    "FI": {
+      "zoneName": "Finlande"
+    },
+    "FJ": {
+      "zoneName": "Fidji"
+    },
+    "FK": {
+      "zoneName": "Malouines"
+    },
+    "FM": {
+      "zoneName": "Micronésie"
+    },
+    "FO": {
+      "zoneName": "Îles Féroé"
+    },
+    "FR": {
+      "zoneName": "France"
+    },
+    "FR-COR": {
+      "countryName": "France",
+      "zoneName": "Corse"
+    },
+    "GA": {
+      "zoneName": "Gabon"
+    },
+    "GB": {
+      "zoneName": "Grande-Bretagne"
+    },
+    "GB-NIR": {
+      "zoneName": "Irlande du Nord"
+    },
+    "GB-ORK": {
+      "countryName": "Grande Bretagne",
+      "zoneName": "Orcades"
+    },
+    "GB-SHI": {
+      "countryName": "Grande Bretagne",
+      "zoneName": "Shetland"
+    },
+    "GB-ZET": {
+      "countryName": "Grande Bretagne",
+      "zoneName": "Shetland"
+    },
+    "GD": {
+      "zoneName": "Grenade"
+    },
+    "GE": {
+      "zoneName": "Géorgie"
+    },
+    "GF": {
+      "countryName": "France",
+      "zoneName": "Guyane Française"
+    },
+    "GG": {
+      "zoneName": "Guernesey"
+    },
+    "GH": {
+      "zoneName": "Ghana"
+    },
+    "GI": {
+      "zoneName": "Gibraltar"
+    },
+    "GL": {
+      "zoneName": "Groenland"
+    },
+    "GM": {
+      "zoneName": "Gambie"
+    },
+    "GN": {
+      "zoneName": "Guinée"
+    },
+    "GP": {
+      "countryName": "France",
+      "zoneName": "Guadeloupe"
+    },
+    "GQ": {
+      "zoneName": "Guinée équatoriale"
+    },
+    "GR": {
+      "zoneName": "Grèce"
+    },
+    "GR-IS": {
+      "countryName": "Grèce",
+      "zoneName": "Îles Égéennes"
+    },
+    "GS": {
+      "zoneName": "Géorgie du Sud-et-les Îles Sandwich du Sud"
+    },
+    "GT": {
+      "zoneName": "Guatémala"
+    },
+    "GU": {
+      "zoneName": "Guam"
+    },
+    "GW": {
+      "zoneName": "Guinée-Bissau"
+    },
+    "GY": {
+      "zoneName": "Guyana"
+    },
+    "HK": {
+      "zoneName": "Hong Kong"
+    },
+    "HM": {
+      "zoneName": "Îles Heard-et-MacDonald"
+    },
+    "HN": {
+      "zoneName": "Honduras"
+    },
+    "HR": {
+      "zoneName": "Croatie"
+    },
+    "HT": {
+      "zoneName": "Haïti"
+    },
+    "HU": {
+      "zoneName": "Hongrie"
+    },
+    "ID": {
+      "zoneName": "Indonésie"
+    },
+    "IE": {
+      "zoneName": "Irlande"
+    },
+    "IL": {
+      "zoneName": "Israël"
+    },
+    "IM": {
+      "zoneName": "Île de Man"
+    },
+    "IN-AN": {
+      "countryName": "Inde",
+      "zoneName": "Andaman and Nicobar Islands"
+    },
+    "IN-AP": {
+      "countryName": "Inde",
+      "zoneName": "Andhra Pradesh"
+    },
+    "IN-AR": {
+      "countryName": "Inde",
+      "zoneName": "Arunachal Pradesh"
+    },
+    "IN-AS": {
+      "countryName": "Inde",
+      "zoneName": "Assam"
+    },
+    "IN-BR": {
+      "countryName": "Inde",
+      "zoneName": "Bihar"
+    },
+    "IN-CT": {
+      "countryName": "Inde",
+      "zoneName": "Chhattisgarh"
+    },
+    "IN-DL": {
+      "countryName": "Inde",
+      "zoneName": "Delhi"
+    },
+    "IN-DN": {
+      "countryName": "Inde",
+      "zoneName": "Dadra et Nagar Haveli"
+    },
+    "IN-GA": {
+      "countryName": "Inde",
+      "zoneName": "Goa"
+    },
+    "IN-GJ": {
+      "countryName": "Inde",
+      "zoneName": "Gujarat"
+    },
+    "IN-HP": {
+      "countryName": "Inde",
+      "zoneName": "Himachal Pradesh"
+    },
+    "IN-HR": {
+      "countryName": "Inde",
+      "zoneName": "Haryana"
+    },
+    "IN-JH": {
+      "countryName": "Inde",
+      "zoneName": "Jharkhand"
+    },
+    "IN-JK": {
+      "countryName": "Inde",
+      "zoneName": "Jammu and Kashmir"
+    },
+    "IN-KA": {
+      "countryName": "Inde",
+      "zoneName": "Karnataka"
+    },
+    "IN-KL": {
+      "countryName": "Inde",
+      "zoneName": "Kerala"
+    },
+    "IN-MH": {
+      "countryName": "Inde",
+      "zoneName": "Maharashtra"
+    },
+    "IN-ML": {
+      "countryName": "Inde",
+      "zoneName": "Meghalaya"
+    },
+    "IN-MN": {
+      "countryName": "Inde",
+      "zoneName": "Manipur"
+    },
+    "IN-MP": {
+      "countryName": "Inde",
+      "zoneName": "Madhya Pradesh"
+    },
+    "IN-MZ": {
+      "countryName": "Inde",
+      "zoneName": "Mizoram"
+    },
+    "IN-NL": {
+      "countryName": "Inde",
+      "zoneName": "Nagaland"
+    },
+    "IN-OR": {
+      "countryName": "Inde",
+      "zoneName": "Orissa"
+    },
+    "IN-PB": {
+      "countryName": "Inde",
+      "zoneName": "Punjab"
+    },
+    "IN-PY": {
+      "countryName": "Inde",
+      "zoneName": "Pondicherry"
+    },
+    "IN-RJ": {
+      "countryName": "Inde",
+      "zoneName": "Rajasthan"
+    },
+    "IN-SK": {
+      "countryName": "Inde",
+      "zoneName": "Sikkim"
+    },
+    "IN-TN": {
+      "countryName": "Inde",
+      "zoneName": "Tamil Nadu"
+    },
+    "IN-TR": {
+      "countryName": "Inde",
+      "zoneName": "Tripura"
+    },
+    "IN-UP": {
+      "countryName": "Inde",
+      "zoneName": "Uttar Pradesh"
+    },
+    "IN-UT": {
+      "countryName": "Inde",
+      "zoneName": "Uttarakhand"
+    },
+    "IN-WB": {
+      "countryName": "Inde",
+      "zoneName": "West Bengal"
+    },
+    "IO": {
+      "zoneName": "Territoire britannique de l’océan Indien"
+    },
+    "IQ": {
+      "zoneName": "Irak"
+    },
+    "IQ-KUR": {
+      "countryName": "Irak",
+      "zoneName": "Kurdistan"
+    },
+    "IR": {
+      "zoneName": "Iran"
+    },
+    "IS": {
+      "zoneName": "Islande"
+    },
+    "IT": {
+      "zoneName": "Italie"
+    },
+    "IT-CNO": {
+      "countryName": "Italie",
+      "zoneName": "Centre nord"
+    },
+    "IT-CSO": {
+      "countryName": "Italie",
+      "zoneName": "Centre sud"
+    },
+    "IT-NO": {
+      "countryName": "Italie",
+      "zoneName": "Nord"
+    },
+    "IT-SAR": {
+      "countryName": "Italie",
+      "zoneName": "Sardaigne"
+    },
+    "IT-SIC": {
+      "countryName": "Italie",
+      "zoneName": "Sicile"
+    },
+    "IT-SO": {
+      "countryName": "Italie",
+      "zoneName": "Sud"
+    },
+    "JE": {
+      "zoneName": "Jersey"
+    },
+    "JM": {
+      "zoneName": "Jamaïque"
+    },
+    "JO": {
+      "zoneName": "Jordanie"
+    },
+    "JP-CB": {
+      "countryName": "Japon",
+      "zoneName": "Chūbu"
+    },
+    "JP-CG": {
+      "countryName": "Japon",
+      "zoneName": "Chūgoku"
+    },
+    "JP-HKD": {
+      "countryName": "Japon",
+      "zoneName": "Hokkaidō"
+    },
+    "JP-HR": {
+      "countryName": "Japon",
+      "zoneName": "Hokuriku"
+    },
+    "JP-KN": {
+      "countryName": "Japon",
+      "zoneName": "Kansai"
+    },
+    "JP-KY": {
+      "countryName": "Japon",
+      "zoneName": "Kyūshū"
+    },
+    "JP-ON": {
+      "countryName": "Japon",
+      "zoneName": "Okinawa"
+    },
+    "JP-SK": {
+      "countryName": "Japon",
+      "zoneName": "Shikoku"
+    },
+    "JP-TH": {
+      "countryName": "Japon",
+      "zoneName": "Tōhoku"
+    },
+    "JP-TK": {
+      "countryName": "Japon",
+      "zoneName": "Tokyo"
+    },
+    "KE": {
+      "zoneName": "Kenya"
+    },
+    "KG": {
+      "zoneName": "Kirghizistan"
+    },
+    "KH": {
+      "zoneName": "Cambodge"
+    },
+    "KI": {
+      "zoneName": "Kiribati"
+    },
+    "KM": {
+      "zoneName": "Comores"
+    },
+    "KN": {
+      "zoneName": "Saint-Christophe-et-Niévès"
+    },
+    "KP": {
+      "zoneName": "Corée du Nord"
+    },
+    "KR": {
+      "zoneName": "Corée du Sud"
+    },
+    "KW": {
+      "zoneName": "Koweït"
+    },
+    "KY": {
+      "zoneName": "Îles Caïmans"
+    },
+    "KZ": {
+      "zoneName": "Kazakhstan"
+    },
+    "LA": {
+      "zoneName": "Laos"
+    },
+    "LB": {
+      "zoneName": "Liban"
+    },
+    "LC": {
+      "zoneName": "Sainte-Lucie"
+    },
+    "LI": {
+      "zoneName": "Liechtenstein"
+    },
+    "LK": {
+      "zoneName": "Sri Lanka"
+    },
+    "LR": {
+      "zoneName": "Liberia"
+    },
+    "LS": {
+      "zoneName": "Lesotho"
+    },
+    "LT": {
+      "zoneName": "Lituanie"
+    },
+    "LU": {
+      "zoneName": "Luxembourg"
+    },
+    "LV": {
+      "zoneName": "Lettonie"
+    },
+    "LY": {
+      "zoneName": "Libya"
+    },
+    "MA": {
+      "zoneName": "Maroc"
+    },
+    "MC": {
+      "zoneName": "Monaco"
+    },
+    "MD": {
+      "zoneName": "Moldavie"
+    },
+    "ME": {
+      "zoneName": "Monténégro"
+    },
+    "MF": {
+      "countryName": "France",
+      "zoneName": "Saint-Martin"
+    },
+    "MG": {
+      "zoneName": "Madagascar"
+    },
+    "MH": {
+      "zoneName": "Îles Marshall"
+    },
+    "MK": {
+      "zoneName": "Macédoine du Nord"
+    },
+    "ML": {
+      "zoneName": "Mali"
+    },
+    "MM": {
+      "zoneName": "Birmanie"
+    },
+    "MN": {
+      "zoneName": "Mongolia"
+    },
+    "MO": {
+      "zoneName": "Macao"
+    },
+    "MP": {
+      "zoneName": "Îles Mariannes du Nord"
+    },
+    "MQ": {
+      "countryName": "France",
+      "zoneName": "Martinique"
+    },
+    "MR": {
+      "zoneName": "Mauritanie"
+    },
+    "MS": {
+      "zoneName": "Montserrat"
+    },
+    "MT": {
+      "zoneName": "Malte"
+    },
+    "MU": {
+      "zoneName": "Maurice"
+    },
+    "MV": {
+      "zoneName": "Maldives"
+    },
+    "MW": {
+      "zoneName": "Malawi"
+    },
+    "MX": {
+      "zoneName": "Mexique"
+    },
+    "MX-BC": {
+      "countryName": "Mexique",
+      "zoneName": "Baja California"
+    },
+    "MX-CE": {
+      "countryName": "Mexique",
+      "zoneName": "Centre"
+    },
+    "MX-NE": {
+      "countryName": "Mexique",
+      "zoneName": "Nord-est"
+    },
+    "MX-NO": {
+      "countryName": "Mexique",
+      "zoneName": "Nord"
+    },
+    "MX-NW": {
+      "countryName": "Mexique",
+      "zoneName": "Nord-ouest"
+    },
+    "MX-OC": {
+      "countryName": "Mexique",
+      "zoneName": "Occidental"
+    },
+    "MX-OR": {
+      "countryName": "Mexique",
+      "zoneName": "Oriental"
+    },
+    "MX-PN": {
+      "countryName": "Mexique",
+      "zoneName": "Péninsule"
+    },
+    "MY-EM": {
+      "countryName": "Malaisie",
+      "zoneName": "Borneo"
+    },
+    "MY-WM": {
+      "countryName": "Malaisie",
+      "zoneName": "Peninsule"
+    },
+    "MZ": {
+      "zoneName": "Mozambique"
+    },
+    "NA": {
+      "zoneName": "Namibie"
+    },
+    "NC": {
+      "zoneName": "Nouvelle-Calédonie"
+    },
+    "NE": {
+      "zoneName": "Niger"
+    },
+    "NF": {
+      "zoneName": "Île Norfolk"
+    },
+    "NG": {
+      "zoneName": "Nigeria"
+    },
+    "NI": {
+      "zoneName": "Nicaragua"
+    },
+    "NKR": {
+      "zoneName": "Haut-Karabagh"
+    },
+    "NL": {
+      "zoneName": "Pays-Bas"
+    },
+    "NO-NO1": {
+      "countryName": "Norvège",
+      "zoneName": "Norvège du Sud-Est"
+    },
+    "NO-NO2": {
+      "countryName": "Norvège",
+      "zoneName": "Norvège du Sud-Ouest"
+    },
+    "NO-NO3": {
+      "countryName": "Norvège",
+      "zoneName": "Norvège Centre"
+    },
+    "NO-NO4": {
+      "countryName": "Norvège",
+      "zoneName": "Norvège Nord"
+    },
+    "NO-NO5": {
+      "countryName": "Norvège",
+      "zoneName": "Norvège Ouest"
+    },
+    "NP": {
+      "zoneName": "Népal"
+    },
+    "NR": {
+      "zoneName": "Nauru"
+    },
+    "NU": {
+      "zoneName": "Niue"
+    },
+    "NZ": {
+      "zoneName": "Nouvelle-Zélande"
+    },
+    "NZ-NZA": {
+      "countryName": "Nouvelle-Zélande",
+      "zoneName": "Îles Auckland"
+    },
+    "NZ-NZC": {
+      "countryName": "Nouvelle-Zélande",
+      "zoneName": "Îles Chatham"
+    },
+    "OM": {
+      "zoneName": "Oman"
+    },
+    "PA": {
+      "zoneName": "Panama"
+    },
+    "PE": {
+      "zoneName": "Pérou"
+    },
+    "PF": {
+      "zoneName": "Polynésie française"
+    },
+    "PG": {
+      "zoneName": "Papouasie-Nouvelle-Guinée"
+    },
+    "PH": {
+      "zoneName": "Philippines"
+    },
+    "PK": {
+      "zoneName": "Pakistan"
+    },
+    "PL": {
+      "zoneName": "Pologne"
+    },
+    "PM": {
+      "countryName": "France",
+      "zoneName": "Saint-Pierre-et-Miquelon"
+    },
+    "PN": {
+      "zoneName": "Îles Pitcairn"
+    },
+    "PR": {
+      "zoneName": "Porto Rico"
+    },
+    "PS": {
+      "zoneName": "Palestine"
+    },
+    "PT": {
+      "zoneName": "Portugal"
+    },
+    "PT-AC": {
+      "countryName": "Portugal",
+      "zoneName": "Açores"
+    },
+    "PT-MA": {
+      "countryName": "Portugal",
+      "zoneName": "Madère"
+    },
+    "PW": {
+      "zoneName": "Palaos"
+    },
+    "PY": {
+      "zoneName": "Paraguay"
+    },
+    "QA": {
+      "zoneName": "Qatar"
+    },
+    "RE": {
+      "countryName": "France",
+      "zoneName": "La Réunion"
+    },
+    "RO": {
+      "zoneName": "Roumanie"
+    },
+    "RS": {
+      "zoneName": "Serbie"
+    },
+    "RU": {
+      "zoneName": "Russie"
+    },
+    "RU-1": {
+      "countryName": "Russie",
+      "zoneName": "Europe-Oural"
+    },
+    "RU-2": {
+      "countryName": "Russie",
+      "zoneName": "Sibérie"
+    },
+    "RU-EU": {
+      "countryName": "Russie",
+      "zoneName": "Arctique"
+    },
+    "RU-AS": {
+      "countryName": "Russie",
+      "zoneName": "Orient"
+    },
+    "RU-FE": {
+      "countryName": "Russie",
+      "zoneName": "Extrême-Orient"
+    },
+    "RU-KGD": {
+      "countryName": "Russie",
+      "zoneName": "Kaliningrad"
+    },
+    "RW": {
+      "zoneName": "Rwanda"
+    },
+    "SA": {
+      "zoneName": "Arabie saoudite"
+    },
+    "SB": {
+      "zoneName": "Salomon"
+    },
+    "SC": {
+      "zoneName": "Seychelles"
+    },
+    "SD": {
+      "zoneName": "Soudan"
+    },
+    "SE": {
+      "zoneName": "Suède"
+    },
+    "SG": {
+      "zoneName": "Singapour"
+    },
+    "SH": {
+      "zoneName": "Sainte-Hélène, Ascension et Tristan da Cunha"
+    },
+    "SI": {
+      "zoneName": "Slovénie"
+    },
+    "SJ": {
+      "zoneName": "Svalbard et ile Jan Mayen"
+    },
+    "SK": {
+      "zoneName": "Slovaquie"
+    },
+    "SL": {
+      "zoneName": "Sierra Leone"
+    },
+    "SM": {
+      "zoneName": "Sain Marin"
+    },
+    "SN": {
+      "zoneName": "Sénégal"
+    },
+    "SO": {
+      "zoneName": "Somalie"
+    },
+    "SR": {
+      "zoneName": "Suriname"
+    },
+    "SS": {
+      "zoneName": "Soudan du Sud"
+    },
+    "ST": {
+      "zoneName": "Sao Tomé et Principe"
+    },
+    "SV": {
+      "zoneName": "Salvador"
+    },
+    "SX": {
+      "countryName": "Saint Martin",
+      "zoneName": "Pays-Bas"
+    },
+    "SY": {
+      "zoneName": "Syrie"
+    },
+    "SZ": {
+      "zoneName": "Swaziland"
+    },
+    "TC": {
+      "zoneName": "Îles Turques-et-Caïques"
+    },
+    "TD": {
+      "zoneName": "Tchad"
+    },
+    "TF": {
+      "zoneName": "Terres australes et antarctiques françaises"
+    },
+    "TG": {
+      "zoneName": "Togo"
+    },
+    "TH": {
+      "zoneName": "Thaïlande"
+    },
+    "TJ": {
+      "zoneName": "Tadjikistan"
+    },
+    "TK": {
+      "zoneName": "Tokelau"
+    },
+    "TL": {
+      "zoneName": "Timor oriental"
+    },
+    "TM": {
+      "zoneName": "Turkménistan"
+    },
+    "TN": {
+      "zoneName": "Tunisie"
+    },
+    "TO": {
+      "zoneName": "Tonga"
+    },
+    "TR": {
+      "zoneName": "Turquie"
+    },
+    "TT": {
+      "zoneName": "Trinité et Tobago"
+    },
+    "TV": {
+      "zoneName": "Tuvalu"
+    },
+    "TW": {
+      "zoneName": "Taïwan"
+    },
+    "TZ": {
+      "zoneName": "Tanzanie"
+    },
+    "UA": {
+      "zoneName": "Ukraine"
+    },
+    "UA-CR": {
+      "zoneName": "Crimée",
+      "countryName": "Ukraine"
+    },
+    "UG": {
+      "zoneName": "Ouganda"
+    },
+    "UM": {
+      "zoneName": "Îles mineures éloignées des États-Unis"
+    },
+    "US-HI": {
+      "countryName": "États-Unis d’Amérique",
+      "zoneName": "Hawaï"
+    },
+    "US-HI-HA": {
+      "countryName": "États Unis d’Amérique",
+      "zoneName": "Hawaï"
+    },
+    "US-HI-KA": {
+      "countryName": "États Unis d’Amérique",
+      "zoneName": "Kauai"
+    },
+    "US-HI-KH": {
+      "countryName": "États Unis d’Amérique",
+      "zoneName": "Kahoolawe"
+    },
+    "US-HI-LA": {
+      "countryName": "États Unis d’Amérique",
+      "zoneName": "Lanai"
+    },
+    "US-HI-MA": {
+      "countryName": "États Unis d’Amérique",
+      "zoneName": "Maui"
+    },
+    "US-HI-MO": {
+      "countryName": "États Unis d’Amérique",
+      "zoneName": "Molokai"
+    },
+    "US-HI-NI": {
+      "countryName": "États Unis d’Amérique",
+      "zoneName": "Niihau"
+    },
+    "US-HI-OA": {
+      "countryName": "États Unis d’Amérique",
+      "zoneName": "Oahu"
+    },
+    "UY": {
+      "zoneName": "Uruguay"
+    },
+    "UZ": {
+      "zoneName": "Ouzbékistan"
+    },
+    "VA": {
+      "zoneName": "Cité du Vatican"
+    },
+    "VC": {
+      "zoneName": "Saint-Vincent-et-les Grenadines"
+    },
+    "VE": {
+      "zoneName": "Venezuela"
+    },
+    "VG": {
+      "countryName": "Îles Vierges",
+      "zoneName": "Îles Vierges britanniques"
+    },
+    "VI": {
+      "countryName": "États-Unis d’Amérique",
+      "zoneName": "Îles Vierges des États-Unis"
+    },
+    "VN": {
+      "zoneName": "Viêt Nam"
+    },
+    "VU": {
+      "zoneName": "Vanuatu"
+    },
+    "WF": {
+      "countryName": "France",
+      "zoneName": "Wallis-et-Futuna"
+    },
+    "WS": {
+      "zoneName": "Samoa"
+    },
+    "XX": {
+      "zoneName": "Chypre du Nord"
+    },
+    "YE": {
+      "zoneName": "Yémen"
+    },
+    "YT": {
+      "countryName": "France",
+      "zoneName": "Mayotte"
+    },
+    "ZA": {
+      "zoneName": "Afrique du Sud"
+    },
+    "ZM": {
+      "zoneName": "Zambie"
+    },
+    "ZW": {
+      "zoneName": "Zimbabwe"
+    },
+    "AUS-TAS-CBI": {
+      "countryName": "Australie",
+      "zoneName": "Île du Cap Barren"
+    },
+    "AUS-TAS-FI": {
+      "countryName": "Australie",
+      "zoneName": "Île Flinders"
+    },
+    "BR-I": {
+      "countryName": "Brésil",
+      "zoneName": "Systèmes isolés"
+    },
+    "CA-NL-LB": {
+      "countryName": "Canada",
+      "zoneName": "Labrador"
+    },
+    "CA-NL-NF": {
+      "countryName": "Canada",
+      "zoneName": "Terre-Neuve"
+    },
+    "FO-MI": {
+      "countryName": "Îles Féroé",
+      "zoneName": "Iles principales"
+    },
+    "FO-SI": {
+      "countryName": "Îles Féroé",
+      "zoneName": "Île du Sud"
+    },
+    "NO": {
+      "zoneName": "Norvège"
+    },
+    "NZ-NZST": {
+      "countryName": "Nouvelle-Zélande",
+      "zoneName": "Île Stewart"
+    },
+    "SE-SE1": {
+      "countryName": "Suède",
+      "zoneName": "Nord de la Suède"
+    },
+    "SE-SE2": {
+      "countryName": "Suède",
+      "zoneName": "Centre-Nord de la Suède"
+    },
+    "SE-SE3": {
+      "countryName": "Suède",
+      "zoneName": "Centre-Sud de la Suède"
+    },
+    "SE-SE4": {
+      "countryName": "Suède",
+      "zoneName": "Sud de la Suède"
+    },
+    "US-CAL-BANC": {
+      "countryName": "USA",
+      "zoneName": "Autorité d'équilibrage de la Californie du Nord"
+    },
+    "US-CAL-CISO": {
+      "countryName": "USA",
+      "zoneName": "Opérateur de réseau indépendant de Californie"
+    },
+    "US-CAL-IID": {
+      "countryName": "USA",
+      "zoneName": "District d'irrigation impérial"
+    },
+    "US-CAL-LDWP": {
+      "countryName": "USA",
+      "zoneName": "Département de l'eau et de l'électricité de Los Angeles"
+    },
+    "US-CAL-TIDC": {
+      "countryName": "USA",
+      "zoneName": "District d'irrigation de Turlock"
+    },
+    "US-CAR-CPLE": {
+      "countryName": "USA",
+      "zoneName": "Duke Energy Progress East"
+    },
+    "US-CAR-CPLW": {
+      "countryName": "USA",
+      "zoneName": "Duke Energy Progress West"
+    },
+    "US-CAR-DUK": {
+      "countryName": "USA",
+      "zoneName": "Duke Energy Carolines"
+    },
+    "US-CAR-SC": {
+      "countryName": "USA",
+      "zoneName": "Autorité des services publics de Caroline du Sud"
+    },
+    "US-CAR-SCEG": {
+      "countryName": "USA",
+      "zoneName": "Compagnie d'électricité et de gaz de Caroline du Sud"
+    },
+    "US-CAR-YAD": {
+      "countryName": "USA",
+      "zoneName": "Génération d'énergie Alcoa, Inc. Division de Yadkin"
+    },
+    "US-CENT-SPA": {
+      "countryName": "USA",
+      "zoneName": "Administration de l'électricité du sud-ouest"
+    },
+    "US-CENT-SWPP": {
+      "countryName": "USA",
+      "zoneName": "Pool énergétique du sud-ouest"
+    },
+    "US-FLA-FMPP": {
+      "countryName": "USA",
+      "zoneName": "Pool énergétique municipal de Floride"
+    },
+    "US-FLA-FPC": {
+      "countryName": "USA",
+      "zoneName": "Duke Energy Floride Inc"
+    },
+    "US-FLA-FPL": {
+      "countryName": "USA",
+      "zoneName": "Compagnie d'électricité et d'éclairage de Floride"
+    },
+    "US-FLA-GVL": {
+      "countryName": "USA",
+      "zoneName": "Services publics régionaux de Gainesville"
+    },
+    "US-FLA-HST": {
+      "countryName": "USA",
+      "zoneName": "Ville de Homestead"
+    },
+    "US-FLA-JEA": {
+      "countryName": "USA",
+      "zoneName": "Autorité électrique de Jacksonville"
+    },
+    "US-FLA-NSB": {
+      "countryName": "USA",
+      "zoneName": "Commission des services publics de New Smyrna Beach"
+    },
+    "US-FLA-SEC": {
+      "countryName": "USA",
+      "zoneName": "Coopérative électrique de Seminole"
+    },
+    "US-FLA-TAL": {
+      "countryName": "USA",
+      "zoneName": "Ville de Tallahassee"
+    },
+    "US-FLA-TEC": {
+      "countryName": "USA",
+      "zoneName": "Compagnie d'électricité de Tampa"
+    },
+    "US-MIDA-PJM": {
+      "countryName": "USA",
+      "zoneName": "PJM Interconnection, Llc"
+    },
+    "US-MIDW-AECI": {
+      "countryName": "USA",
+      "zoneName": "Coopérative électrique associée, Inc."
+    },
+    "US-MIDW-GLHB": {
+      "countryName": "USA",
+      "zoneName": "GridLiance"
+    },
+    "US-MIDW-LGEE": {
+      "countryName": "USA",
+      "zoneName": "Compagnie de gaz et d'électricité de Louisville et services publics du Kentucky"
+    },
+    "US-MIDW-MISO": {
+      "countryName": "USA",
+      "zoneName": "Midcontinent Independent Transmission System Operator, Inc."
+    },
+    "US-NE-ISNE": {
+      "countryName": "USA",
+      "zoneName": "Iso Nouvelle-Angleterre Inc."
+    },
+    "US-NW-AVA": {
+      "countryName": "USA",
+      "zoneName": "Avista Corporation"
+    },
+    "US-NW-AVRN": {
+      "countryName": "USA",
+      "zoneName": "Coopérative d'énergies renouvelables d'Avangrid"
+    },
+    "US-NW-BPAT": {
+      "countryName": "USA",
+      "zoneName": "Administration de l'électricité de Bonneville"
+    },
+    "US-NW-CHPD": {
+      "countryName": "USA",
+      "zoneName": "PUD n°1 du comté de Chelan"
+    },
+    "US-NW-DOPD": {
+      "countryName": "USA",
+      "zoneName": "PUD n°1 du comté de Douglas"
+    },
+    "US-NW-GCPD": {
+      "countryName": "USA",
+      "zoneName": "PUD n°2 du comté de Grant, Washington"
+    },
+    "US-NW-GRID": {
+      "countryName": "USA",
+      "zoneName": "Gestion de l'énergie Gridforce, LLC"
+    },
+    "US-NW-GWA": {
+      "countryName": "USA",
+      "zoneName": "Naturener Power Watch, Llc (Gwa)"
+    },
+    "US-NW-IPCO": {
+      "countryName": "USA",
+      "zoneName": "Société d'électricité d'Idaho"
+    },
+    "US-NW-NEVP": {
+      "countryName": "USA",
+      "zoneName": "Société d'électricité du Nevada"
+    },
+    "US-NW-NWMT": {
+      "countryName": "USA",
+      "zoneName": "Énergie du Nord-Ouest"
+    },
+    "US-NW-PACE": {
+      "countryName": "USA",
+      "zoneName": "Pacificorp East"
+    },
+    "US-NW-PACW": {
+      "countryName": "USA",
+      "zoneName": "Pacificorp West"
+    },
+    "US-NW-PGE": {
+      "countryName": "USA",
+      "zoneName": "Compagnie électrique générale de Portland"
+    },
+    "US-NW-PSCO": {
+      "countryName": "USA",
+      "zoneName": "Société de service public du Colorado"
+    },
+    "US-NW-PSEI": {
+      "countryName": "USA",
+      "zoneName": "Puget Sound Energy"
+    },
+    "US-NW-SCL": {
+      "countryName": "USA",
+      "zoneName": "Seattle City Light"
+    },
+    "US-NW-TPWR": {
+      "countryName": "USA",
+      "zoneName": "Ville de Tacoma, Département des services publics, Division de la lumière"
+    },
+    "US-NW-WACM": {
+      "countryName": "USA",
+      "zoneName": "Western Area Power Administration - Région des Rocheuses"
+    },
+    "US-NW-WAUW": {
+      "countryName": "USA",
+      "zoneName": "Administration de l'électricité de la région de l'Ouest UGP Ouest"
+    },
+    "US-NW-WWA": {
+      "countryName": "USA",
+      "zoneName": "Naturener Wind Watch, Llc"
+    },
+    "US-NY-NYIS": {
+      "countryName": "USA",
+      "zoneName": "Exploitant de réseau indépendant de New York"
+    },
+    "US-SE-AEC": {
+      "countryName": "USA",
+      "zoneName": "Coopérative d'énergie Powersouth"
+    },
+    "US-SE-SEPA": {
+      "countryName": "USA",
+      "zoneName": "Administration de l'électricité du Sud-Est"
+    },
+    "US-SE-SOCO": {
+      "countryName": "USA",
+      "zoneName": "Southern Company Services, Inc. - Trans"
+    },
+    "US-SW-AZPS": {
+      "countryName": "USA",
+      "zoneName": "Société de services publics de l'Arizona"
+    },
+    "US-SW-DEAA": {
+      "countryName": "USA",
+      "zoneName": "Arlington Valley, LLC"
+    },
+    "US-SW-EPE": {
+      "countryName": "USA",
+      "zoneName": "Compagnie électrique El Paso"
+    },
+    "US-SW-GRIF": {
+      "countryName": "USA",
+      "zoneName": "Griffith Energy, LLC"
+    },
+    "US-SW-GRMA": {
+      "countryName": "USA",
+      "zoneName": "Gila River Power, LLC"
+    },
+    "US-SW-HGMA": {
+      "countryName": "USA",
+      "zoneName": "New Harquahala Generating Company, LLC"
+    },
+    "US-SW-PNM": {
+      "countryName": "USA",
+      "zoneName": "Société de service public du Nouveau-Mexique"
+    },
+    "US-SW-SRP": {
+      "countryName": "USA",
+      "zoneName": "Projet Salt River"
+    },
+    "US-SW-TEPC": {
+      "countryName": "USA",
+      "zoneName": "Société d'énergie électrique de Tucson"
+    },
+    "US-SW-WALC": {
+      "countryName": "USA",
+      "zoneName": "Western Area Power Administration - Région du sud-ouest désertique"
+    },
+    "US-TEN-TVA": {
+      "countryName": "USA",
+      "zoneName": "Autorité de la vallée du Tennessee"
+    },
+    "US-TEX-ERCO": {
+      "countryName": "USA",
+      "zoneName": "Conseil de fiabilité électrique du Texas, Inc."
+    },
+    "XK": {
+      "zoneName": "Kosovo"
+    }
+  },
+  "info-modal": {
+    "title": "Info",
+    "intro-text": "L'application Electricity Maps fournit des informations en temps réel sur le web et sur les mobiles pour les citoyens, les experts en énergie, les ONG et les décideurs politiques, favorisant ainsi une meilleure compréhension des défis de la transition énergétique.",
+    "open-source-text": "Cette application est <a href=\\\"%s\\\" target=\\\"_blank\\\">Open Source</a> (<a href=\\\"%s\\\" target=\\\"_blank\\\">voir les sources de données</a>) et alimentée par la communauté.",
+    "feedback-button": "Partagez vos commentaires",
+    "github-button": "Visiter notre Github",
+    "twitter-button": "Partager sur Twitter",
+    "slack-button": "Rejoindre la communauté Slack",
+    "privacy-policy": "Politique de confidentialité",
+    "legal-notice": "Informations légales"
+  },
+  "settings-modal": {
+    "title": "Paramètres"
+  },
+  "time-controller": {
+    "title": "Afficher les données passées"
+  },
+  "aggregateButtons": {
+    "country": "pays",
+    "zone": "zone"
+  },
+  "windDataError": "Les données sur le vent sont actuellement indisponibles",
+  "solarDataError": "Les données solaires sont actuellement indisponibles"
 }


### PR DESCRIPTION
## Issue

https://github.com/electricitymaps/electricitymaps-contrib/issues/4604

## Description

I used the script `translation-helper.js` to generate the new json file 

While I'm a native french speaker, this exercice is quite complicated. Here are some thoughts about the translations:

- I translated "Open Source" by..."Open Source". One of the official translation in French is "Logiciel libre", but it is very common to keep the English wording "open source". I even found it on some French official website so I kept this way

- The word `zone`, as I don't have always the context, I was not sure to translate by `zone` or `region`. I used `zone` but this is not definitive

- Multiple wordings with "in the last" ask for french to choose a gender. I picked masculine just because it is more common, for example if the word `month` (`mois` in French, masculine) is after, but it could be wrong for another word like `year` (`année`, feminine). 

- The most difficult was the foreign agencies or companies. Sometimes I felt it was better to translate (like Electricity Company) because it would give a clue to a french non-english reader. But sometimes I didn't translated because it would have been meaningless (for example for `Naturener Wind Watch`).
However the decisions were based on my intuition, so there might be multiple improvements as I'm not a translator 😄 

Don't hesitate for changing requests !


NB: in the diff we can observe a lot of changes due to code styling.
I checked with `npx prettier --check .` but I didn't see any issue with it. Do I need to so anything about it ?

### Preview

No preview available.
