### PR TITLE
run CI only on master pushes

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -1,6 +1,8 @@
 name: CI
 on:
   push:
+    branches:
+      - master
   pull_request:
 
 jobs:


### PR DESCRIPTION
## Issue
CI runs on every push. Restrict it to run only on master. Close #4745 
## Description

Restrict CI runs to only run on pushes for master. Keep CI run on PRs.
