### PR TITLE
add US-FLA-HST to byPassedZones

### DIFF
--- a/config/zones/US.yaml
+++ b/config/zones/US.yaml
@@ -1,10 +1,11 @@
 bounding_box:
-  - - -171.791110603
-    - 18.91619
-  - - -66.96466
-    - 71.3577635769
+  - - -230.800781
+    - -23.885838
+  - - -32.343750
+    - 74.019543
 bypassedSubZones:
   - US-AK
+  - US-FLA-HST
   - US-HI-HA
   - US-HI-KA
   - US-HI-KH
@@ -156,4 +157,4 @@ subZoneNames:
   - US-SW-WALC
   - US-TEN-TVA
   - US-TEX-ERCO
-timezone: US-Central
+timezone: US/Central


### PR DESCRIPTION
## Description

Fix bounding box for the US and time zone.
Add US-FLA-HST to the bypassed aggregation subzones as it seems to be often lacking data.