### PR TITLE
Ignore index.html

### DIFF
--- a/web/.earthlyignore
+++ b/web/.earthlyignore
@@ -1,0 +1,3 @@
+# To prevent server.js from serving this file instead of redirecting to /map
+# TODO: Remove this when we deprecate server.js and switch to a fully static site
+public/index.html


### PR DESCRIPTION
Ignore index.html. This was previously ignore in .dockerignore, but earthly can't read that file.