### PR TITLE
add US-SE-SEPA to bypassed subzones for the US

### DIFF
--- a/config/zones/US.yaml
+++ b/config/zones/US.yaml
@@ -6,6 +6,7 @@ bounding_box:
 bypassedSubZones:
   - US-AK
   - US-FLA-HST
+  - US-SE-SEPA
   - US-HI-HA
   - US-HI-KA
   - US-HI-KH


### PR DESCRIPTION
## Issue

US-SE-SEPA is frequently without data lately. Add it to the bypassed subzones until we activate an estimation model for it.

