### PR TITLE
created Contributor Code of Conduct

### DIFF
--- a/code_of_conduct.md
+++ b/code_of_conduct.md
@@ -1,0 +1,39 @@
+
+# Contributor Code of Conduct
+
+## Our Standards
+We pledge as a community to hold ourselves and our peers accountable for upholding high standards for how we treat others. The Electricity Maps contributors community strives to find success in our projects and personal goals by uplifting and empowering each other **regardless of age, body size, visible or invisible disability, ethnicity, sex characteristics, gender identity and expression, level of experience, education, socio-economic status, nationality, personal appearance, race, caste, color, religion, or sexual identity and orientation.** [1] 
+
+To uphold this code of conduct we will prioritize the following values:
+1. Treat ourselves and others with respect and dignity at all times
+2. Strive to uplift each contributor to achieve their goals and grow as contributors/developers
+3. Provide a safe and inviting space for all questions and inquiries 
+4. Seek out less experienced developers to offer assistance 
+
+## Our People
+Our community consists of persons who contribute in many ways. Our standards apply to all persons who are contributing to this project at all times. These members include but are not limited to contributors who:
+
+* manage projects and own products
+* develop software or write code
+* create pull requests
+* review and produce feedback for pull requests
+* create or edit documentation
+* find or verify data sources
+* send messages in the Slack group 
+* participate in the Discussions and Issues forums
+
+## Violations and Reporting
+This code of conduct is enforced communally through contributors monitoring and reporting behavior which violates our standards and values. Violations can be reported by:
+1. Filling out the [Conduct Violations Reporting Form](https://docs.google.com/forms/d/1B1hRzmUxGI2YDdFyv5NbHSw6vAycrgswwqEG0WCgKlM) [2] (optionally anonymous)
+2. Messaging community leaders directly on Slack
+3. Creating a new post for the purpose of community awareness and feedback on the Github Issues forums.
+
+**Remember to hold yourself to the code of conduct even when reporting violations.** 
+
+### Consequences
+The consequences for code of conduct violations are at the discretion of our community leaders. These consequences include but are not limited to temporary bans from contributing or participating in the project, communications suspensions and bans from Slack and forums, and discretionary limitations on how and when to contribute. 
+
+## Notes
+[1] From the [Contributor Covenant](https://www.contributor-covenant.org/version/2/1/code_of_conduct/). This document was highly inspired by the Contributor Covenant.
+
+[2] [Conduct Violations Reporting Form](https://docs.google.com/forms/d/1B1hRzmUxGI2YDdFyv5NbHSw6vAycrgswwqEG0WCgKlM)


### PR DESCRIPTION
## Issue
We do not have a Code of Conduct (as far as I know).

## Description

I have created a Contributor Code of Conduct for our community. My writing was inspired by [the Contributor Covenant](https://www.contributor-covenant.org/version/2/1/code_of_conduct/). 

The document also includes a [Conduct Violations Reporting Form](https://docs.google.com/forms/d/1B1hRzmUxGI2YDdFyv5NbHSw6vAycrgswwqEG0WCgKlM) (Google Form) for reporting violations. I am currently the owner of this form and am ready to give up ownership to the team leaders.