### PR TITLE
Italian time period translation/bugfix

### DIFF
--- a/web/public/locales/it.json
+++ b/web/public/locales/it.json
@@ -84,22 +84,46 @@
       "yearly": "Intensità di carbonio negli ultimi 5 anni"
     },
     "emissions": {
-      "default": "Emissioni nell'ultimo %1$s"
+      "default": "Emissioni nell'ultimo %1$s",
+      "hourly": "Emissioni nelle ultime 24 ore",
+      "daily": "Emissioni nell'ultimo mese",
+      "monthly": "Emissioni nell'ultimo anno",
+      "yearly": "Emissioni negli ultimi 5 anni"
     },
     "emissionsorigin": {
-      "default": "Origine delle emissioni nell' ultimo %1$s"
+      "default": "Origine delle emissioni nell' ultimo %1$s",
+      "hourly": "Origine delle emissioni nelle ultime 24 ore",
+      "daily": "Origine delle emissioni nell'ultimo mese",
+      "monthly": "Origine delle emissioni nell'ultimo anno",
+      "yearly": "Origine delle emissioni negli ultimi 5 anni"
     },
     "emissionsproduction": {
-      "default": "Emissioni prodotte nell' ultimo %1$s"
+      "default": "Emissioni prodotte nell' ultimo %1$s",
+      "hourly": "Emissioni prodotte nelle ultime 24 ore",
+      "daily": "Emissioni prodotte nell'ultimo mese",
+      "monthly": "Emissioni prodotte nell'ultimo anno",
+      "yearly": "Emissioni prodotte negli ultimi 5 anni"
     },
     "electricityorigin": {
-      "default": "Origine dell'elettricità nell' ultimo %1$s"
+      "default": "Origine dell'elettricità nell' ultimo %1$s",
+      "hourly": "Origine dell'elettricità nelle ultime 24 ore",
+      "daily": "Origine dell'elettricità nell'ultimo mese",
+      "monthly": "Origine dell'elettricità nell'ultimo anno",
+      "yearly": "Origine dell'elettricità negli ultimi 5 anni"
     },
     "electricityproduction": {
-      "default": "Produzione elettrica nell' ultimo %1$s"
+      "default": "Produzione elettrica nell' ultimo %1$s",
+      "hourly": "Produzione elettrica nelle ultime 24 ore",
+      "daily": "Produzione elettrica nell'ultimo mese",
+      "monthly": "Produzione elettrica nell'ultimo anno",
+      "yearly": "Produzione elettrica negli ultimi 5 anni"
     },
     "electricityprices": {
-      "default": "Prezzi dell'elettricità nell' ultimo %1$s"
+      "default": "Prezzi dell'elettricità nell' ultimo %1$s",
+      "hourly": "Prezzi dell'elettricità nelle ultime 24 ore",
+      "daily": "Prezzi dell'elettricità nell'ultimo mese",
+      "monthly": "Prezzi dell'elettricità nell'ultimo anno",
+      "yearly": "Prezzi dell'elettricità negli ultimi 5 anni"
     },
     "Getdata": "Ottieni dati orari storici, in tempo reale e previsioni con le API di Electricity Maps"
   },

--- a/web/public/locales/it.json
+++ b/web/public/locales/it.json
@@ -99,7 +99,7 @@
       "default": "Produzione elettrica nell' ultimo %1$s"
     },
     "electricityprices": {
-      "hourly": "Prezzi dell'elettricità nell' ultimo %1$s"
+      "default": "Prezzi dell'elettricità nell' ultimo %1$s"
     },
     "Getdata": "Ottieni dati orari storici, in tempo reale e previsioni con le API di Electricity Maps"
   },


### PR DESCRIPTION
## Issue

I noticed the Italian title for energy price wasn't rendering correctly:

![Screen Shot 2022-12-08 at 17 21 26](https://user-images.githubusercontent.com/56697956/206526248-34c3fb86-36c0-427e-8400-32e98f3cf292.png)

This was due to the `default` locale string incorrectly having the `hourly` key. Fixing that just introduced bad grammar so I've just added all time periods separately (Italian is my second language)

I'm aware you're mid-frontend-refactor so let me know how you want to proceed - Thanks!