### PR TITLE
Updated FI wind & solar capacities based on Fingrid values (#4857)

### DIFF
--- a/DATA_SOURCES.md
+++ b/DATA_SOURCES.md
@@ -240,6 +240,8 @@ For many European countries, data is available from [ENTSO-E](https://transparen
 - Finland:
   - Nuclear: [IAEA](https://pris.iaea.org/PRIS/CountryStatistics/CountryDetails.aspx?current=FI)
   - Renewables: [IRENA](https://www.irena.org/publications/2022/Apr/Renewable-Capacity-Statistics-2022)
+  - Wind: [Fingrid](https://data.fingrid.fi/en/dataset/total-wind-production-capacity)
+  - Solar: [Fingrid](https://data.fingrid.fi/en/dataset/total-solar-production-capacity)
   - Other: [ENTSO-E](https://transparency.entsoe.eu/generation/r2/installedGenerationCapacityAggregation/show)
 - France:
   - Geothermal: [IRENA](https://www.irena.org/publications/2022/Apr/Renewable-Capacity-Statistics-2022)

--- a/config/zones/FI.yaml
+++ b/config/zones/FI.yaml
@@ -11,9 +11,9 @@ capacity:
   hydro: 3178
   nuclear: 4394
   oil: 1051
-  solar: 404
+  solar: 606
   unknown: 784
-  wind: 3257
+  wind: 5121
 contributors:
   - corradio
   - nessie2013
@@ -266,4 +266,8 @@ sources:
     for 2022-2026" Wind Europe Proceedings (2021)
   : link: https://unece.org/sites/default/files/2022-04/LCA_3_FINAL%20March%202022.pdf#page=37,
       https://proceedings.windeurope.org/biplatform/rails/active_storage/disk/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdDRG9JYTJWNVNTSWhORFJ0ZDJJMWVUbG9OMll6TVRaaGEza3lkamgxZG1aM056WnZZZ1k2QmtWVU9oQmthWE53YjNOcGRHbHZia2tpQVk1cGJteHBibVU3SUdacGJHVnVZVzFsUFNKWGFXNWtaWFZ5YjNCbExWZHBibVF0Wlc1bGNtZDVMV2x1TFVWMWNtOXdaUzB5TURJeExYTjBZWFJwYzNScFkzTXVjR1JtSWpzZ1ptbHNaVzVoYldVcVBWVlVSaTA0SnlkWGFXNWtaWFZ5YjNCbExWZHBibVF0Wlc1bGNtZDVMV2x1TFVWMWNtOXdaUzB5TURJeExYTjBZWFJwYzNScFkzTXVjR1JtQmpzR1ZEb1JZMjl1ZEdWdWRGOTBlWEJsU1NJVVlYQndiR2xqWVhScGIyNHZjR1JtQmpzR1ZBPT0iLCJleHAiOiIyMDIyLTExLTAyVDE1OjU0OjAzLjEyNFoiLCJwdXIiOiJibG9iX2tleSJ9fQ==--c25280a7345257bd91bfaf6d64ddb75c55eef799/Windeurope-Wind-energy-in-Europe-2021-statistics.pdf?content_type=application%2Fpdf&disposition=inline%3B+filename%3D%22Windeurope-Wind-energy-in-Europe-2021-statistics.pdf%22%3B+filename%2A%3DUTF-8%27%27Windeurope-Wind-energy-in-Europe-2021-statistics.pdf
+  ? Fingrid, Total production capacity used in the wind power forecast
+  : link : https://data.fingrid.fi/en/dataset/total-wind-production-capacity
+  ? Fingrid, Total production capacity used in the solar power forecast
+  : link : https://data.fingrid.fi/en/dataset/total-wind-production-capacity
 timezone: Europe/Helsinki

--- a/config/zones/FI.yaml
+++ b/config/zones/FI.yaml
@@ -266,8 +266,4 @@ sources:
     for 2022-2026" Wind Europe Proceedings (2021)
   : link: https://unece.org/sites/default/files/2022-04/LCA_3_FINAL%20March%202022.pdf#page=37,
       https://proceedings.windeurope.org/biplatform/rails/active_storage/disk/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdDRG9JYTJWNVNTSWhORFJ0ZDJJMWVUbG9OMll6TVRaaGEza3lkamgxZG1aM056WnZZZ1k2QmtWVU9oQmthWE53YjNOcGRHbHZia2tpQVk1cGJteHBibVU3SUdacGJHVnVZVzFsUFNKWGFXNWtaWFZ5YjNCbExWZHBibVF0Wlc1bGNtZDVMV2x1TFVWMWNtOXdaUzB5TURJeExYTjBZWFJwYzNScFkzTXVjR1JtSWpzZ1ptbHNaVzVoYldVcVBWVlVSaTA0SnlkWGFXNWtaWFZ5YjNCbExWZHBibVF0Wlc1bGNtZDVMV2x1TFVWMWNtOXdaUzB5TURJeExYTjBZWFJwYzNScFkzTXVjR1JtQmpzR1ZEb1JZMjl1ZEdWdWRGOTBlWEJsU1NJVVlYQndiR2xqWVhScGIyNHZjR1JtQmpzR1ZBPT0iLCJleHAiOiIyMDIyLTExLTAyVDE1OjU0OjAzLjEyNFoiLCJwdXIiOiJibG9iX2tleSJ9fQ==--c25280a7345257bd91bfaf6d64ddb75c55eef799/Windeurope-Wind-energy-in-Europe-2021-statistics.pdf?content_type=application%2Fpdf&disposition=inline%3B+filename%3D%22Windeurope-Wind-energy-in-Europe-2021-statistics.pdf%22%3B+filename%2A%3DUTF-8%27%27Windeurope-Wind-energy-in-Europe-2021-statistics.pdf
-  ? Fingrid, Total production capacity used in the wind power forecast
-  : link : https://data.fingrid.fi/en/dataset/total-wind-production-capacity
-  ? Fingrid, Total production capacity used in the solar power forecast
-  : link : https://data.fingrid.fi/en/dataset/total-wind-production-capacity
 timezone: Europe/Helsinki


### PR DESCRIPTION
## Issue
New renewable generation capacity has been growing quite quickly in the recent years with wind generation capacity already up 1917 MW since January this year. Fingrid, the national grid operator of Finland, provides two APIs for more up to date estimates for Finnish wind and solar generation capacities.

## Description
Wind and solar capacity figures in ```config/zones/FI.yaml``` have been updated based on the Fingrid data from 14 December 2022. The new data sources have been added to the relevant lists.
