### PR TITLE
Add fetch price to FR_O regions

### DIFF
--- a/config/zones/FR-COR.yaml
+++ b/config/zones/FR-COR.yaml
@@ -69,6 +69,7 @@ emissionFactors:
       value: 12.62
 parsers:
   production: FR_O.fetch_production
+  price: FR_O.fetch_price
 sources:
   EU-ETS, ENTSO-E 2021:
     link: https://drive.google.com/file/d/15UeUHyhcjVw8fGLc0Zx_HELSx20cw_-e/view?usp=share_link

--- a/config/zones/GF.yaml
+++ b/config/zones/GF.yaml
@@ -14,4 +14,5 @@ contributors:
   - VIKTORVAV99
 parsers:
   production: FR_O.fetch_production
+  price: FR_O.fetch_price
 timezone: Europe/Paris

--- a/config/zones/GP.yaml
+++ b/config/zones/GP.yaml
@@ -16,4 +16,5 @@ contributors:
   - VIKTORVAV99
 parsers:
   production: FR_O.fetch_production
+  price: FR_O.fetch_price
 timezone: Europe/Paris

--- a/config/zones/MQ.yaml
+++ b/config/zones/MQ.yaml
@@ -16,4 +16,5 @@ contributors:
   - VIKTORVAV99
 parsers:
   production: FR_O.fetch_production
+  price: FR_O.fetch_price
 timezone: Europe/Paris

--- a/config/zones/RE.yaml
+++ b/config/zones/RE.yaml
@@ -106,4 +106,5 @@ fallbackZoneMixes:
         wind: 0.00160462179363718
 parsers:
   production: FR_O.fetch_production
+  price: FR_O.fetch_price
 timezone: Indian/Reunion

--- a/parsers/test/mocks/FR_O/FR_RE.json
+++ b/parsers/test/mocks/FR_O/FR_RE.json
@@ -1,0 +1,28 @@
+[
+    {
+        "territoire": "Réunion",
+        "production_totale_mwh" :259.9774783,
+        "bagasse_charbon_mwh": 196.4090964,
+        "statut": "Validé",
+        "hydraulique_mwh": 32.09856161,
+        "cout_moyen_de_production_eur_mwh": 193.7,
+        "photovoltaique_mwh": -0.23266477,
+        "bioenergies_mwh": 0.955333333,
+        "date_heure": "2018-01-01T00:00:00+00:00",
+        "eolien_mwh": 0.536,
+        "thermique_mwh": 30.21115168
+    },
+    {
+        "territoire": "Réunion",
+        "production_totale_mwh": 252.2947686,
+        "bagasse_charbon_mwh": 194.6044467,
+        "statut": "Validé",
+        "hydraulique_mwh": 26.79243513,
+        "cout_moyen_de_production_eur_mwh": 195.8,
+        "photovoltaique_mwh": -0.172447205,
+        "bioenergies_mwh": 0.9555,
+        "date_heure": "2018-01-01T01:00:00+00:00",
+        "eolien_mwh": 0.435666667,
+        "thermique_mwh": 29.67916731
+    }
+]

--- a/parsers/test/test_FR_O.py
+++ b/parsers/test/test_FR_O.py
@@ -1,5 +1,6 @@
 import unittest
 from json import loads
+from datetime import datetime
 
 from pkg_resources import resource_string
 from requests import Session
@@ -58,6 +59,34 @@ class TestFR_O(unittest.TestCase):
                     production, expected_data[index]["production"][production_type]
                 )
 
+    def test_fetch_price(self):
+            json_data = resource_string("parsers.test.mocks.FR_O", "FR_RE.json")
+            self.adapter.register_uri(ANY, ANY, json=loads(json_data.decode("utf-8")))
+            data_list = FR_O.fetch_price("RE", self.session, datetime(2018, 1, 1))
+            self.assertIsNotNone(data_list)
+            expected_data = [
+                {
+                    "zoneKey": "RE",
+                    "currency": "EUR",
+                    "datetime": datetime.fromisoformat("2018-01-01T00:00:00+00:00"),
+                    "source": "edf.fr",
+                    "price": 193.7,
+                },
+                {
+                    "zoneKey": "RE",
+                    "currency": "EUR",
+                    "datetime": datetime.fromisoformat("2018-01-01T01:00:00+00:00"),
+                    "source": "edf.fr",
+                    "price": 195.8,
+                },
+            ]
+            self.assertEqual(len(data_list), len(expected_data))
+            for index, actual in enumerate(data_list):
+                self.assertEqual(actual["zoneKey"], expected_data[index]["zoneKey"])
+                self.assertEqual(actual["currency"], expected_data[index]["currency"])
+                self.assertEqual(actual["datetime"], expected_data[index]["datetime"])
+                self.assertEqual(actual["source"], expected_data[index]["source"])
+                self.assertEqual(actual["price"], expected_data[index]["price"])
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Issue
https://github.com/electricitymaps/electricitymaps-contrib/issues/4747

## Description

Fetches prices for the FR_O zones, which are available only for historical data. The price is no longer reported since the beginning of 2020, but historical data can still be meaningful to know.

Testing: poetry run test_parser RE price --target_datetime 2016-01-01