### PR TITLE
Add estimation method to Brazil

### DIFF
--- a/config/zones/BR.yaml
+++ b/config/zones/BR.yaml
@@ -15,3 +15,4 @@ subZoneNames:
   - BR-N
   - BR-NE
   - BR-S
+estimation_method: RECONSTRUCT_BREAKDOWN


### PR DESCRIPTION
## Issue

Aggregated zones need to have an estimation method attached otherwise, the app-backend will not return results for the zone.

## Description
Add estimation method to the aggregated Brazil
