### PR TITLE
Add US-CAR-YAD to bypassed while there's an outage of US-CAR-YAD

### DIFF
--- a/config/zones/US.yaml
+++ b/config/zones/US.yaml
@@ -6,6 +6,7 @@ bounding_box:
 bypassedSubZones:
   - US-FLA-HST
   - US-SE-SEPA
+  - US-CAR-YAD
 capacity:
   battery storage: 4832.0
   biomass: 14487.1


### PR DESCRIPTION
## Issue
The EIA is currently reporting null values for US-CAR-YAD and our estimation model picks up on those null values to also return null. This makes the US aggregation fail.

## Description

Bypass US-CAR-YAD in the aggregation until the EIA problem is fixed.

