### PR TITLE
Filter out null values in the EIA parser

### DIFF
--- a/parsers/EIA.py
+++ b/parsers/EIA.py
@@ -456,7 +456,11 @@ def fetch_production_mix(
             # As null values can cause problems in the estimation models if there's
             # only null values.
             # Integrate with data quality layer later.
-            additional_mix = [datapoint for datapoint in additional_mix if datapoint["value"] is not None]
+            additional_mix = [
+                datapoint
+                for datapoint in additional_mix
+                if datapoint["value"] is not None
+            ]
             for point in additional_mix:
                 point.update({"value": point["value"] * percentage})
             mix = _merge_production_mix([mix, additional_mix])
@@ -625,12 +629,12 @@ def _get_utc_datetime_from_datapoint(dt: datetime):
 if __name__ == "__main__":
     from pprint import pprint
 
-    pprint(fetch_production_mix("US-NW-NEVP"))
-    # # pprint(fetch_consumption_forecast('US-CAL-CISO'))
-    # pprint(
-    #     fetch_exchange(
-    #         zone_key1="US-CENT-SWPP",
-    #         zone_key2="CA-SK",
-    #         target_datetime=datetime(2022, 3, 1),
-    #     )
-    # )
+    #pprint(fetch_production_mix("US-NW-NEVP"))
+    # pprint(fetch_consumption_forecast('US-CAL-CISO'))
+    pprint(
+        fetch_exchange(
+            zone_key1="US-CENT-SWPP",
+            zone_key2="CA-SK",
+            target_datetime=datetime(2022, 3, 1),
+        )
+    )

--- a/parsers/EIA.py
+++ b/parsers/EIA.py
@@ -575,7 +575,12 @@ def _fetch(
             "value": datapoint["value"],
             "source": "eia.gov",
         }
+        # TODO Currently manually filtering out datapoints with null values
+        # As null values can cause problems in the estimation models if there's
+        # only null values.
+        # Integrate with data quality layer later.
         for datapoint in raw_data["response"]["data"]
+        if datapoint["value"] is not None
     ]
 
 

--- a/parsers/EIA.py
+++ b/parsers/EIA.py
@@ -14,12 +14,11 @@ from typing import Any, Dict, List, Optional
 
 import arrow
 from dateutil import parser, tz
-from requests import Session
-
 from parsers.ENTSOE import merge_production_outputs
 from parsers.lib.config import refetch_frequency
 from parsers.lib.utils import get_token
 from parsers.lib.validation import validate
+from requests import Session
 
 # Reverse exchanges need to be multiplied by -1, since they are reported in the opposite direction
 REVERSE_EXCHANGES = [
@@ -419,6 +418,11 @@ def fetch_production_mix(
             target_datetime=target_datetime,
             logger=logger,
         )
+        # TODO Currently manually filtering out datapoints with null values
+        # As null values can cause problems in the estimation models if there's
+        # only null values.
+        # Integrate with data quality layer later.
+        mix = [datapoint for datapoint in mix if datapoint["value"] is not None]
 
         # EIA does not currently split production from the Virgil Summer C
         # plant across the two owning/ utilizing BAs:
@@ -448,6 +452,11 @@ def fetch_production_mix(
                 target_datetime=target_datetime,
                 logger=logger,
             )
+            # TODO Currently manually filtering out datapoints with null values
+            # As null values can cause problems in the estimation models if there's
+            # only null values.
+            # Integrate with data quality layer later.
+            additional_mix = [datapoint for datapoint in additional_mix if datapoint["value"] is not None]
             for point in additional_mix:
                 point.update({"value": point["value"] * percentage})
             mix = _merge_production_mix([mix, additional_mix])
@@ -575,12 +584,7 @@ def _fetch(
             "value": datapoint["value"],
             "source": "eia.gov",
         }
-        # TODO Currently manually filtering out datapoints with null values
-        # As null values can cause problems in the estimation models if there's
-        # only null values.
-        # Integrate with data quality layer later.
         for datapoint in raw_data["response"]["data"]
-        if datapoint["value"] is not None
     ]
 
 
@@ -621,12 +625,12 @@ def _get_utc_datetime_from_datapoint(dt: datetime):
 if __name__ == "__main__":
     from pprint import pprint
 
-    # pprint(fetch_production('US-CENT-SWPP'))
+    pprint(fetch_production_mix("US-NW-NEVP"))
     # # pprint(fetch_consumption_forecast('US-CAL-CISO'))
-    pprint(
-        fetch_exchange(
-            zone_key1="US-CENT-SWPP",
-            zone_key2="CA-SK",
-            target_datetime=datetime(2022, 3, 1),
-        )
-    )
+    # pprint(
+    #     fetch_exchange(
+    #         zone_key1="US-CENT-SWPP",
+    #         zone_key2="CA-SK",
+    #         target_datetime=datetime(2022, 3, 1),
+    #     )
+    # )

--- a/parsers/EIA.py
+++ b/parsers/EIA.py
@@ -14,11 +14,12 @@ from typing import Any, Dict, List, Optional
 
 import arrow
 from dateutil import parser, tz
+from requests import Session
+
 from parsers.ENTSOE import merge_production_outputs
 from parsers.lib.config import refetch_frequency
 from parsers.lib.utils import get_token
 from parsers.lib.validation import validate
-from requests import Session
 
 # Reverse exchanges need to be multiplied by -1, since they are reported in the opposite direction
 REVERSE_EXCHANGES = [
@@ -629,7 +630,7 @@ def _get_utc_datetime_from_datapoint(dt: datetime):
 if __name__ == "__main__":
     from pprint import pprint
 
-    #pprint(fetch_production_mix("US-NW-NEVP"))
+    # pprint(fetch_production_mix("US-NW-NEVP"))
     # pprint(fetch_consumption_forecast('US-CAL-CISO'))
     pprint(
         fetch_exchange(

--- a/parsers/test/mocks/EIA/US-NW-PGE-with-nulls.json
+++ b/parsers/test/mocks/EIA/US-NW-PGE-with-nulls.json
@@ -1,0 +1,31 @@
+{
+  "response": {
+    "query execution": 0.008633325,
+    "count query execution": 0.021634831,
+    "total": 3,
+    "dateFormat": "YYYY-MM-DD\"T\"HH24",
+    "frequency": "hourly",
+    "data": [
+      {
+        "period": "2022-10-31T11",
+        "respondent": "PGE",
+        "respondent-name": "Avangrid Renewables, LLC",
+        "fueltype": "NG",
+        "type-name": "Natural gas",
+        "value": null,
+        "value-units": "megawatthours"
+      },
+      {
+        "period": "2022-10-31T12",
+        "respondent": "PGE",
+        "respondent-name": "Avangrid Renewables, LLC",
+        "fueltype": "NG",
+        "type-name": "Natural gas",
+        "value": 400,
+        "value-units": "megawatthours"
+      }
+    ],
+    "description": "Hourly net generation by balancing authority and energy source.  \n    Source: Form EIA-930\n    Product: Hourly Electric Grid Monitor"
+  },
+  "apiVersion": "2.0.3"
+}


### PR DESCRIPTION
## Issue

The EIA sometimes reports null values. Those cause problems with our estimation models in zones where the entire production might be null, as the estimation models will start reporting null values as well.

## Description

Filter out null values, manually for now. To be later integrated with the data quality layer.
