### PR TITLE
Create MK ENTSOE wrapper

### DIFF
--- a/config/zones/MK.yaml
+++ b/config/zones/MK.yaml
@@ -9,6 +9,13 @@ capacity:
   hydro: 506
   nuclear: 0
   wind: 35
+delays:
+  consumption: 24
+  consumptionForecast: 24
+  generationForecast: 24
+  price: 24
+  production: 24
+  productionPerModeForecast: 24
 emissionFactors:
   direct:
     battery discharge:

--- a/config/zones/MK.yaml
+++ b/config/zones/MK.yaml
@@ -181,10 +181,10 @@ fallbackZoneMixes:
         unknown: 0.000786094652001343
         wind: 0.038732684412767976
 parsers:
-  consumption: ENTSOE.fetch_consumption
-  consumptionForecast: ENTSOE.fetch_consumption_forecast
-  generationForecast: ENTSOE.fetch_generation_forecast
-  price: ENTSOE.fetch_price
-  production: ENTSOE.fetch_production
-  productionPerModeForecast: ENTSOE.fetch_wind_solar_forecasts
+  consumption: MK_wrapper.fetch_consumption
+  consumptionForecast: MK_wrapper.fetch_consumption_forecast
+  generationForecast: MK_wrapper.fetch_generation_forecast
+  price: MK_wrapper.fetch_price
+  production: MK_wrapper.fetch_production
+  productionPerModeForecast: MK_wrapper.fetch_wind_solar_forecasts
 timezone: Europe/Skopje

--- a/parsers/MK_wrapper.py
+++ b/parsers/MK_wrapper.py
@@ -2,6 +2,7 @@ from datetime import datetime, timedelta
 from logging import Logger, getLogger
 from typing import List, Optional, Union
 
+from pytz import utc
 from requests import Session
 
 from . import ENTSOE
@@ -16,7 +17,7 @@ If no target_datetime is provided, the wrapper will provide a target datetime th
 
 def modify_target_datetime(target_datetime: Optional[datetime]) -> datetime:
     if target_datetime is None:
-        return datetime.utcnow() - timedelta(hours=24)
+        return datetime.now(tz=utc) - timedelta(hours=24)
     else:
         return target_datetime
 

--- a/parsers/MK_wrapper.py
+++ b/parsers/MK_wrapper.py
@@ -1,6 +1,6 @@
 from datetime import datetime, timedelta
 from logging import Logger, getLogger
-from typing import List, Optional, Union
+from typing import Optional
 
 from pytz import utc
 from requests import Session
@@ -28,7 +28,7 @@ def fetch_consumption(
     session: Session = Session(),
     target_datetime: Optional[datetime] = None,
     logger: Logger = getLogger(__name__),
-) -> Union[List[dict], dict, None]:
+) -> list:
     target_datetime = modify_target_datetime(target_datetime)
     return ENTSOE.fetch_consumption(
         zone_key=zone_key,

--- a/parsers/MK_wrapper.py
+++ b/parsers/MK_wrapper.py
@@ -1,0 +1,105 @@
+from datetime import datetime, timedelta
+from logging import Logger, getLogger
+from typing import List, Optional, Union
+
+from requests import Session
+from . import ENTSOE
+
+"""
+This wrapper is used to fetch data from ENTSOE for the country of North Macedonia.
+If no target_datetime is provided, the wrapper will provide a target datetime that is
+24 hours in the past due to intermittent data availability.
+"""
+
+def modify_target_datetime(target_datetime: Optional[datetime]) -> datetime:
+    if target_datetime is None:
+        return datetime.utcnow() - timedelta(hours=24)
+    else:
+        return target_datetime
+
+def fetch_consumption(
+    zone_key: str = "MK",
+    session: Session = Session(),
+    target_datetime: Optional[datetime] = None,
+    logger: Logger = getLogger(__name__),
+)   -> Union[List[dict], dict, None]:
+    target_datetime = modify_target_datetime(target_datetime)
+    return ENTSOE.fetch_consumption(
+        zone_key=zone_key,
+        session=session,
+        target_datetime=target_datetime,
+        logger=logger,
+    )
+
+def fetch_consumption_forecast(
+    zone_key: str = "MK",
+    session: Session = Session(),
+    target_datetime: Optional[datetime] = None,
+    logger: Logger = getLogger(__name__),
+)   -> list:
+    target_datetime = modify_target_datetime(target_datetime)
+    return ENTSOE.fetch_consumption_forecast(
+        zone_key=zone_key,
+        session=session,
+        target_datetime=target_datetime,
+        logger=logger,
+    )
+
+def fetch_generation_forecast(
+    zone_key: str = "MK",
+    session: Session = Session(),
+    target_datetime: Optional[datetime] = None,
+    logger: Logger = getLogger(__name__),
+)   -> list:
+    target_datetime = modify_target_datetime(target_datetime)
+    return ENTSOE.fetch_generation_forecast(
+        zone_key=zone_key,
+        session=session,
+        target_datetime=target_datetime,
+        logger=logger,
+    )
+
+def fetch_price(
+    zone_key: str = "MK",
+    session: Session = Session(),
+    target_datetime: Optional[datetime] = None,
+    logger: Logger = getLogger(__name__),
+)   -> list:
+    target_datetime = modify_target_datetime(target_datetime)
+    return ENTSOE.fetch_price(
+        zone_key=zone_key,
+        session=session,
+        target_datetime=target_datetime,
+        logger=logger,
+    )
+
+def fetch_production(
+    zone_key: str = "MK",
+    session: Session = Session(),
+    target_datetime: Optional[datetime] = None,
+    logger: Logger= getLogger(__name__),
+) -> list:
+    target_datetime = modify_target_datetime(target_datetime)
+    return ENTSOE.fetch_production(
+        zone_key=zone_key,
+        session=session,
+        target_datetime=target_datetime,
+        logger=logger,
+    )
+
+def fetch_wind_solar_forecasts(
+    zone_key: str = "MK",
+    session: Session = Session(),
+    target_datetime: Optional[datetime] = None,
+    logger: Logger = getLogger(__name__),
+)   -> list:
+    target_datetime = modify_target_datetime(target_datetime)
+    return ENTSOE.fetch_wind_solar_forecasts(
+        zone_key=zone_key,
+        session=session,
+        target_datetime=target_datetime,
+        logger=logger,
+    )
+
+
+

--- a/parsers/MK_wrapper.py
+++ b/parsers/MK_wrapper.py
@@ -3,7 +3,9 @@ from logging import Logger, getLogger
 from typing import List, Optional, Union
 
 from requests import Session
+
 from . import ENTSOE
+from .lib.config import refetch_frequency
 
 """
 This wrapper is used to fetch data from ENTSOE for the country of North Macedonia.
@@ -11,18 +13,21 @@ If no target_datetime is provided, the wrapper will provide a target datetime th
 24 hours in the past due to intermittent data availability.
 """
 
+
 def modify_target_datetime(target_datetime: Optional[datetime]) -> datetime:
     if target_datetime is None:
         return datetime.utcnow() - timedelta(hours=24)
     else:
         return target_datetime
 
+
+@refetch_frequency(timedelta(days=2))
 def fetch_consumption(
     zone_key: str = "MK",
     session: Session = Session(),
     target_datetime: Optional[datetime] = None,
     logger: Logger = getLogger(__name__),
-)   -> Union[List[dict], dict, None]:
+) -> Union[List[dict], dict, None]:
     target_datetime = modify_target_datetime(target_datetime)
     return ENTSOE.fetch_consumption(
         zone_key=zone_key,
@@ -31,12 +36,14 @@ def fetch_consumption(
         logger=logger,
     )
 
+
+@refetch_frequency(timedelta(days=2))
 def fetch_consumption_forecast(
     zone_key: str = "MK",
     session: Session = Session(),
     target_datetime: Optional[datetime] = None,
     logger: Logger = getLogger(__name__),
-)   -> list:
+) -> list:
     target_datetime = modify_target_datetime(target_datetime)
     return ENTSOE.fetch_consumption_forecast(
         zone_key=zone_key,
@@ -45,12 +52,14 @@ def fetch_consumption_forecast(
         logger=logger,
     )
 
+
+@refetch_frequency(timedelta(days=2))
 def fetch_generation_forecast(
     zone_key: str = "MK",
     session: Session = Session(),
     target_datetime: Optional[datetime] = None,
     logger: Logger = getLogger(__name__),
-)   -> list:
+) -> list:
     target_datetime = modify_target_datetime(target_datetime)
     return ENTSOE.fetch_generation_forecast(
         zone_key=zone_key,
@@ -59,12 +68,14 @@ def fetch_generation_forecast(
         logger=logger,
     )
 
+
+@refetch_frequency(timedelta(days=2))
 def fetch_price(
     zone_key: str = "MK",
     session: Session = Session(),
     target_datetime: Optional[datetime] = None,
     logger: Logger = getLogger(__name__),
-)   -> list:
+) -> list:
     target_datetime = modify_target_datetime(target_datetime)
     return ENTSOE.fetch_price(
         zone_key=zone_key,
@@ -73,11 +84,13 @@ def fetch_price(
         logger=logger,
     )
 
+
+@refetch_frequency(timedelta(days=2))
 def fetch_production(
     zone_key: str = "MK",
     session: Session = Session(),
     target_datetime: Optional[datetime] = None,
-    logger: Logger= getLogger(__name__),
+    logger: Logger = getLogger(__name__),
 ) -> list:
     target_datetime = modify_target_datetime(target_datetime)
     return ENTSOE.fetch_production(
@@ -87,12 +100,14 @@ def fetch_production(
         logger=logger,
     )
 
+
+@refetch_frequency(timedelta(days=2))
 def fetch_wind_solar_forecasts(
     zone_key: str = "MK",
     session: Session = Session(),
     target_datetime: Optional[datetime] = None,
     logger: Logger = getLogger(__name__),
-)   -> list:
+) -> list:
     target_datetime = modify_target_datetime(target_datetime)
     return ENTSOE.fetch_wind_solar_forecasts(
         zone_key=zone_key,
@@ -100,6 +115,3 @@ def fetch_wind_solar_forecasts(
         target_datetime=target_datetime,
         logger=logger,
     )
-
-
-


### PR DESCRIPTION
## Issue
The data for North Macedonia have very intermittent publishing times so sometimes we miss production due to the fact it has not been published yet (but so far it always have been, up to 3 days behind).

So this wrapper wraps the ENTSO-E parser and modify the `target_datetime` to be 24 hours in the past when run without a `target_datetime` passed to it.

This should give us a 48+24 hour window to catch the "live" data so we don't have to manually re-run it. (This can be bumped if needed)
