### PR TITLE
Fix. change color of update link in newVersion component (#4892)

### DIFF
--- a/web/src/layout/main.jsx
+++ b/web/src/layout/main.jsx
@@ -49,6 +49,10 @@ const MapContainer = styled.div`
 
 const NewVersionInner = styled.div`
   background-color: #3f51b5;
+  & > span > a {
+    color: inherit;
+    text-decoration: underline;
+  }
 `;
 
 const NewVersionButton = styled.button`


### PR DESCRIPTION
## Issue
The update link is almost invisible when an update is available on the web app. #4892 

## Description
Changed colour of the <a> tag in the NewVersion component by adding styles to styled component.

### Preview
<img width="872" alt="Screenshot 2022-12-23 at 1 59 43 AM" src="https://user-images.githubusercontent.com/46367738/209220664-bbbbdee2-6c20-4fc6-a609-a0d83aa40f83.png">

