### PR TITLE
Fix DK's exchange parser's invalid datetime format

### DIFF
--- a/parsers/DK.py
+++ b/parsers/DK.py
@@ -4,8 +4,8 @@ from typing import List, Optional, Union
 
 from requests import Response, Session
 
-from .lib.config import refetch_frequency
-from .lib.exceptions import ParserException
+from electricitymap.contrib.parsers.lib.config import refetch_frequency
+from electricitymap.contrib.parsers.lib.exceptions import ParserException
 
 EXCHANGE_MAPPING = {
     "DE->DK-DK1": {"id": "ExchangeGermany", "direction": 1, "priceArea": "DK1"},
@@ -29,6 +29,11 @@ def fetch_data(
     Helper function to fetch data from the API.
     """
     ses = session or Session()
+
+    if target_datetime.tzinfo:
+        # Data source doesn't support timezone aware
+        # datetimes.
+        target_datetime.replace(tzinfo=None)
 
     params = {
         "limit": 144,

--- a/parsers/DK.py
+++ b/parsers/DK.py
@@ -4,8 +4,8 @@ from typing import List, Optional, Union
 
 from requests import Response, Session
 
-from electricitymap.contrib.parsers.lib.config import refetch_frequency
-from electricitymap.contrib.parsers.lib.exceptions import ParserException
+from parsers.lib.config import refetch_frequency
+from parsers.lib.exceptions import ParserException
 
 EXCHANGE_MAPPING = {
     "DE->DK-DK1": {"id": "ExchangeGermany", "direction": 1, "priceArea": "DK1"},

--- a/parsers/DK.py
+++ b/parsers/DK.py
@@ -33,7 +33,7 @@ def fetch_data(
     if target_datetime.tzinfo:
         # Data source doesn't support timezone aware
         # datetimes.
-        target_datetime.replace(tzinfo=None)
+        target_datetime = target_datetime.replace(tzinfo=None)
 
     params = {
         "limit": 144,


### PR DESCRIPTION
## Issue

NL parser is down at the moment, this is due to the fact that NL calls the DK exchange parser which doesn't handle timezone aware datetimes in the API call.

## Description

If the datetime is passed with a timezone to DK's exchange fetcher then remove it.