### PR TITLE
Adds missing translations of zone names

### DIFF
--- a/web/public/locales/en.json
+++ b/web/public/locales/en.json
@@ -288,6 +288,9 @@
     "AT": {
       "zoneName": "Austria"
     },
+    "AU": {
+      "zoneName": "Australia"
+    },
     "AU-NSW": {
       "countryName": "Australia",
       "zoneName": "New South Wales"
@@ -774,6 +777,24 @@
     },
     "IM": {
       "zoneName": "Isle of Man"
+    },
+    "IN": {
+      "zoneName": "India"
+    },
+    "IN-EA": {
+      "zoneName": "Eastern"
+    },
+    "IN-NE": {
+      "zoneName": "North Eastern"
+    },
+    "IN-NO": {
+      "zoneName": "Northern"
+    },
+    "IN-SO": {
+      "zoneName": "Southern"
+    },
+    "IN-WE": {
+      "zoneName": "Western"
     },
     "IN-AN": {
       "countryName": "India",

--- a/web/public/locales/en.json
+++ b/web/public/locales/en.json
@@ -782,18 +782,23 @@
       "zoneName": "India"
     },
     "IN-EA": {
+      "countryName": "India",
       "zoneName": "Eastern"
     },
     "IN-NE": {
+      "countryName": "India",
       "zoneName": "North Eastern"
     },
     "IN-NO": {
+      "countryName": "India",
       "zoneName": "Northern"
     },
     "IN-SO": {
+      "countryName": "India",
       "zoneName": "Southern"
     },
     "IN-WE": {
+      "countryName": "India",
       "zoneName": "Western"
     },
     "IN-AN": {


### PR DESCRIPTION
## Description

Just noticed that https://api.electricitymap.org/v3/zones returns a bunch of unknown names because we're still missing English translations for new zones and aggregates. This should ideally not happen, as we're also leaving areas on the map with weird titles :(

Related to #4782 for the Indian zones - I just went ahead and used the names from this Wikipedia: https://en.wikipedia.org/wiki/National_Grid_(India)#:~:text=Individual%20State%20grids%20were%20interconnected,between%20States%20in%20each%20region.
