### PR TITLE
fix_IE_parser

### DIFF
--- a/parsers/IE.py
+++ b/parsers/IE.py
@@ -105,7 +105,7 @@ def fetch_production(
         else:
             exchange = 0
         data_point = {
-            "zoneKey": "IE",
+            "zoneKey": zone_key,
             "datetime": datetime.strptime(dt, "%d-%b-%Y %H:%M:%S").replace(
                 tzinfo=pytz.timezone("Europe/Dublin")
             ),


### PR DESCRIPTION
## Issue
We accidentally hardcoded the return key for the production function to IE so it failed for GB-NIR.
