### PR TITLE
Add storage to FR_O parser

### DIFF
--- a/parsers/FR_O.py
+++ b/parsers/FR_O.py
@@ -71,7 +71,7 @@ API_PARAMETER_GROUPS = {
         ],
         "unknown": ["bagasse_charbon_mwh", "charbon_bagasse_mw"],
     },
-    "storage": {},
+    "storage": {"battery": ["solde_stockage"]},
     "price": {
         "price": ["cout_moyen_de_production_eur_mwh"],
     },


### PR DESCRIPTION
I added `solde_stockage` to `battery` in the FR_O parser. Now that this belong to battery is just a educated guess based on the fact there is a battery storage system on Corsica that seems to roughly match the outputs.

In the future it might make sense to add a `Unknown` category for storage as well.