### PR TITLE
TH: Updated Capacity Data from December 2022

### DIFF
--- a/config/zones/TH.yaml
+++ b/config/zones/TH.yaml
@@ -7,9 +7,9 @@ capacity:
   battery storage: 0
   biomass: 1040.79
   coal: 6067.5
-  gas: 29358
+  gas: 29833
   geothermal: 0.3
-  hydro: 7530.03
+  hydro: 7544.03
   hydro storage: 1000
   nuclear: 0
   oil: 1497.4


### PR DESCRIPTION
# TH: Updated Capacity Data from December 2022

## Description
New capacity data from December 2022 is now available (the old one was from August 2022) [Full Breakdown Here](https://docs.google.com/spreadsheets/d/1piW1SCzfWM6qjZa9qWPGRZVc6Ami-KhhazSCcHEYpgU/edit?usp=sharing)

This is the same source as #4403 and #4628, which are:
- [EGAT's own generating capacity](https://www.egat.co.th/home/statistics-all-egat/)
- [EGAT's private&international purchased capacity](https://www.egat.co.th/home/statistics-all-3rdparty/)

## Changelog:
- **EGAT**: [Pha Chuk MHPP](https://www.egat.co.th/home/en/pha-chuk-rohpp/) starts generating power, accounting for 14MW increase in generating capacity.
- **IPP**: [Gulf SRC's Powerplant Phase 4](https://hub.optiwise.io/en/documents/61142/6443705C1BDBC53B2A43725E1ADAC538670F715712A9C23D1046715619DAB4301045755E18DECC3A6641752C1BA9C13E64426C1E4E8DCF386542725C1AD9C7386E43765D19DBC63E60366C1E4E8D_031020220804330366E.pdf) starts generating power, with all previous three units also switched from Gas/Diesel Mix to Gas-only, accounting for a 625MW increase in generating capacity.
- **SPP Firm**: Reduction of around 150MW generating capacity from contracts expiring/maintenance across 70 Gas-only powerplants in this category.

![TH_capacity_dec22](https://user-images.githubusercontent.com/19505219/214215400-185919d3-4f6e-4c55-b716-9f5d8db2102d.png)
