### PR TITLE
Bumps Node version to 18 everywhere

### DIFF
--- a/.github/workflows/eslint.yml
+++ b/.github/workflows/eslint.yml
@@ -23,10 +23,10 @@ jobs:
         uses: pnpm/action-setup@v2
         with:
           version: 7
-      - name: Setup Node v14.x
+      - name: Setup Node v18.x
         uses: actions/setup-node@v3
         with:
-          node-version: 14
+          node-version: 18
       - name: Restore node_modules for web
         id: cache-web
         uses: actions/cache@v3

--- a/.github/workflows/jsonlint.yml
+++ b/.github/workflows/jsonlint.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Setup Node LTS
         uses: actions/setup-node@v3
         with:
-          node-version: lts/*
+          node-version: 18
       - name: Install jsonlint-mod
         run: |
           npm install -g jsonlint-mod

--- a/.github/workflows/prettier.yml
+++ b/.github/workflows/prettier.yml
@@ -15,10 +15,10 @@ jobs:
         uses: pnpm/action-setup@v2
         with:
           version: 7
-      - name: Setup Node v14.x
+      - name: Setup Node v18.x
         uses: actions/setup-node@v3
         with:
-          node-version: 14
+          node-version: 18
       - name: Restore node_modules for web
         id: cache-web
         uses: actions/cache@v3

--- a/.github/workflows/validate_generated_files.yml
+++ b/.github/workflows/validate_generated_files.yml
@@ -16,10 +16,10 @@ jobs:
         uses: pnpm/action-setup@v2
         with:
           version: 7
-      - name: Setup Node v14.x
+      - name: Setup Node v18.x
         uses: actions/setup-node@v3
         with:
-          node-version: 14
+          node-version: 18
       - name: Restore node_modules
         id: cache
         uses: actions/cache@v3

--- a/mobileapp/package.json
+++ b/mobileapp/package.json
@@ -4,6 +4,9 @@
   "description": "A real-time visualisation of the CO2 emissions of electricity consumption",
   "license": "AGPL-3.0-or-later",
   "main": "index.js",
+  "engines": {
+    "node": ">=18"
+  },
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
     "build-web": "pnpm -C ../web build",

--- a/web/Earthfile
+++ b/web/Earthfile
@@ -1,5 +1,5 @@
 VERSION 0.6
-FROM node:14.18
+FROM node:18.13
 WORKDIR /contrib/web
 
 src-files:

--- a/web/package.json
+++ b/web/package.json
@@ -4,7 +4,7 @@
   "description": "A real-time visualisation of the CO2 emissions of electricity consumption",
   "license": "AGPL-3.0-or-later",
   "engines": {
-    "node": ">=14.18"
+    "node": ">=18"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Description

Bumps Node version. 

Version 14 is harder to install on M1 Macbooks and therefore it's harder and slower to test things locally if we stay on v14.
