### PR TITLE
Fixes breaking builds!

### DIFF
--- a/web/Earthfile
+++ b/web/Earthfile
@@ -31,7 +31,7 @@ test:
 build:
   FROM +prepare
   RUN pnpm version minor
-  RUN --secret SENTRY_AUTH_TOKEN=+secrets/SENTRY_AUTH_TOKEN VITE_PUBLIC_ELECTRICITYMAP_PUBLIC_TOKEN=+secrets/ELECTRICITYMAP_PUBLIC_TOKEN pnpm run build
+  RUN --secret SENTRY_AUTH_TOKEN=+secrets/SENTRY_AUTH_TOKEN --secret VITE_PUBLIC_ELECTRICITYMAP_PUBLIC_TOKEN=+secrets/ELECTRICITYMAP_PUBLIC_TOKEN pnpm run build
   RUN pnpm run generate-index-files
 
   # Local outputs for debugging

--- a/web/Earthfile
+++ b/web/Earthfile
@@ -16,7 +16,7 @@ prepare:
   FROM +src-files
   RUN npm install -g pnpm
   RUN pnpm install --frozen-lockfile
-  COPY index.html tsconfig.json tsconfig.node.json vite.config.ts .
+  COPY index.html .postcssrc.json tailwind.config.js tsconfig.json tsconfig.node.json vite.config.ts .
   COPY scripts/generate-zones-config.ts ./scripts/generate-zones-config.ts
   COPY scripts/generate-index-files.ts ./scripts/generate-index-files.ts
   COPY --dir config geo public src ./

--- a/web/Earthfile
+++ b/web/Earthfile
@@ -62,7 +62,7 @@ deploy:
         # Copy assets first to ensure they are available when the new index.html is served
         gsutil -m cp -a public-read -r dist/assets/* gs://app.electricitymaps.com/assets && \
         gsutil -m cp -a public-read -r dist/* gs://app.electricitymaps.com && \
-        gsutil web set -m index.html -e index.html gs://beta.electricitymaps.com && \
-        gsutil setmeta -h "Cache-Control:no-cache,max-age=0" gs://app.electricitymaps.com/index.html && \
+        gsutil web set -m index.html -e index.html gs://app.electricitymaps.com && \
+        gsutil -m setmeta -h "Cache-Control:no-cache,no-store,max-age=0" gs://app.electricitymaps.com/**/index.html && \
         gsutil setmeta -h "Cache-Control:no-cache,max-age=0" gs://app.electricitymaps.com/client-version.json && \
         gcloud auth revoke

--- a/web/src/features/error-boundary/ErrorBoundary.tsx
+++ b/web/src/features/error-boundary/ErrorBoundary.tsx
@@ -18,7 +18,7 @@ export default function ErrorComponent({ error }: Props) {
         <a href="https://github.com/electricityMaps/electricitymaps-contrib">on Github</a>{' '}
         so we can fix this!
       </p>
-      <pre className="rounded-lg bg-gray-300 p-2 text-xs">
+      <pre className="rounded-lg bg-gray-300 p-2 text-xs dark:bg-black">
         Error message: {error?.toString()}
         <br />
         Url: {url}

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -20,9 +20,6 @@ const manualChunkMap = {
 };
 
 export default defineConfig(({ mode }) => ({
-  optimizeDeps: {
-    disabled: false,
-  },
   define: {
     APP_VERSION: JSON.stringify(process.env.npm_package_version),
   },

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -9,11 +9,10 @@ import { defineConfig } from 'vite';
 import tsconfigPaths from 'vite-tsconfig-paths';
 
 const manualChunkMap = {
-  // These dependencies are disabled for now, as we had problems were Radix would crash the app because it did not have React available
-  //   '@sentry': 'sentry',
-  //   '@radix-ui': 'radix',
-  //   'country-flag-icons': 'flags',
-  //   recharts: 'recharts',
+  '@sentry': 'sentry',
+  '@radix-ui': 'radix',
+  'country-flag-icons': 'flags',
+  recharts: 'recharts',
   'world.json': 'world',
   'zones.json': 'config',
   'exchanges.json': 'config',

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -25,9 +25,6 @@ export default defineConfig(({ mode }) => ({
   },
   build: {
     sourcemap: true,
-    commonjsOptions: {
-      include: [],
-    },
     rollupOptions: {
       output: {
         manualChunks(id) {


### PR DESCRIPTION
## Description

The new app is currently disabled because it would occasionally create a build that was broken due to the way modules got bundled.
I also don't know why the boilerplate we used set it up like this, so reverting to the default Vite approach is probably also better :)

Also:
- Enabled chunk mapping for more modules
- Made error message visible in dark mode
- Fixed a bunch of smaller things in the deployment script