### PR TITLE
display correct axis on ff

### DIFF
--- a/web/src/features/time/TimeAxis.tsx
+++ b/web/src/features/time/TimeAxis.tsx
@@ -94,12 +94,6 @@ function TimeAxis({
     );
   }
 
-  // The svg transform attribute is different from the CSS transform property,
-  // so we need to replace the commas with spaces and remove the 'px' suffix.
-  const svgTransform = transform
-    ? transform.replace(/px/g, '').replace(/,/g, ' ')
-    : undefined;
-
   const scale = getTimeScale(
     scaleWidth ?? width,
     datetimes[0],
@@ -108,7 +102,7 @@ function TimeAxis({
   const [x1, x2] = scale.range();
 
   return (
-    <svg className={className} transform={svgTransform} ref={ref}>
+    <svg className={className} transform={transform} ref={ref}>
       <g fill="none" textAnchor="middle" style={{ pointerEvents: 'none', transform }}>
         <path stroke="none" d={`M${x1 + 0.5},6V0.5H${x2 + 0.5}V6`} />
         {datetimes.map((v, index) =>


### PR DESCRIPTION
## Issue
Fixes #5034

## Description
The time axis was not showing correctly in firefox, this PR makes it aligned correctly in chrome and firefox

### Preview
Before:
<img width="435" alt="image" src="https://user-images.githubusercontent.com/18622768/216994561-00724c1f-e572-459f-b69a-9c3b17de6890.png">

After:
<img width="363" alt="image" src="https://user-images.githubusercontent.com/18622768/216994650-0204af5e-b395-4f6f-9ced-0a4c180dbb04.png">

