### PR TITLE
Ignore paths instead of query for CodeQL

### DIFF
--- a/.github/codeql-config.yml
+++ b/.github/codeql-config.yml
@@ -1,4 +1,4 @@
 name: 'CodeQL config'
-query-filters:
-  - exclude:
-      id: js/missing-rate-limiting
+paths-ignore:
+  - mockserver
+  - 'web/**/*.test.ts'


### PR DESCRIPTION
Instead of excluding a query we should ignore the test paths instead. We can expand this to the python tests later if necessary.
