### PR TITLE
Add consumption parser for CA-SK and update capacity values

### DIFF
--- a/config/zones/CA-SK.yaml
+++ b/config/zones/CA-SK.yaml
@@ -4,12 +4,16 @@ bounding_box:
   - - -100.86433964677866
     - 60.50005890629359
 capacity:
-  biomass: 16
+  _source: SaskPower
+  _url: https://www.saskpower.com/Our-Power-Future/Our-Electricity/Electrical-System/System-Map
+  biomass: 8
   coal: 1389
   gas: 2160
   hydro: 864
-  solar: 81
+  solar: 82
   wind: 617
   unknown: 26
 flag_file_name: ca.png
+parsers:
+  consumption: CA_SK.fetch_consumption
 timezone: America/Regina

--- a/parsers/CA_SK.py
+++ b/parsers/CA_SK.py
@@ -1,0 +1,47 @@
+#!/usr/bin/env python3
+
+from datetime import datetime
+from logging import Logger, getLogger
+from typing import Optional
+
+# The arrow library is used to handle datetimes consistently with other parsers
+import arrow
+from requests import Session
+
+TIMEZONE = "America/Regina"
+# Source: https://www.saskpower.com/Our-Power-Future/Our-Electricity/Electrical-System/System-Map
+URL = "https://www.saskpower.com/ignitionapi/Content/GetNetLoad"
+
+
+def fetch_consumption(
+    zone_key: str = "CA-SK",
+    session: Optional[Session] = None,
+    target_datetime: Optional[datetime] = None,
+    logger: Logger = getLogger(__name__),
+) -> dict:
+    """Requests the last known consumption data (in MW) of the CA-SK zone."""
+
+    if target_datetime:
+        raise NotImplementedError("This parser is not yet able to parse past dates")
+
+    requests_obj = session or Session()
+    load_data = requests_obj.get(URL).json()
+    consumption = int(load_data)
+    if consumption < 0 or consumption > 5500:
+        raise ValueError("Consumption value is not valid")
+
+    data = {
+        "datetime": arrow.utcnow().datetime,
+        "zoneKey": zone_key,
+        "consumption": consumption,
+        "source": "saskpower.com",
+    }
+
+    return data
+
+
+if __name__ == "__main__":
+    """Main method, never used by the Electricity Map backend, but handy for testing."""
+
+    print("fetch_consumption() ->")
+    print(fetch_consumption())


### PR DESCRIPTION
## Description

This PR adds a parser for the real-time consumption value for CA-SK. The breakdown into production modes and the exchanges are not available in real-time, but this information can already be useful.
I also updated the capacity values in the zone configuration.