### PR TITLE
Create Newfoundland consumption-parser

### DIFF
--- a/parsers/CA-NL-NF.py
+++ b/parsers/CA-NL-NF.py
@@ -1,0 +1,48 @@
+#!/usr/bin/env python3
+
+from datetime import datetime
+from logging import Logger, getLogger
+from typing import Optional
+
+from bs4 import BeautifulSoup
+from pytz import timezone
+from requests import Session
+
+# This parser fetches demand data for Canada-Newfoundland. The source-website https://nlhydro.com/ states:
+# "Current Island System Generation", so I assume only generation for Newfoundland island, excluding Labrador, is shown.
+# "Current system generation = current demand on the system" and
+# "Any generation from non-utility generators, including Star Lake, Rattle Brook, Corner Brook Pulp and Paper,
+# and wind generation from the St. Lawrence and Fermeuse wind farms, is included in our Hydro System Generation."
+# This means we have a mix of hydro, oil, biomass and wind energy represented in the demand/generation figure.
+
+NF_DEMAND_URL = "https://nlhydro.com/system-information/supply-and-demand/"
+TZ = "Canada/Newfoundland"  # UTC-3:30
+
+def fetch_consumption(
+    zone_key: str = "CA-NL-NF",
+    session: Session = Session(),
+    target_datetime: Optional[datetime] = None,
+    logger: Logger = getLogger(__name__),
+):
+    if target_datetime:
+        raise NotImplementedError("This parser is not yet able to parse past dates.")
+    with session.get(NF_DEMAND_URL) as response:
+        NF_DEMAND_SOUP = BeautifulSoup(response.content, "html.parser")
+
+    consumption_MW = float(NF_DEMAND_SOUP.find_all("p")[1].text.strip(" MW"))
+
+    timestamp_raw = NF_DEMAND_SOUP.find_all("p")[2].text.strip("AS OF ")
+    timestamp = datetime.strptime(timestamp_raw, "%m/%d/%Y %H:%M %p")
+
+    data = {
+        "zoneKey": zone_key,
+        "datetime": timestamp.replace(tzinfo=timezone(TZ)),
+        "consumption": consumption_MW,
+        "source": "https://nlhydro.com/",
+    }
+
+    return data
+
+if __name__ == "__main__":
+    print("fetch_consumption() ->")
+    print(fetch_consumption())

--- a/parsers/CA-NL-NF.py
+++ b/parsers/CA-NL-NF.py
@@ -1,11 +1,11 @@
 #!/usr/bin/env python3
 
+import arrow
 from datetime import datetime
 from logging import Logger, getLogger
 from typing import Optional
 
 from bs4 import BeautifulSoup
-from pytz import timezone
 from requests import Session
 
 # This parser fetches demand data for Canada-Newfoundland. The source-website https://nlhydro.com/ states:
@@ -32,11 +32,11 @@ def fetch_consumption(
     consumption_MW = float(NF_DEMAND_SOUP.find_all("p")[1].text.strip(" MW"))
 
     timestamp_raw = NF_DEMAND_SOUP.find_all("p")[2].text.strip("AS OF ")
-    timestamp = datetime.strptime(timestamp_raw, "%m/%d/%Y %H:%M %p")
+    timestamp = arrow.get(timestamp_raw, "M/D/YYYY H:m A", tzinfo=TZ)
 
     data = {
         "zoneKey": zone_key,
-        "datetime": timestamp.replace(tzinfo=timezone(TZ)),
+        "datetime": timestamp,
         "consumption": consumption_MW,
         "source": "https://nlhydro.com/",
     }


### PR DESCRIPTION
I've overlooked that we already had a thread for Newfoundland in #2541 and #503 where the source was mentioned back then, and even a parser was written but PR #3077 was closed. So hopefully this is no duplicate.
The parser fetches consumption for CA-NL-NF only, as there is no further breakdown of the fuel types. 5-minute-granularity.