### PR TITLE
Fixed flaky future test

### DIFF
--- a/parsers/test/mocks/quality_check.py
+++ b/parsers/test/mocks/quality_check.py
@@ -71,7 +71,7 @@ e3 = {
     "source": "mysource.com",
 }
 
-future = datetime.datetime.utcnow() + datetime.timedelta(seconds=5 * 60)
+future = datetime.datetime.utcnow() + datetime.timedelta(minutes=55)
 
 e4 = {
     "sortedZoneKeys": "DK->NO",


### PR DESCRIPTION
The `parsers/test/test_quality.py::ExchangeTestCase::test_future_not_allowed ` was failing randomly. It happens if the CI is under heavy load and there are more than 5 minutes between the initialization to when the test is being run.

I changed it to 55 minutes into the future, which should make the test more stable.