### PR TITLE
Changes how the cache key works for ESLint

### DIFF
--- a/.github/workflows/eslint.yml
+++ b/.github/workflows/eslint.yml
@@ -47,7 +47,6 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-eslint_cache-${{ github.ref_name }}
             ${{ runner.os }}-eslint_cache-master
-            ${{ runner.os }}-eslint_cache
       - name: ESLint
         run: node_modules/.bin/eslint .
           --ignore-path .gitignore

--- a/.github/workflows/eslint.yml
+++ b/.github/workflows/eslint.yml
@@ -43,9 +43,9 @@ jobs:
         uses: actions/cache@v3
         with:
           path: ./web/node_modules/.cache/eslint/.eslintcache
-          key: ${{ runner.os }}-eslint_cache-${{ github.head_ref }}-${{ github.run_id }}
+          key: ${{ runner.os }}-eslint_cache-${{ github.ref_name }}-${{ github.run_id }}
           restore-keys: |
-            ${{ runner.os }}-eslint_cache-${{ github.head_ref }}
+            ${{ runner.os }}-eslint_cache-${{ github.ref_name }}
             ${{ runner.os }}-eslint_cache-master
             ${{ runner.os }}-eslint_cache
       - name: ESLint


### PR DESCRIPTION
## Issue
There are some weird behavior with ESLint in on of the PR's.

## Description
This changes how the caches are handled (this is probably how it was supposed to be in the first place) 😅

### Preview
Previously it saved keys without the ref such as `Linux-eslint_cache--4261546878`

Now it saves keys with the ref like this: `Linux-eslint_cache-5125/merge-4262063308`

- [x] I have run `pnpx prettier --write .` and `poetry run format` to format my changes.
