### PR TITLE
Md/ele 1807 is add validation to discard fake 0null

### DIFF
--- a/parsers/lib/quality.py
+++ b/parsers/lib/quality.py
@@ -201,4 +201,7 @@ def validate_production(obj: Dict[str, Any], zone_key: ZoneKey) -> None:
                 % (key, zone_key)
             )
 
+    if all((obj["production"][key]==0) or (obj["production"][key] is None) for key in obj.get("production", {})):
+        raise ValidationError(f"{zone_key}, {obj.get('datetime')}: unrealistic datapoint, all production values are 0.0 MW or null")
+
     validate_reasonable_time(obj, zone_key)

--- a/parsers/lib/quality.py
+++ b/parsers/lib/quality.py
@@ -201,7 +201,13 @@ def validate_production(obj: Dict[str, Any], zone_key: ZoneKey) -> None:
                 % (key, zone_key)
             )
 
-    if all((obj["production"][key]==0) or (obj["production"][key] is None) for key in obj.get("production", {})):
-        raise ValidationError(f"{zone_key}, {obj.get('datetime')}: unrealistic datapoint, all production values are 0.0 MW or null")
+    if all(
+        (obj.get("production").get(key) == 0)
+        or (obj.get("production").get(key) is None)
+        for key in obj.get("production", {})
+    ):
+        raise ValidationError(
+            f"{zone_key}, {obj.get('datetime')}: unrealistic datapoint, all production values are 0.0 MW or null"
+        )
 
     validate_reasonable_time(obj, zone_key)

--- a/parsers/test/mocks/quality_check.py
+++ b/parsers/test/mocks/quality_check.py
@@ -285,3 +285,13 @@ p14 = {
     "datetime": dt,
     "source": "entsoe.eu",
 }
+
+p15 = {"zoneKey": "IS",
+ "datetime": dt,
+ "production": {
+  "coal": None,
+  "hydro": 0.0,
+  "oil": 0.0,
+  "geothermal":0.0},
+
+ "source": "mysource.com"}

--- a/parsers/test/test_quality.py
+++ b/parsers/test/test_quality.py
@@ -95,6 +95,10 @@ class ProductionTestCase(unittest.TestCase):
     def test_good_datapoint(self):
         self.assertFalse(validate_production(p9, "FR"), msg="This datapoint is good!")
 
+    def test_all_zeros_or_null(self):
+        breakpoint()
+        with self.assertRaises(Exception, msg="Suspicious data point, all zeros or null"):
+            validate_production(p15, "IS")
 
 if __name__ == "__main__":
     unittest.main()

--- a/parsers/test/test_quality.py
+++ b/parsers/test/test_quality.py
@@ -96,7 +96,6 @@ class ProductionTestCase(unittest.TestCase):
         self.assertFalse(validate_production(p9, "FR"), msg="This datapoint is good!")
 
     def test_all_zeros_or_null(self):
-        breakpoint()
         with self.assertRaises(Exception, msg="Suspicious data point, all zeros or null"):
             validate_production(p15, "IS")
 


### PR DESCRIPTION
## Issue

<!-- If you want to close an issue automatically when your PR is merged, write "Closes X" where X is the PR number. For example: Closes #000 -->

## Description

- added validation to ensure that empty datapoints are not loaded to the DB. For example, in IS the parser collects production data points with only 0 (see image). These are "fake" zeros and should be discarded.
![image](https://user-images.githubusercontent.com/107848894/221562995-1e6567d2-229c-4e12-b346-84f358d9cf3e.png)

### Preview
![image](https://user-images.githubusercontent.com/107848894/221568939-0e22998e-5514-4369-98d5-4f788c593c47.png)
The datapoint will be discarded if all values are None or 0 

### Double check

- [ ] I have tested my parser changes locally with `poetry run test_parser "zone_key"`
- [ ] I have run `pnpx prettier --write .` and `poetry run format` to format my changes.
