### PR TITLE
Replaces the fallback flag with a square

### DIFF
--- a/web/src/components/Flag.tsx
+++ b/web/src/components/Flag.tsx
@@ -29,7 +29,7 @@ export function CountryFlag({
   const FlagIcon = flags[countryName];
 
   if (!FlagIcon) {
-    return <span className={`text-[14px]`}>🏴‍☠️</span>;
+    return <span className="h-[12px] w-[18px] bg-gray-400 text-[14px]"></span>;
   }
   return (
     <FlagIcon

--- a/web/src/components/Flag.tsx
+++ b/web/src/components/Flag.tsx
@@ -2,13 +2,8 @@ import flags from 'country-flag-icons/react/3x2';
 
 const DEFAULT_FLAG_SIZE = 18;
 
-const SPECIAL_ZONE_NAMES = {
-  AUS: 'AU',
-} as { [index: string]: string };
-
 function getCountryName(zoneId: string) {
-  const country = zoneId.split('-')[0];
-  const flagName = SPECIAL_ZONE_NAMES[country] || country;
+  const flagName = zoneId.split('-')[0];
   return flagName.toUpperCase();
 }
 

--- a/web/src/features/panels/zone/ZoneHeaderTitle.tsx
+++ b/web/src/features/panels/zone/ZoneHeaderTitle.tsx
@@ -42,9 +42,9 @@ export default function ZoneHeaderTitle({
               <CountryFlag
                 zoneId={zoneId}
                 size={18}
-                className="mr-2 shadow-[0_0px_3px_rgba(0,0,0,0.2)]"
+                className="shadow-[0_0px_3px_rgba(0,0,0,0.2)]"
               />
-              <div className="flex flex-row">
+              <div className="ml-2 flex flex-row">
                 <h2
                   className="max-w-[300px] overflow-hidden truncate text-lg font-medium sm:max-w-[230px] md:max-w-[270px]"
                   data-test-id="zone-name"


### PR DESCRIPTION
## Description

Turns out the fallback flag I initially added for fun was actually shown on a zone after all... Replacing it with something more appropriate and also removes an edge case for handling AUS zones, which is not needed now that we have renamed the zones! 🥳 

### Preview

![Screenshot 2023-03-01 at 14 21 10](https://user-images.githubusercontent.com/3296643/222150809-ceabe6f7-da5e-4380-822e-a841da72fa7a.png)



### Double check

- [x] I have run `pnpx prettier --write .` and `poetry run format` to format my changes.
