### PR TITLE
create config for enabling aggregated view

### DIFF
--- a/config/zones/JP.yaml
+++ b/config/zones/JP.yaml
@@ -1,0 +1,37 @@
+bounding_box:
+  - - 138.5
+    - 34.52
+  - - 141.16
+    - 37.17
+capacity:
+  battery storage: null
+  biomass: 2847.6
+  coal: 33620
+  gas: 92381.7
+  geothermal: 426.0
+  hydro: 17215
+  hydro storage: 22052
+  nuclear: 27019
+  oil: 28579.8
+  solar: 28577.9
+  unknown: 9976.9
+  wind: 3978.8
+contributors:
+  - kongkille
+  - lorrieq
+  - tmslaine
+  - wobniarin
+  - pierresegonne
+  - nessie2013
+subZoneNames:
+  - JP-CB
+  - JP-CG
+  - JP-HKD
+  - JP-HR
+  - JP-KN
+  - JP-KY
+  - JP-ON
+  - JP-SK
+  - JP-TH
+  - JP-TK
+timezone: Japan/Tokyo


### PR DESCRIPTION
## Issue
Japan is not visible under the aggregated view yet. 

## Description
This PR creates the config file for Japan `JP.yaml` so that the aggregated view can be generated. 
At the moment, since the estimation model is not implemented yet, there is no flowtraced data and therefore the mock data is no available at the moment. 

### Preview

<img width="1505" alt="Screenshot 2023-03-06 at 15 18 58" src="https://user-images.githubusercontent.com/50823290/223137928-070f6489-35c4-49c4-8cd4-90ae09ba9d25.png">
