### PR TITLE
Tvs/unflake tests

### DIFF
--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -12,7 +12,7 @@ jobs:
         uses: pnpm/action-setup@v2
         with:
           version: 7
-      - name: Cypress run
+      - name: Cypress run e2e tests
         uses: cypress-io/github-action@v5
         env:
           TZ: Europe/Copenhagen
@@ -21,3 +21,13 @@ jobs:
           build: pnpm run build --mode testing
           start: pnpm run preview
           config: baseUrl=http://127.0.0.1:4173/
+      - name: Cypress run component tests
+        uses: cypress-io/github-action@v5
+        env:
+          TZ: Europe/Copenhagen
+        with:
+          working-directory: ./web
+          # we have already installed everything
+          install: false
+          # to run component tests we need to use "component: true"
+          component: true

--- a/web/cypress/e2e/countrypanel.spec.ts
+++ b/web/cypress/e2e/countrypanel.spec.ts
@@ -7,7 +7,8 @@ describe('Country Panel', () => {
   it('interacts with details', () => {
     cy.interceptAPI('v6/details/hourly/DK-DK2');
 
-    cy.visit('/zone/DK-DK2?skip-onboarding=true&lang=en-GB');
+    cy.visit('/zone/DK-DK2?lang=en-GB');
+    cy.get('[data-test-id=close-modal]').click();
     cy.waitForAPISuccess('v6/state/hourly');
     cy.waitForAPISuccess('v6/details/hourly/DK-DK2');
     cy.contains('East Denmark');

--- a/web/cypress/e2e/map.spec.ts
+++ b/web/cypress/e2e/map.spec.ts
@@ -3,7 +3,8 @@
 describe('Map', () => {
   it('interacts with the map', () => {
     cy.interceptAPI('v6/state/hourly');
-    cy.visit('/?skip-onboarding=true&lang=en-GB');
+    cy.visit('/?lang=en-GB');
+    cy.get('[data-test-id=close-modal]').click();
     cy.waitForAPISuccess(`v6/state/hourly`);
 
     // closes left panel

--- a/web/cypress/e2e/onboarding.spec.ts
+++ b/web/cypress/e2e/onboarding.spec.ts
@@ -1,7 +1,0 @@
-// TODO: Convert to component test and uncomment tests
-describe('Onboarding', () => {
-  it('Asserts onboarding works', () => {
-    cy.visit('/map?lang=en-GB');
-    cy.get('[data-test-id=onboarding]').should('be.visible');
-  });
-});

--- a/web/cypress/e2e/ranking.spec.ts
+++ b/web/cypress/e2e/ranking.spec.ts
@@ -3,7 +3,8 @@ describe('Ranking Panel', () => {
   it('interacts with details', () => {
     cy.interceptAPI('v6/state/hourly');
     cy.interceptAPI('v6/details/hourly/DK-DK2');
-    cy.visit('/?skip-onboarding=true&lang=en-GB');
+    cy.visit('/?lang=en-GB');
+    cy.get('[data-test-id=close-modal]').click();
     cy.waitForAPISuccess(`v6/state/hourly`);
 
     // See more than X countries on the list by default

--- a/web/cypress/e2e/timeslider.spec.ts
+++ b/web/cypress/e2e/timeslider.spec.ts
@@ -48,8 +48,8 @@ describe('TimeController', () => {
     cy.interceptAPI('v6/details/yearly/DK-DK2');
 
     // Note that we force language here as CI and local machines might display dates differently otherwise
-    cy.visit('/zone/DK-DK2?skip-onboarding=true&lang=en-GB');
-
+    cy.visit('/zone/DK-DK2?lang=en-GB');
+    cy.get('[data-test-id=close-modal]').click();
     // Hourly
     cy.waitForAPISuccess(`v6/state/hourly`);
     cy.waitForAPISuccess(`v6/details/hourly/DK-DK2`);
@@ -138,6 +138,6 @@ describe('TimeController', () => {
   // TODO: Figure out how to get open/drag bottom sheet in Cypress on mobile
   // I have tried a bunch of combinations with mousemove, etc. without success
   it.skip('interacts with the timecontroller on mobile', () => {
-    cy.visitOnMobile('/?skip-onboarding=true');
+    cy.visitOnMobile('/zone/DK-DK2?lang=en-GB');
   });
 });

--- a/web/src/components/modals/OnboardingModal.cy.tsx
+++ b/web/src/components/modals/OnboardingModal.cy.tsx
@@ -1,6 +1,6 @@
 import { OnboardingModal } from './OnboardingModal';
 
 it('mounts', () => {
-  cy.mount(<OnboardingModal isComponentTest={true} />);
+  cy.mount(<OnboardingModal />);
   cy.contains('Electricity Maps');
 });

--- a/web/src/components/modals/OnboardingModal.cy.tsx
+++ b/web/src/components/modals/OnboardingModal.cy.tsx
@@ -1,0 +1,6 @@
+import { OnboardingModal } from './OnboardingModal';
+
+it('mounts', () => {
+  cy.mount(<OnboardingModal isComponentTest={true} />);
+  cy.contains('Electricity Maps');
+});

--- a/web/src/components/modals/OnboardingModal.tsx
+++ b/web/src/components/modals/OnboardingModal.tsx
@@ -62,13 +62,10 @@ const views = [
   },
 ];
 
-export function OnboardingModal({ isComponentTest }: { isComponentTest?: boolean }) {
+export function OnboardingModal() {
   const [hasOnboardingBeenSeen, setHasOnboardingBeenSeen] = useAtom(
     hasOnboardingBeenSeenAtom
   );
-  if (import.meta.env.TEST && !isComponentTest) {
-    setHasOnboardingBeenSeen(true);
-  }
   const handleDismiss = () => {
     setHasOnboardingBeenSeen(true);
   };

--- a/web/src/components/modals/OnboardingModal.tsx
+++ b/web/src/components/modals/OnboardingModal.tsx
@@ -1,4 +1,4 @@
-import { resolvePath, useSearchParams } from 'react-router-dom';
+import { resolvePath } from 'react-router-dom';
 import { hasOnboardingBeenSeenAtom } from 'utils/state/atoms';
 
 import { useAtom } from 'jotai';
@@ -62,14 +62,13 @@ const views = [
   },
 ];
 
-export function OnboardingModal() {
+export function OnboardingModal({ isComponentTest }: { isComponentTest?: boolean }) {
   const [hasOnboardingBeenSeen, setHasOnboardingBeenSeen] = useAtom(
     hasOnboardingBeenSeenAtom
   );
-  const [searchParameters] = useSearchParams();
-  const skipOnboarding = searchParameters.get('skip-onboarding') === 'true';
-  const visible = !hasOnboardingBeenSeen && !skipOnboarding;
-
+  if (import.meta.env.TEST && !isComponentTest) {
+    setHasOnboardingBeenSeen(true);
+  }
   const handleDismiss = () => {
     setHasOnboardingBeenSeen(true);
   };
@@ -77,7 +76,7 @@ export function OnboardingModal() {
     <Modal
       modalName="onboarding"
       data-test-id="onboarding"
-      visible={visible}
+      visible={!hasOnboardingBeenSeen}
       onDismiss={handleDismiss}
       views={views}
     />

--- a/web/src/components/modals/OnboardingModalInner.tsx
+++ b/web/src/components/modals/OnboardingModalInner.tsx
@@ -45,6 +45,7 @@ function Modal({
   const RightButton = isOnLastView() ? (
     <button
       className="flex h-10 w-10 items-center justify-center rounded-full bg-brand-green shadow"
+      data-test-id="close-modal"
       onClick={onDismiss}
     >
       <HiCheck size="24" color="white" />


### PR DESCRIPTION
## Issue
Occasionally the e2e tests would flake on CI

## Description
This PR seeks to prevent flaky cypress tests by using the cy.click() function over checking for url search params.

Tests usually fail on CI due to the onboarding modal being on top of the component being tested, the onboarding modal should have disappeared due to the search params functionality that was in the component, my hypothesis is that the modal was briefly rendered and blocked cypress during the test window. 

I have removed the search params functionality and will rely on the cy.click() to close the modal

