### PR TITLE
use-resze-observer impl. #5166

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -96,7 +96,8 @@
     "tailwindcss-radix": "^2.6.1",
     "tiny-invariant": "^1.3.1",
     "topojson-client": "^3.1.0",
-    "topojson-server": "^3.0.1"
+    "topojson-server": "^3.0.1",
+    "use-resize-observer": "^9.1.0"
   },
   "devDependencies": {
     "@mdx-js/react": "^2.1.5",

--- a/web/pnpm-lock.yaml
+++ b/web/pnpm-lock.yaml
@@ -134,6 +134,7 @@ specifiers:
   topojson-server: ^3.0.1
   ts-node: ^10.9.1
   typescript: 4.8.4
+  use-resize-observer: ^9.1.0
   vite: 3.1.8
   vite-plugin-pwa: 0.13.1
   vite-tsconfig-paths: 3.5.2
@@ -200,6 +201,7 @@ dependencies:
   tiny-invariant: 1.3.1
   topojson-client: 3.1.0
   topojson-server: 3.0.1
+  use-resize-observer: 9.1.0_biqbaboplfbrettd7655fr4n2y
 
 devDependencies:
   '@mdx-js/react': 2.1.5_react@18.2.0
@@ -16675,6 +16677,17 @@ packages:
     dependencies:
       '@types/react': 18.0.22
       react: 18.2.0
+    dev: false
+
+  /use-resize-observer/9.1.0_biqbaboplfbrettd7655fr4n2y:
+    resolution: {integrity: sha512-R25VqO9Wb3asSD4eqtcxk8sJalvIOYBqS8MNZlpDSQ4l4xMQxC/J7Id9HoTqPq8FwULIn0PVW+OAqF2dyYbjow==}
+    peerDependencies:
+      react: 16.8.0 - 18
+      react-dom: 16.8.0 - 18
+    dependencies:
+      '@juggle/resize-observer': 3.4.0
+      react: 18.2.0
+      react-dom: 18.2.0_react@18.2.0
     dev: false
 
   /use-sidecar/1.1.2_gd4tregka43x4eiz452mfdbv4y:

--- a/web/src/features/charts/bar-breakdown/BarBreakdownChart.tsx
+++ b/web/src/features/charts/bar-breakdown/BarBreakdownChart.tsx
@@ -7,13 +7,13 @@ import { useTranslation } from 'translation/translation';
 import { ElectricityModeType, ZoneDetail, ZoneKey } from 'types';
 import { displayByEmissionsAtom } from 'utils/state/atoms';
 import { useBreakpoint } from 'utils/styling';
-import { useReferenceWidthHeightObserver } from 'utils/viewport';
 import useBarBreakdownChartData from '../hooks/useBarElectricityBreakdownChartData';
 import BreakdownChartTooltip from '../tooltips/BreakdownChartTooltip';
 import BarBreakdownEmissionsChart from './BarBreakdownEmissionsChart';
 import BarElectricityBreakdownChart from './BarElectricityBreakdownChart';
 import EmptyBarBreakdownChart from './EmptyBarBreakdownChart';
 import BySource from './elements/BySource';
+import useResizeObserver from 'use-resize-observer';
 
 const X_PADDING = 9;
 
@@ -27,10 +27,10 @@ function BarBreakdownChart() {
     height,
   } = useBarBreakdownChartData();
   const [displayByEmissions] = useAtom(displayByEmissionsAtom);
-  const { ref, width } = useReferenceWidthHeightObserver(X_PADDING);
+  const { ref, width: observerWidth = 0 } = useResizeObserver();
   const { __ } = useTranslation();
   const isBiggerThanMobile = useBreakpoint('sm');
-
+  const width = observerWidth - X_PADDING;
   const [tooltipData, setTooltipData] = useState<{
     selectedLayerKey: ElectricityModeType | ZoneKey;
     x: number;

--- a/web/src/features/charts/elements/AreaGraph.tsx
+++ b/web/src/features/charts/elements/AreaGraph.tsx
@@ -5,7 +5,7 @@ import { stack, stackOffsetDiverging } from 'd3-shape';
 import TimeAxis from 'features/time/TimeAxis'; // TODO: Move to a shared folder
 import useResizeObserver from 'use-resize-observer';
 import { useAtom } from 'jotai';
-import React, { useMemo, useState } from 'react';
+import React, { useMemo, useRef, useState } from 'react';
 import { ZoneDetail } from 'types';
 import { TimeAverages } from 'utils/constants';
 import { selectedDatetimeIndexAtom } from 'utils/state/atoms';
@@ -105,11 +105,9 @@ function AreaGraph({
   tooltip,
   tooltipSize,
 }: AreagraphProps) {
-  const {
-    ref,
-    width: observerWidth = 0,
-    height: observerHeight = 0,
-  } = useResizeObserver<SVGSVGElement>();
+  const reference = useRef(null);
+  const { width: observerWidth = 0, height: observerHeight = 0 } =
+    useResizeObserver<SVGSVGElement>({ ref: reference });
 
   const containerWidth = observerWidth - Y_AXIS_WIDTH;
   const containerHeight = observerHeight - X_AXIS_HEIGHT;
@@ -222,7 +220,7 @@ function AreaGraph({
     <svg
       data-test-id={testId}
       height={height}
-      ref={ref}
+      ref={reference}
       className="w-full overflow-visible"
     >
       <GraphBackground
@@ -232,7 +230,7 @@ function AreaGraph({
         mouseMoveHandler={mouseMoveHandler}
         mouseOutHandler={mouseOutHandler}
         isMobile={isMobile}
-        svgNode={ref}
+        svgNode={reference.current}
       />
       <AreaGraphLayers
         layers={layers}
@@ -242,7 +240,7 @@ function AreaGraph({
         mouseMoveHandler={mouseMoveHandler}
         mouseOutHandler={mouseOutHandler}
         isMobile={isMobile}
-        svgNode={ref}
+        svgNode={reference.current}
       />
       {!isOverlayEnabled && (
         <TimeAxis
@@ -269,7 +267,7 @@ function AreaGraph({
         markerHideHandler={markerHideHandler}
         selectedLayerIndex={selectedLayerIndex}
         selectedTimeIndex={hoverLineTimeIndex}
-        svgNode={ref}
+        svgNode={reference.current}
       />
       {tooltip && (
         <AreaGraphTooltip

--- a/web/src/features/charts/elements/AreaGraph.tsx
+++ b/web/src/features/charts/elements/AreaGraph.tsx
@@ -3,13 +3,13 @@
 import { scaleLinear } from 'd3-scale';
 import { stack, stackOffsetDiverging } from 'd3-shape';
 import TimeAxis from 'features/time/TimeAxis'; // TODO: Move to a shared folder
+import useResizeObserver from 'use-resize-observer';
 import { useAtom } from 'jotai';
 import React, { useMemo, useState } from 'react';
 import { ZoneDetail } from 'types';
 import { TimeAverages } from 'utils/constants';
 import { selectedDatetimeIndexAtom } from 'utils/state/atoms';
 import { useBreakpoint } from 'utils/styling';
-import { useReferenceWidthHeightObserver } from 'utils/viewport';
 import { getTimeScale, isEmpty } from '../graphUtils';
 import AreaGraphTooltip from '../tooltips/AreaGraphTooltip';
 import { AreaGraphElement, InnerAreaGraphTooltipProps } from '../types';
@@ -107,10 +107,12 @@ function AreaGraph({
 }: AreagraphProps) {
   const {
     ref,
-    width: containerWidth,
-    height: containerHeight,
-    node,
-  } = useReferenceWidthHeightObserver(Y_AXIS_WIDTH, X_AXIS_HEIGHT);
+    width: observerWidth = 0,
+    height: observerHeight = 0,
+  } = useResizeObserver<SVGSVGElement>();
+
+  const containerWidth = observerWidth - Y_AXIS_WIDTH;
+  const containerHeight = observerHeight - X_AXIS_HEIGHT;
 
   const [selectedDate] = useAtom(selectedDatetimeIndexAtom);
   const [tooltipData, setTooltipData] = useState<TooltipData | null>(null);
@@ -230,7 +232,7 @@ function AreaGraph({
         mouseMoveHandler={mouseMoveHandler}
         mouseOutHandler={mouseOutHandler}
         isMobile={isMobile}
-        svgNode={node}
+        svgNode={ref}
       />
       <AreaGraphLayers
         layers={layers}
@@ -240,7 +242,7 @@ function AreaGraph({
         mouseMoveHandler={mouseMoveHandler}
         mouseOutHandler={mouseOutHandler}
         isMobile={isMobile}
-        svgNode={node}
+        svgNode={ref}
       />
       {!isOverlayEnabled && (
         <TimeAxis
@@ -267,7 +269,7 @@ function AreaGraph({
         markerHideHandler={markerHideHandler}
         selectedLayerIndex={selectedLayerIndex}
         selectedTimeIndex={hoverLineTimeIndex}
-        svgNode={node}
+        svgNode={ref}
       />
       {tooltip && (
         <AreaGraphTooltip

--- a/web/src/features/exchanges/ExchangeLayer.tsx
+++ b/web/src/features/exchanges/ExchangeLayer.tsx
@@ -3,12 +3,12 @@ import { useExchangeArrowsData } from 'hooks/arrows';
 import { useAtom } from 'jotai';
 import React from 'react';
 import { MapboxMap } from 'react-map-gl';
-import { useReferenceWidthHeightObserver } from 'utils/viewport';
 import ExchangeArrow from './ExchangeArrow';
+import useResizeObserver from 'use-resize-observer';
 
 function ExchangeLayer({ map }: { map?: MapboxMap }) {
   const [isMapMoving] = useAtom(mapMovingAtom);
-  const { ref, width, height } = useReferenceWidthHeightObserver();
+  const { ref, height = 0, width = 0 } = useResizeObserver();
   const arrows = useExchangeArrowsData();
 
   return (

--- a/web/src/features/time/TimeAxis.tsx
+++ b/web/src/features/time/TimeAxis.tsx
@@ -2,8 +2,8 @@ import { ScaleTime, scaleTime } from 'd3-scale';
 import { useTranslation } from 'react-i18next';
 import PulseLoader from 'react-spinners/PulseLoader';
 import { TimeAverages } from 'utils/constants';
-import { useReferenceWidthHeightObserver } from 'utils/viewport';
 import { formatDateTick } from '../../utils/formatting';
+import useResizeObserver from 'use-resize-observer';
 
 // Frequency at which values are displayed for a tick
 const TIME_TO_TICK_FREQUENCY = {
@@ -84,8 +84,8 @@ function TimeAxis({
   className,
 }: TimeAxisProps) {
   const { i18n } = useTranslation();
-  const { ref, width } = useReferenceWidthHeightObserver(24);
-
+  const { ref, width: observerWidth = 0 } = useResizeObserver();
+  const width = observerWidth - 24;
   if (datetimes === undefined || isLoading) {
     return (
       <div className="flex h-[22px]  w-full justify-center">

--- a/web/src/features/weather-layers/solar/SolarLayer.tsx
+++ b/web/src/features/weather-layers/solar/SolarLayer.tsx
@@ -32,14 +32,14 @@ export default function SolarLayer({ map }: { map?: MapboxMap }) {
   });
   const solarData = solarDataArray?.[0];
 
-  const ref = useRef<HTMLCanvasElement>(null);
-  const { width, height } = useResizeObserver({ ref });
+  const reference = useRef<HTMLCanvasElement>(null);
+  const { width, height } = useResizeObserver({ ref: reference });
   const isVisible = isSuccess && !isMapMoving && isSolarLayerEnabled;
 
   // Render the processed solar forecast image into the canvas.
   useEffect(() => {
-    if (map && ref && isVisible && solarData && width && height) {
-      const canvas = (ref.current as HTMLCanvasElement).getContext('2d');
+    if (map && reference && isVisible && solarData && width && height) {
+      const canvas = (reference.current as HTMLCanvasElement).getContext('2d');
       if (!canvas) {
         return;
       }
@@ -89,14 +89,14 @@ export default function SolarLayer({ map }: { map?: MapboxMap }) {
       canvas.putImageData(image, 0, 0);
       setIsLoadingSolarLayer(false);
     }
-  }, [ref, isVisible, solarData, width, height, map]);
+  }, [reference, isVisible, solarData, width, height, map]);
 
   return (
     <canvas
       id="solar"
       width={width}
       height={height}
-      ref={ref}
+      ref={reference}
       className={`pointer-events-none absolute inset-0 h-full w-full duration-300 ${
         isVisible ? 'opacity-100' : 'opacity-0'
       }`}

--- a/web/src/features/weather-layers/wind-layer/WindLayer.tsx
+++ b/web/src/features/weather-layers/wind-layer/WindLayer.tsx
@@ -30,7 +30,9 @@ export default function WindLayer({ map }: { map?: MapboxMap }) {
   const [isMapMoving] = useAtom(mapMovingAtom);
   const [windy, setWindy] = useState<Maybe<WindyType>>(null);
   const reference = useRef<HTMLCanvasElement>(null);
-  const { height = 0, width = 0 } = useResizeObserver<HTMLCanvasElement>({ ref: reference });
+  const { height = 0, width = 0 } = useResizeObserver<HTMLCanvasElement>({
+    ref: reference,
+  });
   const viewport = useMemo(() => {
     const sw = map?.unproject([0, height]);
     const ne = map?.unproject([width, 0]);

--- a/web/src/features/weather-layers/wind-layer/WindLayer.tsx
+++ b/web/src/features/weather-layers/wind-layer/WindLayer.tsx
@@ -29,8 +29,8 @@ const createWindy = async (canvas: HTMLCanvasElement, data: any, map: MapboxMap)
 export default function WindLayer({ map }: { map?: MapboxMap }) {
   const [isMapMoving] = useAtom(mapMovingAtom);
   const [windy, setWindy] = useState<Maybe<WindyType>>(null);
-  const ref = useRef<HTMLCanvasElement>(null);
-  const { height = 0, width = 0 } = useResizeObserver<HTMLCanvasElement>({ ref });
+  const reference = useRef<HTMLCanvasElement>(null);
+  const { height = 0, width = 0 } = useResizeObserver<HTMLCanvasElement>({ ref: reference });
   const viewport = useMemo(() => {
     const sw = map?.unproject([0, height]);
     const ne = map?.unproject([width, 0]);
@@ -57,8 +57,8 @@ export default function WindLayer({ map }: { map?: MapboxMap }) {
   const isVisible = isSuccess && !isMapMoving && isWindLayerEnabled;
 
   useEffect(() => {
-    if (map && !windy && isVisible && ref && isWindLayerEnabled && windData) {
-      createWindy(ref.current as HTMLCanvasElement, windData, map).then((w) => {
+    if (map && !windy && isVisible && reference && isWindLayerEnabled && windData) {
+      createWindy(reference.current as HTMLCanvasElement, windData, map).then((w) => {
         const { bounds, width, height, extent } = viewport;
         w.start(bounds, width, height, extent);
         setWindy(w);
@@ -68,7 +68,7 @@ export default function WindLayer({ map }: { map?: MapboxMap }) {
       windy.stop();
       setWindy(null);
     }
-  }, [isVisible, isSuccess, ref, windy, viewport]);
+  }, [isVisible, isSuccess, reference, windy, viewport]);
 
   return (
     <canvas
@@ -80,7 +80,7 @@ export default function WindLayer({ map }: { map?: MapboxMap }) {
       id="wind"
       width={width}
       height={height}
-      ref={ref}
+      ref={reference}
     />
   );
 }

--- a/web/src/features/weather-layers/wind-layer/WindLayer.tsx
+++ b/web/src/features/weather-layers/wind-layer/WindLayer.tsx
@@ -1,7 +1,7 @@
 import { useGetWind } from 'api/getWeatherData';
 import { mapMovingAtom } from 'features/map/mapAtoms';
 import { useAtom, useSetAtom } from 'jotai';
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import { MapboxMap } from 'react-map-gl';
 import { Maybe } from 'types';
 import { ToggleOptions } from 'utils/constants';
@@ -10,8 +10,8 @@ import {
   windLayerAtom,
   windLayerLoadingAtom,
 } from 'utils/state/atoms';
-import { useReferenceWidthHeightObserver } from 'utils/viewport';
 import Windy from './windy';
+import useResizeObserver from 'use-resize-observer';
 
 type WindyType = ReturnType<typeof Windy>;
 let windySingleton: Maybe<WindyType> = null;
@@ -29,7 +29,8 @@ const createWindy = async (canvas: HTMLCanvasElement, data: any, map: MapboxMap)
 export default function WindLayer({ map }: { map?: MapboxMap }) {
   const [isMapMoving] = useAtom(mapMovingAtom);
   const [windy, setWindy] = useState<Maybe<WindyType>>(null);
-  const { ref, node, width, height } = useReferenceWidthHeightObserver();
+  const ref = useRef<HTMLCanvasElement>(null);
+  const { height = 0, width = 0 } = useResizeObserver<HTMLCanvasElement>({ ref });
   const viewport = useMemo(() => {
     const sw = map?.unproject([0, height]);
     const ne = map?.unproject([width, 0]);
@@ -56,8 +57,8 @@ export default function WindLayer({ map }: { map?: MapboxMap }) {
   const isVisible = isSuccess && !isMapMoving && isWindLayerEnabled;
 
   useEffect(() => {
-    if (map && !windy && isVisible && node && isWindLayerEnabled && windData) {
-      createWindy(node as HTMLCanvasElement, windData, map).then((w) => {
+    if (map && !windy && isVisible && ref && isWindLayerEnabled && windData) {
+      createWindy(ref.current as HTMLCanvasElement, windData, map).then((w) => {
         const { bounds, width, height, extent } = viewport;
         w.start(bounds, width, height, extent);
         setWindy(w);
@@ -67,7 +68,7 @@ export default function WindLayer({ map }: { map?: MapboxMap }) {
       windy.stop();
       setWindy(null);
     }
-  }, [isVisible, isSuccess, node, windy, viewport]);
+  }, [isVisible, isSuccess, ref, windy, viewport]);
 
   return (
     <canvas

--- a/web/src/utils/viewport.ts
+++ b/web/src/utils/viewport.ts
@@ -28,7 +28,7 @@ export function useReferenceWidthHeightObserver(offsetX = 0, offsetY = 0) {
       // Update container width on every resize
       window.addEventListener('resize', update);
     },
-    [offsetX, offsetY]
+    [offsetX, offsetY, window.innerWidth]
   );
 
   return {


### PR DESCRIPTION
## Issue

<!-- If you want to close an issue automatically when your PR is merged, write "Closes X" where X is the PR number. For example: Closes #000 -->
Charts don't re-size when the window size changes https://github.com/electricitymaps/electricitymaps-contrib/issues/5141
## Description
Implemented [use-resize-observer](https://github.com/ZeeCoder/use-resize-observer) hook for this scenario
<!-- Explains the goal of this PR -->

### Preview

<!-- Please add screenshots and/or gif that shows visual changes (if applicable) -->

### Double check

- [ ] I have tested my parser changes locally with `poetry run test_parser "zone_key"`
- [x] I have run `pnpx prettier --write .` and `poetry run format` to format my changes.
