### PR TITLE
fix(SV): migrate http to https to avoid connection error

### DIFF
--- a/parsers/SV.py
+++ b/parsers/SV.py
@@ -21,7 +21,7 @@ from requests import Session
 
 # Thanks to jarek for figuring out how to make the correct POST request to the data url.
 
-url = "http://estadistico.ut.com.sv/OperacionDiaria.aspx"
+url = "https://estadistico.ut.com.sv/OperacionDiaria.aspx"
 
 generation_map = {
     0: "biomass",


### PR DESCRIPTION
## Issue

<!-- If you want to close an issue automatically when your PR is merged, write "Closes X" where X is the PR number. For example: Closes #000 -->

fixes #5158

## Description

<!-- Explains the goal of this PR -->

To connect the website correctly, HTTPS connection was needed: https://estadistico.ut.com.sv/OperacionDiaria.aspx.

Error:
```py
HTTPConnectionPool(host='estadistico.ut.com.sv', port=80): Max retries exceeded with url: /OperacionDiaria.aspx (Caused by NewConnectionError('<urllib3.connection.HTTPConnection object at 0x3ee4feb8b460>: Failed to establish a new connection: [Errno 111] Connection refused'))
```

Now I was able to run the parser locally.

```shell
> poetry run test_parser SV
/opt/homebrew/lib/python3.9/site-packages/setuptools/command/install.py:34: SetuptoolsDeprecationWarning: setup.py install is deprecated. Use build and pip and other standards-based tools.
  warnings.warn(
2023-03-13 00:55:47,728 DEBUG    urllib3.connectionpool         Starting new HTTPS connection (1): estadistico.ut.com.sv:443
2023-03-13 00:55:48,834 DEBUG    urllib3.connectionpool         https://estadistico.ut.com.sv:443 "GET /OperacionDiaria.aspx HTTP/1.1" 200 86114
2023-03-13 00:55:49,907 DEBUG    urllib3.connectionpool         https://estadistico.ut.com.sv:443 "POST /OperacionDiaria.aspx HTTP/1.1" 200 23856
Parser result:
[{'datetime': datetime.datetime(2023, 3, 12, 0, 0, tzinfo=tzstr('UTC-6')),
  'production': {'biomass': 148.47,
                 'coal': 0.0,
                 'gas': 0.0,
                 'geothermal': 168.01,
                 'hydro': 124.7,
                 'nuclear': 0.0,
                 'oil': 362.44,
                 'solar': 0.0,
                 'unknown': 0.0,
                 'wind': 0.0},
  'source': 'ut.com.sv',
  'storage': {'hydro': None},
  'zoneKey': 'SV'},
 {'datetime': datetime.datetime(2023, 3, 12, 1, 0, tzinfo=tzstr('UTC-6')),
  'production': {'biomass': 152.1,
                 'coal': 0.0,
                 'gas': 0.0,
                 'geothermal': 167.52,
                 'hydro': 91.3,
                 'nuclear': 0.0,
                 'oil': 341.54,
                 'solar': 0.0,
                 'unknown': 0.0,
                 'wind': 0.0},
  'source': 'ut.com.sv',
  'storage': {'hydro': None},
  'zoneKey': 'SV'},
 {'datetime': datetime.datetime(2023, 3, 12, 2, 0, tzinfo=tzstr('UTC-6')),
  'production': {'biomass': 150.43,
                 'coal': 0.0,
                 'gas': 0.0,
                 'geothermal': 166.11,
                 'hydro': 61.51,
                 'nuclear': 0.0,
                 'oil': 348.48,
                 'solar': 0.0,
                 'unknown': 0.0,
                 'wind': 0.27},
  'source': 'ut.com.sv',
  'storage': {'hydro': None},
  'zoneKey': 'SV'},
 {'datetime': datetime.datetime(2023, 3, 12, 3, 0, tzinfo=tzstr('UTC-6')),
  'production': {'biomass': 153.41,
                 'coal': 0.0,
                 'gas': 0.0,
                 'geothermal': 166.65,
                 'hydro': 45.39,
                 'nuclear': 0.0,
                 'oil': 354.85,
                 'solar': 0.0,
                 'unknown': 0.0,
                 'wind': 0.0},
  'source': 'ut.com.sv',
  'storage': {'hydro': None},
  'zoneKey': 'SV'},
 {'datetime': datetime.datetime(2023, 3, 12, 4, 0, tzinfo=tzstr('UTC-6')),
  'production': {'biomass': 155.29,
                 'coal': 0.0,
                 'gas': 0.0,
                 'geothermal': 167.24,
                 'hydro': 49.24,
                 'nuclear': 0.0,
                 'oil': 377.36,
                 'solar': 0.0,
                 'unknown': 0.0,
                 'wind': 0.0},
  'source': 'ut.com.sv',
  'storage': {'hydro': None},
  'zoneKey': 'SV'},
 {'datetime': datetime.datetime(2023, 3, 12, 5, 0, tzinfo=tzstr('UTC-6')),
  'production': {'biomass': 155.9,
                 'coal': 0.0,
                 'gas': 0.0,
                 'geothermal': 167.06,
                 'hydro': 48.91,
                 'nuclear': 0.0,
                 'oil': 363.87,
                 'solar': 0.0,
                 'unknown': 0.0,
                 'wind': 0.0},
  'source': 'ut.com.sv',
  'storage': {'hydro': None},
  'zoneKey': 'SV'},
 {'datetime': datetime.datetime(2023, 3, 12, 6, 0, tzinfo=tzstr('UTC-6')),
  'production': {'biomass': 154.98,
                 'coal': 0.0,
                 'gas': 0.0,
                 'geothermal': 165.94,
                 'hydro': 28.98,
                 'nuclear': 0.0,
                 'oil': 301.7,
                 'solar': 9.66,
                 'unknown': 0.0,
                 'wind': 0.0},
  'source': 'ut.com.sv',
  'storage': {'hydro': None},
  'zoneKey': 'SV'},
 {'datetime': datetime.datetime(2023, 3, 12, 7, 0, tzinfo=tzstr('UTC-6')),
  'production': {'biomass': 153.84,
                 'coal': 0.0,
                 'gas': 0.0,
                 'geothermal': 165.21,
                 'hydro': 27.92,
                 'nuclear': 0.0,
                 'oil': 266.32,
                 'solar': 75.09,
                 'unknown': 0.0,
                 'wind': 0.0},
  'source': 'ut.com.sv',
  'storage': {'hydro': None},
  'zoneKey': 'SV'},
 {'datetime': datetime.datetime(2023, 3, 12, 8, 0, tzinfo=tzstr('UTC-6')),
  'production': {'biomass': 146.17,
                 'coal': 0.0,
                 'gas': 0.0,
                 'geothermal': 166.03,
                 'hydro': 28.12,
                 'nuclear': 0.0,
                 'oil': 193.1,
                 'solar': 136.8,
                 'unknown': 0.0,
                 'wind': 0.0},
  'source': 'ut.com.sv',
  'storage': {'hydro': None},
  'zoneKey': 'SV'}]
---------------------
took 2.25s
min returned datetime: 2023-03-12T06:00:00+00:00 UTC
max returned datetime: 2023-03-12T14:00:00+00:00 UTC  -- OK, <2h from now :) (now=2023-03-12T15:55:49.974697+00:00 UTC)
```

### Preview

<!-- Please add screenshots and/or gif that shows visual changes (if applicable) -->

### Double check

- [x] I have tested my parser changes locally with `poetry run test_parser "zone_key"`
- [x] I have run `pnpx prettier --write .` and `poetry run format` to format my changes.
