### PR TITLE
Parser cleanup focusing on hardcoded 0 returns

### DIFF
--- a/parsers/CA_QC.py
+++ b/parsers/CA_QC.py
@@ -15,7 +15,7 @@ timezone_id = "America/Montreal"
 
 def fetch_production(
     zone_key: str = "CA-QC",
-    session: Optional[Session] = None,
+    session: Session = Session(),
     target_datetime: Optional[datetime] = None,
     logger: Logger = getLogger(__name__),
 ) -> list:
@@ -49,18 +49,13 @@ def fetch_production(
                     "datetime": arrow.get(elem["date"], tzinfo=timezone_id).datetime,
                     "production": {
                         "biomass": if_exists(elem, "biomass"),
-                        "coal": 0.0,
                         "hydro": if_exists(elem, "hydro"),
-                        "nuclear": 0.0,
-                        "oil": 0.0,
                         "solar": if_exists(elem, "solar"),
                         "wind": if_exists(elem, "wind"),
                         # See Github issue #3218, Québec's thermal generation is at Bécancour gas turbine.
                         # It is reported with a delay, and data source returning 0.0 can indicate either no generation or not-yet-reported generation.
                         # Thus, if value is 0.0, overwrite it to None, so that backend can know this is not entirely reliable and might be updated later.
                         "gas": if_exists(elem, "thermal") or None,
-                        # There are no geothermal electricity generation stations in Québec (and all of Canada for that matter).
-                        "geothermal": 0.0,
                         "unknown": if_exists(elem, "unknown"),
                     },
                     "source": "hydroquebec.com",
@@ -71,7 +66,7 @@ def fetch_production(
 
 def fetch_consumption(
     zone_key: str = "CA-QC",
-    session: Optional[Session] = None,
+    session: Session = Session(),
     target_datetime: Optional[datetime] = None,
     logger: Logger = getLogger(__name__),
 ):
@@ -91,10 +86,9 @@ def fetch_consumption(
 
 
 def _fetch_quebec_production(
-    session: Optional[Session] = None, logger: Logger = getLogger(__name__)
+    session: Session, logger: Logger = getLogger(__name__)
 ) -> str:
-    s = session or Session()
-    response = s.get(PRODUCTION_URL)
+    response = session.get(PRODUCTION_URL)
 
     if not response.ok:
         logger.info(
@@ -106,10 +100,9 @@ def _fetch_quebec_production(
 
 
 def _fetch_quebec_consumption(
-    session: Optional[Session] = None, logger: Logger = getLogger(__name__)
+    session: Session, logger: Logger = getLogger(__name__)
 ) -> str:
-    s = session or Session()
-    response = s.get(CONSUMPTION_URL)
+    response = session.get(CONSUMPTION_URL)
 
     if not response.ok:
         logger.info(

--- a/parsers/CA_YT.py
+++ b/parsers/CA_YT.py
@@ -13,7 +13,7 @@ timezone = "America/Whitehorse"
 
 def fetch_production(
     zone_key: str = "CA-YT",
-    session: Optional[Session] = None,
+    session: Session = Session(),
     target_datetime: Optional[datetime] = None,
     logger: Logger = getLogger(__name__),
 ) -> dict:
@@ -54,10 +54,8 @@ def fetch_production(
     if target_datetime:
         raise NotImplementedError("This parser is not yet able to parse past dates")
 
-    requests_obj = session or Session()
-
     url = "http://www.yukonenergy.ca/consumption/chart_current.php?chart=current&width=420"
-    response = requests_obj.get(url)
+    response = session.get(url)
 
     soup = BeautifulSoup(response.text, "html.parser")
 
@@ -106,13 +104,7 @@ def fetch_production(
         "production": {
             "unknown": thermal_generation,
             "hydro": hydro_generation,
-            # specify some sources that aren't present in Yukon as zero,
-            # this allows the analyzer to better estimate CO2eq
-            "coal": 0,
-            "nuclear": 0,
-            "geothermal": 0,
         },
-        "storage": {},
         "source": "www.yukonenergy.ca",
     }
 

--- a/parsers/DO.py
+++ b/parsers/DO.py
@@ -88,15 +88,14 @@ thermal_plants = {
 }
 
 
-def get_data(session: Optional[Session] = None) -> list:
+def get_data(session: Session) -> list:
     """
     Makes a request to source url.
     Finds main table and creates a list of all table elements in string format.
     """
 
     data = []
-    s = session or Session()
-    data_req = s.get(url)
+    data_req = session.get(url)
     soup = BeautifulSoup(data_req.content, "lxml")
 
     tbs = soup.find("table", id="PostdespachoUnidadesTermicasGrid_DXMainTable")
@@ -287,7 +286,7 @@ def merge_production(thermal, total) -> List[dict]:
 
 def fetch_production(
     zone_key: str = "DO",
-    session: Optional[Session] = None,
+    session: Session = Session(),
     target_datetime: Optional[datetime] = None,
     logger: Logger = getLogger(__name__),
 ) -> List[dict]:
@@ -295,7 +294,7 @@ def fetch_production(
     if target_datetime:
         raise NotImplementedError("This parser is not yet able to parse past dates")
 
-    dat = data_formatter(get_data(session=session))
+    dat = data_formatter(get_data(session))
     tot = data_parser(dat["totals"])
     th = data_parser(dat["thermal"])
     thermal = thermal_production(th, logger)
@@ -312,15 +311,10 @@ def fetch_production(
                 "coal": hour.get("coal", 0.0),
                 "gas": hour.get("gas", 0.0),
                 "hydro": hour.get("hydro", 0.0),
-                "nuclear": 0.0,
                 "oil": hour.get("oil", 0.0),
                 "solar": hour.get("solar", 0.0),
                 "wind": hour.get("wind", 0.0),
-                "geothermal": 0.0,
                 "unknown": hour.get("unknown", 0.0),
-            },
-            "storage": {
-                "hydro": None,
             },
             "source": "oc.org.do",
         }

--- a/parsers/IN_KA.py
+++ b/parsers/IN_KA.py
@@ -181,16 +181,11 @@ def fetch_production(
         "production": {
             "biomass": biomass_value,
             "coal": coal_value,
-            "gas": 0.0,
             "hydro": hydro_value,
-            "nuclear": 0.0,
-            "oil": 0.0,
             "solar": solar_value,
             "wind": wind_value,
-            "geothermal": 0.0,
             "unknown": unknown_value,
         },
-        "storage": {"hydro": 0.0},
         "source": "kptclsldc.in",
     }
 

--- a/parsers/NI.py
+++ b/parsers/NI.py
@@ -203,7 +203,7 @@ def get_production_from_summary(requests_obj) -> tuple:
 
 def fetch_production(
     zone_key: str = "NI",
-    session: Optional[Session] = None,
+    session: Session = Session(),
     target_datetime: Optional[datetime] = None,
     logger: Logger = getLogger(__name__),
 ) -> dict:
@@ -211,16 +211,10 @@ def fetch_production(
     if target_datetime:
         raise NotImplementedError("This parser is not yet able to parse past dates")
 
-    requests_obj = session or Session()
-
     # We're currently using the summary page (SUMMARY_URL, via get_production_from_summary())
     # rather than the detailed map page (MAP_URL, via get_production_from_map())
     # in order to get solar production.
-    production, data_datetime = get_production_from_summary(requests_obj)
-
-    # Explicitly report types that are not used in Nicaragua as zero.
-    # Source for the installed capacity of Nicaragua is INE (Nicaraguan Institute of Energy -- see link in DATA_SOURCES.md).
-    production.update({"nuclear": 0, "coal": 0, "gas": 0})
+    production, data_datetime = get_production_from_summary(session)
 
     data = {
         "datetime": data_datetime,

--- a/parsers/NZ.py
+++ b/parsers/NZ.py
@@ -17,10 +17,9 @@ timezone = "Pacific/Auckland"
 NZ_PRICE_REGIONS = set([i for i in range(1, 14)])
 
 
-def fetch(session: Optional[Session] = None):
-    r = session or Session()
+def fetch(session: Session):
     url = "https://www.transpower.co.nz/system-operator/live-system-and-market-data/consolidated-live-data"
-    response = r.get(url)
+    response = session.get(url)
     soup = BeautifulSoup(response.text, "html.parser")
     for item in soup.find_all("script"):
         if item.attrs.get("data-drupal-selector"):
@@ -31,7 +30,7 @@ def fetch(session: Optional[Session] = None):
 
 def fetch_price(
     zone_key: str = "NZ",
-    session: Optional[Session] = None,
+    session: Session = Session(),
     target_datetime: Optional[datetime] = None,
     logger: Logger = getLogger(__name__),
 ) -> dict:
@@ -46,9 +45,8 @@ def fetch_price(
             "This parser is not able to retrieve data for past dates"
         )
 
-    r = session or Session()
     url = "https://api.em6.co.nz/ords/em6/data_api/region/price/"
-    response = r.get(url, verify=False)
+    response = session.get(url, verify=False)
     obj = response.json()
     region_prices = []
 
@@ -74,7 +72,7 @@ def fetch_price(
 
 def fetch_production(
     zone_key: str = "NZ",
-    session: Optional[Session] = None,
+    session: Session = Session(),
     target_datetime: Optional[datetime] = None,
     logger: Logger = getLogger(__name__),
 ) -> dict:
@@ -105,7 +103,6 @@ def fetch_production(
             "hydro": productions.get("Hydro", {"generation": None})["generation"],
             "solar": productions.get("Solar", {"generation": None})["generation"],
             "unknown": productions.get("Co-Gen", {"generation": None})["generation"],
-            "nuclear": 0,  # famous issue in NZ politics
         },
         "capacity": {
             "coal": productions.get("Coal", {"capacity": None})["capacity"],

--- a/parsers/SG.py
+++ b/parsers/SG.py
@@ -195,9 +195,6 @@ def fetch_production(
 
     generation_by_type["solar"] = get_solar(requests_obj, logger)
 
-    # some generation methods that are not used in Singapore
-    generation_by_type.update({"nuclear": 0, "wind": 0, "hydro": 0})
-
     return {
         "datetime": sg_data_to_datetime(data),
         "zoneKey": zone_key,

--- a/parsers/SV.py
+++ b/parsers/SV.py
@@ -167,18 +167,11 @@ def fetch_production(
             "datetime": hour["datetime"],
             "production": {
                 "biomass": hour.get("biomass", 0.0),
-                "coal": 0.0,
-                "gas": 0.0,
                 "hydro": hour.get("hydro", 0.0),
-                "nuclear": 0.0,
                 "oil": hour.get("thermal", 0.0),
                 "solar": hour.get("solar", 0.0),
                 "wind": hour.get("wind", 0.0),
                 "geothermal": hour.get("geothermal", 0.0),
-                "unknown": 0.0,
-            },
-            "storage": {
-                "hydro": None,
             },
             "source": "ut.com.sv",
         }

--- a/parsers/test/test_IN_KA.py
+++ b/parsers/test/test_IN_KA.py
@@ -50,7 +50,6 @@ class Test_IN_KA(unittest.TestCase):
             self.assertIsNotNone(data["datetime"])
             self.assertIsNotNone(data["production"])
             self.assertEqual(data["production"]["hydro"], 2434.0)
-            self.assertIsNotNone(data["storage"])
         except Exception as ex:
             self.fail(
                 "IN_KA.fetch_production() raised Exception: {0}".format(ex.message)


### PR DESCRIPTION
## Issue
There are several parsers that are returning hardcoded 0 values for production.

## Description

This PR takes care of the easy ones that could be removed without changing any of the parser logic.

>**Note**
> There are still parsers that return hardcoded 0 values when they should return None.

### Double check

- [x] I have tested my parser changes locally with `poetry run test_parser "zone_key"`
- [x] I have run `pnpx prettier --write .` and `poetry run format` to format my changes.
