### PR TITLE
on outside click for mobile exchange tooltip

### DIFF
--- a/web/src/components/tooltips/MobileTooltipWrapper.tsx
+++ b/web/src/components/tooltips/MobileTooltipWrapper.tsx
@@ -41,6 +41,9 @@ export default function MobileTooltipWrapper(
             onClick={() => {
               setIsOpen(false);
             }}
+            onPointerDownOutside={() => {
+              setIsOpen(false);
+            }}
           >
             <div>{tooltipContent}</div>
           </Tooltip.Content>


### PR DESCRIPTION
## Issue
Multiple exchange tooltips

## Description
I discovered that the radix tooltip content has a nice onPointerDownOutside function so we can easily fix the multiple tooltips issue. 