### PR TITLE
speed up generate-world by skipping validation if the world file is the same as the current one

### DIFF
--- a/web/geo/generateTopojson.ts
+++ b/web/geo/generateTopojson.ts
@@ -70,7 +70,7 @@ function generateTopojson(fc, { OUT_PATH, verifyNoUpdates }) {
   const currentTopo = fileExists(OUT_PATH) ? getJSON(OUT_PATH) : {};
   if (JSON.stringify(currentTopo) === JSON.stringify(topo)) {
     console.info(`No changes to ${output}`);
-    return;
+    return { skipped: true };
   }
 
   if (verifyNoUpdates) {
@@ -81,6 +81,7 @@ function generateTopojson(fc, { OUT_PATH, verifyNoUpdates }) {
   }
 
   writeJSON(OUT_PATH, topo);
+  return { skipped: false };
 }
 
 export { generateTopojson };

--- a/web/geo/generateWorld.ts
+++ b/web/geo/generateWorld.ts
@@ -7,6 +7,7 @@ import { generateExchangesToIgnore } from './generateExchangesToExclude.js';
 import { generateTopojson } from './generateTopojson.js';
 import { getJSON, round } from './utilities.js';
 import { validateGeometry } from './validate.js';
+import { createHash } from 'node:crypto';
 
 const config = {
   WORLD_PATH: path.resolve(fileURLToPath(new URL('world.geojson', import.meta.url))),
@@ -35,6 +36,12 @@ coordEach(fc, (coord) => {
   coord[1] = round(coord[1], 4);
 });
 
-validateGeometry(fc, config);
-generateTopojson(fc, config);
+const { skipped } = generateTopojson(fc, config);
+
 generateExchangesToIgnore(EXCHANGE_OUT_PATH, zoneConfig);
+
+if (skipped === true) {
+  console.info('No changes to world.json');
+} else {
+  validateGeometry(fc, config);
+}

--- a/web/geo/generateWorld.ts
+++ b/web/geo/generateWorld.ts
@@ -7,7 +7,6 @@ import { generateExchangesToIgnore } from './generateExchangesToExclude.js';
 import { generateTopojson } from './generateTopojson.js';
 import { getJSON, round } from './utilities.js';
 import { validateGeometry } from './validate.js';
-import { createHash } from 'node:crypto';
 
 const config = {
   WORLD_PATH: path.resolve(fileURLToPath(new URL('world.geojson', import.meta.url))),


### PR DESCRIPTION
## Issue
No real issue but will improve DX.

## Description
Speed up the generate-world file by skipping validation if the existing world file is identical to the generated one.

- [x] I have run `pnpx prettier --write .` and `poetry run format` to format my changes.
