### PR TITLE
add tooltip for zone titles longer than 20 char

### DIFF
--- a/web/src/features/panels/zone/ZoneHeaderTitle.tsx
+++ b/web/src/features/panels/zone/ZoneHeaderTitle.tsx
@@ -44,19 +44,24 @@ export default function ZoneHeaderTitle({
                 size={18}
                 className="shadow-[0_0px_3px_rgba(0,0,0,0.2)]"
               />
-              <div className="ml-2 flex flex-row">
-                <h2
-                  className="max-w-[300px] overflow-hidden truncate text-lg font-medium sm:max-w-[230px] md:max-w-[270px]"
-                  data-test-id="zone-name"
-                >
-                  {title}
-                </h2>
-                {isSubZone && (
-                  <p className="ml-2 flex w-auto items-center whitespace-nowrap rounded-full bg-gray-200 py-0.5 px-2  text-sm dark:bg-gray-900">
-                    {countryName || zoneId}
-                  </p>
-                )}
-              </div>
+              <TooltipWrapper
+                tooltipContent={title.length > 20 ? title : undefined}
+                side="bottom"
+              >
+                <div className="ml-2 flex flex-row">
+                  <h2
+                    className="max-w-[300px] overflow-hidden truncate text-lg font-medium sm:max-w-[230px] md:max-w-[270px]"
+                    data-test-id="zone-name"
+                  >
+                    {title}
+                  </h2>
+                  {isSubZone && (
+                    <p className="ml-2 flex w-auto items-center whitespace-nowrap rounded-full bg-gray-200 py-0.5 px-2  text-sm dark:bg-gray-900">
+                      {countryName || zoneId}
+                    </p>
+                  )}
+                </div>
+              </TooltipWrapper>
             </div>
             {disclaimer && (
               <TooltipWrapper side="bottom" tooltipContent={disclaimer}>


### PR DESCRIPTION
## Issue
Some zones have extra long names which are then truncated in the zone title

## Description
This PR adds a tooltip of the zone name to zone titles that are longer than 20 char.

<img width="409" alt="image" src="https://user-images.githubusercontent.com/18622768/225105283-6e55ecf5-ca8e-44b1-8ba9-8fc75ee7a1c4.png">

