### PR TITLE
[TW] add http status for parser data

### DIFF
--- a/parsers/TW.py
+++ b/parsers/TW.py
@@ -9,6 +9,7 @@ import pandas as pd
 from requests import Session
 
 from parsers.lib.config import refetch_frequency
+from parsers.lib.exceptions import ParserException
 
 
 @refetch_frequency(timedelta(days=1))
@@ -24,6 +25,10 @@ def fetch_production(
     url = "http://www.taipower.com.tw/d006/loadGraph/loadGraph/data/genary.txt"
     s = session or Session()
     response = s.get(url)
+    if not response.status_code == 200:
+        raise ParserException(
+            f"Query failed with status code {response.status_code} and {response.content}"
+        )
     data = response.json()
 
     dumpDate = data[""]


### PR DESCRIPTION
## Issue
When we run the parser for TW locally, we get data from the data source. 

However, when it runs on GCP we don't get any data and the JSON is None, so there is no data stored in the parser_data table. 


## Description
This PR is linked to this issue on Linear regarding missing data for TW.


### Preview

If we run it locally we get the following response 

![image](https://user-images.githubusercontent.com/50823290/225317459-48f8a376-79d2-43cd-947a-f9746068f7dd.png)


Whereas when it runs on GCP, we get the following error:

![image](https://user-images.githubusercontent.com/50823290/225317603-6e7c4f63-4c8b-478f-af6a-b10e1d81c238.png)


### Double check

- [x] I have tested my parser changes locally with `poetry run test_parser "zone_key"`
- [x] I have run `pnpx prettier --write .` and `poetry run format` to format my changes.
