### PR TITLE
WIP: exchange capacity parsing for the ENTSO-E parser

### DIFF
--- a/parsers/ENTSOE.py
+++ b/parsers/ENTSOE.py
@@ -1605,8 +1605,3 @@ def fetch_wind_solar_forecasts(
         )
 
     return data
-
-
-if __name__ == "__main__":
-    session = Session()
-    print()


### PR DESCRIPTION
## Description

Adds exchange capacity parsing for the ENTSO-E parser using the day-ahead capacity information (A61).

This still need some testing and such but it's open for comments.
Unfortunately, less zones than I was initially expecting had live capacity data for exchanges, but it does work well when it is available, and it will gracefully fall back if it's not.

One thing to note is that I needed to add 2 api calls to get this data so we might have to plan for that in the rate limits and wait for [ELE-1595](https://linear.app/electricitymaps/issue/ELE-1595/rotate-ips-for-entso-e-to-avoid-hitting-rate-limits) until we merge this (1 api call if there is no data).

Also, just to note: This is technically forecasted capacity data but it should be orders of magnitudes more accurate than the static factors. 

### Preview
```python
 {'capacity': [-2300.0, 3653.0],
  'datetime': datetime.datetime(2023, 3, 13, 18, 0, tzinfo=tzutc()),
  'netFlow': 2528.0,
  'sortedZoneKeys': 'ES->FR',
  'source': 'entsoe.eu'}
```

### Double check

- [x] I have tested my parser changes locally with `poetry run test_parser "zone_key"`
- [x] I have run `pnpx prettier --write .` and `poetry run format` to format my changes.
