### PR TITLE
Fix error in ParserException - add zone_code in ParserException

### DIFF
--- a/parsers/TW.py
+++ b/parsers/TW.py
@@ -27,7 +27,8 @@ def fetch_production(
     response = s.get(url)
     if not response.status_code == 200:
         raise ParserException(
-            f"Query failed with status code {response.status_code} and {response.content}"
+            "TW",
+            f"Query failed with status code {response.status_code} and {response.content}",
         )
     data = response.json()
 


### PR DESCRIPTION
## Issue

TW parser returns no data when we run it on GCP. We are trying to get more information by logging the status code in order to know what is going on, since we can run the parser locally without problems. 

## Description

When we wrote the ParserException call, we did not include the `ZONE_ID` so the exception could not be raised. This is fixed in this PR. 

### Double check

- [X] I have tested my parser changes locally with `poetry run test_parser "zone_key"`
- [X] I have run `pnpx prettier --write .` and `poetry run format` to format my changes.
