### PR TITLE
common helper for fossil fuel ratio

### DIFF
--- a/web/src/features/map/MapTooltip.tsx
+++ b/web/src/features/map/MapTooltip.tsx
@@ -16,6 +16,7 @@ import {
   timeAverageAtom,
 } from 'utils/state/atoms';
 import { hoveredZoneAtom, mapMovingAtom, mousePositionAtom } from './mapAtoms';
+import { getFossilFuelPercentage } from 'utils/helpers';
 
 function TooltipInner({
   zoneData,
@@ -38,7 +39,11 @@ function TooltipInner({
 
   const [currentMode] = useAtom(productionConsumptionAtom);
   const isConsumption = currentMode === Mode.CONSUMPTION;
-  const fossilFuel = (isConsumption ? fossilFuelRatio : fossilFuelRatioProduction) ?? 0;
+  const fossilFuelPercentage = getFossilFuelPercentage(
+    isConsumption,
+    fossilFuelRatio,
+    fossilFuelRatioProduction
+  );
   return (
     <div className="w-full text-center">
       <div className="pl-2">
@@ -51,7 +56,10 @@ function TooltipInner({
             intensity={isConsumption ? co2intensity : co2intensityProduction}
           />
           <div className="pl-2 pr-6">
-            <CircularGauge name={__('country-panel.lowcarbon')} ratio={1 - fossilFuel} />
+            <CircularGauge
+              name={__('country-panel.lowcarbon')}
+              ratio={fossilFuelPercentage}
+            />
           </div>
           <CircularGauge
             name={__('country-panel.renewable')}

--- a/web/src/features/panels/zone/ZoneHeader.tsx
+++ b/web/src/features/panels/zone/ZoneHeader.tsx
@@ -3,6 +3,7 @@ import { CircularGauge } from 'components/CircularGauge';
 import { useAtom } from 'jotai';
 import { useTranslation } from 'translation/translation';
 import { Mode } from 'utils/constants';
+import { getFossilFuelPercentage } from 'utils/helpers';
 import { productionConsumptionAtom } from 'utils/state/atoms';
 import ZoneHeaderTitle from './ZoneHeaderTitle';
 
@@ -46,8 +47,11 @@ export function ZoneHeader({
   const isConsumption = currentMode === Mode.CONSUMPTION;
   const intensity = isConsumption ? co2intensity : co2intensityProduction;
   const renewable = isConsumption ? renewableRatio : renewableRatioProduction;
-  const fossilFuel =
-    (isConsumption ? fossilFuelRatio : fossilFuelRatioProduction) ?? null;
+  const fossilFuelPercentage = getFossilFuelPercentage(
+    isConsumption,
+    fossilFuelRatio,
+    fossilFuelRatioProduction
+  );
 
   return (
     <div className="mt-1 grid w-full gap-y-5 sm:pr-4">
@@ -64,7 +68,7 @@ export function ZoneHeader({
         />
         <CircularGauge
           name={__('country-panel.lowcarbon')}
-          ratio={fossilFuel ? 1 - fossilFuel : Number.NaN}
+          ratio={fossilFuelPercentage}
           tooltipContent={<LowCarbonTooltip />}
           testId="zone-header-lowcarbon-gauge"
         />

--- a/web/src/utils/helpers.test.ts
+++ b/web/src/utils/helpers.test.ts
@@ -1,0 +1,59 @@
+import { getFossilFuelPercentage } from './helpers';
+
+describe('getFossilFuelPercentage', () => {
+  // Tests for consumption
+  describe('consumption', () => {
+    it('returns 1 when fossil fuel ratio is 0', () => {
+      const actual = getFossilFuelPercentage(true, 0, 0);
+      expect(actual).toBe(1);
+    });
+
+    it('returns 0 when fossil fuel ratio is 1', () => {
+      const actual = getFossilFuelPercentage(true, 1, 1);
+      expect(actual).toBe(0);
+    });
+
+    it('returns NaN when fossil fuel ratio is null', () => {
+      const actual = getFossilFuelPercentage(true, null, null);
+      expect(actual).toBeNaN();
+    });
+
+    it('returns NaN when fossil fuel ratio is undefined', () => {
+      const actual = getFossilFuelPercentage(true, undefined, undefined);
+      expect(actual).toBeNaN();
+    });
+
+    it('returns 1 - fossil fuel ratio when fossil fuel ratio is between 0 and 1', () => {
+      const actual = getFossilFuelPercentage(true, 0.3, 0.5);
+      expect(actual).toBe(0.7);
+    });
+  });
+
+  // Tests for production
+  describe('production', () => {
+    it('returns 1 when fossil fuel ratio is 0', () => {
+      const actual = getFossilFuelPercentage(false, 0, 0);
+      expect(actual).toBe(1);
+    });
+
+    it('returns 0 when fossil fuel ratio is 1', () => {
+      const actual = getFossilFuelPercentage(false, 1, 1);
+      expect(actual).toBe(0);
+    });
+
+    it('returns NaN when fossil fuel ratio is null', () => {
+      const actual = getFossilFuelPercentage(false, null, null);
+      expect(actual).toBeNaN();
+    });
+
+    it('returns NaN when fossil fuel ratio is undefined', () => {
+      const actual = getFossilFuelPercentage(false, undefined, undefined);
+      expect(actual).toBeNaN();
+    });
+
+    it('returns 1 - fossil fuel ratio when fossil fuel ratio is between 0 and 1', () => {
+      const actual = getFossilFuelPercentage(false, 0.5, 0.3);
+      expect(actual).toBe(0.7);
+    });
+  });
+});

--- a/web/src/utils/helpers.ts
+++ b/web/src/utils/helpers.ts
@@ -58,9 +58,9 @@ export function createToWithState(to: string) {
  */
 export function getFossilFuelPercentage(
   isConsumption: boolean,
-  fossilFuelRatio: number | undefined,
-  fossilFuelRatioProduction: number | undefined
-) {
+  fossilFuelRatio: number | null | undefined,
+  fossilFuelRatioProduction: number | null | undefined
+): number {
   const fossilFuelRatioToUse = isConsumption
     ? fossilFuelRatio
     : fossilFuelRatioProduction;

--- a/web/src/utils/helpers.ts
+++ b/web/src/utils/helpers.ts
@@ -49,3 +49,34 @@ export function getProductionCo2Intensity(
 export function createToWithState(to: string) {
   return `${to}${location.search}${location.hash}`;
 }
+
+/**
+ * Returns the fossil fuel percentage of a zone
+ * @param isConsumption - Whether the percentage is for consumption or production
+ * @param fossilFuelRatio - The fossil fuel ratio for consumption
+ * @param fossilFuelRatioProduction - The fossil fuel ratio for production
+ */
+export function getFossilFuelPercentage(
+  isConsumption: boolean,
+  fossilFuelRatio: number | undefined,
+  fossilFuelRatioProduction: number | undefined
+) {
+  const fossilFuelRatioToUse = isConsumption
+    ? fossilFuelRatio
+    : fossilFuelRatioProduction;
+  switch (fossilFuelRatioToUse) {
+    case 0: {
+      return 1;
+    }
+    case 1: {
+      return 0;
+    }
+    case null:
+    case undefined: {
+      return Number.NaN;
+    }
+    default: {
+      return 1 - fossilFuelRatioToUse;
+    }
+  }
+}


### PR DESCRIPTION
## Issue
resolves: #5207 

## Description

Introduce a common helper to get the fossil fuel ratio, this reduce code duplication and the new helper function should be more robust.

This should also prevent any miss matches between the tooltip and the left panel as observed in #5207 

## Todo:

- [x] Add unit tests to cover the new helper function.

### Double check

- [x] I have run `pnpx prettier --write .` and `poetry run format` to format my changes.
