### PR TITLE
close dropdown on outside click

### DIFF
--- a/web/src/components/Button.tsx
+++ b/web/src/components/Button.tsx
@@ -15,6 +15,7 @@ interface ButtonProps {
   href?: string;
   className?: string;
   onClick?: () => void;
+  renderAsDiv?: boolean;
 }
 
 export function Button({
@@ -25,10 +26,13 @@ export function Button({
   textColor,
   href,
   className,
+  renderAsDiv,
   ...restProps
 }: ButtonProps) {
   const renderAsLink = Boolean(href);
-  const As = renderAsLink ? 'a' : 'button';
+  const ButtonOrDiv = renderAsDiv ? 'div' : 'button';
+  const As = renderAsLink ? 'a' : ButtonOrDiv;
+
   const isIconOnly = !children && Boolean(icon);
 
   return (

--- a/web/src/components/Button.tsx
+++ b/web/src/components/Button.tsx
@@ -30,8 +30,8 @@ export function Button({
   ...restProps
 }: ButtonProps) {
   const renderAsLink = Boolean(href);
-  const ButtonOrDiv = renderAsDiv ? 'div' : 'button';
-  const As = renderAsLink ? 'a' : ButtonOrDiv;
+  const buttonOrDiv = renderAsDiv ? 'div' : 'button';
+  const As = renderAsLink ? 'a' : buttonOrDiv;
 
   const isIconOnly = !children && Boolean(icon);
 

--- a/web/src/features/map-controls/LanguageSelector.tsx
+++ b/web/src/features/map-controls/LanguageSelector.tsx
@@ -24,7 +24,7 @@ export function LanguageSelector({ isMobile }: { isMobile?: boolean }) {
     <MapOptionSelector
       trigger={
         isMobile ? (
-          <Button icon={<HiLanguage size={21} />} className="mb-0">
+          <Button renderAsDiv icon={<HiLanguage size={21} />} className="mb-0">
             {__('tooltips.selectLanguage')}
           </Button>
         ) : (

--- a/web/src/features/map-controls/MapControls.cy.tsx
+++ b/web/src/features/map-controls/MapControls.cy.tsx
@@ -9,14 +9,17 @@ it('can change language', () => {
   cy.contains('zone');
   cy.contains('production');
   cy.contains('consumption');
+  cy.get('[data-test-id=language-selector-open-button]').click();
   cy.contains('Deutsch').click();
   cy.contains('Produktion');
   cy.contains('Verbrauch');
+  cy.get('[data-test-id=language-selector-open-button]').click();
   cy.contains('Svenska').click();
   cy.contains('produktion');
   cy.contains('konsumtion');
   cy.contains('land');
   cy.contains('zon');
+  cy.get('[data-test-id=language-selector-open-button]').click();
   cy.contains('English').click();
 });
 
@@ -30,6 +33,7 @@ it('can change theme', () => {
     .should(() => {
       expect(localStorage.getItem('theme')).to.eq('"light"');
     });
+  cy.get('[data-test-id=theme-selector-open-button]').click();
   cy.contains('Dark')
     .click()
     .should(() => {

--- a/web/src/features/map-controls/MapOptionSelector.tsx
+++ b/web/src/features/map-controls/MapOptionSelector.tsx
@@ -19,9 +19,6 @@ export default function MapOptionSelector({
   const toggleTooltip = () => {
     setIsOpen(!isOpen);
   };
-  // if (!trigger) {
-  //   return null;
-  // }
   return (
     <Root open={isOpen} modal={false}>
       <Trigger

--- a/web/src/features/map-controls/MapOptionSelector.tsx
+++ b/web/src/features/map-controls/MapOptionSelector.tsx
@@ -19,8 +19,11 @@ export default function MapOptionSelector({
   const toggleTooltip = () => {
     setIsOpen(!isOpen);
   };
+  // if (!trigger) {
+  //   return null;
+  // }
   return (
-    <Root open={isOpen} onOpenChange={toggleTooltip} modal={false}>
+    <Root open={isOpen} modal={false}>
       <Trigger
         className={isOpen ? 'pointer-events-none' : 'pointer-events-auto'}
         data-test-id={testId}
@@ -30,10 +33,11 @@ export default function MapOptionSelector({
       </Trigger>
       <Portal>
         <Content
-          className="pointer-events-auto z-30 max-h-[190px] w-[120px] overflow-auto rounded bg-white dark:bg-gray-900"
+          className="pointer-events-auto z-40 max-h-[190px] w-[120px] overflow-auto rounded bg-white dark:bg-gray-900"
           sideOffset={5}
           side={isMobile ? 'bottom' : 'left'}
           onClick={toggleTooltip}
+          onPointerDownOutside={toggleTooltip}
         >
           {children}
           <Arrow className="fill-white dark:fill-gray-900" />

--- a/web/src/features/map-controls/MapOptionSelector.tsx
+++ b/web/src/features/map-controls/MapOptionSelector.tsx
@@ -1,5 +1,6 @@
 import { useTranslation } from 'translation/translation';
 import { Root, Trigger, Portal, Content, Arrow } from '@radix-ui/react-dropdown-menu';
+import { useState } from 'react';
 
 interface MapOptionSelectorProps {
   trigger: React.ReactNode;
@@ -14,17 +15,25 @@ export default function MapOptionSelector({
   isMobile,
 }: MapOptionSelectorProps) {
   const { __ } = useTranslation();
-
+  const [isOpen, setIsOpen] = useState(false);
+  const toggleTooltip = () => {
+    setIsOpen(!isOpen);
+  };
   return (
-    <Root>
-      <Trigger className="pointer-events-auto" data-test-id={testId}>
+    <Root open={isOpen} onOpenChange={toggleTooltip} modal={false}>
+      <Trigger
+        className={isOpen ? 'pointer-events-none' : 'pointer-events-auto'}
+        data-test-id={testId}
+        onClick={toggleTooltip}
+      >
         {trigger}
       </Trigger>
       <Portal>
         <Content
-          className="pointer-events-auto z-50 max-h-[190px] w-[120px] overflow-auto rounded bg-white dark:bg-gray-900"
+          className="pointer-events-auto z-30 max-h-[190px] w-[120px] overflow-auto rounded bg-white dark:bg-gray-900"
           sideOffset={5}
           side={isMobile ? 'bottom' : 'left'}
+          onClick={toggleTooltip}
         >
           {children}
           <Arrow className="fill-white dark:fill-gray-900" />

--- a/web/src/features/map-controls/ThemeSelector.tsx
+++ b/web/src/features/map-controls/ThemeSelector.tsx
@@ -33,6 +33,7 @@ export default function ThemeSelector({ isMobile }: { isMobile?: boolean }) {
       trigger={
         isMobile ? (
           <Button
+            renderAsDiv
             icon={<BsMoonStars size={14} style={{ strokeWidth: '0.2' }} />}
             className="my-0"
           >

--- a/web/src/features/modals/SettingsModal.cy.tsx
+++ b/web/src/features/modals/SettingsModal.cy.tsx
@@ -11,14 +11,17 @@ it('can change language', () => {
   cy.contains('zone');
   cy.contains('production');
   cy.contains('consumption');
+  cy.get('[data-test-id=language-selector-open-button]').click();
   cy.contains('Deutsch').click();
   cy.contains('Produktion');
   cy.contains('Verbrauch');
+  cy.get('[data-test-id=language-selector-open-button]').click();
   cy.contains('Svenska').click();
   cy.contains('produktion');
   cy.contains('konsumtion');
   cy.contains('land');
   cy.contains('zon');
+  cy.get('[data-test-id=language-selector-open-button]').click();
   cy.contains('English').click();
 });
 
@@ -32,6 +35,7 @@ it('can change theme', () => {
     .should(() => {
       expect(localStorage.getItem('theme')).to.eq('"light"');
     });
+  cy.get('[data-test-id=theme-selector-open-button]').click();
   cy.contains('Dark')
     .click()
     .should(() => {


### PR DESCRIPTION
## Issue
Mobile issue where closing the modal while a dropdown menu was open left the app in a frozen state

## Description
Using multiple radix components with portals can cause strange interactions, the outside click for the modal didn't properly close the portal for the dropdown menu leaving the pointer-events: none state on the body element. 

The fix to this was to specify modal={false} in the child portal, in this case the dropdown menu.

Also added closing of the dropdown menu when a value is selected.