### PR TITLE
Fixes net exchanges not always appearing in the graph when changing selected time

### DIFF
--- a/web/src/features/charts/bar-breakdown/utils.test.ts
+++ b/web/src/features/charts/bar-breakdown/utils.test.ts
@@ -303,18 +303,33 @@ describe('getDataBlockPositions', () => {
 
 describe('getExchangesToDisplay', () => {
   it('shows aggregated exchanges only when required', () => {
-    const ZoneExchanges = ['AT', 'BE', 'NO', 'NO-NO2'];
-    const result = getExchangesToDisplay('DE', true, ZoneExchanges);
+    const ZoneStates = {
+      date1: {
+        ...zoneDetailsData,
+        exchange: { AT: -934, BE: 934, NO: -934, 'NO-NO2': -500 },
+      },
+    };
+    const result = getExchangesToDisplay('DE', true, ZoneStates);
     expect(result).toEqual(['AT', 'BE', 'NO']);
   });
   it('shows non-aggregated exchanges only when required', () => {
-    const ZoneExchanges = ['AT', 'BE', 'NO', 'NO-NO2'];
-    const result = getExchangesToDisplay('DE', false, ZoneExchanges);
+    const ZoneStates = {
+      date1: {
+        ...zoneDetailsData,
+        exchange: { AT: -934, BE: 934, NO: -934, 'NO-NO2': -500 },
+      },
+    };
+    const result = getExchangesToDisplay('DE', false, ZoneStates);
     expect(result).toEqual(['AT', 'BE', 'NO-NO2']);
   });
   it('handles empty exchange', () => {
-    const ZoneExchanges = [] as string[];
-    const result = getExchangesToDisplay('DE', false, ZoneExchanges);
+    const ZoneStates = {
+      date1: {
+        ...zoneDetailsData,
+        exchange: {},
+      },
+    };
+    const result = getExchangesToDisplay('DE', false, ZoneStates);
     expect(result).toEqual([]);
   });
 });

--- a/web/src/features/charts/bar-breakdown/utils.test.ts
+++ b/web/src/features/charts/bar-breakdown/utils.test.ts
@@ -3,6 +3,7 @@ import {
   getProductionData,
   getElectricityProductionValue,
   ExchangeDataType,
+  getExchangesToDisplay,
 } from './utils';
 
 const zoneDetailsData = {
@@ -297,5 +298,23 @@ describe('getDataBlockPositions', () => {
       productionY: 22,
       productionHeight: 240,
     });
+  });
+});
+
+describe('getExchangesToDisplay', () => {
+  it('shows aggregated exchanges only when required', () => {
+    const ZoneExchanges = ['AT', 'BE', 'NO', 'NO-NO2'];
+    const result = getExchangesToDisplay('DE', true, ZoneExchanges);
+    expect(result).toEqual(['AT', 'BE', 'NO']);
+  });
+  it('shows non-aggregated exchanges only when required', () => {
+    const ZoneExchanges = ['AT', 'BE', 'NO', 'NO-NO2'];
+    const result = getExchangesToDisplay('DE', false, ZoneExchanges);
+    expect(result).toEqual(['AT', 'BE', 'NO-NO2']);
+  });
+  it('handles empty exchange', () => {
+    const ZoneExchanges = [] as string[];
+    const result = getExchangesToDisplay('DE', false, ZoneExchanges);
+    expect(result).toEqual([]);
   });
 });

--- a/web/src/features/charts/bar-breakdown/utils.ts
+++ b/web/src/features/charts/bar-breakdown/utils.ts
@@ -2,7 +2,6 @@ import { max as d3Max } from 'd3-array';
 import {
   ElectricityModeType,
   ElectricityStorageKeyType,
-  Exchange,
   GenerationType,
   Maybe,
   ZoneDetail,
@@ -163,7 +162,7 @@ export const getExchangeData = (
 export const getExchangesToDisplay = (
   currentZoneKey: ZoneKey,
   isAggregatedToggled: boolean,
-  exchangeZoneKeysForCurrentZone: Exchange
+  exchangeZoneKeysForCurrentZone: ZoneKey[]
 ): ZoneKey[] => {
   const exchangeKeysToRemove = isAggregatedToggled
     ? exchangesToExclude.exchangesToExcludeCountryView
@@ -179,10 +178,7 @@ export const getExchangesToDisplay = (
     })
   );
 
-  const currentExchanges = Object.keys(exchangeZoneKeysForCurrentZone);
-  return currentExchanges
-    ? currentExchanges.filter(
-        (exchangeZoneKey) => !exchangeZoneKeysToRemove.has(exchangeZoneKey)
-      )
-    : [];
+  return exchangeZoneKeysForCurrentZone.filter(
+    (exchangeZoneKey) => !exchangeZoneKeysToRemove.has(exchangeZoneKey)
+  );
 };

--- a/web/src/features/charts/bar-breakdown/utils.ts
+++ b/web/src/features/charts/bar-breakdown/utils.ts
@@ -162,7 +162,9 @@ export const getExchangeData = (
 export const getExchangesToDisplay = (
   currentZoneKey: ZoneKey,
   isAggregatedToggled: boolean,
-  exchangeZoneKeysForCurrentZone: ZoneKey[]
+  zoneStates: {
+    [key: string]: ZoneDetail;
+  }
 ): ZoneKey[] => {
   const exchangeKeysToRemove = isAggregatedToggled
     ? exchangesToExclude.exchangesToExcludeCountryView
@@ -178,7 +180,16 @@ export const getExchangesToDisplay = (
     })
   );
 
-  return exchangeZoneKeysForCurrentZone.filter(
+  // get all exchanges for the given period
+  const allExchangeKeys = new Set<string>();
+  for (const state of Object.values(zoneStates)) {
+    for (const key of Object.keys(state.exchange)) {
+      allExchangeKeys.add(key);
+    }
+  }
+  const uniqueExchangeKeys = [...allExchangeKeys];
+
+  return uniqueExchangeKeys.filter(
     (exchangeZoneKey) => !exchangeZoneKeysToRemove.has(exchangeZoneKey)
   );
 };

--- a/web/src/features/charts/hooks/useBarElectricityBreakdownChartData.ts
+++ b/web/src/features/charts/hooks/useBarElectricityBreakdownChartData.ts
@@ -44,7 +44,7 @@ export default function useBarBreakdownChartData() {
   const exchangeKeys = getExchangesToDisplay(
     zoneId,
     isAggregateToggled,
-    zoneData?.zoneStates
+    zoneData.zoneStates
   );
 
   const productionData = getProductionData(currentData); // TODO: Consider memoing this

--- a/web/src/features/charts/hooks/useBarElectricityBreakdownChartData.ts
+++ b/web/src/features/charts/hooks/useBarElectricityBreakdownChartData.ts
@@ -44,7 +44,7 @@ export default function useBarBreakdownChartData() {
   const exchangeKeys = getExchangesToDisplay(
     zoneId,
     isAggregateToggled,
-    currentData.exchange
+    zoneData?.zoneStates
   );
 
   const productionData = getProductionData(currentData); // TODO: Consider memoing this

--- a/web/src/features/charts/hooks/useBreakdownChartData.ts
+++ b/web/src/features/charts/hooks/useBreakdownChartData.ts
@@ -10,12 +10,12 @@ import { scalePower } from 'utils/formatting';
 import {
   displayByEmissionsAtom,
   productionConsumptionAtom,
-  selectedDatetimeIndexAtom,
   spatialAggregateAtom,
 } from 'utils/state/atoms';
 import { getExchangesToDisplay } from '../bar-breakdown/utils';
 import { getGenerationTypeKey } from '../graphUtils';
 import { AreaGraphElement } from '../types';
+import { useParams } from 'react-router-dom';
 
 export const getLayerFill = (
   exchangeKeys: string[],
@@ -37,20 +37,19 @@ export const getLayerFill = (
 export default function useBreakdownChartData() {
   const { data: zoneData, isLoading, isError } = useGetZone();
   const co2ColorScale = useCo2ColorScale();
+  const { zoneId } = useParams();
   const [mixMode] = useAtom(productionConsumptionAtom);
   const [displayByEmissions] = useAtom(displayByEmissionsAtom);
   const [aggregateToggle] = useAtom(spatialAggregateAtom);
   const isAggregateToggled = aggregateToggle === ToggleOptions.ON;
-  const [selectedDatetime] = useAtom(selectedDatetimeIndexAtom);
-  const currentData = zoneData?.zoneStates?.[selectedDatetime.datetimeString];
-  if (isLoading || isError || !currentData) {
+  if (isLoading || isError || !zoneData || !zoneId) {
     return { isLoading, isError };
   }
 
   const exchangesForSelectedAggregate = getExchangesToDisplay(
-    currentData.zoneKey,
+    zoneId,
     isAggregateToggled,
-    currentData.exchange
+    zoneData?.zoneStates
   );
 
   const { valueFactor, valueAxisLabel } = getValuesInfo(

--- a/web/src/features/charts/hooks/useBreakdownChartData.ts
+++ b/web/src/features/charts/hooks/useBreakdownChartData.ts
@@ -49,7 +49,7 @@ export default function useBreakdownChartData() {
   const exchangesForSelectedAggregate = getExchangesToDisplay(
     zoneId,
     isAggregateToggled,
-    zoneData?.zoneStates
+    zoneData.zoneStates
   );
 
   const { valueFactor, valueAxisLabel } = getValuesInfo(


### PR DESCRIPTION
## Issue

Closes #5066

## Description


Due to the way we looked at what exchanges should appear in the breakdown graph (and the breakdown "table" too), we would only show exchanges if there was data for that specific timestamp - even though the graph shows all 24 hours.

### Preview

See before and after in this video:

https://user-images.githubusercontent.com/3296643/226741749-7b0bda1e-6634-4782-ba2d-9cbd8a7c94ef.mp4


### Double check

- [x] I have run `pnpx prettier --write .` and `poetry run format` to format my changes.
