### PR TITLE
Reduces panel re-rerenders when dragging timeslider

### DIFF
--- a/web/src/features/panels/zone/Attribution.tsx
+++ b/web/src/features/panels/zone/Attribution.tsx
@@ -1,8 +1,10 @@
 import { useMemo } from 'react';
+import { useAtom } from 'jotai';
 import { useTranslation } from 'translation/translation';
 import { formatDataSources } from 'utils/formatting';
 import { getContributors } from './util';
-
+import { selectedDatetimeIndexAtom } from 'utils/state/atoms';
+import { ZoneDetails } from 'types';
 export function removeDuplicateSources(source: string | undefined) {
   if (!source) {
     return [''];
@@ -20,13 +22,16 @@ export function removeDuplicateSources(source: string | undefined) {
 }
 
 export default function Attribution({
-  dataSources,
+  data,
   zoneId,
 }: {
   zoneId: string;
-  dataSources?: string;
+  data?: ZoneDetails;
 }) {
   const { __, i18n } = useTranslation();
+  const [selectedDatetime] = useAtom(selectedDatetimeIndexAtom);
+  const selectedData = data?.zoneStates[selectedDatetime.datetimeString];
+  const dataSources = selectedData?.source;
 
   // TODO: Handle sources formatting in DBT or app-backend
   const formattedDataSources = useMemo(() => {

--- a/web/src/features/panels/zone/ZoneDetails.tsx
+++ b/web/src/features/panels/zone/ZoneDetails.tsx
@@ -3,11 +3,7 @@ import BarBreakdownChart from 'features/charts/bar-breakdown/BarBreakdownChart';
 import { useAtom } from 'jotai';
 import { Navigate, useParams } from 'react-router-dom';
 import { TimeAverages } from 'utils/constants';
-import {
-  displayByEmissionsAtom,
-  selectedDatetimeIndexAtom,
-  timeAverageAtom,
-} from 'utils/state/atoms';
+import { displayByEmissionsAtom, timeAverageAtom } from 'utils/state/atoms';
 import AreaGraphContainer from './AreaGraphContainer';
 import Attribution from './Attribution';
 import DisplayByEmissionToggle from './DisplayByEmissionToggle';
@@ -20,7 +16,6 @@ export default function ZoneDetails(): JSX.Element {
   const { zoneId } = useParams();
   const [timeAverage] = useAtom(timeAverageAtom);
   const [displayByEmissions] = useAtom(displayByEmissionsAtom);
-  const [selectedDatetime] = useAtom(selectedDatetimeIndexAtom);
   const { data, isError, isLoading } = useGetZone({
     enabled: Boolean(zoneId),
   });
@@ -31,9 +26,6 @@ export default function ZoneDetails(): JSX.Element {
     return <Navigate to="/" replace />;
   }
 
-  // TODO: Fix rendering issue where this is shortly unavailable for some reason
-  const selectedData = data?.zoneStates[selectedDatetime.datetimeString];
-
   const zoneDataStatus = getZoneDataStatus(zoneId, data);
 
   const datetimes = Object.keys(data?.zoneStates || {})?.map((key) => new Date(key));
@@ -41,9 +33,8 @@ export default function ZoneDetails(): JSX.Element {
     <>
       <ZoneHeader
         zoneId={zoneId}
-        {...selectedData}
+        data={data}
         isAggregated={timeAverage !== TimeAverages.HOURLY}
-        isEstimated={selectedData?.estimationMethod !== undefined}
       />
       {zoneDataStatus !== ZoneDataStatus.NO_INFORMATION && <DisplayByEmissionToggle />}
       <div className="h-[calc(100%-290px)] overflow-y-scroll p-4 pt-2 pb-40">
@@ -61,7 +52,7 @@ export default function ZoneDetails(): JSX.Element {
               displayByEmissions={displayByEmissions}
             />
           )}
-          <Attribution dataSources={selectedData?.source} zoneId={zoneId} />
+          <Attribution data={data} zoneId={zoneId} />
         </ZoneDetailsContent>
       </div>
     </>

--- a/web/src/features/panels/zone/ZoneHeader.tsx
+++ b/web/src/features/panels/zone/ZoneHeader.tsx
@@ -4,8 +4,9 @@ import { useAtom } from 'jotai';
 import { useTranslation } from 'translation/translation';
 import { Mode } from 'utils/constants';
 import { getFossilFuelPercentage } from 'utils/helpers';
-import { productionConsumptionAtom } from 'utils/state/atoms';
+import { productionConsumptionAtom, selectedDatetimeIndexAtom } from 'utils/state/atoms';
 import ZoneHeaderTitle from './ZoneHeaderTitle';
+import { ZoneDetails } from 'types';
 
 function LowCarbonTooltip() {
   const { __ } = useTranslation();
@@ -21,30 +22,27 @@ function LowCarbonTooltip() {
 
 interface ZoneHeaderProps {
   zoneId: string;
-  isEstimated?: boolean;
+  data: ZoneDetails | undefined;
   isAggregated?: boolean;
-  co2intensity?: number;
-  renewableRatio?: number;
-  fossilFuelRatio?: number;
-  co2intensityProduction?: number;
-  renewableRatioProduction?: number;
-  fossilFuelRatioProduction?: number;
 }
 
-export function ZoneHeader({
-  zoneId,
-  isEstimated,
-  isAggregated,
-  co2intensity,
-  renewableRatio,
-  fossilFuelRatio,
-  co2intensityProduction,
-  renewableRatioProduction,
-  fossilFuelRatioProduction,
-}: ZoneHeaderProps) {
+export function ZoneHeader({ zoneId, data, isAggregated }: ZoneHeaderProps) {
   const { __ } = useTranslation();
   const [currentMode] = useAtom(productionConsumptionAtom);
+  const [selectedDatetime] = useAtom(selectedDatetimeIndexAtom);
   const isConsumption = currentMode === Mode.CONSUMPTION;
+  const selectedData = data?.zoneStates[selectedDatetime.datetimeString];
+
+  const {
+    co2intensity,
+    renewableRatio,
+    fossilFuelRatio,
+    co2intensityProduction,
+    renewableRatioProduction,
+    fossilFuelRatioProduction,
+    estimationMethod,
+  } = selectedData || {};
+
   const intensity = isConsumption ? co2intensity : co2intensityProduction;
   const renewable = isConsumption ? renewableRatio : renewableRatioProduction;
   const fossilFuelPercentage = getFossilFuelPercentage(
@@ -52,6 +50,7 @@ export function ZoneHeader({
     fossilFuelRatio,
     fossilFuelRatioProduction
   );
+  const isEstimated = estimationMethod !== undefined;
 
   return (
     <div className="mt-1 grid w-full gap-y-5 sm:pr-4">


### PR DESCRIPTION
## Description

While working on #5222, I found that a lot of components were rerendering when changing the selected time, even though they didn't need this.

I have solved this here by moving the logic down to the few components that actually need it :)

### Preview

**Before**
![Screenshot 2023-03-22 at 21 32 11](https://user-images.githubusercontent.com/3296643/227032667-cef9f9d1-4404-44b1-928c-769c76c51cff.png)

**After**
![Screenshot 2023-03-22 at 21 32 37](https://user-images.githubusercontent.com/3296643/227032661-28e13001-7a7a-47f5-a3e2-a8f7c9255b8c.png)



### Double check

- [x] I have run `pnpx prettier --write .` and `poetry run format` to format my changes.
