### PR TITLE
fix aggregateButtons country-zone toggle translation [de.json]

### DIFF
--- a/web/public/locales/de.json
+++ b/web/public/locales/de.json
@@ -125,6 +125,10 @@
     "zoomOut": "Raus zoomen",
     "aggregateInfo": "Wechsel zwischen spezifischer Zonenansicht und aggregierter Länderansicht"
   },
+  "aggregateButtons": {
+    "country": "Land",
+    "zone": "Gebiet"
+  },
   "themeOptions": {
     "dark": "Dunkel",
     "light": "Hell",


### PR DESCRIPTION
## Issue

translation for country-zone toggle missing as mentioned in issue #4689.

## Description

Added translation for german in the country-zone toggle by using the [web/public/locales/sv.json](https://github.com/electricitymaps/electricitymaps-contrib/blob/ec7d7c8b16e1bb285ea209ff96e56870cc92d03c/web/public/locales/sv.json#L173-L175) template, which works with the current web version. 

### Preview

Did not run it locally. 