### PR TITLE
allow landscape for android and hide header when native

### DIFF
--- a/mobileapp/android/app/build.gradle
+++ b/mobileapp/android/app/build.gradle
@@ -6,8 +6,8 @@ android {
         applicationId "com.tmrow.electricitymap"
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
-        versionCode 101200
-        versionName "1.12.0"
+        versionCode 101700
+        versionName "1.17.0"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         aaptOptions {
              // Files and dirs to omit from the packaged assets dir, modified to accommodate modern web apps.

--- a/mobileapp/android/app/src/main/AndroidManifest.xml
+++ b/mobileapp/android/app/src/main/AndroidManifest.xml
@@ -15,7 +15,7 @@
             android:theme="@style/AppTheme.NoActionBarLaunch"
             android:launchMode="singleTask"
             android:exported="true"
-            android:screenOrientation="portrait">
+            android:screenOrientation="unspecified">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />

--- a/mobileapp/ios/App/App.xcodeproj/project.pbxproj
+++ b/mobileapp/ios/App/App.xcodeproj/project.pbxproj
@@ -194,10 +194,10 @@
 			buildActionMask = 2147483647;
 			files = (
 			);
-			inputPaths = (
+			inputFileListPaths = (
 			);
 			name = "[CP] Embed Pods Frameworks";
-			outputPaths = (
+			outputFileListPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;

--- a/mobileapp/ios/App/App.xcodeproj/project.pbxproj
+++ b/mobileapp/ios/App/App.xcodeproj/project.pbxproj
@@ -351,7 +351,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 1.12.3;
+				CURRENT_PROJECT_VERSION = 1.17.1;
 				DEVELOPMENT_TEAM = MP3LBAUPG8;
 				INFOPLIST_FILE = App/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = "Electricity Maps";
@@ -361,7 +361,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.12.3;
+				MARKETING_VERSION = 1.17.1;
 				OTHER_SWIFT_FLAGS = "$(inherited) \"-D\" \"COCOAPODS\" \"-DDEBUG\"";
 				PRODUCT_BUNDLE_IDENTIFIER = com.tmrow.electricitymap;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -380,7 +380,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 1.12.3;
+				CURRENT_PROJECT_VERSION = 1.17.1;
 				DEVELOPMENT_TEAM = MP3LBAUPG8;
 				INFOPLIST_FILE = App/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = "Electricity Maps";
@@ -390,7 +390,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.12.3;
+				MARKETING_VERSION = 1.17.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.tmrow.electricitymap;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";

--- a/mobileapp/package.json
+++ b/mobileapp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "electricitymaps-mobile",
-  "version": "1.12.0",
+  "version": "1.17.0",
   "description": "A real-time visualisation of the CO2 emissions of electricity consumption",
   "license": "AGPL-3.0-or-later",
   "main": "index.js",

--- a/web/src/components/Button.tsx
+++ b/web/src/components/Button.tsx
@@ -35,7 +35,7 @@ export function Button({
   return (
     <As
       className={twMerge(
-        `my-3 mx-2 flex w-fit items-center justify-center gap-x-2 rounded-full bg-white py-3 px-2 text-md font-bold shadow-[0px_0px_13px_rgb(0_0_0/12%)] transition duration-200 hover:shadow-[0px_0px_23px_rgb(0_0_0/20%)] dark:bg-gray-600 dark:hover:shadow-[0px_0px_23px_rgb(0_0_0/50%)]`,
+        `my-3 mx-2 flex min-h-[45px] w-fit items-center justify-center gap-x-2 rounded-full bg-white py-3 px-2 text-md font-bold shadow-[0px_0px_13px_rgb(0_0_0/12%)] transition duration-200 hover:shadow-[0px_0px_23px_rgb(0_0_0/20%)] dark:bg-gray-600 dark:hover:shadow-[0px_0px_23px_rgb(0_0_0/50%)]`,
         !isIconOnly && BUTTON_MIN_WIDTH_CLASS,
         `${disabled ? 'opacity-60 hover:shadow-[0px_0px_13px_rgb(0_0_0/12%)]' : ''}`,
         className

--- a/web/src/components/Button.tsx
+++ b/web/src/components/Button.tsx
@@ -15,7 +15,6 @@ interface ButtonProps {
   href?: string;
   className?: string;
   onClick?: () => void;
-  renderAsDiv?: boolean;
 }
 
 export function Button({
@@ -26,12 +25,10 @@ export function Button({
   textColor,
   href,
   className,
-  renderAsDiv,
   ...restProps
 }: ButtonProps) {
   const renderAsLink = Boolean(href);
-  const buttonOrDiv = renderAsDiv ? 'div' : 'button';
-  const As = renderAsLink ? 'a' : buttonOrDiv;
+  const As = renderAsLink ? 'a' : 'button';
 
   const isIconOnly = !children && Boolean(icon);
 

--- a/web/src/features/header/Header.tsx
+++ b/web/src/features/header/Header.tsx
@@ -1,6 +1,8 @@
 import * as NavigationMenu from '@radix-ui/react-navigation-menu';
 import trackEvent from 'utils/analytics';
 import Logo from './Logo';
+import { Capacitor } from '@capacitor/core';
+import { twMerge } from 'tailwind-merge';
 
 interface MenuLinkProps {
   href: string;
@@ -32,8 +34,14 @@ function MenuLink({ children, href, active, id }: MenuLinkProps): JSX.Element {
 }
 
 export default function Header(): JSX.Element {
+  const isMobileApp = Capacitor.isNativePlatform();
   return (
-    <header className="z-30 hidden w-full items-center justify-between bg-white pl-4 pr-8 shadow-[0_4px_6px_-2px_rgba(0,0,0,0.1)] dark:bg-gray-900 dark:shadow-[0_4px_6px_-2px_rgba(0,0,0,0.25)] sm:flex">
+    <header
+      className={twMerge(
+        'z-30 hidden w-full items-center justify-between bg-white pl-4 pr-8 shadow-[0_4px_6px_-2px_rgba(0,0,0,0.1)] dark:bg-gray-900 dark:shadow-[0_4px_6px_-2px_rgba(0,0,0,0.25)]',
+        !isMobileApp && 'sm:flex'
+      )}
+    >
       <Logo className="h-12 w-56 fill-black dark:fill-white" />
       <NavigationMenu.Root className="hidden md:block">
         <NavigationMenu.List className="flex space-x-2">

--- a/web/src/features/map-controls/LanguageSelector.tsx
+++ b/web/src/features/map-controls/LanguageSelector.tsx
@@ -24,9 +24,10 @@ export function LanguageSelector({ isMobile }: { isMobile?: boolean }) {
     <MapOptionSelector
       trigger={
         isMobile ? (
-          <Button renderAsDiv icon={<HiLanguage size={21} />} className="mb-0">
+          <div className="flex w-fit min-w-[232px] items-center justify-center gap-x-2 ">
+            <HiLanguage size={21} />
             {__('tooltips.selectLanguage')}
-          </Button>
+          </div>
         ) : (
           <MapButton
             icon={<HiLanguage size={20} style={{ strokeWidth: '0.5' }} />}

--- a/web/src/features/map-controls/MapOptionSelector.tsx
+++ b/web/src/features/map-controls/MapOptionSelector.tsx
@@ -1,6 +1,7 @@
 import { useTranslation } from 'translation/translation';
 import { Root, Trigger, Portal, Content, Arrow } from '@radix-ui/react-dropdown-menu';
 import { useState } from 'react';
+import { twMerge } from 'tailwind-merge';
 
 interface MapOptionSelectorProps {
   trigger: React.ReactNode;
@@ -22,9 +23,14 @@ export default function MapOptionSelector({
   return (
     <Root open={isOpen} modal={false}>
       <Trigger
-        className={isOpen ? 'pointer-events-none' : 'pointer-events-auto'}
+        className={twMerge(
+          isOpen ? 'pointer-events-none' : 'pointer-events-auto',
+          isMobile &&
+            'rounded-full bg-white py-3  text-md font-bold shadow-[0px_0px_13px_rgb(0_0_0/12%)] transition duration-200 hover:shadow-[0px_0px_23px_rgb(0_0_0/20%)] dark:bg-gray-600 dark:hover:shadow-[0px_0px_23px_rgb(0_0_0/50%)]'
+        )}
         data-test-id={testId}
         onClick={toggleTooltip}
+        type={undefined}
       >
         {trigger}
       </Trigger>

--- a/web/src/features/map-controls/ThemeSelector.tsx
+++ b/web/src/features/map-controls/ThemeSelector.tsx
@@ -32,13 +32,10 @@ export default function ThemeSelector({ isMobile }: { isMobile?: boolean }) {
     <MapOptionSelector
       trigger={
         isMobile ? (
-          <Button
-            renderAsDiv
-            icon={<BsMoonStars size={14} style={{ strokeWidth: '0.2' }} />}
-            className="my-0"
-          >
+          <div className="flex w-fit min-w-[232px] items-center justify-center gap-x-2 ">
+            <BsMoonStars size={14} style={{ strokeWidth: '0.2' }} />
             {__('tooltips.changeTheme')}
-          </Button>
+          </div>
         ) : (
           <MapButton
             icon={<BsMoonStars size={14} style={{ strokeWidth: '0.2' }} />}


### PR DESCRIPTION
## Issue
We've had some complaints about not being able to use landscape mode on tablets, this PR enables the mobile apps to use landscape mode and hides the header when on landscape in mobile. 

iOS was already allowing landscape 
