### PR TITLE
change german term for 'zone'

### DIFF
--- a/web/public/locales/de.json
+++ b/web/public/locales/de.json
@@ -127,7 +127,7 @@
   },
   "aggregateButtons": {
     "country": "Land",
-    "zone": "Gebiet"
+    "zone": "Zone"
   },
   "themeOptions": {
     "dark": "Dunkel",


### PR DESCRIPTION
## Issue

As discussed in the comments of merged PR #5228 from yesterday I would change the german translation from 'Gebiet' to the more technical term 'Zone' in german translation to keep consistency. Sorry!
