### PR TITLE
Fix exchange bar background in Bar Breakdown Cart

### DIFF
--- a/web/src/features/charts/bar-breakdown/BarElectricityBreakdownChart.tsx
+++ b/web/src/features/charts/bar-breakdown/BarElectricityBreakdownChart.tsx
@@ -152,8 +152,8 @@ function BarElectricityBreakdownChart({
             <CountryFlag zoneId={d.zoneKey} className="pointer-events-none" />
 
             <HorizontalBar
-              className="capacity"
-              fill="rgba(0, 0, 0, 0.15)"
+              className="text-black/10 dark:text-white/10"
+              fill="currentColor"
               range={d.exchangeCapacityRange}
               scale={powerScale}
             />


### PR DESCRIPTION
## Issue
Resolves: #5185 

## Description

Aligns the background color of the production bars and the exchange bars.

### Preview

Before:
![image](https://user-images.githubusercontent.com/30777521/227720132-12f4f70a-0a5d-4dd4-8ad7-9550cc687c9b.png)

After:
![image](https://user-images.githubusercontent.com/30777521/227720148-2b8d1532-206d-4f1a-9a2a-a1ea99715d83.png)


### Double check

- [x] I have run `pnpx prettier --write .` and `poetry run format` to format my changes.
