### PR TITLE
Add retry strategy for AU-NT (NETSMO parser)

### DIFF
--- a/parsers/NTESMO.py
+++ b/parsers/NTESMO.py
@@ -11,12 +11,11 @@ from typing import Callable, Dict, List, TypedDict
 import arrow
 import pandas as pd
 from bs4 import BeautifulSoup
+from parsers.lib.config import refetch_frequency
+from parsers.lib.exceptions import ParserException
 from pytz import timezone
 from requests import Session
 from requests.adapters import HTTPAdapter, Retry
-
-from parsers.lib.config import refetch_frequency
-from parsers.lib.exceptions import ParserException
 
 australia_tz = timezone("Australia/Darwin")
 
@@ -61,7 +60,8 @@ PLANT_MAPPING = {
     "HP01": Generator(power_plant="", fuel_type="unknown"),
 }
 
-
+# For some reason the page doesn't always load on first attempt.
+# Therefore we retry a few times.
 retry_strategy = Retry(
     total=3,
     status_forcelist=[500, 502, 503, 504],

--- a/parsers/lib/config.py
+++ b/parsers/lib/config.py
@@ -1,5 +1,6 @@
+from copy import deepcopy
 from datetime import timedelta
-from typing import Optional
+from logging import getLogger
 
 from requests import Session
 from requests.adapters import HTTPAdapter, Retry
@@ -32,10 +33,19 @@ def retry_policy(retry_policy: Retry):
     def wrap(f):
         def wrapped_f(*args, **kwargs):
             session = args[1] if len(args) > 2 else kwargs.get("session")
+            logger = kwargs.get("logger", getLogger(__name__))
             session = Session() if session is None else session
+            old_adapters = None
+            if "https://" in session.adapters or "http://" in session.adapters:
+                logger.warning("Session already has adapters, they will be overriden.")
+                old_adapters = deepcopy(session.adapters)
             session.mount("https://", HTTPAdapter(max_retries=retry_policy))
+            session.mount("http://", HTTPAdapter(max_retries=retry_policy))
             result = f(*args, **kwargs)
             del session.adapters["https://"]
+            del session.adapters["http://"]
+            if old_adapters is not None:
+                session.adapters.update(old_adapters)
             return result
 
         return wrapped_f


### PR DESCRIPTION
## Issue

NETSMO parser has been down for a few days. It seems that the first call to the website always end with a 502 error at the moment. Strangely, retrying to get the website works fine afterwards.

## Description
Adds a retry strategy to NETSMO parser so that it can avoid those issues.

### Preview

![image](https://user-images.githubusercontent.com/38283096/227929348-92065f63-5a66-4c67-8e4d-2ac1afef2a9a.png)
Getting data with test_parser.
