### PR TITLE
update fetch_production

### DIFF
--- a/parsers/US_PJM.py
+++ b/parsers/US_PJM.py
@@ -169,9 +169,7 @@ def fetch_production(
                 production[mode] = row.get("mw")
         data_point = {
             "zoneKey": zone_key,
-            "datetime": arrow.get(dt).datetime.replace(
-                tzinfo=pytz.timezone("US/Eastern")
-            ),
+            "datetime": arrow.get(dt).replace(tzinfo="US/Eastern").datetime,
             "production": production,
             "storage": storage,
             "source": "pjm.com",


### PR DESCRIPTION
## Issue
the datetime stored in the database are weird due to a pytz issue
<img width="380" alt="image" src="https://user-images.githubusercontent.com/107848894/229529938-75730846-4695-4df3-a612-138efa71a9b0.png">

## Description

We want data to be stored at the start of the hour to have consistency with other zones

### Preview
we do not use the pytz library anymore to avoid this issue
<img width="700" alt="image" src="https://user-images.githubusercontent.com/107848894/229530200-41b525b0-04d0-427d-98b6-66aec7e00c8f.png">


### Double check

- [ ] I have tested my parser changes locally with `poetry run test_parser "zone_key"`
- [ ] I have run `pnpx prettier --write .` and `poetry run format` to format my changes.
