### PR TITLE
md/update gas EF for eu

### DIFF
--- a/config/zones/AX.yaml
+++ b/config/zones/AX.yaml
@@ -40,7 +40,7 @@ emissionFactors:
     gas:
       datetime: '2021-01-01'
       source: EU-ETS, ENTSO-E 2021
-      value: 419.8221756
+      value: 295.9885661
     hydro discharge:
       - datetime: '2018-01-01'
         source: Electricity Maps, 2018 average
@@ -83,7 +83,7 @@ emissionFactors:
     gas:
       datetime: '2021-01-01'
       source: EU-ETS, ENTSO-E 2021; IPCC 2014
-      value: 539.8221756
+      value: 415.9885661
     hydro:
       datetime: '2020-01-01'
       source: UNECE 2022

--- a/config/zones/AX.yaml
+++ b/config/zones/AX.yaml
@@ -40,7 +40,7 @@ emissionFactors:
     gas:
       datetime: '2021-01-01'
       source: EU-ETS, ENTSO-E 2021
-      value: 684.2607818
+      value: 419.8221756
     hydro discharge:
       - datetime: '2018-01-01'
         source: Electricity Maps, 2018 average
@@ -83,7 +83,7 @@ emissionFactors:
     gas:
       datetime: '2021-01-01'
       source: EU-ETS, ENTSO-E 2021; IPCC 2014
-      value: 804.2607818
+      value: 539.8221756
     hydro:
       datetime: '2020-01-01'
       source: UNECE 2022

--- a/config/zones/BG.yaml
+++ b/config/zones/BG.yaml
@@ -57,7 +57,7 @@ emissionFactors:
     gas:
       datetime: '2021-01-01'
       source: EU-ETS, ENTSO-E 2021
-      value: 481.60707
+      value: 419.8221756
     hydro discharge:
       - datetime: '2015-01-01'
         source: Electricity Maps, 2015 average
@@ -119,7 +119,7 @@ emissionFactors:
     gas:
       datetime: '2021-01-01'
       source: EU-ETS, ENTSO-E 2021; IPCC 2014
-      value: 601.60707
+      value: 539.8221756
     hydro:
       datetime: '2020-01-01'
       source: UNECE 2022

--- a/config/zones/CY.yaml
+++ b/config/zones/CY.yaml
@@ -48,7 +48,7 @@ emissionFactors:
     gas:
       datetime: '2021-01-01'
       source: EU-ETS, ENTSO-E 2021
-      value: 481.60707
+      value: 419.8221756
     hydro discharge:
       - datetime: '2017-01-01'
         source: Electricity Maps, 2017 average
@@ -97,7 +97,7 @@ emissionFactors:
     gas:
       datetime: '2021-01-01'
       source: EU-ETS, ENTSO-E 2021; IPCC 2014
-      value: 601.60707
+      value: 539.8221756
     hydro:
       datetime: '2020-01-01'
       source: UNECE 2022

--- a/config/zones/CZ.yaml
+++ b/config/zones/CZ.yaml
@@ -52,7 +52,7 @@ emissionFactors:
     gas:
       datetime: '2021-01-01'
       source: EU-ETS, ENTSO-E 2021
-      value: 481.60707
+      value: 419.8221756
     hydro discharge:
       - datetime: '2015-01-01'
         source: Electricity Maps, 2015 average
@@ -114,7 +114,7 @@ emissionFactors:
     gas:
       datetime: '2021-01-01'
       source: EU-ETS, ENTSO-E 2021; IPCC 2014
-      value: 601.60707
+      value: 539.8221756
     hydro:
       datetime: '2020-01-01'
       source: UNECE 2022

--- a/config/zones/DE.yaml
+++ b/config/zones/DE.yaml
@@ -61,7 +61,7 @@ emissionFactors:
     gas:
       datetime: '2021-01-01'
       source: EU-ETS, ENTSO-E 2021
-      value: 540.5939971
+      value: 472.8075167
     hydro discharge:
       - datetime: '2015-01-01'
         source: Electricity Maps, 2015 average
@@ -123,7 +123,7 @@ emissionFactors:
     gas:
       datetime: '2021-01-01'
       source: EU-ETS, ENTSO-E 2021; IPCC 2014
-      value: 660.5939971
+      value: 592.8075167
     hydro:
       datetime: '2020-01-01'
       source: UNECE 2022

--- a/config/zones/DK-DK1.yaml
+++ b/config/zones/DK-DK1.yaml
@@ -14,8 +14,8 @@ capacity:
   nuclear: 0
   oil: 195
   solar: 1702
-  wind: 5233
   unknown: 112
+  wind: 5233
 contributors:
   - corradio
   - tmslaine

--- a/config/zones/DK-DK2.yaml
+++ b/config/zones/DK-DK2.yaml
@@ -14,8 +14,8 @@ capacity:
   nuclear: 0
   oil: 764
   solar: 620
-  wind: 1838
   unknown: 24
+  wind: 1838
 contributors:
   - corradio
   - tmslaine

--- a/config/zones/DK.yaml
+++ b/config/zones/DK.yaml
@@ -13,8 +13,8 @@ capacity:
   nuclear: 0
   oil: 959
   solar: 2322
-  wind: 7017
   unknown: 136
+  wind: 7017
 contributors:
   - corradio
   - Manu1400

--- a/config/zones/EE.yaml
+++ b/config/zones/EE.yaml
@@ -53,7 +53,7 @@ emissionFactors:
     gas:
       datetime: '2021-01-01'
       source: EU-ETS, ENTSO-E 2021
-      value: 481.60707
+      value: 419.8221756
     hydro discharge:
       - datetime: '2015-01-01'
         source: Electricity Maps, 2015 average
@@ -114,7 +114,7 @@ emissionFactors:
     gas:
       datetime: '2021-01-01'
       source: EU-ETS, ENTSO-E 2021; IPCC 2014
-      value: 601.60707
+      value: 539.8221756
     hydro:
       datetime: '2020-01-01'
       source: UNECE 2022

--- a/config/zones/ES-CN-FVLZ.yaml
+++ b/config/zones/ES-CN-FVLZ.yaml
@@ -32,7 +32,7 @@ emissionFactors:
     gas:
       datetime: '2021-01-01'
       source: EU-ETS, ENTSO-E 2021
-      value: 422.8263312
+      value: 397.8527093
     hydro discharge:
       - datetime: '2018-01-01'
         source: Electricity Maps, 2018 average
@@ -76,7 +76,7 @@ emissionFactors:
     gas:
       datetime: '2021-01-01'
       source: EU-ETS, ENTSO-E 2021; IPCC 2014
-      value: 542.8263312
+      value: 517.8527093
     hydro:
       datetime: '2020-01-01'
       source: UNECE 2022

--- a/config/zones/ES-CN-GC.yaml
+++ b/config/zones/ES-CN-GC.yaml
@@ -32,7 +32,7 @@ emissionFactors:
     gas:
       datetime: '2021-01-01'
       source: EU-ETS, ENTSO-E 2021
-      value: 422.8263312
+      value: 397.8527093
     hydro discharge:
       - datetime: '2018-01-01'
         source: Electricity Maps, 2018 average
@@ -76,7 +76,7 @@ emissionFactors:
     gas:
       datetime: '2021-01-01'
       source: EU-ETS, ENTSO-E 2021; IPCC 2014
-      value: 542.8263312
+      value: 517.8527093
     hydro:
       datetime: '2020-01-01'
       source: UNECE 2022

--- a/config/zones/ES-CN-HI.yaml
+++ b/config/zones/ES-CN-HI.yaml
@@ -36,7 +36,7 @@ emissionFactors:
     gas:
       datetime: '2021-01-01'
       source: EU-ETS, ENTSO-E 2021
-      value: 422.8263312
+      value: 397.8527093
     hydro discharge:
       - datetime: '2018-01-01'
         source: Electricity Maps, 2018 average
@@ -80,7 +80,7 @@ emissionFactors:
     gas:
       datetime: '2021-01-01'
       source: EU-ETS, ENTSO-E 2021; IPCC 2014
-      value: 542.8263312
+      value: 517.8527093
     hydro:
       datetime: '2020-01-01'
       source: UNECE 2022

--- a/config/zones/ES-CN-IG.yaml
+++ b/config/zones/ES-CN-IG.yaml
@@ -34,7 +34,7 @@ emissionFactors:
     gas:
       datetime: '2021-01-01'
       source: EU-ETS, ENTSO-E 2021
-      value: 422.8263312
+      value: 397.8527093
     hydro discharge:
       - datetime: '2018-01-01'
         source: Electricity Maps, 2018 average
@@ -78,7 +78,7 @@ emissionFactors:
     gas:
       datetime: '2021-01-01'
       source: EU-ETS, ENTSO-E 2021; IPCC 2014
-      value: 542.8263312
+      value: 517.8527093
     hydro:
       datetime: '2020-01-01'
       source: UNECE 2022

--- a/config/zones/ES-CN-LP.yaml
+++ b/config/zones/ES-CN-LP.yaml
@@ -32,7 +32,7 @@ emissionFactors:
     gas:
       datetime: '2021-01-01'
       source: EU-ETS, ENTSO-E 2021
-      value: 422.8263312
+      value: 397.8527093
     hydro discharge:
       - datetime: '2018-01-01'
         source: Electricity Maps, 2018 average
@@ -76,7 +76,7 @@ emissionFactors:
     gas:
       datetime: '2021-01-01'
       source: EU-ETS, ENTSO-E 2021; IPCC 2014
-      value: 542.8263312
+      value: 517.8527093
     hydro:
       datetime: '2020-01-01'
       source: UNECE 2022

--- a/config/zones/ES-CN-TE.yaml
+++ b/config/zones/ES-CN-TE.yaml
@@ -32,7 +32,7 @@ emissionFactors:
     gas:
       datetime: '2021-01-01'
       source: EU-ETS, ENTSO-E 2021
-      value: 422.8263312
+      value: 397.8527093
     hydro discharge:
       - datetime: '2018-01-01'
         source: Electricity Maps, 2018 average
@@ -76,7 +76,7 @@ emissionFactors:
     gas:
       datetime: '2021-01-01'
       source: EU-ETS, ENTSO-E 2021; IPCC 2014
-      value: 542.8263312
+      value: 517.8527093
     hydro:
       datetime: '2020-01-01'
       source: UNECE 2022

--- a/config/zones/ES-IB-FO.yaml
+++ b/config/zones/ES-IB-FO.yaml
@@ -30,7 +30,7 @@ emissionFactors:
     gas:
       datetime: '2021-01-01'
       source: EU-ETS, ENTSO-E 2021
-      value: 422.8263312
+      value: 397.8527093
     hydro discharge:
       - datetime: '2019-01-01'
         source: Electricity Maps, 2019 average
@@ -68,7 +68,7 @@ emissionFactors:
     gas:
       datetime: '2021-01-01'
       source: EU-ETS, ENTSO-E 2021; IPCC 2014
-      value: 542.8263312
+      value: 517.8527093
     hydro:
       datetime: '2020-01-01'
       source: UNECE 2022

--- a/config/zones/ES-IB-IZ.yaml
+++ b/config/zones/ES-IB-IZ.yaml
@@ -30,7 +30,7 @@ emissionFactors:
     gas:
       datetime: '2021-01-01'
       source: EU-ETS, ENTSO-E 2021
-      value: 422.8263312
+      value: 397.8527093
     hydro discharge:
       - datetime: '2019-01-01'
         source: Electricity Maps, 2019 average
@@ -68,7 +68,7 @@ emissionFactors:
     gas:
       datetime: '2021-01-01'
       source: EU-ETS, ENTSO-E 2021; IPCC 2014
-      value: 542.8263312
+      value: 517.8527093
     hydro:
       datetime: '2020-01-01'
       source: UNECE 2022

--- a/config/zones/ES-IB-MA.yaml
+++ b/config/zones/ES-IB-MA.yaml
@@ -33,7 +33,7 @@ emissionFactors:
     gas:
       datetime: '2021-01-01'
       source: EU-ETS, ENTSO-E 2021
-      value: 422.8263312
+      value: 397.8527093
     hydro discharge:
       - datetime: '2018-01-01'
         source: Electricity Maps, 2018 average
@@ -77,7 +77,7 @@ emissionFactors:
     gas:
       datetime: '2021-01-01'
       source: EU-ETS, ENTSO-E 2021; IPCC 2014
-      value: 542.8263312
+      value: 517.8527093
     hydro:
       datetime: '2020-01-01'
       source: UNECE 2022

--- a/config/zones/ES-IB-ME.yaml
+++ b/config/zones/ES-IB-ME.yaml
@@ -33,7 +33,7 @@ emissionFactors:
     gas:
       datetime: '2021-01-01'
       source: EU-ETS, ENTSO-E 2021
-      value: 422.8263312
+      value: 397.8527093
     hydro discharge:
       - datetime: '2018-01-01'
         source: Electricity Maps, 2018 average
@@ -77,7 +77,7 @@ emissionFactors:
     gas:
       datetime: '2021-01-01'
       source: EU-ETS, ENTSO-E 2021; IPCC 2014
-      value: 542.8263312
+      value: 517.8527093
     hydro:
       datetime: '2020-01-01'
       source: UNECE 2022

--- a/config/zones/ES.yaml
+++ b/config/zones/ES.yaml
@@ -60,7 +60,7 @@ emissionFactors:
     gas:
       datetime: '2021-01-01'
       source: EU-ETS, ENTSO-E 2021
-      value: 422.8263312
+      value: 397.8527093
     hydro discharge:
       - datetime: '2015-01-01'
         source: Electricity Maps, 2015 average
@@ -122,7 +122,7 @@ emissionFactors:
     gas:
       datetime: '2021-01-01'
       source: EU-ETS, ENTSO-E 2021; IPCC 2014
-      value: 542.8263312
+      value: 517.8527093
     hydro:
       datetime: '2020-01-01'
       source: UNECE 2022

--- a/config/zones/FI.yaml
+++ b/config/zones/FI.yaml
@@ -53,7 +53,7 @@ emissionFactors:
     gas:
       datetime: '2021-01-01'
       source: EU-ETS, ENTSO-E 2021
-      value: 684.2607818
+      value: 295.9885661
     hydro discharge:
       - datetime: '2015-01-01'
         source: Electricity Maps, 2015 average
@@ -115,7 +115,7 @@ emissionFactors:
     gas:
       datetime: '2021-01-01'
       source: EU-ETS, ENTSO-E 2021; IPCC 2014
-      value: 804.2607818
+      value: 415.9885661
     hydro:
       datetime: '2020-01-01'
       source: UNECE 2022

--- a/config/zones/FO-MI.yaml
+++ b/config/zones/FO-MI.yaml
@@ -21,7 +21,7 @@ emissionFactors:
     gas:
       datetime: '2021-01-01'
       source: EU-ETS, ENTSO-E 2021
-      value: 419.8221756
+      value: 336.9719859
     oil:
       datetime: '2021-01-01'
       source: EU-ETS, ENTSO-E 2021
@@ -41,7 +41,7 @@ emissionFactors:
     gas:
       datetime: '2021-01-01'
       source: EU-ETS, ENTSO-E 2021; IPCC 2014
-      value: 539.8221756
+      value: 456.9719859
     hydro:
       datetime: '2020-01-01'
       source: UNECE 2022

--- a/config/zones/FO-MI.yaml
+++ b/config/zones/FO-MI.yaml
@@ -21,7 +21,7 @@ emissionFactors:
     gas:
       datetime: '2021-01-01'
       source: EU-ETS, ENTSO-E 2021
-      value: 336.9719859
+      value: 419.8221756
     oil:
       datetime: '2021-01-01'
       source: EU-ETS, ENTSO-E 2021
@@ -41,7 +41,7 @@ emissionFactors:
     gas:
       datetime: '2021-01-01'
       source: EU-ETS, ENTSO-E 2021; IPCC 2014
-      value: 456.9719859
+      value: 539.8221756
     hydro:
       datetime: '2020-01-01'
       source: UNECE 2022

--- a/config/zones/FO-SI.yaml
+++ b/config/zones/FO-SI.yaml
@@ -20,7 +20,7 @@ emissionFactors:
     gas:
       datetime: '2021-01-01'
       source: EU-ETS, ENTSO-E 2021
-      value: 419.8221756
+      value: 336.9719859
     oil:
       datetime: '2021-01-01'
       source: EU-ETS, ENTSO-E 2021
@@ -37,7 +37,7 @@ emissionFactors:
     gas:
       datetime: '2021-01-01'
       source: EU-ETS, ENTSO-E 2021; IPCC 2014
-      value: 539.8221756
+      value: 456.9719859
     hydro:
       datetime: '2020-01-01'
       source: UNECE 2022

--- a/config/zones/FO-SI.yaml
+++ b/config/zones/FO-SI.yaml
@@ -20,7 +20,7 @@ emissionFactors:
     gas:
       datetime: '2021-01-01'
       source: EU-ETS, ENTSO-E 2021
-      value: 336.9719859
+      value: 419.8221756
     oil:
       datetime: '2021-01-01'
       source: EU-ETS, ENTSO-E 2021
@@ -37,7 +37,7 @@ emissionFactors:
     gas:
       datetime: '2021-01-01'
       source: EU-ETS, ENTSO-E 2021; IPCC 2014
-      value: 456.9719859
+      value: 539.8221756
     hydro:
       datetime: '2020-01-01'
       source: UNECE 2022

--- a/config/zones/FR-COR.yaml
+++ b/config/zones/FR-COR.yaml
@@ -27,7 +27,7 @@ emissionFactors:
     gas:
       datetime: '2021-01-01'
       source: EU-ETS, ENTSO-E 2021
-      value: 504.846764
+      value: 380.5979557
     oil:
       datetime: '2021-01-01'
       source: EU-ETS, ENTSO-E 2021
@@ -45,7 +45,7 @@ emissionFactors:
     gas:
       datetime: '2021-01-01'
       source: EU-ETS, ENTSO-E 2021; IPCC 2014
-      value: 624.846764
+      value: 500.5979557
     hydro:
       datetime: '2020-01-01'
       source: UNECE 2022
@@ -68,8 +68,8 @@ emissionFactors:
         outlook for 2022-2026" Wind Europe Proceedings (2021)
       value: 12.62
 parsers:
-  production: FR_O.fetch_production
   price: FR_O.fetch_price
+  production: FR_O.fetch_production
 sources:
   EU-ETS, ENTSO-E 2021:
     link: https://drive.google.com/file/d/15UeUHyhcjVw8fGLc0Zx_HELSx20cw_-e/view?usp=share_link

--- a/config/zones/FR.yaml
+++ b/config/zones/FR.yaml
@@ -56,7 +56,7 @@ emissionFactors:
     gas:
       datetime: '2021-01-01'
       source: EU-ETS, ENTSO-E 2021
-      value: 504.846764
+      value: 380.5979557
     hydro discharge:
       - datetime: '2015-01-01'
         source: Electricity Maps, 2015 average
@@ -118,7 +118,7 @@ emissionFactors:
     gas:
       datetime: '2021-01-01'
       source: EU-ETS, ENTSO-E 2021; IPCC 2014
-      value: 624.846764
+      value: 500.5979557
     hydro:
       datetime: '2020-01-01'
       source: UNECE 2022

--- a/config/zones/HR.yaml
+++ b/config/zones/HR.yaml
@@ -40,7 +40,7 @@ emissionFactors:
     gas:
       datetime: '2021-01-01'
       source: EU-ETS, ENTSO-E 2021
-      value: 481.60707
+      value: 419.8221756
     hydro discharge:
       - datetime: '2019-01-01'
         source: Electricity Maps, 2019 average
@@ -78,7 +78,7 @@ emissionFactors:
     gas:
       datetime: '2021-01-01'
       source: EU-ETS, ENTSO-E 2021; IPCC 2014
-      value: 601.60707
+      value: 539.8221756
     hydro:
       datetime: '2020-01-01'
       source: UNECE 2022

--- a/config/zones/IE.yaml
+++ b/config/zones/IE.yaml
@@ -52,7 +52,7 @@ emissionFactors:
     gas:
       datetime: '2021-01-01'
       source: EU-ETS, ENTSO-E 2021
-      value: 465.9170756
+      value: 396.8903896
     hydro discharge:
       - datetime: '2015-01-01'
         source: Electricity Maps, 2015 average
@@ -114,7 +114,7 @@ emissionFactors:
     gas:
       datetime: '2021-01-01'
       source: EU-ETS, ENTSO-E 2021; IPCC 2014
-      value: 585.9170756
+      value: 516.8903895999999
     hydro:
       datetime: '2020-01-01'
       source: UNECE 2022

--- a/config/zones/IT-CNO.yaml
+++ b/config/zones/IT-CNO.yaml
@@ -52,7 +52,7 @@ emissionFactors:
     gas:
       datetime: '2021-01-01'
       source: EU-ETS, ENTSO-E 2021
-      value: 446.1813452
+      value: 427.8711931
     hydro discharge:
       - datetime: '2015-01-01'
         source: Electricity Maps, 2015 average
@@ -114,7 +114,7 @@ emissionFactors:
     gas:
       datetime: '2021-01-01'
       source: EU-ETS, ENTSO-E 2021; IPCC 2014
-      value: 566.1813452
+      value: 547.8711931
     hydro:
       datetime: '2020-01-01'
       source: UNECE 2022

--- a/config/zones/IT-CSO.yaml
+++ b/config/zones/IT-CSO.yaml
@@ -52,7 +52,7 @@ emissionFactors:
     gas:
       datetime: '2021-01-01'
       source: EU-ETS, ENTSO-E 2021
-      value: 446.1813452
+      value: 427.8711931
     hydro discharge:
       - datetime: '2015-01-01'
         source: Electricity Maps, 2015 average
@@ -114,7 +114,7 @@ emissionFactors:
     gas:
       datetime: '2021-01-01'
       source: EU-ETS, ENTSO-E 2021; IPCC 2014
-      value: 566.1813452
+      value: 547.8711931
     hydro:
       datetime: '2020-01-01'
       source: UNECE 2022

--- a/config/zones/IT-NO.yaml
+++ b/config/zones/IT-NO.yaml
@@ -52,7 +52,7 @@ emissionFactors:
     gas:
       datetime: '2021-01-01'
       source: EU-ETS, ENTSO-E 2021
-      value: 446.1813452
+      value: 427.8711931
     hydro discharge:
       - datetime: '2015-01-01'
         source: Electricity Maps, 2015 average
@@ -114,7 +114,7 @@ emissionFactors:
     gas:
       datetime: '2021-01-01'
       source: EU-ETS, ENTSO-E 2021; IPCC 2014
-      value: 566.1813452
+      value: 547.8711931
     hydro:
       datetime: '2020-01-01'
       source: UNECE 2022

--- a/config/zones/IT-SAR.yaml
+++ b/config/zones/IT-SAR.yaml
@@ -52,7 +52,7 @@ emissionFactors:
     gas:
       datetime: '2021-01-01'
       source: EU-ETS, ENTSO-E 2021
-      value: 446.1813452
+      value: 427.8711931
     hydro discharge:
       - datetime: '2015-01-01'
         source: Electricity Maps, 2015 average
@@ -114,7 +114,7 @@ emissionFactors:
     gas:
       datetime: '2021-01-01'
       source: EU-ETS, ENTSO-E 2021; IPCC 2014
-      value: 566.1813452
+      value: 547.8711931
     hydro:
       datetime: '2020-01-01'
       source: UNECE 2022

--- a/config/zones/IT-SIC.yaml
+++ b/config/zones/IT-SIC.yaml
@@ -52,7 +52,7 @@ emissionFactors:
     gas:
       datetime: '2021-01-01'
       source: EU-ETS, ENTSO-E 2021
-      value: 446.1813452
+      value: 427.8711931
     hydro discharge:
       - datetime: '2015-01-01'
         source: Electricity Maps, 2015 average
@@ -114,7 +114,7 @@ emissionFactors:
     gas:
       datetime: '2021-01-01'
       source: EU-ETS, ENTSO-E 2021; IPCC 2014
-      value: 566.1813452
+      value: 547.8711931
     hydro:
       datetime: '2020-01-01'
       source: UNECE 2022

--- a/config/zones/IT-SO.yaml
+++ b/config/zones/IT-SO.yaml
@@ -52,7 +52,7 @@ emissionFactors:
     gas:
       datetime: '2021-01-01'
       source: EU-ETS, ENTSO-E 2021
-      value: 446.1813452
+      value: 427.8711931
     hydro discharge:
       - datetime: '2015-01-01'
         source: Electricity Maps, 2015 average
@@ -114,7 +114,7 @@ emissionFactors:
     gas:
       datetime: '2021-01-01'
       source: EU-ETS, ENTSO-E 2021; IPCC 2014
-      value: 566.1813452
+      value: 547.8711931
     hydro:
       datetime: '2020-01-01'
       source: UNECE 2022

--- a/config/zones/IT.yaml
+++ b/config/zones/IT.yaml
@@ -51,7 +51,7 @@ emissionFactors:
     gas:
       datetime: '2021-01-01'
       source: EU-ETS, ENTSO-E 2021
-      value: 446.1813452
+      value: 427.8711931
     hydro discharge:
       - datetime: '2015-01-01'
         source: Electricity Maps, 2015 average
@@ -113,7 +113,7 @@ emissionFactors:
     gas:
       datetime: '2021-01-01'
       source: EU-ETS, ENTSO-E 2021; IPCC 2014
-      value: 566.1813452
+      value: 547.8711931
     hydro:
       datetime: '2020-01-01'
       source: UNECE 2022

--- a/config/zones/LU.yaml
+++ b/config/zones/LU.yaml
@@ -34,7 +34,7 @@ emissionFactors:
     gas:
       datetime: '2021-01-01'
       source: EU-ETS, ENTSO-E 2021
-      value: 481.60707
+      value: 419.8221756
     hydro discharge:
       - datetime: '2021-01-01'
         source: Electricity Maps, 2021 average
@@ -59,7 +59,7 @@ emissionFactors:
     gas:
       datetime: '2021-01-01'
       source: EU-ETS, ENTSO-E 2021; IPCC 2014
-      value: 601.60707
+      value: 539.8221756
     hydro:
       datetime: '2020-01-01'
       source: UNECE 2022

--- a/config/zones/LV.yaml
+++ b/config/zones/LV.yaml
@@ -46,7 +46,7 @@ emissionFactors:
     gas:
       datetime: '2021-01-01'
       source: EU-ETS, ENTSO-E 2021
-      value: 481.60707
+      value: 419.8221756
     hydro discharge:
       - datetime: '2015-01-01'
         source: Electricity Maps, 2015 average
@@ -107,7 +107,7 @@ emissionFactors:
     gas:
       datetime: '2021-01-01'
       source: EU-ETS, ENTSO-E 2021; IPCC 2014
-      value: 601.60707
+      value: 539.8221756
     hydro:
       datetime: '2020-01-01'
       source: UNECE 2022

--- a/config/zones/MT.yaml
+++ b/config/zones/MT.yaml
@@ -16,7 +16,7 @@ emissionFactors:
     gas:
       datetime: '2021-01-01'
       source: EU-ETS, ENTSO-E 2021
-      value: 481.60707
+      value: 419.8221756
     oil:
       datetime: '2021-01-01'
       source: EU-ETS, ENTSO-E 2021
@@ -33,7 +33,7 @@ emissionFactors:
     gas:
       datetime: '2021-01-01'
       source: EU-ETS, ENTSO-E 2021; IPCC 2014
-      value: 601.60707
+      value: 539.8221756
     hydro:
       datetime: '2020-01-01'
       source: UNECE 2022

--- a/config/zones/NL.yaml
+++ b/config/zones/NL.yaml
@@ -50,7 +50,7 @@ emissionFactors:
     gas:
       datetime: '2021-01-01'
       source: EU-ETS, ENTSO-E 2021
-      value: 470.7521775
+      value: 402.3363923
     hydro discharge:
       - datetime: '2015-01-01'
         source: Electricity Maps, 2015 average
@@ -112,7 +112,7 @@ emissionFactors:
     gas:
       datetime: '2021-01-01'
       source: EU-ETS, ENTSO-E 2021; IPCC 2014
-      value: 590.7521775
+      value: 522.3363922999999
     hydro:
       datetime: '2020-01-01'
       source: UNECE 2022

--- a/config/zones/RO.yaml
+++ b/config/zones/RO.yaml
@@ -53,7 +53,7 @@ emissionFactors:
     gas:
       datetime: '2021-01-01'
       source: EU-ETS, ENTSO-E 2021
-      value: 1068.215856
+      value: 687.5901733
     hydro discharge:
       - datetime: '2015-01-01'
         source: Electricity Maps, 2015 average
@@ -115,7 +115,7 @@ emissionFactors:
     gas:
       datetime: '2021-01-01'
       source: EU-ETS, ENTSO-E 2021; IPCC 2014
-      value: 1188.215856
+      value: 807.5901733
     hydro:
       datetime: '2020-01-01'
       source: UNECE 2022

--- a/config/zones/SI.yaml
+++ b/config/zones/SI.yaml
@@ -53,7 +53,7 @@ emissionFactors:
     gas:
       datetime: '2021-01-01'
       source: EU-ETS, ENTSO-E 2021
-      value: 481.60707
+      value: 419.8221756
     hydro discharge:
       - datetime: '2015-01-01'
         source: Electricity Maps, 2015 average
@@ -115,7 +115,7 @@ emissionFactors:
     gas:
       datetime: '2021-01-01'
       source: EU-ETS, ENTSO-E 2021; IPCC 2014
-      value: 601.60707
+      value: 539.8221756
     hydro:
       datetime: '2020-01-01'
       source: UNECE 2022

--- a/parsers/test/test_config.py
+++ b/parsers/test/test_config.py
@@ -37,7 +37,7 @@ class EmissionFactorTestCase(unittest.TestCase):
             "battery discharge": 66.82067058776849,
             "biomass": 230.0,
             "coal": 953.9335274,
-            "gas": 624.846764,
+            "gas": 500.5979557,
             "geothermal": 38,
             "hydro": 10.7,
             "hydro charge": 0,


### PR DESCRIPTION
## Issue

Fixes issue [1878](https://linear.app/electricitymaps/issue/ELE-1878/suspiciously-high-co2-intensity-for-gas-in-ro)

## Description
Gas emission factor for Romania was way too high because of undetected outliers
We have now set the upper limit to 800 gCO2eq/kWh for gas
This also makes the EU average decrease hence the modification of EF for zones which use the default EU average

### Preview

See this [sheet](https://docs.google.com/spreadsheets/d/1dITlaKmWC5E21M-CTRhQzgNqjPz7YjqW7U6dGEQOf9A/edit?usp=sharing) for updated factors


### Double check

- [x] I have tested my parser changes locally with `poetry run test_parser "zone_key"`
- [x] I have run `pnpx prettier --write .` and `poetry run format` to format my changes.
