### PR TITLE
Update granularity of FR realtime parser

### DIFF
--- a/parsers/FR.py
+++ b/parsers/FR.py
@@ -196,9 +196,6 @@ def fetch_consumption(
     datapoints = []
     for row in df_consumption.itertuples():
 
-        if arrow.get(row.datetime).datetime.minute not in [0, 30]:
-            continue
-
         datapoints.append(
             {
                 "zoneKey": zone_key,

--- a/parsers/FR.py
+++ b/parsers/FR.py
@@ -156,10 +156,6 @@ def fetch_production(
         if not any([is_not_nan_and_truthy(v) for k, v in production.items()]):
             continue
 
-        # only keep datapoints which minutes are 0 and 30 (ignore 15 and 45)
-        if arrow.get(row[1]["date_heure"]).datetime.minute not in [0, 30]:
-            continue
-
         datapoint = {
             "zoneKey": zone_key,
             "datetime": arrow.get(row[1]["date_heure"])

--- a/parsers/FR.py
+++ b/parsers/FR.py
@@ -182,7 +182,7 @@ def fetch_production(
 
         datapoint = {
             "zoneKey": zone_key,
-            "datetime": arrow.get(row[1]["datetime_30"])
+            "datetime": arrow.get(row[1]["date_heure"])
             .replace(tzinfo="Europe/Paris")
             .datetime,
             "production": production,

--- a/parsers/FR.py
+++ b/parsers/FR.py
@@ -214,9 +214,6 @@ def fetch_consumption(
 ) -> list:
     df_consumption = get_data(session, target_datetime)
     df_consumption = df_consumption[["date_heure", "consommation"]].dropna()
-    df_consumption["datetime"] = pd.to_datetime(
-        df_consumption["date_heure"]
-    ).dt.tz_convert("Europe/Paris")
 
     # reindex df_consumption to get 1/2 hourly values
     df_consumption_reindexed = reindex_data(df_consumption)

--- a/parsers/FR.py
+++ b/parsers/FR.py
@@ -157,7 +157,7 @@ def fetch_production(
             continue
 
         # only keep datapoints which minutes are 0 and 30 (ignore 15 and 45)
-        if arrow.get(row[1]["date_heure"]).datetime.minute not in [0,30]:
+        if arrow.get(row[1]["date_heure"]).datetime.minute not in [0, 30]:
             continue
 
         datapoint = {
@@ -200,7 +200,7 @@ def fetch_consumption(
     datapoints = []
     for row in df_consumption.itertuples():
 
-        if arrow.get(row.datetime).datetime.minute not in [0,30]:
+        if arrow.get(row.datetime).datetime.minute not in [0, 30]:
             continue
 
         datapoints.append(

--- a/parsers/FR.py
+++ b/parsers/FR.py
@@ -40,6 +40,9 @@ DATASET_REAL_TIME = "eco2mix-national-tr"
 DATASET_CONSOLIDATED = "eco2mix-national-cons-def"  # API called is Données éCO2mix nationales consolidées et définitives for datetimes older than 9 months
 
 
+DELTA_15 = timedelta(minutes=15)
+
+
 def is_not_nan_and_truthy(v) -> bool:
     if isinstance(v, float) and math.isnan(v):
         return False
@@ -92,6 +95,23 @@ def get_data(
     return df
 
 
+def reindex_data(df_to_reindex: pd.DataFrame) -> pd.DataFrame:
+    """Reindex data to get averaged half-hourly values instead of quart-hourly values. This is done to ensure consistency between the historical set (1/2 hourly granularity) and the real-time set (1/4 hourly granularity)"""
+    df_to_reindex = df_to_reindex.copy()
+    # Round dates to the lower bound with 30 minutes granularity
+    df_to_reindex["datetime"] = df_to_reindex["date_heure"].apply(
+        lambda x: arrow.get(x).datetime
+    )
+    df_to_reindex["datetime_30"] = df_to_reindex["datetime"].apply(
+        lambda x: x if x.minute in [0, 30] else x - DELTA_15
+    )
+
+    # Average data points corresponding to the same time with 30 min granularity
+    df_reindexed = df_to_reindex.groupby("datetime_30").mean().reset_index()
+    df_reindexed = df_reindexed.rename(columns={"datetime_30": "date_heure"})
+    return df_reindexed
+
+
 @refetch_frequency(timedelta(days=1))
 def fetch_production(
     zone_key: str = "FR",
@@ -117,17 +137,12 @@ def fetch_production(
     df_production = df_production.loc[:, ["date_heure"] + present_fuels]
     df_production[present_fuels] = df_production[present_fuels].astype(float)
 
-    delta_15 = timedelta(minutes = 15)
-
-    #Round dates to the lower bound with 30 minutes granularity
-    df_production['datetime'] = df_production["date_heure"].apply(lambda x : arrow.get(x).datetime)
-    df_production['datetime_30'] = df_production["datetime"].apply(lambda x : x if x.minute in [0, 30] else x-delta_15)
-
-    #Average data points corresponding to the same time with 30 min granularity
-    df_production_30 = df_production.groupby('datetime_30').mean().reset_index()
+    # reindex df_production to get 1/2 hourly values
+    df_production_reindexed = reindex_data(df_production)
+    df_production_reindexed = df_production_reindexed.dropna(how="any", axis=0)
 
     datapoints = list()
-    for row in df_production_30.iterrows():
+    for row in df_production_reindexed.iterrows():
         production = dict()
         for key, value in MAP_GENERATION.items():
             if key not in present_fuels:
@@ -142,11 +157,11 @@ def fetch_production(
 
         # Hydro is a special case!
         has_hydro_production = all(
-            i in df_production_30.columns
+            i in df_production_reindexed.columns
             for i in ["hydraulique_lacs", "hydraulique_fil_eau_eclusee"]
         )
         has_hydro_storage = all(
-            i in df_production_30.columns
+            i in df_production_reindexed.columns
             for i in ["pompage", "hydraulique_step_turbinage"]
         )
         if has_hydro_production:
@@ -202,17 +217,15 @@ def fetch_consumption(
     df_consumption["datetime"] = pd.to_datetime(
         df_consumption["date_heure"]
     ).dt.tz_convert("Europe/Paris")
-    delta_15 = timedelta(minutes = 15)
-    #Average data points corresponding to the same time with 30 min granularity
-    df_consumption['datetime_30'] = df_consumption["datetime"].apply(lambda x : x if x.minute in [0, 30] else x-delta_15)
-    df_consumption_30 = df_consumption.groupby('datetime_30').mean().reset_index()
-    datapoints = []
-    for row in df_consumption_30.itertuples():
 
+    # reindex df_consumption to get 1/2 hourly values
+    df_consumption_reindexed = reindex_data(df_consumption)
+    datapoints = []
+    for row in df_consumption_reindexed.itertuples():
         datapoints.append(
             {
                 "zoneKey": zone_key,
-                "datetime": arrow.get(row.datetime_30)
+                "datetime": arrow.get(row.date_heure)
                 .replace(tzinfo="Europe/Paris")
                 .datetime,
                 "consumption": row.consommation,

--- a/parsers/FR.py
+++ b/parsers/FR.py
@@ -204,13 +204,17 @@ def fetch_consumption(
     df_consumption["datetime"] = pd.to_datetime(
         df_consumption["date_heure"]
     ).dt.tz_convert("Europe/Paris")
+    delta_15 = timedelta(minutes = 15)
+    #Average data points corresponding to the same time with 30 min granularity
+    df_consumption['datetime_30'] = df_consumption["datetime"].apply(lambda x : x if x.minute in [0, 30] else x-delta_15)
+    df_consumption_30 = df_consumption.groupby('datetime_30').mean().reset_index()
     datapoints = []
-    for row in df_consumption.itertuples():
+    for row in df_consumption_30.itertuples():
 
         datapoints.append(
             {
                 "zoneKey": zone_key,
-                "datetime": arrow.get(row.datetime)
+                "datetime": arrow.get(row.datetime_30)
                 .replace(tzinfo="Europe/Paris")
                 .datetime,
                 "consumption": row.consommation,

--- a/parsers/FR.py
+++ b/parsers/FR.py
@@ -156,6 +156,10 @@ def fetch_production(
         if not any([is_not_nan_and_truthy(v) for k, v in production.items()]):
             continue
 
+        # only keep datapoints which minutes are 0 and 30 (ignore 15 and 45)
+        if arrow.get(row[1]["date_heure"]).datetime.minute not in [0,30]:
+            continue
+
         datapoint = {
             "zoneKey": zone_key,
             "datetime": arrow.get(row[1]["date_heure"])

--- a/parsers/FR.py
+++ b/parsers/FR.py
@@ -125,11 +125,9 @@ def fetch_production(
 
     #Average data points corresponding to the same time with 30 min granularity
     df_production_30 = df_production.groupby('datetime_30').mean().reset_index()
-    df_production_30 = df_production_30.merge(df_production, left_on='datetime_30', how='left',right_on='datetime',suffixes=(None,'_y'))
-    df_production = df_production_30.loc[:,['date_heure']+present_fuels]
 
     datapoints = list()
-    for row in df_production.iterrows():
+    for row in df_production_30.iterrows():
         production = dict()
         for key, value in MAP_GENERATION.items():
             if key not in present_fuels:
@@ -144,11 +142,11 @@ def fetch_production(
 
         # Hydro is a special case!
         has_hydro_production = all(
-            i in df_production.columns
+            i in df_production_30.columns
             for i in ["hydraulique_lacs", "hydraulique_fil_eau_eclusee"]
         )
         has_hydro_storage = all(
-            i in df_production.columns
+            i in df_production_30.columns
             for i in ["pompage", "hydraulique_step_turbinage"]
         )
         if has_hydro_production:
@@ -169,7 +167,7 @@ def fetch_production(
 
         datapoint = {
             "zoneKey": zone_key,
-            "datetime": arrow.get(row[1]["date_heure"])
+            "datetime": arrow.get(row[1]["datetime_30"])
             .replace(tzinfo="Europe/Paris")
             .datetime,
             "production": production,

--- a/parsers/FR.py
+++ b/parsers/FR.py
@@ -199,6 +199,10 @@ def fetch_consumption(
     ).dt.tz_convert("Europe/Paris")
     datapoints = []
     for row in df_consumption.itertuples():
+
+        if arrow.get(row.datetime).datetime.minute not in [0,30]:
+            continue
+
         datapoints.append(
             {
                 "zoneKey": zone_key,


### PR DESCRIPTION
## Description

Change the granularity of the real time parser from 15 minutes to 30 minutes for consistency with the historical data parser (only available with 30min granularity)

Real-time dataset specs
![image](https://user-images.githubusercontent.com/107848894/231161140-9d1ba2c6-aaed-4a98-9d2f-e34ef0c4ce2c.png)

Historical dataset specs
![image](https://user-images.githubusercontent.com/107848894/231161167-63aeb3eb-eb96-420c-b4f5-c02e09a18b38.png)

### Double check

- [ ] I have tested my parser changes locally with `poetry run test_parser "zone_key"`
- [ ] I have run `pnpx prettier --write .` and `poetry run format` to format my changes.
