### PR TITLE
make negative price data gray

### DIFF
--- a/web/pnpm-lock.yaml
+++ b/web/pnpm-lock.yaml
@@ -5098,7 +5098,7 @@ packages:
       '@storybook/csf-plugin': 7.0.0-alpha.47
       '@storybook/csf-tools': 7.0.0-alpha.47
       '@storybook/docs-tools': 7.0.0-alpha.47(react-dom@18.2.0)(react@18.2.0)(typescript@4.8.4)
-      '@storybook/mdx2-csf': 1.0.0-next.6
+      '@storybook/mdx2-csf': 1.0.0-next.8
       '@storybook/node-logger': 7.0.0-alpha.47
       '@storybook/postinstall': 7.0.0-alpha.47
       '@storybook/preview-web': 7.0.0-alpha.47(react-dom@18.2.0)(react@18.2.0)
@@ -5137,7 +5137,7 @@ packages:
       '@storybook/components': 7.0.0-alpha.54(react-dom@18.2.0)(react@18.2.0)
       '@storybook/csf-plugin': 7.0.0-alpha.54
       '@storybook/csf-tools': 7.0.0-alpha.54
-      '@storybook/mdx2-csf': 1.0.0-next.6
+      '@storybook/mdx2-csf': 1.0.0-next.8
       '@storybook/node-logger': 7.0.0-alpha.54
       '@storybook/postinstall': 7.0.0-alpha.54
       '@storybook/preview-api': 7.0.0-alpha.54
@@ -5251,7 +5251,7 @@ packages:
     dependencies:
       '@storybook/client-logger': 7.0.0-alpha.54
       '@storybook/core-events': 7.0.0-alpha.54
-      '@storybook/csf': 0.0.2-next.10
+      '@storybook/csf': 0.0.2-next.11
       '@storybook/manager-api': 7.0.0-alpha.54(react-dom@18.2.0)(react@18.2.0)
       '@storybook/preview-api': 7.0.0-alpha.54
       '@storybook/router': 7.0.0-alpha.54(react-dom@18.2.0)(react@18.2.0)
@@ -5516,7 +5516,7 @@ packages:
       '@storybook/channels': 7.0.0-alpha.47
       '@storybook/client-logger': 7.0.0-alpha.47
       '@storybook/core-events': 7.0.0-alpha.47
-      '@storybook/csf': 0.0.2-next.10
+      '@storybook/csf': 0.0.2-next.11
       '@storybook/router': 7.0.0-alpha.47(react-dom@18.2.0)(react@18.2.0)
       '@storybook/theming': 7.0.0-alpha.47(react-dom@18.2.0)(react@18.2.0)
       '@storybook/types': 7.0.0-alpha.47
@@ -5545,7 +5545,7 @@ packages:
       '@storybook/client-logger': 7.0.0-alpha.47
       '@storybook/components': 7.0.0-alpha.47(react-dom@18.2.0)(react@18.2.0)
       '@storybook/core-events': 7.0.0-alpha.47
-      '@storybook/csf': 0.0.2-next.10
+      '@storybook/csf': 0.0.2-next.11
       '@storybook/docs-tools': 7.0.0-alpha.47(react-dom@18.2.0)(react@18.2.0)(typescript@4.8.4)
       '@storybook/preview-web': 7.0.0-alpha.47(react-dom@18.2.0)(react@18.2.0)
       '@storybook/store': 7.0.0-alpha.47(react-dom@18.2.0)(react@18.2.0)
@@ -5579,7 +5579,7 @@ packages:
       '@storybook/client-logger': 7.0.0-alpha.54
       '@storybook/components': 7.0.0-alpha.54(react-dom@18.2.0)(react@18.2.0)
       '@storybook/core-events': 7.0.0-alpha.54
-      '@storybook/csf': 0.0.2-next.10
+      '@storybook/csf': 0.0.2-next.11
       '@storybook/docs-tools': 7.0.0-alpha.54(react-dom@18.2.0)(react@18.2.0)(typescript@4.8.4)
       '@storybook/manager-api': 7.0.0-alpha.54(react-dom@18.2.0)(react@18.2.0)
       '@storybook/preview-api': 7.0.0-alpha.54
@@ -5645,7 +5645,7 @@ packages:
       '@storybook/client-api': 7.0.0-alpha.54
       '@storybook/client-logger': 7.0.0-alpha.54
       '@storybook/core-common': 7.0.0-alpha.54(react-dom@18.2.0)(react@18.2.0)(typescript@4.8.4)
-      '@storybook/mdx2-csf': 1.0.0-next.6
+      '@storybook/mdx2-csf': 1.0.0-next.8
       '@storybook/node-logger': 7.0.0-alpha.54
       '@storybook/preview': 7.0.0-alpha.54
       '@storybook/preview-api': 7.0.0-alpha.54
@@ -5788,7 +5788,7 @@ packages:
     resolution: {integrity: sha512-IQgWW7e3juJ9aARrZ4ue0WDkiAhhyVXf3ZOZHlDaIxj458rg/ClOT4TTbXMoicg8tQO1hV4CrpfnwnOLU/3q3A==}
     dependencies:
       '@babel/types': 7.20.2
-      '@storybook/csf': 0.0.2-next.10
+      '@storybook/csf': 0.0.2-next.11
       '@storybook/csf-tools': 7.0.0-alpha.54
       '@storybook/node-logger': 7.0.0-alpha.54
       '@storybook/types': 7.0.0-alpha.54
@@ -5811,7 +5811,7 @@ packages:
       react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0
     dependencies:
       '@storybook/client-logger': 7.0.0-alpha.47
-      '@storybook/csf': 0.0.2-next.10
+      '@storybook/csf': 0.0.2-next.11
       '@storybook/theming': 7.0.0-alpha.47(react-dom@18.2.0)(react@18.2.0)
       '@storybook/types': 7.0.0-alpha.47
       memoizerific: 1.11.3
@@ -5829,7 +5829,7 @@ packages:
       react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0
     dependencies:
       '@storybook/client-logger': 7.0.0-alpha.54
-      '@storybook/csf': 0.0.2-next.10
+      '@storybook/csf': 0.0.2-next.11
       '@storybook/theming': 7.0.0-alpha.54(react-dom@18.2.0)(react@18.2.0)
       '@storybook/types': 7.0.0-alpha.54
       memoizerific: 1.11.3
@@ -5963,9 +5963,9 @@ packages:
       '@storybook/builder-manager': 7.0.0-alpha.54(react-dom@18.2.0)(react@18.2.0)(typescript@4.8.4)
       '@storybook/core-common': 7.0.0-alpha.54(react-dom@18.2.0)(react@18.2.0)(typescript@4.8.4)
       '@storybook/core-events': 7.0.0-alpha.54
-      '@storybook/csf': 0.0.2-next.10
+      '@storybook/csf': 0.0.2-next.11
       '@storybook/csf-tools': 7.0.0-alpha.54
-      '@storybook/docs-mdx': 0.0.1-next.6
+      '@storybook/docs-mdx': 0.0.1-next.7
       '@storybook/node-logger': 7.0.0-alpha.54
       '@storybook/preview-api': 7.0.0-alpha.54
       '@storybook/telemetry': 7.0.0-alpha.54(react-dom@18.2.0)(react@18.2.0)(typescript@4.8.4)
@@ -6031,7 +6031,7 @@ packages:
     resolution: {integrity: sha512-SQrLwy1+kfI4MYFJDfo+GY3aUBpblpMVLDreTm5utif1zH5UvFCgTpVPkxnxML7OrxjI7GKvgSjWlR23NUwexA==}
     dependencies:
       '@babel/types': 7.20.2
-      '@storybook/csf': 0.0.2-next.10
+      '@storybook/csf': 0.0.2-next.11
       '@storybook/types': 7.0.0-alpha.47
       fs-extra: 9.1.0
       ts-dedent: 2.2.0
@@ -6043,7 +6043,7 @@ packages:
     resolution: {integrity: sha512-Eq7L37zYLtUouWUQ/l6nZf3XeuJPJ/GQXylNexC0qcNmhUrTv1wVvfMO9+36d/7kMEa/psuvaM/ZtaR1KiCA7w==}
     dependencies:
       '@babel/types': 7.20.2
-      '@storybook/csf': 0.0.2-next.10
+      '@storybook/csf': 0.0.2-next.11
       '@storybook/types': 7.0.0-alpha.54
       fs-extra: 9.1.0
       ts-dedent: 2.2.0
@@ -6063,14 +6063,14 @@ packages:
       lodash: 4.17.21
     dev: true
 
-  /@storybook/csf@0.0.2-next.10:
-    resolution: {integrity: sha512-m2PFgBP/xRIF85VrDhvesn9ktaD2pN3VUjvMqkAL/cINp/3qXsCyI81uw7N5VEOkQAbWrY2FcydnvEPDEdE8fA==}
+  /@storybook/csf@0.0.2-next.11:
+    resolution: {integrity: sha512-xGt0YSVxZb43sKmEf1GIQD8xEbo+c+S6khDEL7Qu/pYA0gh5z3WUuhOlovnelYj/YJod+XRsfVvk23AaRfUJ4Q==}
     dependencies:
       type-fest: 2.19.0
     dev: true
 
-  /@storybook/docs-mdx@0.0.1-next.6:
-    resolution: {integrity: sha512-DjoSIXADmLJtdroXAjUotFiZlcZ2usWhqrS7aeOtZs0DVR0Ws5WQjnwtpDUXt8gryTSd+OZJ0cNsDcqg4JDEvQ==}
+  /@storybook/docs-mdx@0.0.1-next.7:
+    resolution: {integrity: sha512-JbgBf/EMBtx65iXtB3pOiX3818UeL9jZ+KAY241OAPqJVXjMQ5KaVOdg/57MSmd508HDIGx7CiImOMEmWwQ9/g==}
     dev: true
 
   /@storybook/docs-tools@7.0.0-alpha.47(react-dom@18.2.0)(react@18.2.0)(typescript@4.8.4):
@@ -6140,7 +6140,7 @@ packages:
       '@storybook/channels': 7.0.0-alpha.54
       '@storybook/client-logger': 7.0.0-alpha.54
       '@storybook/core-events': 7.0.0-alpha.54
-      '@storybook/csf': 0.0.2-next.10
+      '@storybook/csf': 0.0.2-next.11
       '@storybook/router': 7.0.0-alpha.54(react-dom@18.2.0)(react@18.2.0)
       '@storybook/theming': 7.0.0-alpha.54(react-dom@18.2.0)(react@18.2.0)
       '@storybook/types': 7.0.0-alpha.54
@@ -6162,8 +6162,8 @@ packages:
     resolution: {integrity: sha512-lMRKO083NQSSvO/FgOETzn0sf6eZ5YPirvp1+KD+sWkwzPTib8p+g14fbbH/88MV1GpMaXIHP/FD/pEc1jf4Cw==}
     dev: true
 
-  /@storybook/mdx2-csf@1.0.0-next.6:
-    resolution: {integrity: sha512-m6plojocU/rmrqWd26yvm8D+oHZPZ6PtSSFmZIgpNDEPVmc8s4fBD6LXOAB5MiPI5f8KLUr2HVhOMZ97o5pDTw==}
+  /@storybook/mdx2-csf@1.0.0-next.8:
+    resolution: {integrity: sha512-t2O5s/HHTH5evZVHgVtCWTZgMZ/CaqDu3xVGgjVbKeTvpPAbi0Waab5SSX8T9PG5jNDei/x+jpAVCcNMOHoWzg==}
     dev: true
 
   /@storybook/node-logger@6.5.13:
@@ -6209,7 +6209,7 @@ packages:
       '@storybook/channels': 7.0.0-alpha.54
       '@storybook/client-logger': 7.0.0-alpha.54
       '@storybook/core-events': 7.0.0-alpha.54
-      '@storybook/csf': 0.0.2-next.10
+      '@storybook/csf': 0.0.2-next.11
       '@storybook/types': 7.0.0-alpha.54
       '@types/qs': 6.9.7
       dequal: 2.0.3
@@ -6375,7 +6375,7 @@ packages:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0
       react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0
     dependencies:
-      '@storybook/csf': 0.0.2-next.10
+      '@storybook/csf': 0.0.2-next.11
       '@storybook/types': 7.0.0-alpha.54
       estraverse: 5.3.0
       lodash: 4.17.21
@@ -6395,7 +6395,7 @@ packages:
       '@storybook/addons': 7.0.0-alpha.47(react-dom@18.2.0)(react@18.2.0)
       '@storybook/client-logger': 7.0.0-alpha.47
       '@storybook/core-events': 7.0.0-alpha.47
-      '@storybook/csf': 0.0.2-next.10
+      '@storybook/csf': 0.0.2-next.11
       '@storybook/types': 7.0.0-alpha.47
       dequal: 2.0.3
       global: 4.4.0
@@ -9246,6 +9246,7 @@ packages:
   /autoprefixer@10.4.12(postcss@8.4.18):
     resolution: {integrity: sha512-WrCGV9/b97Pa+jtwf5UGaRjgQIg7OK3D06GnoYoZNcG1Xb8Gt3EfuKjlhh9i/VtT16g6PYjZ69jdJ2g8FxSC4Q==}
     engines: {node: ^10 || ^12 || >=14}
+    hasBin: true
     peerDependencies:
       postcss: ^8.1.0
     dependencies:
@@ -11516,6 +11517,7 @@ packages:
 
   /eslint-config-prettier@8.5.0(eslint@8.26.0):
     resolution: {integrity: sha512-obmWKLUNCnhtQRKc+tmnYuQl0pFU1ibYJQ5BGhTVB08bHe9wC8qUeG7c08dj9XX+AuPj1YSGSQIHl1pnDHZR0Q==}
+    hasBin: true
     peerDependencies:
       eslint: '>=7.0.0'
     dependencies:
@@ -13808,6 +13810,7 @@ packages:
 
   /jscodeshift@0.13.1(@babel/preset-env@7.20.2):
     resolution: {integrity: sha512-lGyiEbGOvmMRKgWk4vf+lUrCWO/8YR8sUR3FKF1Cq5fovjZDlIcw3Hu5ppLHAnEXshVffvaM0eyuY/AbOeYpnQ==}
+    hasBin: true
     peerDependencies:
       '@babel/preset-env': ^7.1.6
     dependencies:
@@ -14975,6 +14978,7 @@ packages:
   /msw@0.47.4(typescript@4.8.4):
     resolution: {integrity: sha512-Psftt8Yfl0+l+qqg9OlmKEsxF8S/vtda0CmlR6y8wTaWrMMzuCDa55n2hEGC0ZRDwuV6FFWc/4CjoDsBpATKBw==}
     engines: {node: '>=14'}
+    hasBin: true
     requiresBuild: true
     peerDependencies:
       typescript: '>= 4.2.x <= 4.8.x'
@@ -17692,6 +17696,7 @@ packages:
   /tailwindcss@3.2.4(postcss@8.4.18)(ts-node@10.9.1):
     resolution: {integrity: sha512-AhwtHCKMtR71JgeYDaswmZXhPcW9iuI9Sp2LvZPo9upDZ7231ZJ7eA9RaURbhpXGVlrjX4cFNlB4ieTetEb7hQ==}
     engines: {node: '>=12.13.0'}
+    hasBin: true
     peerDependencies:
       postcss: ^8.0.9
     dependencies:
@@ -17992,6 +17997,7 @@ packages:
 
   /ts-node@10.9.1(@types/node@18.11.17)(typescript@4.8.4):
     resolution: {integrity: sha512-NtVysVPkxxrwFGUUxGYhfux8k78pQB3JqYBXlLRZgdGUqTO5wU/UyHop5p70iEbGhB7q5KmiZiU0Y3KlJrScEw==}
+    hasBin: true
     peerDependencies:
       '@swc/core': '>=1.2.50'
       '@swc/wasm': '>=1.2.50'
@@ -18298,6 +18304,7 @@ packages:
 
   /update-browserslist-db@1.0.9(browserslist@4.21.4):
     resolution: {integrity: sha512-/xsqn21EGVdXI3EXSum1Yckj3ZVZugqyOZQ/CxYPBD/R+ko9NSUScf8tFF4dOKY+2pvSSJA/S+5B8s4Zr4kyvg==}
+    hasBin: true
     peerDependencies:
       browserslist: '>= 4.21.0'
     dependencies:
@@ -18503,6 +18510,7 @@ packages:
   /vite@3.1.8:
     resolution: {integrity: sha512-m7jJe3nufUbuOfotkntGFupinL/fmuTNuQmiVE7cH2IZMuf4UbfbGYMUT3jVWgGYuRVLY9j8NnrRqgw5rr5QTg==}
     engines: {node: ^14.18.0 || >=16.0.0}
+    hasBin: true
     peerDependencies:
       less: '*'
       sass: '*'
@@ -18529,6 +18537,7 @@ packages:
   /vite@4.2.1(@types/node@18.11.17):
     resolution: {integrity: sha512-7MKhqdy0ISo4wnvwtqZkjke6XN4taqQ2TBaTccLIpOKv7Vp2h4Y+NpmWCnGDeSvvn45KxvWgGyb0MkHvY1vgbg==}
     engines: {node: ^14.18.0 || >=16.0.0}
+    hasBin: true
     peerDependencies:
       '@types/node': '>= 14'
       less: '*'
@@ -18562,6 +18571,7 @@ packages:
   /vitest@0.24.3(jsdom@20.0.1):
     resolution: {integrity: sha512-aM0auuPPgMSstWvr851hB74g/LKaKBzSxcG3da7ejfZbx08Y21JpZmbmDYrMTCGhVZKqTGwzcnLMwyfz2WzkhQ==}
     engines: {node: '>=v14.16.0'}
+    hasBin: true
     peerDependencies:
       '@edge-runtime/vm': '*'
       '@vitest/browser': '*'

--- a/web/src/features/charts/hooks/usePriceChartData.ts
+++ b/web/src/features/charts/hooks/usePriceChartData.ts
@@ -12,7 +12,7 @@ export function getFills(data: AreaGraphElement[]) {
 
   const priceColorScale = scaleLinear<string>()
     .domain([priceMinValue, 0, priceMaxValue])
-    .range(['brown', 'lightgray', '#616161']);
+    .range(['gray', 'lightgray', '#616161']);
 
   const layerFill = (key: string) => (d: { data: AreaGraphElement }) =>
     priceColorScale(d.data.layerData[key]);


### PR DESCRIPTION
## Issue
Negative price charts are currently brown
![image](https://user-images.githubusercontent.com/18622768/231978374-b88627e4-e931-4b72-83b1-6f6f474f5160.png)
## Description
This PR changes the color of negative price data chart values to gray

### Preview
![image](https://user-images.githubusercontent.com/18622768/231978201-0ab6c0b6-d944-4a35-9b19-a90f188d752d.png)


Bonus lockfile update


