### PR TITLE
don't show wind sprite tails on iOS

### DIFF
--- a/web/src/features/weather-layers/wind-layer/windy.ts
+++ b/web/src/features/weather-layers/wind-layer/windy.ts
@@ -18,6 +18,7 @@
 
 import { Point } from 'mapbox-gl';
 import { windColor } from './scales';
+import { Capacitor } from '@capacitor/core';
 
 var Windy = function (params: any) {
   var VELOCITY_SCALE = 1 / 100000; //1/70000             // scale for wind velocity (completely arbitrary--this value looks nice)
@@ -187,7 +188,8 @@ var Windy = function (params: any) {
       navigator.userAgent
     );
   };
-
+  var isIphone =
+    Capacitor.getPlatform() === 'ios' || /iPad|iPhone|iPod/.test(navigator.userAgent);
   /**
    * Calculate distortion of the wind vector caused by the shape of the projection at point (x, y). The wind
    * vector is modified in place and returned by this function.
@@ -488,7 +490,7 @@ var Windy = function (params: any) {
       var b = deltaMs < 16 ? 1 : 16 / deltaMs;
 
       // Fade existing particle trails.
-      g.globalCompositeOperation = 'destination-in';
+      g.globalCompositeOperation = isIphone ? 'destination-out' : 'destination-in';
       // This is the parameter concerning the fade property/bug
       g.globalAlpha = Math.pow(0.9, b);
       g.fillRect(bounds.x, bounds.y, bounds.width, bounds.height);

--- a/web/src/features/weather-layers/wind-layer/windy.ts
+++ b/web/src/features/weather-layers/wind-layer/windy.ts
@@ -183,12 +183,12 @@ var Windy = function (params: any) {
   /**
    * @returns {Boolean} true if agent is probably a mobile device. Don't really care if this is accurate.
    */
-  var isMobile = function () {
+  const isMobile = function () {
     return /android|blackberry|iemobile|ipad|iphone|ipod|opera mini|webos/i.test(
       navigator.userAgent
     );
   };
-  var isIphone =
+  const isIphone =
     Capacitor.getPlatform() === 'ios' || /iPad|iPhone|iPod/.test(navigator.userAgent);
   /**
    * Calculate distortion of the wind vector caused by the shape of the projection at point (x, y). The wind


### PR DESCRIPTION
## Issue
![image](https://user-images.githubusercontent.com/18622768/232049975-989bc03c-9988-4d27-8772-feb030a654f7.png)

The wind layer on older iOS devices was not fading out after the wind animation

## Description
This PR adds the check for iOS devices, then uses an animation without a trail for iOS devices.

### Preview

https://user-images.githubusercontent.com/18622768/232050000-0825ba21-2011-4fdb-a4a6-6fc4d29f0eaf.mov

