### PR TITLE
round viewport values

### DIFF
--- a/web/src/utils/viewport.ts
+++ b/web/src/utils/viewport.ts
@@ -33,8 +33,8 @@ export function useReferenceWidthHeightObserver(offsetX = 0, offsetY = 0) {
 
   return {
     ref: reference,
-    width,
-    height,
+    width: Math.round(width),
+    height: Math.round(height),
     node,
   };
 }


### PR DESCRIPTION
## Issue
![Screenshot_20230414_154633_Chrome](https://user-images.githubusercontent.com/18622768/232061458-9b579e17-85e2-4ddd-8428-ba205b662540.jpg)

Android devices are showing a distorted view of the solar layer

## Description
This PR rounds the values returned for viewport width and height, android would return long values like 512.23435253 which would throw off our solar layer projections. 

### Preview
![Screenshot_20230414_154646_Chrome](https://user-images.githubusercontent.com/18622768/232061864-db48c876-83fc-420a-9356-5eec180d59db.jpg)


### Double check

- [x] I have tested my parser changes locally with `poetry run test_parser "zone_key"`
- [x] I have run `pnpx prettier --write .` and `poetry run format` to format my changes.
