### PR TITLE
Update German nuclear capacity after closue of the last three reactors on April 15, 2023

### DIFF
--- a/DATA_SOURCES.md
+++ b/DATA_SOURCES.md
@@ -261,7 +261,7 @@ For many European countries, data is available from [ENTSO-E](https://transparen
   - Thermal: [service-public.pf](https://www.service-public.pf/sde/documentation-2/rapports-delegataires)
 - Germany:
   - Nuclear: [IAEA](https://pris.iaea.org/PRIS/CountryStatistics/CountryDetails.aspx?current=DE)
-  - Nuclear [BASE](https://www.base.bund.de/EN/ns/nuclear-phase-out/nuclear-phase-out_node.html)
+  - Nuclear: [BASE](https://www.base.bund.de/EN/ns/nuclear-phase-out/nuclear-phase-out_node.html)
   - Geothermal and Unknown: [Bundesnetzagentur](https://www.bundesnetzagentur.de/DE/Sachgebiete/ElektrizitaetundGas/Unternehmen_Institutionen/Versorgungssicherheit/Erzeugungskapazitaeten/Kraftwerksliste/kraftwerksliste-node.html)
   - Other: [Frauenhofer ISE](https://energy-charts.info/charts/installed_power/chart.htm)
 - Georgia: [ENTSO-E](https://transparency.entsoe.eu/generation/r2/installedGenerationCapacityAggregation/show)

--- a/DATA_SOURCES.md
+++ b/DATA_SOURCES.md
@@ -261,6 +261,7 @@ For many European countries, data is available from [ENTSO-E](https://transparen
   - Thermal: [service-public.pf](https://www.service-public.pf/sde/documentation-2/rapports-delegataires)
 - Germany:
   - Nuclear: [IAEA](https://pris.iaea.org/PRIS/CountryStatistics/CountryDetails.aspx?current=DE)
+  - Nuclear [BASE](https://www.base.bund.de/EN/ns/nuclear-phase-out/nuclear-phase-out_node.html)
   - Geothermal and Unknown: [Bundesnetzagentur](https://www.bundesnetzagentur.de/DE/Sachgebiete/ElektrizitaetundGas/Unternehmen_Institutionen/Versorgungssicherheit/Erzeugungskapazitaeten/Kraftwerksliste/kraftwerksliste-node.html)
   - Other: [Frauenhofer ISE](https://energy-charts.info/charts/installed_power/chart.htm)
 - Georgia: [ENTSO-E](https://transparency.entsoe.eu/generation/r2/installedGenerationCapacityAggregation/show)

--- a/DATA_SOURCES.md
+++ b/DATA_SOURCES.md
@@ -260,6 +260,7 @@ For many European countries, data is available from [ENTSO-E](https://transparen
   - Hydro & Solar: [service-public.pf](https://www.service-public.pf/sde/wp-content/uploads/sites/15/2021/02/BEPF-2019-VF_online_mail_light_compressed.pdf)
   - Thermal: [service-public.pf](https://www.service-public.pf/sde/documentation-2/rapports-delegataires)
 - Germany:
+  - Nuclear: [IAEA](https://pris.iaea.org/PRIS/CountryStatistics/CountryDetails.aspx?current=DE)
   - Geothermal and Unknown: [Bundesnetzagentur](https://www.bundesnetzagentur.de/DE/Sachgebiete/ElektrizitaetundGas/Unternehmen_Institutionen/Versorgungssicherheit/Erzeugungskapazitaeten/Kraftwerksliste/kraftwerksliste-node.html)
   - Other: [Frauenhofer ISE](https://energy-charts.info/charts/installed_power/chart.htm)
 - Georgia: [ENTSO-E](https://transparency.entsoe.eu/generation/r2/installedGenerationCapacityAggregation/show)

--- a/config/zones/DE.yaml
+++ b/config/zones/DE.yaml
@@ -14,7 +14,7 @@ capacity:
   geothermal: 47
   hydro: 4940
   hydro storage: 9780
-  nuclear: 4055
+  nuclear: 0
   oil: 4720
   solar: 69060
   unknown: 3700


### PR DESCRIPTION
Use data from IAEA PRIS (Power Reactor Information System): https://pris.iaea.org/PRIS/CountryStatistics/CountryDetails.aspx?current=DE

Before:
Emsland: 1335 MW
Isar-2: 1410 MW
Neckarwestheim-2: 1310 MW
Total: 4055 MW

After:
Total: 0 MW
