### PR TITLE
Update US-FLA-TEC coal generation capacity

### DIFF
--- a/DATA_SOURCES.md
+++ b/DATA_SOURCES.md
@@ -435,6 +435,8 @@ For many European countries, data is available from [ENTSO-E](https://transparen
     - CEC: [CEC](https://ww2.energy.ca.gov/almanac/electricity_data/electric_generation_capacity.html)
     - Renewables: [CAISO](http://www.caiso.com/informed/Pages/CleanGrid/default.aspx)
     - Nuclear: [wikipedia.org](https://en.wikipedia.org/wiki/Diablo_Canyon_Power_Plant)
+  - Florida TECO (US-FLA-TEC)
+    - Coal: [Github|electricitymaps-contrib|PR#5297](https://github.com/electricitymaps/electricitymaps-contrib/pull/5297)
   - Hawaii
     - Battery storage: [Kapolei Energy Storage Project](https://www.kapoleienergystorage.com/)
     - Coal: [The Guardian: Hawaii to close its only coal power plant in a step toward renewable energy](https://web.archive.org/web/20220902132250/https://www.theguardian.com/us-news/2022/aug/31/hawaii-close-coal-power-plant-renewable-energy)

--- a/config/zones/US-FLA-TEC.yaml
+++ b/config/zones/US-FLA-TEC.yaml
@@ -6,7 +6,7 @@ bounding_box:
 capacity:
   battery storage: 0
   biomass: 71.6
-  coal: 678.9
+  coal: 233.4
   gas: 6331.3
   geothermal: 0
   hydro: 0

--- a/config/zones/US-FLA-TEC.yaml
+++ b/config/zones/US-FLA-TEC.yaml
@@ -18,6 +18,7 @@ capacity:
   wind: 0
 comment: Tampa Electric Company
 contributors:
+  - brandongalbraith
   - systemcatch
   - robertahunt
   - KabelWlan


### PR DESCRIPTION
## Description

Reduces US-FLA-TEC Florida Tampa Electric zone capacity of coal due to Unit 3 retirement at Big Bend Power Station.

### Ciations

https://en.wikipedia.org/wiki/Big_Bend_Power_Station

https://www.gem.wiki/Big_Bend_Station#Project_details

https://www.tampaelectric.com/mediacenter/2023/Tampa-Electric-Completes-Big-Bend-Modernization-Project/

https://www.tampaelectric.com/mediacenter/2023/Tampa-Electric-to-Dismantle-Two-Chimneys-at-Big-Bend-Power-Plant/

![image](https://user-images.githubusercontent.com/350893/232341070-08c76dd3-4ea4-4712-b62f-c0403a12627d.png)

![image](https://user-images.githubusercontent.com/350893/232341030-d4de4779-64a7-4dd0-90b5-1710185cb077.png)
