### PR TITLE
Production mode carbon emission graph's y-axis scale fixed

### DIFF
--- a/web/src/features/charts/hooks/useEmissionChartData.ts
+++ b/web/src/features/charts/hooks/useEmissionChartData.ts
@@ -2,14 +2,13 @@ import useGetZone from 'api/getZone';
 import { max as d3Max } from 'd3-array';
 import { scaleLinear } from 'd3-scale';
 import { useAtom } from 'jotai';
-import { Mode } from 'utils/constants';
-import { productionConsumptionAtom } from 'utils/state/atoms';
+import { displayByEmissionsAtom } from 'utils/state/atoms';
 import { getTotalElectricity, tonsPerHourToGramsPerMinute } from '../graphUtils';
 import { AreaGraphElement } from '../types';
 
 export function useEmissionChartData() {
   const { data, isLoading, isError } = useGetZone();
-  const [mixMode] = useAtom(productionConsumptionAtom);
+  const [displayByEmissions] = useAtom(displayByEmissionsAtom);
 
   if (isLoading || isError) {
     return { isLoading, isError };
@@ -22,7 +21,7 @@ export function useEmissionChartData() {
         datetime,
         layerData: {
           emissions: tonsPerHourToGramsPerMinute(
-            getTotalElectricity(value, mixMode === Mode.CONSUMPTION)
+            getTotalElectricity(value, displayByEmissions)
           ),
         },
         meta: value,


### PR DESCRIPTION
## Issue
Incorrect axis labels in emissions chart (production mode) #5140 

## Description
The goal of this PR is to fix the y-axis scale of Carbon Emission graph under the Production Mode. Previously, as represented in the issue link, the y-axis values was completely off and do not match with actual values of graph. In order to fix it, when calling the function "getTotalElectricity(zoneData, displayByEmissions)" in useEmissionChartData.ts file, I had to change the second parameter to use "displayByEmissionsAtom" instead of mixMode.

### Preview
![image](https://user-images.githubusercontent.com/64814632/233758651-f7279b0d-3e3d-4612-b11b-08bf713ab170.png)
As you can see in the picture, the y-axis is correctly scaled.

### Double check
- [N/A] I have tested my parser changes locally with `poetry run test_parser "zone_key"`
- [DONE ] I have run `pnpx prettier --write .` and `poetry run format` to format my changes.
