### PR TITLE
Fix storage cannot be a None

### DIFF
--- a/electricitymap/contrib/lib/models/events.py
+++ b/electricitymap/contrib/lib/models/events.py
@@ -271,7 +271,7 @@ class ProductionBreakdown(Event):
             "datetime": self.datetime,
             "zoneKey": self.zoneKey,
             "production": self.production.dict(exclude_none=True),
-            "storage": self.storage.dict(exclude_none=True) if self.storage else None,
+            "storage": self.storage.dict(exclude_none=True) if self.storage else {},
             "source": self.source,
         }
 


### PR DESCRIPTION
## Issue

Returning a None as a default storage is causing issues. We should return an empty dict instead.
