### PR TITLE
Use new header for ESIOS parser

### DIFF
--- a/parsers/ESIOS.py
+++ b/parsers/ESIOS.py
@@ -33,7 +33,7 @@ def fetch_exchange(
     headers = {
         "Content-Type": "application/json",
         "Accept": "application/json; application/vnd.esios-api-v2+json",
-        "Authorization": 'Token token="{0}"'.format(token),
+        "x-api-key": token,
     }
 
     # Request query url


### PR DESCRIPTION
## Issue
We don't have any data for the ES->MA exchange since the 21st of February. Turns out they made an API change now the header is a bit different.

## Description

Update to new header format.