### PR TITLE
prevent google translate on buttons

### DIFF
--- a/web/src/components/Button.tsx
+++ b/web/src/components/Button.tsx
@@ -40,6 +40,7 @@ export function Button({
         `${disabled ? 'opacity-60 hover:shadow-[0px_0px_13px_rgb(0_0_0/12%)]' : ''}`,
         className
       )}
+      translate="no"
       disabled={disabled}
       style={{ color: textColor, background: background }}
       {...(renderAsLink ? { href } : { type: 'button' })}


### PR DESCRIPTION
## Issue
https://github.com/facebook/react/issues/11538

## Description
When using the chrome base google translate while using the wind or solar buttons on mobile the whole app can crash

This PR prevents google translate operating on the buttons

Fixes this sentry error:
NotFoundError
Failed to execute 'insertBefore' on 'Node': The node before which the new node is to be inserted is not a child of this node.

copilot:poem