### PR TITLE
Updated parser for Puerto Rico (US-PR)

### DIFF
--- a/DATA_SOURCES.md
+++ b/DATA_SOURCES.md
@@ -146,7 +146,7 @@ Real-time electricity data is obtained using [parsers](https://github.com/electr
   - New England: [NEISO](https://www.iso-ne.com/isoexpress/)
   - New York: [NYISO](http://www.nyiso.com/public/markets_operations/market_data/graphs/index.jsp)
   - PJM: [PJM](http://www.pjm.com/markets-and-operations.aspx)
-  - Puerto Rico: [AEEPR](https://aeepr.com/en-us/Pages/Generaci%C3%B3n.aspx)
+  - Puerto Rico: [AEEPR](https://aeepr.com/es-pr/Paginas/NewGen/dashboard.aspx)
   - Southwest Power Pool: [SPP](https://marketplace.spp.org/pages/generation-mix)
   - Southwest Variable Energy Resource Initiative: [SVERI](https://sveri.energy.arizona.edu/#generation-by-fuel-type)
   - Texas: [ERCOT](http://www.ercot.com/content/cdr/html/real_time_system_conditions.html)

--- a/parsers/US_PREPA.py
+++ b/parsers/US_PREPA.py
@@ -388,8 +388,8 @@ def fetch_production(
                 f"of expected value ({fuel_type_value_percent}%)."
             )
 
-    with open(fetch_dt.strftime("%Y-%m-%d-%H-%M") + ".txt", "w") as text_file:
-        text_file.write(data_js)  # TODO debug out to file
+    # with open(fetch_dt.strftime("%Y-%m-%d-%H-%M") + ".txt", "w") as text_file:
+    #     text_file.write(data_js)  # TODO debug out to file
 
     return data
 

--- a/parsers/US_PREPA.py
+++ b/parsers/US_PREPA.py
@@ -266,7 +266,7 @@ def fetch_production(
     data_js = res.text
 
     # parse datetime contained in the received .js file
-    fetch_dt = parse_datetime(data_js, zone_key)
+    fetch_dt = parse_datetime(data_js, zone_key, logger)
     if fetch_dt is None:
         raise ParserException(
             parser="US_PREPA.py",

--- a/parsers/US_PREPA.py
+++ b/parsers/US_PREPA.py
@@ -28,21 +28,8 @@ GENERATION_BREAKDOWN_URL = (
     # f"{US_PROXY}/es-pr/generacion/Documents/DataJS/dataSource.js{HOST_PARAMETER}"
 )
 
-"""
-Two more endpoints, not needed here. Contain status of power plants, and 24h history of frequency and generation sum.
-/es-pr/generacion/Documents/DataJS/dataGraph.js"
-/es-pr/generacion/Documents/DataJS/dataUnitStatus.js"
-"""
-
-VAILDATION_THRESHOLD_PERCENT = 2.0
-
-# Source data identifiers -> Production types. See also comments at oil/gas validation
-SRC_POWER_TYPE_TO_PRODUCTION_TYPE = {
-    # fossil
-    "Turbina de Gas": "gas",
-    "COGEN": "gas",  # see get_production_type_from_site()
-    "Vapor": "combined",  # oil & diesel & gas, hybrid
-    "Ciclo Combinado": "combined",  # oil & diesel & gas, hybrid
+# renewable source data identifiers -> Production types
+RENEWABLE_SRC_TYPE_TO_PRODUCTION_TYPE = {
     # renewables
     "Hidroelectricas": "hydro",
     "Wind": "wind",
@@ -51,36 +38,36 @@ SRC_POWER_TYPE_TO_PRODUCTION_TYPE = {
 }
 
 
-def get_production_type_from_site(json_site):
+def get_site_renewable_type(site_info, logger):
+    """
+    Get the renewable power type from the site info.
+    """
+    # Type could be 'Hidroelectricas'
+    if site_info["Type"] in RENEWABLE_SRC_TYPE_TO_PRODUCTION_TYPE.keys():
+        return RENEWABLE_SRC_TYPE_TO_PRODUCTION_TYPE[site_info["Type"]]
 
-    if json_site["Type"] == "Renovable":
-        # Renovable-Type has specific type in 'Desc' attribute
-        return SRC_POWER_TYPE_TO_PRODUCTION_TYPE[json_site["Desc"]]
-    elif json_site["Type"] == "COGEN":
-        # "Cogeneradoras" (cogeneration units),  there are two active:
-        #   Ecoelectrica = gas (https://www.power-technology.com/marketdata/power-plant-profile-ecoelectrica-penuelas-power-plant-puerto-rico/)
-        #   AES = coal (https://www.power-technology.com/marketdata/power-plant-profile-guayama-coal-fired-power-plant-puerto-rico/)
-        if json_site["Desc"] == "Ecoelectrica":
-            return "gas"  # https://www.eia.gov/state/analysis.php?sid=RQ
-        elif json_site["Desc"] == "AES":
-            return "coal"
+    # On other cases, the type is just 'Renovable'
+    if site_info["Type"] == "Renovable":
+        # Renovable-Type has specific type in 'Desc' attribute (solar, wind...)
+        type_desc = site_info["Desc"]
 
-    if json_site["Type"] in SRC_POWER_TYPE_TO_PRODUCTION_TYPE:
-        return SRC_POWER_TYPE_TO_PRODUCTION_TYPE[json_site["Type"]]
+        if type_desc not in RENEWABLE_SRC_TYPE_TO_PRODUCTION_TYPE.keys():
+            logger.warn(f"Unknown renewable type in data: {type_desc}, skipping...")
+            return None
+
+        return RENEWABLE_SRC_TYPE_TO_PRODUCTION_TYPE[type_desc]
     else:
         return None
 
 
-def parse_datetime(
-    input_data: str, zone_key: str, logger: Logger = getLogger(__name__)
-):
+def parse_datetime(input_data: str, zone_key: str, logger: Logger):
     """
     Parses the timezone-aware datetime object from the time specified in the .js file
 
     Expected format in file:
     const dataFechaAcualizado = '4/25/2023' + ' 3:06:05 PM';
     Expected format as string:
-    M/DD/YYYY h:mm:ss A
+    M/D/YYYY h:mm:ss A
 
     Arguments:
     ----------
@@ -96,7 +83,7 @@ def parse_datetime(
     date_matches = re.search(
         r"\Aconst\sdataFechaAcualizado\s*=\s*'(.*)'\s\+\s'(.*)';", input_data
     )
-    date_fmt = "M/DD/YYYY h:mm:ss A"
+    date_fmt = "M/D/YYYY h:mm:ss A"
 
     date_str = "".join(date_matches.group(1, 2))
     logger.debug(
@@ -184,59 +171,6 @@ def get_field_value(in_json, kv_access: tuple, get_id: str):
     return None
 
 
-def validate_fuel_type(
-    fuel_type: str,
-    production_data,
-    total_production: int,
-    expected_perc: float,
-    logger: Logger = getLogger(__name__),
-):
-    """
-    Validate the source ratio of different fuel types. The data source gives us the ratio of
-    oil/gas/coal/diesel/renewables, and we accumulate the production over each plant. This method
-    validates whether the accumulated production matches the given total ratio.
-
-    Arguments:
-    ----------
-    fuel_type: string identifier of fuel type in the data source
-    production_data: the production data we create accumulated over all production sites
-    total_production: total production given by data source
-    expected_perc: Expected percent of this fuel type given by the data source
-    ----------
-    Returns:
-    ----------
-    The difference of expected and actual fuelType ratio in percent.
-    """
-
-    if fuel_type == "Bunker" or fuel_type == "Diesel":
-        logger.warning(
-            f"Cannot validate fuel type {fuel_type} since Bunker/Diesel are aggregated."
-        )
-        return 0.0
-    elif fuel_type == "LNG":
-        acc_production_perc = (
-            100.0 * production_data["production"]["gas"] / total_production
-        )
-    elif fuel_type == "Coal":
-        acc_production_perc = (
-            100.0 * production_data["production"]["coal"] / total_production
-        )
-    elif fuel_type == "Renew":
-        acc_production_perc = (
-            100.0
-            * (
-                production_data["production"]["biomass"]
-                + production_data["production"]["hydro"]
-                + production_data["production"]["solar"]
-                + production_data["production"]["wind"]
-                + production_data["production"]["geothermal"]
-            )
-            / total_production
-        )
-
-    return abs(expected_perc - acc_production_perc)
-
-
 def fetch_production(
     zone_key: str = "US-PR",
     session: Optional[Session] = None,
@@ -274,6 +208,7 @@ def fetch_production(
     data_metrics = parse_js_block_to_json(data_js, "dataMetrics", zone_key)
     data_load_per_site = parse_js_block_to_json(data_js, "dataLoadPerSite", zone_key)
 
+    # Total generation
     data_metrics_total_gen = get_field_value(
         data_metrics, ("Desc", "Total de Generación"), "value"
     )
@@ -296,59 +231,53 @@ def fetch_production(
         "source": "aeepr.com",
     }
 
-    # logger.debug(f"Raw generation breakdown: {data_load_per_site}", extra={"key": zone_key})
-    # logger.debug(f"Past 24h metrics: {data_metrics}", extra={"key": zone_key})
-    # logger.debug(f"Breakdown by fuel type: {data_by_fuel}", extra={"key": zone_key})
-    # logger.debug(f"Fuel cost breakdown: {data_fuel_cost}", extra={"key": zone_key})
-
-    # DataByFuel splits source already in 5 types, but do not further specify sub-type (e.g., renewables)
-    # Accumulate data from renewables & coal. Oil & gas not clear from source, infer their ratios later.
-    total_sites_mw = 0
-    for site_info in data_load_per_site:
-
-        production_type = get_production_type_from_site(site_info)
-
-        output_mw = site_info["SiteTotal"]
-        total_sites_mw += output_mw
-
-        if production_type in ["oil", "gas", "combined"]:
-            # Don't account in data["production"] for now
-            continue
-
-        if production_type is None:
-            logger.warning(
-                f"Cannot parse production type {site_info['Type']} from site. Putting it into 'unkown'."
-            )
-            production_type = "unknown"
-
-        site_desc = site_info["Desc"]
-        logger.debug(
-            f"Adding source {site_desc} to type {production_type} - generating {output_mw} MW.",
-            extra={"key": zone_key},
-        )
-
-        data["production"][production_type] += output_mw
-
     """
     Some of the plants in PR are capable of combusting both gas and oil. Currently, PR is in the process of 
     transforming some of the power plants from oil driven to gas or even hybrid. The data does not contain 
     information, on which mode a plant is currently operating on. However, we know the production
-    percentage of oil and gas over PR in total. Therefore, we infer oil/gas based on given ratios (%)
+    percentage of oil and gas over PR in total. Therefore, we infer fossil sources based on given ratios (%)
     from the data source.
     Report of a power plant operating on both modes:
     https://energia.pr.gov/wp-content/uploads/sites/7/2022/06/SL-015976.SJ_San-Juan-IE-Report_-Draft-13Nov2020.pdf
+
+    Renewables are parsed from the precise sources to get their power type.
     """
 
+    total_sites_mw = 0
+    # For each site, if renewable, account for it in data field.
+    for site_info in data_load_per_site:
+
+        # production_type = get_production_type_from_site(site_info)
+        output_mw = site_info["SiteTotal"]
+        site_desc = site_info["Desc"]
+        total_sites_mw += output_mw
+
+        renewable_production_type = get_site_renewable_type(site_info, logger)
+        if renewable_production_type is None:
+            continue  # site is not renewable
+
+        logger.debug(
+            f"Adding source {site_desc} to type {renewable_production_type} - generating {output_mw} MW.",
+            extra={"key": zone_key},
+        )
+        data["production"][renewable_production_type] += output_mw
+
+    # Get % production of fossile sources
     # our 'oil' is oil (Bunker) and diesel
     oil_perc = get_field_value(
         data_by_fuel, ("fuel", "Bunker"), "value"
     ) + get_field_value(data_by_fuel, ("fuel", "Diesel"), "value")
     gas_perc = get_field_value(data_by_fuel, ("fuel", "LNG"), "value")
+    coal_perc = get_field_value(data_by_fuel, ("fuel", "Coal"), "value")
+
     oil_mw = data_metrics_total_gen * oil_perc / 100.0
     gas_mw = data_metrics_total_gen * gas_perc / 100.0
+    coal_mw = data_metrics_total_gen * coal_perc / 100.0
 
     data["production"]["oil"] = oil_mw
     data["production"]["gas"] = gas_mw
+    data["production"]["coal"] = coal_mw
+
     logger.debug(
         f"Infer type 'oil' from ratio table ({oil_perc}%) - generating {oil_mw} MW.",
         extra={"key": zone_key},
@@ -357,39 +286,18 @@ def fetch_production(
         f"Infer type 'gas' from ratio table ({gas_perc}%) - generating {gas_mw} MW.",
         extra={"key": zone_key},
     )
+    logger.debug(
+        f"Infer type 'gas' from ratio table ({coal_perc}%) - generating {coal_mw} MW.",
+        extra={"key": zone_key},
+    )
 
     # Sanity check: compare sum over power sources with given total generation.
     # Compare it with number of sites since these are round off errors.
-    total_production_mw = sum(data["production"].values())
     if abs(total_sites_mw - data_metrics_total_gen) > len(data_load_per_site):
         logger.warning(
             f"Sum of production of all sites in zone {zone_key} at {fetch_dt} "
             f"is {total_sites_mw} MW, but given total production is {data_metrics_total_gen} MW."
         )
-    if abs(total_production_mw - data_metrics_total_gen) > len(data_load_per_site):
-        logger.warning(
-            f"Sum of renewables, coal, and infered oil/gas in zone {zone_key} at {fetch_dt} "
-            f"is {total_production_mw} MW, but given total production is {data_metrics_total_gen} MW."
-        )
-
-    # Validate again and make sure everything within bounds now.
-    for fuel_type in data_by_fuel:
-        fuel_type_identifier = fuel_type["fuel"]
-        if fuel_type_identifier in ["Bunker", "Diesel", "LNG"]:
-            continue  # dont need validation check, these were infered
-
-        fuel_type_value_percent = fuel_type["value"]
-        err_percent = validate_fuel_type(
-            fuel_type_identifier, data, data_metrics_total_gen, fuel_type["value"]
-        )
-        if err_percent >= VAILDATION_THRESHOLD_PERCENT:
-            logger.warning(
-                f"Sum of computed production type for {fuel_type_identifier} is {err_percent}% "
-                f"of expected value ({fuel_type_value_percent}%)."
-            )
-
-    # with open(fetch_dt.strftime("%Y-%m-%d-%H-%M") + ".txt", "w") as text_file:
-    #     text_file.write(data_js)  # TODO debug out to file
 
     return data
 

--- a/parsers/US_PREPA.py
+++ b/parsers/US_PREPA.py
@@ -3,7 +3,7 @@
 """
 Real-time parser for Puerto Rico.
 
-Fetches data from various pages embedded as an iframe at https://aeepr.com/en-us/Pages/Generaci%C3%B3n.aspx
+Fetches data from javascript sources used from the dashboard at https://aeepr.com/es-pr/Paginas/NewGen/dashboard.aspx
 
 The electricity authority is known in English as PREPA (Puerto Rico Electric Power Authority) and in Spanish as AEEPR (Autoridad de Energía Eléctrica Puerto Rico)
 """
@@ -14,59 +14,231 @@ from datetime import datetime
 from logging import Logger, getLogger
 from typing import Optional
 
-# The arrow library is used to handle datetimes
 import arrow
-from requests import Session
+from requests import Response, Session
+
+from parsers.lib.exceptions import ParserException
 
 timezone_name = "America/Puerto_Rico"
 US_PROXY = "https://us-ca-proxy-jfnx5klx2a-uw.a.run.app"
 HOST_PARAMETER = "?host=https://aeepr.com"
+
 GENERATION_BREAKDOWN_URL = (
-    f"{US_PROXY}/es-pr/generacion/Documents/combustibles.aspx{HOST_PARAMETER}"
-)
-RENEWABLES_BREAKDOWN_URL = (
-    f"{US_PROXY}/es-pr/generacion/Documents/Unidades_renovables.aspx{HOST_PARAMETER}"
-)
-TIMESTAMP_URL = (
-    f"{US_PROXY}/es-pr/generacion/Documents/CostosCombustible.aspx{HOST_PARAMETER}"
+    f"https://aeepr.com/es-pr/generacion/Documents/DataJS/dataSource.js"
+    # f"{US_PROXY}/es-pr/generacion/Documents/DataJS/dataSource.js{HOST_PARAMETER}"
 )
 
+"""
+Two more endpoints, not needed here. Contain status of power plants, and 24h history of frequency and generation sum.
+/es-pr/generacion/Documents/DataJS/dataGraph.js"
+/es-pr/generacion/Documents/DataJS/dataUnitStatus.js"
+"""
 
-def extract_data(html):
-    """Extracts data from the source code of an HTML page with a FusionCharts chart"""
-    dataSource = re.search(r"dataSource: (\{.+\}\]\})\}\);", html).group(
-        1
-    )  # Extract object with data
-    dataSource = re.sub(
-        r",\s*\}", "}", dataSource
-    )  # ,} is valid JavaScript but not valid JSON
-    dataSource = json.loads(dataSource)
-    sourceData = dataSource[
-        "data"
-    ]  # The rest of the dataSource object contains unnecessary stuff like chart theme, label, axis names etc.
-    return sourceData
+VAILDATION_THRESHOLD_PERCENT = 5.0
+
+# Source data identifiers -> Production types. See also comments at oil/gas validation
+SRC_POWER_TYPE_TO_PRODUCTION_TYPE = {
+    # fossil
+    "Turbina de Gas": "gas",
+    "COGEN": "",  # see get_production_type_from_site()
+    "Vapor": "oil",
+    "Ciclo Combinado": "gas",
+    # renewables
+    "Hidroelectricas": "hydro",
+    "Wind": "wind",
+    "Solar": "solar",
+    "Landfill": "biomass",
+}
 
 
-def convert_timestamp(
-    zone_key: str, timestamp_string: str, logger: Logger = getLogger(__name__)
+def get_production_type_from_site(json_site):
+
+    if json_site["Type"] == "Renovable":
+        # Renovable-Type has specific type in 'Desc' attribute
+        return SRC_POWER_TYPE_TO_PRODUCTION_TYPE[json_site["Desc"]]
+    elif json_site["Type"] == "COGEN":
+        # "Cogeneradoras" (cogeneration units),  there are two active:
+        #   Ecoelectrica = gas (https://www.power-technology.com/marketdata/power-plant-profile-ecoelectrica-penuelas-power-plant-puerto-rico/)
+        #   AES = coal (https://www.power-technology.com/marketdata/power-plant-profile-guayama-coal-fired-power-plant-puerto-rico/)
+        if json_site["Desc"] == "Ecoelectrica":
+            return "gas"  # https://www.eia.gov/state/analysis.php?sid=RQ
+        elif json_site["Desc"] == "AES":
+            return "coal"
+    elif json_site["Type"] == "Vapor":
+        if json_site["Desc"] == "Costa Sur":
+            return "gas"  # https://www.eia.gov/state/analysis.php?sid=RQ
+
+    if json_site["Type"] in SRC_POWER_TYPE_TO_PRODUCTION_TYPE:
+        return SRC_POWER_TYPE_TO_PRODUCTION_TYPE[json_site["Type"]]
+    else:
+        return None
+
+
+def parse_datetime(
+    input_data: str, zone_key: str, logger: Logger = getLogger(__name__)
 ):
     """
-    Converts timestamp fetched from website into timezone-aware datetime object
+    Parses the timezone-aware datetime object from the time specified in the .js file
+
+    Expected format in file:
+    const dataFechaAcualizado = '4/25/2023' + ' 3:06:05 PM';
+    Expected format as string:
+    M/DD/YYYY h:mm:ss A
+
     Arguments:
     ----------
-    timestamp_string: timestamp in the format 06/01/2020 08:40:00 AM
+    input_data: The input .js file as string
+    zone_key: the two letter zone from the map
+    ----------
+    Returns:
+    ----------
+    The datetime specified in the file as outlined above. None if could not be parsed.
     """
-    timestamp_string = re.sub(
-        r"\s+", " ", timestamp_string
-    )  # Replace double spaces with one
 
+    # in file: const dataFechaAcualizado = '4/25/2023' + ' 3:06:05 PM';
+    date_matches = re.search(
+        r"\Aconst\sdataFechaAcualizado\s*=\s*'(.*)'\s\+\s'(.*)';", input_data
+    )
+    date_fmt = "M/DD/YYYY h:mm:ss A"
+
+    date_str = "".join(date_matches.group(1, 2))
     logger.debug(
-        f"PARSED TIMESTAMP {arrow.get(timestamp_string, 'MM/DD/YYYY HH:mm:ss A', tzinfo=timezone_name)}",
+        f"Found timestamp string: {date_str}",
         extra={"key": zone_key},
     )
-    return arrow.get(
-        timestamp_string, "MM/DD/YYYY HH:mm:ss A", tzinfo=timezone_name
-    ).datetime
+
+    try:
+        date_obj = arrow.get(date_str, date_fmt, tzinfo=timezone_name).datetime
+        logger.debug(
+            f"Parsed time: {date_obj}",
+            extra={"key": zone_key},
+        )
+        return date_obj
+
+    except arrow.parser.ParserError as e:
+        logger.warn(f"Could not parse timestamp {date_str} to format {date_fmt}." "{e}")
+        return None
+
+
+def parse_js_block_to_json(
+    input_data: str,
+    identifier: str,
+    zone_key: str,
+    logger: Logger = getLogger(__name__),
+):
+    """
+    Parses a JavaScript Object Literal block in the .js file into a JSON object.
+
+    Expected format in file:
+    const identifier = {JSOL-STYLE};
+
+    Arguments:
+    ----------
+    input_data: The input .js file as string
+    identifier: The const identifier to look for in the file
+    zone_key: the two letter zone from the map
+    ----------
+    Returns:
+    ----------
+    The JSON object if successfully parsed, otherwise None.
+    """
+
+    # create regex expression to extract block and extract it
+    regex = r"const\s" + identifier + r"\s*=\s*(.*?);"
+    id_matches = re.search(regex, input_data, re.DOTALL)
+    if id_matches is None:
+        logger.warning(f"Failed to parse data block identifier {identifier}.")
+        return None
+    dict_match = id_matches.group(1)
+
+    # transform the JSOL to JSON.
+    # add '' to keys
+    dict_match = re.sub(r"(\w+):", r"'\g<1>':", dict_match)
+    # replace all ' with "
+    dict_match = re.sub("'", '"', dict_match)
+    # remove trailing commas at end of object lists
+    dict_match = re.sub(r"\,([\s]*[\}|\]])", r"\g<1>", dict_match)
+
+    try:
+        json_obj = json.loads(dict_match)
+        return json_obj
+    except json.decoder.JSONDecodeError as e:
+        logger.warning(f"Failed to parse for JSOL to JSON converted string. {e}")
+        return None
+
+
+def get_field_value(in_json, kv_access: tuple, get_id: str):
+    """
+    Get a specific attribute value of a json list.
+    Serves as helper function.
+
+    Arguments:
+    ----------
+    in_json: The JSON object having a list of sub-objects
+    kv_access: (key, value) pair to look for in each sub-object
+    get_id: Identifier whose value should be returned
+
+    """
+
+    for sub_obj in in_json:
+        if sub_obj[kv_access[0]] == kv_access[1]:
+            return sub_obj[get_id]
+
+    return None
+
+
+def validate_fuel_type(
+    fuel_type: str,
+    production_data,
+    total_production: int,
+    expected_perc: float,
+    logger: Logger = getLogger(__name__),
+):
+    """
+    Validate the source ratio of different fuel types. The data source gives us the ratio of
+    oil/gas/coal/diesel/renewables, and we accumulate the production over each plant. This method
+    validates whether the accumulated production matches the given total ratio.
+
+    Arguments:
+    ----------
+    fuel_type: string identifier of fuel type in the data source
+    production_data: the production data we create accumulated over all production sites
+    total_production: total production given by data source
+    expected_perc: Expected percent of this fuel type given by the data source
+    ----------
+    Returns:
+    ----------
+    The difference of expected and actual fuelType ratio in percent.
+    """
+
+    if fuel_type == "Bunker":
+        acc_production_perc = (
+            100.0 * production_data["production"]["oil"] / total_production
+        )
+    elif fuel_type == "Diesel":
+        acc_production_perc = 0.0 / total_production  # We do not have a Diesel source.
+    elif fuel_type == "LNG":
+        acc_production_perc = (
+            100.0 * production_data["production"]["gas"] / total_production
+        )
+    elif fuel_type == "Coal":
+        acc_production_perc = (
+            100.0 * production_data["production"]["coal"] / total_production
+        )
+    elif fuel_type == "Renew":
+        acc_production_perc = (
+            100.0
+            * (
+                production_data["production"]["biomass"]
+                + production_data["production"]["hydro"]
+                + production_data["production"]["solar"]
+                + production_data["production"]["wind"]
+                + production_data["production"]["geothermal"]
+            )
+            / total_production
+        )
+
+    return abs(expected_perc - acc_production_perc)
 
 
 def fetch_production(
@@ -77,8 +249,6 @@ def fetch_production(
 ) -> dict:
     """Requests the last known production mix (in MW) of a given region."""
 
-    global renewable_output
-
     if target_datetime is not None:
         raise NotImplementedError(
             "The datasource currently implemented is only real time"
@@ -86,9 +256,35 @@ def fetch_production(
 
     r = session or Session()
 
-    data = {  # To be returned as response data
+    # Fetch production by generation type
+    res: Response = r.get(GENERATION_BREAKDOWN_URL)
+    assert res.ok, (
+        "Exception when fetching production for "
+        "{}: error when calling url={}".format(zone_key, GENERATION_BREAKDOWN_URL)
+    )
+
+    data_js = res.text
+
+    # parse datetime contained in the received .js file
+    fetch_dt = parse_datetime(data_js, zone_key)
+    if fetch_dt is None:
+        raise ParserException(
+            parser="US_PREPA.py",
+            message="The datetime could not be parsed from given data source.",
+        )
+
+    data_fuel_cost = parse_js_block_to_json(data_js, "dataFuelCost", zone_key)
+    data_by_fuel = parse_js_block_to_json(data_js, "dataByFuel", zone_key)
+    data_metrics = parse_js_block_to_json(data_js, "dataMetrics", zone_key)
+    data_load_per_site = parse_js_block_to_json(data_js, "dataLoadPerSite", zone_key)
+
+    data_metrics_total_gen = get_field_value(
+        data_metrics, ("Desc", "Total de Generación"), "value"
+    )
+
+    data = {
         "zoneKey": zone_key,
-        #'datetime': '2017-01-01T00:00:00Z',
+        "datetime": fetch_dt,
         "production": {
             "biomass": 0.0,
             "coal": 0.0,
@@ -101,180 +297,111 @@ def fetch_production(
             "geothermal": 0.0,
             "unknown": 0.0,
         },
-        #   'storage': {
-        #        'hydro': -10.0,
-        #    },
         "source": "aeepr.com",
     }
 
-    renewable_output = 0.0  # Temporarily stored here. We'll subtract solar, wind and biomass (landfill gas) from it and assume the remainder, if any,  is hydro
+    # logger.debug(f"Raw generation breakdown: {data_load_per_site}", extra={"key": zone_key})
+    # logger.debug(f"Past 24h metrics: {data_metrics}", extra={"key": zone_key})
+    # logger.debug(f"Breakdown by fuel type: {data_by_fuel}", extra={"key": zone_key})
+    # logger.debug(f"Fuel cost breakdown: {data_fuel_cost}", extra={"key": zone_key})
 
-    # Step 1: fetch production by generation type
-    # Note: seems to be rounded down (to an integer)
-    # Total at the top of the page fetched in step 3 isn't rounded down, but seems to be lagging behind sometimes.
-    # Difference is only minor, so for now we will IGNORE that total (instead of trying to parse the total and addding the difference to "unknown")
-    res = r.get(GENERATION_BREAKDOWN_URL)
+    # DataByFuel splits source already in 5 types, but do not further specify sub-type (e.g., renewables)
+    # Therefore, accumulate data from each site, and make sanity checks at the end
+    total_sites_mw = 0
+    for site_info in data_load_per_site:
 
-    assert res.status_code == 200, (
-        "Exception when fetching production for "
-        "{}: error when calling url={}".format(zone_key, GENERATION_BREAKDOWN_URL)
-    )
-
-    sourceData = extract_data(res.text)
-
-    logger.debug(f"Raw generation breakdown: {sourceData}", extra={"key": zone_key})
-
-    for (
-        item
-    ) in (
-        sourceData
-    ):  # Item has a label with fuel type + generation in MW, and a value with a percentage
-
-        if item["label"] == "  MW":  # There's one empty item for some reason. Skip it.
-            continue
-
-        logger.debug(item["label"], extra={"key": zone_key})
-
-        parsedLabel = re.search(r"^(.+?)\s+(\d+)\s+MW$", item["label"])
-
-        category = parsedLabel.group(1)  # E.g. GAS NATURAL
-        outputInMW = float(parsedLabel.group(2))
-
-        if category == "BUNKER C" or category == "DIESEL CC" or category == "DIESEL GT":
-            data["production"]["oil"] += outputInMW
-        elif category == "GAS NATURAL":
-            data["production"]["gas"] += outputInMW
-        elif category == "CARBON":
-            data["production"]["coal"] += outputInMW
-        elif category == "RENOVABLES":
-            renewable_output += outputInMW  # Temporarily store aggregate renewable output. We'll subtract solar, wind and biomass (landfill gas) from it and assume the remainder, if any,  is hydro
-        else:
-            logger.warn(
-                f'Unknown energy type "{category}" is present for Puerto Rico',
-                extra={"key": zone_key},
-            )
-
-        logger.info(
-            f'Category "{category}" produces {outputInMW}MW', extra={"key": zone_key}
-        )
-
-    # Step 2: fetch renewable production breakdown
-    # Data from this source isn't rounded. Assume renewable production not accounted for is hydro
-    res = r.get(RENEWABLES_BREAKDOWN_URL)
-
-    assert res.status_code == 200, (
-        "Exception when fetching renewable production for "
-        "{}: error when calling url={}".format(zone_key, RENEWABLES_BREAKDOWN_URL)
-    )
-
-    sourceData = extract_data(res.text)
-    logger.debug(
-        f"Raw renewable generation breakdown: {sourceData}", extra={"key": zone_key}
-    )
-
-    original_renewable_output = renewable_output  # If nothing gets subtracted renewable_output, there probably was no data on the renewables breakdown page
-
-    logger.debug(
-        f"Total (unspecified) renewable output from total generation breakdown: {original_renewable_output}MW",
-        extra={"key": zone_key},
-    )
-
-    for (
-        item
-    ) in (
-        sourceData
-    ):  # Somewhat different from above, the item's label has the generation type and the item's value has generation in MW
-        if item["label"] == "  ":  # There's one empty item for some reason. Skip it.
-            continue
-
-        if item["label"] == "Solar":
-            data["production"]["solar"] += float(item["value"])
-        elif item["label"] == "Eolica":
-            data["production"]["wind"] += float(item["value"])
-        elif item["label"] == "Landfill Gas":
-            data["production"]["biomass"] += float(item["value"])
-        else:
-            logger.warn(
-                f"Unknown renewable type \"{item['label']}\" is present for Puerto Rico",
-                extra={"key": zone_key},
-            )
-
-        renewable_output -= float(
-            item["value"]
-        )  # Subtract production accounted for from the renewable output total
-
-        logger.info(
-            f"Renewable \"{item['label']}\" produces {item['value']}MW",
-            extra={"key": zone_key},
-        )
-        logger.debug(
-            f"Renewable output yet to be accounted for: {renewable_output}MW",
-            extra={"key": zone_key},
-        )
-
-    logger.debug(
-        "Rounding remaining renewable output to 14 decimal places to get rid of floating point errors"
-    )
-    renewable_output = round(renewable_output, 14)
-
-    logger.info(
-        f"Remaining renewable output not accounted for: {renewable_output}MW",
-        extra={"key": zone_key},
-    )
-
-    # Assume renewable generation not accounted for is hydro - if we could fetch the other renewable generation data
-    if renewable_output >= 0.0:
-        if (
-            original_renewable_output == renewable_output
-        ):  # Nothing got subtracted for Solar, Wind or Landfill gas - so the page probably didn't contain any data. Renewable type=unknown
+        production_type = get_production_type_from_site(site_info)
+        if production_type is None:
             logger.warning(
-                f"Renewable generation breakdown page was empty, reporting unspecified renewable output ({renewable_output}MW) as 'unknown'",
-                extra={"key": zone_key},
+                f"Cannot parse production type {site_info['Type']} from site. Putting it into 'unkown'."
             )
-            data["production"]["unknown"] += renewable_output
-        else:  # Otherwise, any remaining renewable output is probably hydro
-            logger.info(
-                f"Assuming remaining renewable output of {renewable_output}MW is hydro",
-                extra={"key": zone_key},
-            )
-            data["production"]["hydro"] += renewable_output
-    else:
-        logger.warn(
-            f"Renewable generation breakdown page total is greater than total renewable output, a difference of {renewable_output}MW",
+            production_type = "unknown"
+
+        output_mw = site_info["SiteTotal"]
+        total_sites_mw += output_mw
+
+        site_desc = site_info["Desc"]
+        logger.debug(
+            f"Adding source {site_desc} to type {production_type} - generating {output_mw} MW.",
             extra={"key": zone_key},
         )
 
-    # Step 3: fetch the timestamp, which is at the bottom of a different iframe
-    # Note: there's a race condition here when requesting data very close to <hour>:10 and <hour>:40, which is when the data gets updated
-    # Sometimes it's some seconds later, so we grab the timestamp from here to know the exact moment
+        data["production"][production_type] += output_mw
 
-    res = r.get(
-        TIMESTAMP_URL
-    )  # TODO do we know for sure the timestamp on this page gets updated *every time* the generation breakdown gets updated?
+        # Sanity check: iterate over units of this plant and make sure they accumuate close to SiteTotal
+        unit_sum_mw = 0
+        for unit in site_info["units"]:
+            unit_sum_mw += unit["MW"]
+        # All information in rounded to integers. Give some leeway when calculating sum.
+        if abs(unit_sum_mw - output_mw) > len(site_info["units"]):
+            logger.warning(
+                f"Sum of production units of site {site_info['Index']} ({unit_sum_mw} MW) "
+                f"does not match given SiteTotal ({output_mw} MW) in zone {zone_key} at {fetch_dt}."
+            )
 
-    assert (
-        res.status_code == 200
-    ), "Exception when fetching timestamp for " "{}: error when calling url={}".format(
-        zone_key, TIMESTAMP_URL
+    # Sanity check: compare sum over power sources with given total generation
+    if abs(total_sites_mw - data_metrics_total_gen) > len(data_load_per_site):
+        logger.warning(
+            f"Sum of production of all sites sites in zone {zone_key} at {fetch_dt} "
+            f"is {total_sites_mw} MW, but given total production is {data_metrics_total_gen} MW."
+        )
+
+    """
+    Some of the plants in PR are capable of combusting both gas and oil. Currently, PR is in the process of 
+    transforming some of the power plants from oil driven to gas or even hybrid. The data does not contain 
+    information, on which mode a plant is currently operating on. However, we know the production
+    percentage of oil and gas over PR in total. Therefore, some of the extracted mappings plant -> fuelType
+    be wrong. Here, we compensate for that error, by taking the given ratios (%) of oil/gas in the data source,
+    and adjust the oil/gas amount accordingly to fulfill this ratio.
+    Report of a power plant operating on both modes:
+    https://energia.pr.gov/wp-content/uploads/sites/7/2022/06/SL-015976.SJ_San-Juan-IE-Report_-Draft-13Nov2020.pdf
+    """
+
+    # Sanity check: Compare src % of oil and gas
+    valid = (
+        validate_fuel_type(
+            "Bunker",
+            data,
+            data_metrics_total_gen,
+            get_field_value(data_by_fuel, ("fuel", "Bunker"), "value"),
+        )
+        < VAILDATION_THRESHOLD_PERCENT
+        and validate_fuel_type(
+            "LNG",
+            data,
+            data_metrics_total_gen,
+            get_field_value(data_by_fuel, ("fuel", "LNG"), "value"),
+        )
+        < VAILDATION_THRESHOLD_PERCENT
     )
 
-    raw_timestamp_match = re.search(
-        r"Ultima Actualizaci�n:  ((?:0[1-9]|1[0-2])/(?:[0-2][0-9]|3[0-2])/2[01][0-9]{2}  [0-2][0-9]:[0-5][0-9]:[0-5][0-9] [AP]M)",
-        res.text,
-    )
+    if not valid:
+        rel_gas_target = get_field_value(data_by_fuel, ("fuel", "LNG"), "value") / 100.0
+        current_gas = data["production"]["gas"] / data_metrics_total_gen
+        # difference to compensate
+        add_gas = rel_gas_target - current_gas
+        logger.warning(
+            f"Correcting gas ratio by {add_gas * 100.0}%, inverse to oil ratio."
+        )
 
-    if raw_timestamp_match is None:
-        raise Exception(f"Could not find timestamp in {res.text}")
+        data["production"]["gas"] += add_gas * data_metrics_total_gen
+        data["production"]["oil"] -= add_gas * data_metrics_total_gen
 
-    raw_timestamp = raw_timestamp_match.group(1)
+    # Validate again and make sure everything within bounds now.
+    for fuel_type in data_by_fuel:
+        fuel_type_identifier = fuel_type["fuel"]
+        fuel_type_value_percent = fuel_type["value"]
+        err_percent = validate_fuel_type(
+            fuel_type_identifier, data, data_metrics_total_gen, fuel_type["value"]
+        )
+        if err_percent >= VAILDATION_THRESHOLD_PERCENT:
+            logger.warning(
+                f"Sum of computed production type for {fuel_type_identifier} is {err_percent}% "
+                f"of expected value ({fuel_type_value_percent}%)."
+            )
 
-    logger.debug(f"RAW TIMESTAMP: {raw_timestamp}", extra={"key": zone_key})
-
-    data["datetime"] = convert_timestamp(zone_key, raw_timestamp)
-
-    assert (
-        data["production"]["oil"] > 0.0
-    ), "{} is missing required generation type: oil".format(zone_key)
+    # with open(fetch_dt.strftime("%Y-%m-%d-%H-%M") + ".txt", "w") as text_file:
+    #     text_file.write(data_js) # TODO debug out to file
 
     return data
 
@@ -283,6 +410,3 @@ if __name__ == "__main__":
     """Main method, never used by the Electricity Map backend, but handy for testing."""
     print("fetch_production() ->")
     print(fetch_production())
-# TODO add forecast parser
-#    print('fetch_generation_forecast() ->')
-#    print(fetch_generation_forecast())

--- a/parsers/test/mocks/US_PREPA_dataSource.js
+++ b/parsers/test/mocks/US_PREPA_dataSource.js
@@ -1,0 +1,215 @@
+const dataFechaAcualizado = '4/25/2023' + ' 3:11:05 PM';
+const dataFuelCost = [
+	{place: 'San Juan', value: 100},
+	{place: 'San Juan CC', value: 144},
+	{place: 'Palo Seco', value: 100},
+	{place: 'Aguirre', value: 106},
+	{place: 'Aguirre CC', value: 147},
+	{place: 'Costa Sur', value: 100},
+	{place: 'Cambalache', value: 150},
+	{place: 'Mayaguez', value: 144},
+	{place: 'Costa Sur LNG', value: 9},
+];
+const dataByFuel = [
+	{fuel: 'Bunker', value: 28},
+	{fuel: 'Diesel', value: 1},
+	{fuel: 'LNG', value: 48},
+	{fuel: 'Coal', value: 19},
+	{fuel: 'Renew', value: 4},
+];
+const dataMetrics = [
+	{Index:'0', Desc:'Total de Generación', value: 2119},
+	{Index:'1', Desc:'PREPA', value: 52},
+	{Index:'2', Desc:'COGEN', value: 48},
+	{Index:'3', Desc:'Reserva en Rotación', value: 291},
+	{Index:'4', Desc:'Reserva Operacional', value: 930},
+	{Index:'5', Desc:'Capacidad Disponible', value: 3046},
+	{Index:'6', Desc:'Próxima Hora MW', value: 2159},
+	{Index:'7', Desc:'Máxima para Hoy', value: 2134},
+	{Index:'8', Desc:'Máxima Mensual', value: 2555},
+];
+const dataLoadPerSite = [
+	{Index:'0', Type:'Hidroelectricas', Desc:'Dos Bocas', SiteTotal: 0,
+		units:[
+			{Index:'0', Unit:'Hidro 1', MW: 0, MVar:'0', Cost:0, ParentId: '0'},
+			{Index:'1', Unit:'Hidro 2', MW: 0, MVar:'1', Cost:0, ParentId: '0'},
+			{Index:'2', Unit:'Hidro 3', MW: 0, MVar:'1', Cost:0, ParentId: '0'},
+		]
+	},
+	{Index:'1', Type:'Hidroelectricas', Desc:'Caonillas', SiteTotal: 0,
+		units:[
+			{Index:'0', Unit:'Hidro 1', MW: 0, MVar:'0', Cost:0, ParentId: '1'},
+			{Index:'1', Unit:'Hidro 2', MW: 0, MVar:'0', Cost:0, ParentId: '1'},
+		]
+	},
+	{Index:'2', Type:'Hidroelectricas', Desc:'Garzas', SiteTotal: 0,
+		units:[
+			{Index:'0', Unit:'Hidro 1', MW: 0, MVar:'0', Cost:0, ParentId: '2'},
+			{Index:'1', Unit:'Hidro 2', MW: 0, MVar:'0', Cost:0, ParentId: '2'},
+			{Index:'2', Unit:'Hidro 3', MW: 0, MVar:'0', Cost:0, ParentId: '2'},
+		]
+	},
+	{Index:'3', Type:'Hidroelectricas', Desc:'Rio Blanco', SiteTotal: 0,
+		units:[
+			{Index:'0', Unit:'Hidro 1', MW: 0, MVar:'0', Cost:0, ParentId: '3'},
+			{Index:'1', Unit:'Hidro 2', MW: 0, MVar:'0', Cost:0, ParentId: '3'},
+		]
+	},
+	{Index:'4', Type:'Hidroelectricas', Desc:'Toro Negro', SiteTotal: 2,
+		units:[
+			{Index:'0', Unit:'Hidro 1', MW: 1, MVar:'0', Cost:0, ParentId: '4'},
+			{Index:'1', Unit:'Hidro 2', MW: 1, MVar:'0', Cost:0, ParentId: '4'},
+			{Index:'2', Unit:'Hidro 3', MW: 0, MVar:'0', Cost:0, ParentId: '4'},
+			{Index:'3', Unit:'Hidro 4', MW: 0, MVar:'0', Cost:0, ParentId: '4'},
+			{Index:'4', Unit:'Hidro 5', MW: 0, MVar:'0', Cost:0, ParentId: '4'},
+		]
+	},
+	{Index:'5', Type:'Hidroelectricas', Desc:'Yauco', SiteTotal: 0,
+		units:[
+			{Index:'0', Unit:'Hidro 1', MW: 0, MVar:'0', Cost:0, ParentId: '5'},
+			{Index:'1', Unit:'Hidro 2', MW: 0, MVar:'0', Cost:0, ParentId: '5'},
+			{Index:'2', Unit:'Hidro 3', MW: 0, MVar:'1', Cost:0, ParentId: '5'},
+		]
+	},
+	{Index:'6', Type:'COGEN', Desc:'AES', SiteTotal: 395,
+		units:[
+			{Index:'0', Unit:'Unit 1', MW: 156, MVar:'77', Cost:4.37, ParentId: '6'},
+			{Index:'1', Unit:'Unit 2', MW: 238, MVar:'49', Cost:4.37, ParentId: '6'},
+		]
+	},
+	{Index:'7', Type:'COGEN', Desc:'Ecoelectrica', SiteTotal: 449,
+		units:[
+			{Index:'0', Unit:'Gas 1', MW: 156, MVar:'39', Cost:6.35, ParentId: '7'},
+			{Index:'1', Unit:'Gas 2', MW: 156, MVar:'34', Cost:6.35, ParentId: '7'},
+			{Index:'2', Unit:'STG', MW: 137, MVar:'43', Cost:6.35, ParentId: '7'},
+		]
+	},
+	{Index:'8', Type:'Turbina de Gas', Desc:'Estaciones GT', SiteTotal: 0,
+		units:[
+			{Index:'0', Unit:'Palo Seco', MW: 0, MVar:'0', Cost:0, ParentId: '8'},
+			{Index:'1', Unit:'Vega Baja', MW: 0, MVar:'0', Cost:0, ParentId: '8'},
+			{Index:'2', Unit:'Costa Sur', MW: 0, MVar:'0', Cost:0, ParentId: '8'},
+			{Index:'3', Unit:'Jobos', MW: 0, MVar:'0', Cost:0, ParentId: '8'},
+			{Index:'4', Unit:'Daguao', MW: 0, MVar:'0', Cost:0, ParentId: '8'},
+			{Index:'5', Unit:'Yabucoa', MW: 0, MVar:'0', Cost:0, ParentId: '8'},
+			{Index:'6', Unit:'Aguirre', MW: 0, MVar:'0', Cost:14.70, ParentId: '8'},
+		]
+	},
+	{Index:'9', Type:'Turbina de Gas', Desc:'Mayaguez', SiteTotal: 0,
+		units:[
+			{Index:'0', Unit:'Gas 1', MW: 0, MVar:'0', Cost:0, ParentId: '9'},
+			{Index:'1', Unit:'Gas 2', MW: 0, MVar:'0', Cost:0, ParentId: '9'},
+			{Index:'2', Unit:'Gas 3', MW: 0, MVar:'0', Cost:0, ParentId: '9'},
+			{Index:'3', Unit:'Gas 4', MW: 0, MVar:'0', Cost:0, ParentId: '9'},
+		]
+	},
+	{Index:'10', Type:'Turbina de Gas', Desc:'Cambalache', SiteTotal: 0,
+		units:[
+			{Index:'0', Unit:'Gas 1', MW: 0, MVar:'0', Cost:0, ParentId: '10'},
+			{Index:'1', Unit:'Gas 2', MW: 0, MVar:'0', Cost:0, ParentId: '10'},
+			{Index:'2', Unit:'Gas 3', MW: 0, MVar:'0', Cost:0, ParentId: '10'},
+		]
+	},
+	{Index:'11', Type:'Ciclo Combinado', Desc:'San Juan', SiteTotal: 331,
+		units:[
+			{Index:'0', Unit:'CTG 5', MW: 125, MVar:'37', Cost:27.47, ParentId: '11'},
+			{Index:'1', Unit:'STG 5', MW: 0, MVar:'0', Cost:27.47, ParentId: '11'},
+			{Index:'2', Unit:'CTG 6', MW: 158, MVar:'48', Cost:7.93, ParentId: '11'},
+			{Index:'3', Unit:'STG 6', MW: 48, MVar:'9', Cost:7.93, ParentId: '11'},
+		]
+	},
+	{Index:'12', Type:'Ciclo Combinado', Desc:'Aguirre Stag 1', SiteTotal: 0,
+		units:[
+			{Index:'0', Unit:'Gas 1', MW: 0, MVar:'0', Cost:0, ParentId: '12'},
+			{Index:'1', Unit:'Gas 2', MW: 0, MVar:'0', Cost:0, ParentId: '12'},
+			{Index:'2', Unit:'Gas 3', MW: 0, MVar:'0', Cost:0, ParentId: '12'},
+			{Index:'3', Unit:'Gas 4', MW: 0, MVar:'0', Cost:0, ParentId: '12'},
+			{Index:'4', Unit:'STG 1', MW: 0, MVar:'0', Cost:0, ParentId: '12'},
+		]
+	},
+	{Index:'13', Type:'Ciclo Combinado', Desc:'Aguirre Stag 2', SiteTotal: 31,
+		units:[
+			{Index:'0', Unit:'Gas 1', MW: 0, MVar:'0', Cost:0, ParentId: '13'},
+			{Index:'1', Unit:'Gas 2', MW: 0, MVar:'0', Cost:0, ParentId: '13'},
+			{Index:'2', Unit:'Gas 3', MW: 0, MVar:'3', Cost:0, ParentId: '13'},
+			{Index:'3', Unit:'Gas 4', MW: 30, MVar:'4', Cost:37.98, ParentId: '13'},
+			{Index:'4', Unit:'STG 2', MW: 0, MVar:'0', Cost:0, ParentId: '13'},
+		]
+	},
+	{Index:'14', Type:'Vapor', Desc:'San Juan', SiteTotal: 0,
+		units:[
+			{Index:'0', Unit:'Unit 7', MW: 0, MVar:'0', Cost:0, ParentId: '14'},
+			{Index:'1', Unit:'Unit 8', MW: 0, MVar:'0', Cost:0, ParentId: '14'},
+			{Index:'2', Unit:'Unit 9', MW: 0, MVar:'0', Cost:0, ParentId: '14'},
+			{Index:'3', Unit:'Unit 10', MW: 0, MVar:'0', Cost:0, ParentId: '14'},
+		]
+	},
+	{Index:'15', Type:'Vapor', Desc:'Palo Seco', SiteTotal: 151,
+		units:[
+			{Index:'0', Unit:'Unit 1', MW: 0, MVar:'0', Cost:0, ParentId: '15'},
+			{Index:'1', Unit:'Unit 2', MW: 0, MVar:'0', Cost:0, ParentId: '15'},
+			{Index:'2', Unit:'Unit 3', MW: 151, MVar:'77', Cost:15.72, ParentId: '15'},
+			{Index:'3', Unit:'Unit 4', MW: 0, MVar:'0', Cost:0, ParentId: '15'},
+		]
+	},
+	{Index:'16', Type:'Vapor', Desc:'Aguirre', SiteTotal: 259,
+		units:[
+			{Index:'0', Unit:'Unit 1', MW: 0, MVar:'0', Cost:0, ParentId: '16'},
+			{Index:'1', Unit:'Unit 2', MW: 259, MVar:'124', Cost:14.67, ParentId: '16'},
+		]
+	},
+	{Index:'17', Type:'Vapor', Desc:'Costa Sur', SiteTotal: 423,
+		units:[
+			{Index:'0', Unit:'Unit 3', MW: 0, MVar:'0', Cost:0, ParentId: '17'},
+			{Index:'1', Unit:'Unit 4', MW: 0, MVar:'0', Cost:0, ParentId: '17'},
+			{Index:'2', Unit:'Unit 5', MW: 173, MVar:'61', Cost:9.20, ParentId: '17'},
+			{Index:'3', Unit:'Unit 6', MW: 250, MVar:'56', Cost:14.28, ParentId: '17'},
+		]
+	},
+	{Index:'18', Type:'Renovable', Desc:'Wind', SiteTotal: 4,
+		units:[
+			{Index:'0', Unit:'Pattern', MW: 4, MVar:'0', Cost:16.29, ParentId: '18'},
+		]
+	},
+	{Index:'19', Type:'Renovable', Desc:'Solar', SiteTotal: 80,
+		units:[
+			{Index:'0', Unit:'San Fermin', MW: 10, MVar:'1', Cost:18.32, ParentId: '19'},
+			{Index:'1', Unit:'Ilumina', MW: 12, MVar:'10', Cost:21.43, ParentId: '19'},
+			{Index:'2', Unit:'Horizon', MW: 9, MVar:'0', Cost:19.60, ParentId: '19'},
+			{Index:'3', Unit:'Coto Laurel', MW: 4, MVar:'2', Cost:19.10, ParentId: '19'},
+			{Index:'4', Unit:'Oriana', MW: 18, MVar:'28', Cost:19.60, ParentId: '19'},
+			{Index:'5', Unit:'Fonroche', MW: 26, MVar:'4', Cost:17, ParentId: '19'},
+		]
+	},
+	{Index:'20', Type:'Renovable', Desc:'Landfill', SiteTotal: 1,
+		units:[
+			{Index:'0', Unit:'Toa Baja', MW: 1, MVar:'0', Cost:10, ParentId: '20'},
+			{Index:'1', Unit:'Fajardo', MW: 0, MVar:'0', Cost:10, ParentId: '20'},
+		]
+	},
+	{Index:'21', Type:'Turbina de Gas', Desc:'Palo Seco', SiteTotal: 0,
+		units:[
+			{Index:'0', Unit:'CT Block 1', MW: 0, MVar:'0', Cost:0, ParentId: '21'},
+			{Index:'1', Unit:'CT Block 2', MW: 0, MVar:'0', Cost:0, ParentId: '21'},
+			{Index:'2', Unit:'CT Block 3', MW: 0, MVar:'0', Cost:0, ParentId: '21'},
+			{Index:'3', Unit:'GT1', MW: 0, MVar:'0', Cost:0, ParentId: '21'},
+			{Index:'4', Unit:'GT2', MW: 0, MVar:'0', Cost:0, ParentId: '21'},
+			{Index:'5', Unit:'GT3', MW: 0, MVar:'0', Cost:0, ParentId: '21'},
+			{Index:'6', Unit:'GT4', MW: 0, MVar:'0', Cost:0, ParentId: '21'},
+			{Index:'7', Unit:'GT5', MW: 0, MVar:'0', Cost:0, ParentId: '21'},
+			{Index:'8', Unit:'GT6', MW: 0, MVar:'0', Cost:0, ParentId: '21'},
+		]
+	},
+	{Index:'22', Type:'Turbina de Gas', Desc:'Aguirre', SiteTotal: 0,
+		units:[
+			{Index:'0', Unit:'GT1', MW: 0, MVar:'0', Cost:0, ParentId: '22'},
+			{Index:'1', Unit:'GT2', MW: 0, MVar:'0', Cost:0, ParentId: '22'},
+		]
+	},
+	{Index:'23', Type:'Turbina de Gas', Desc:'Costa Sur', SiteTotal: 0,
+		units:[
+			{Index:'0', Unit:'GT1', MW: 0, MVar:'0', Cost:19, ParentId: '23'},
+			{Index:'1', Unit:'GT2', MW: 0, MVar:'0', Cost:0, ParentId: '23'},
+		]
+	},
+];

--- a/parsers/test/test_US_PREPA.py
+++ b/parsers/test/test_US_PREPA.py
@@ -1,0 +1,40 @@
+from datetime import datetime
+from unittest import TestCase
+
+import freezegun
+from arrow import get
+from requests import Session
+from requests_mock import ANY, Adapter
+
+from electricitymap.contrib.config import ZoneKey
+from parsers import US_PREPA
+
+
+class TestFetchProduction(TestCase):
+    def setUp(self):
+        self.session = Session()
+        self.adapter = Adapter()
+        self.session.mount("https://", self.adapter)
+        data = open("parsers/test/mocks/US_PREPA_dataSource.js", "rb")
+        self.adapter.register_uri(ANY, ANY, content=data.read())
+
+    @freezegun.freeze_time("2021-01-01 00:00:00")
+    def test_fetch_production_PR(self):
+
+        data = US_PREPA.fetch_production(ZoneKey("US-PR"), self.session)
+
+        with self.subTest():
+            self.assertEqual(data["zoneKey"], "US-PR")
+        with self.subTest():
+            self.assertEqual(data["source"], "aeepr.com")
+        with self.subTest():
+            expected_dt = get(
+                datetime(2023, 4, 25, 15, 11, 5), "America/Puerto_Rico"
+            ).datetime
+            self.assertEqual(data["datetime"], expected_dt)
+        with self.subTest():
+            self.assertAlmostEqual(data["production"]["coal"], 395.0, delta=0.5)
+        with self.subTest():
+            self.assertAlmostEqual(data["production"]["gas"], 1017.12, delta=0.5)
+        with self.subTest():
+            self.assertAlmostEqual(data["production"]["solar"], 80.0, delta=0.5)

--- a/parsers/test/test_US_PREPA.py
+++ b/parsers/test/test_US_PREPA.py
@@ -32,9 +32,17 @@ class TestFetchProduction(TestCase):
                 datetime(2023, 4, 25, 15, 11, 5), "America/Puerto_Rico"
             ).datetime
             self.assertEqual(data["datetime"], expected_dt)
+        # % information is rounded to nearest %, use delta of 1%
+        total_gen = 2119
         with self.subTest():
-            self.assertAlmostEqual(data["production"]["coal"], 395.0, delta=0.5)
+            self.assertAlmostEqual(
+                data["production"]["coal"], 395.0, delta=total_gen / 100
+            )
         with self.subTest():
-            self.assertAlmostEqual(data["production"]["gas"], 1017.12, delta=0.5)
+            self.assertAlmostEqual(
+                data["production"]["gas"], 1017.12, delta=total_gen / 100
+            )
         with self.subTest():
-            self.assertAlmostEqual(data["production"]["solar"], 80.0, delta=0.5)
+            self.assertAlmostEqual(
+                data["production"]["solar"], 80.0, delta=total_gen / 100
+            )


### PR DESCRIPTION
## Issue

The parser for Puerto Rico has been down for a while since the data endpoints were not maintained. However, there is a new(?) data dashboard with a new data source which holds more information than previous sources.

## Description

Fetching production data for Puerto Rico. The dashboard is accessible [here](https://aeepr.com/es-pr/Paginas/NewGen/dashboard.aspx) and contains real time information about all power plants in Puerto Rico. The actual data source is a JavaScript file which gets polled by the dashboard. Therefore, we can just request the [JS file](https://aeepr.com/es-pr/generacion/Documents/DataJS/dataSource.js) once to parse the data. I think these endpoints are only accessible from the US or PR, so a proxy/VPN might be required.

Screenshot of the dashboard:

![brave_95pq8eZNp3](https://user-images.githubusercontent.com/6353009/234682260-2f3914ab-9eea-48ee-9c11-102b5ba96141.png)

Pull request contains:
- Updated parser for US-PR
- Basic unit tests
- Mock file to go along with the unit tests

Some points to discuss:
- There is also a price endpoint. However, I am not sure how to handle these vastly different prices of the power plants.
- We could rename the `US_PREPA.py` parser to `US_PR.py` to use a region identifier instead of the one of the electricity authority.
- Although the source contains information about current production of each power plant, it is not always clear if it is currently fueled by oil/gas/diesel. Some plants are capable of both combusting oil and gas, maybe even simultaneously. I tried to work out how different plants contribute, but this seems to be far too complex (and not important for us). Therefore, only coal and renewables are parsed from the sites directly (to distinguish types of renewables); and the remainder (oil+diesel, gas) is infered by the `dataByFuel` ratio (top right panel on dashboard). So, the returned production data should be accounted correctly.

### Double check

- [x] I have tested my parser changes locally with `poetry run test_parser "zone_key"`
- [x] I have run `pnpx prettier --write .` and `poetry run format` to format my changes.
