### PR TITLE
Add TWEPL-TUGLAK biogas power plant to IN Delhi

### DIFF
--- a/parsers/IN_DL.py
+++ b/parsers/IN_DL.py
@@ -15,6 +15,7 @@ plants = {
     "GT": "Gas",
     "Pragati": "Gas",
     "TOWMP-Okhla": "G2E",
+    "TWEPL-TUGLAK": "G2E",
 }
 
 


### PR DESCRIPTION
## Issue

One of the biogas power plant is missing from the IN-DEL parser, maybe it was added recently

## Description

IN-DL parser fetches its data from [delhisldc](http://www.delhisldc.org/Redirect.aspx?Loc=0804) website

- [X]  Added the biogas plant TWEPL-TUGLAK

<img width="323" alt="Screenshot 2023-05-01 at 5 52 44 PM" src="https://user-images.githubusercontent.com/2438415/235452605-b4937e25-23ac-4754-bb58-58987f3fa446.png">

### Double check

- [X] I have tested my parser changes locally with `poetry run test_parser "zone_key"`
- [X] I have run `pnpx prettier --write .` and `poetry run format` to format my changes.
