### PR TITLE
Add static method to merge production outputs

### DIFF
--- a/electricitymap/contrib/lib/models/events.py
+++ b/electricitymap/contrib/lib/models/events.py
@@ -14,7 +14,7 @@ LOWER_DATETIME_BOUND = datetime(2000, 1, 1, tzinfo=timezone.utc)
 
 
 class Mix(BaseModel, ABC):
-    def set_value(self, mode: str, value: float) -> None:
+    def set_value(self, mode: str, value: Optional[float]) -> None:
         """
         Sets the value of a production mode.
         This can be used if the Production has been initialized empty
@@ -52,7 +52,7 @@ class ProductionMix(Mix):
                 self._corrected_negative_values.add(attr)
                 self.__setattr__(attr, None)
 
-    def __setattr__(self, name: str, value) -> None:
+    def __setattr__(self, name: str, value: Optional[float]) -> None:
         if name in PRODUCTION_MODES:
             if value is not None and value < 0:
                 self._corrected_negative_values.add(name)


### PR DESCRIPTION
## Issue

Some production mix  parsers need to query several endpoints and merge the events together based on datetime.

## Description

Add a static method in ProductionBreakdown list to handle this case.
