### PR TITLE
Move EIA production mix to new datastructure

### DIFF
--- a/electricitymap/contrib/lib/models/event_lists.py
+++ b/electricitymap/contrib/lib/models/event_lists.py
@@ -66,7 +66,7 @@ class ProductionBreakdownList(EventList):
         zoneKey: ZoneKey,
         datetime: datetime,
         source: str,
-        production: ProductionMix,
+        production: Optional[ProductionMix] = None,
         storage: Optional[StorageMix] = None,
         sourceType: EventSourceType = EventSourceType.measured,
     ):

--- a/electricitymap/contrib/lib/models/events.py
+++ b/electricitymap/contrib/lib/models/events.py
@@ -241,6 +241,7 @@ class ProductionBreakdown(Event):
     storage: Optional[StorageMix] = None
     """
     An event representing the production and storage breakdown of a zone at a given time.
+    If a production mix is supplied it should not be fully empty.
     """
 
     @validator("production")

--- a/electricitymap/contrib/lib/models/events.py
+++ b/electricitymap/contrib/lib/models/events.py
@@ -264,7 +264,7 @@ class ProductionBreakdown(Event):
         zoneKey: ZoneKey,
         datetime: datetime,
         source: str,
-        production: Optional[ProductionMix],
+        production: Optional[ProductionMix] = None,
         storage: Optional[StorageMix] = None,
         sourceType: EventSourceType = EventSourceType.measured,
     ) -> Optional["ProductionBreakdown"]:

--- a/electricitymap/contrib/lib/models/events.py
+++ b/electricitymap/contrib/lib/models/events.py
@@ -237,8 +237,11 @@ class TotalProduction(Event):
 
 
 class ProductionBreakdown(Event):
-    production: ProductionMix
+    production: Optional[ProductionMix] = None
     storage: Optional[StorageMix] = None
+    """
+    An event representing the production and storage breakdown of a zone at a given time.
+    """
 
     @validator("production")
     def _validate_production_mix(cls, v):
@@ -260,13 +263,13 @@ class ProductionBreakdown(Event):
         zoneKey: ZoneKey,
         datetime: datetime,
         source: str,
-        production: ProductionMix,
+        production: Optional[ProductionMix],
         storage: Optional[StorageMix] = None,
         sourceType: EventSourceType = EventSourceType.measured,
     ) -> Optional["ProductionBreakdown"]:
         try:
             # Log warning if production has been corrected.
-            if production.has_corrected_negative_values:
+            if production is not None and production.has_corrected_negative_values:
                 logger.warning(
                     f"Negative production values were detected: {production._corrected_negative_values}.\
                     They have been set to None."
@@ -286,7 +289,7 @@ class ProductionBreakdown(Event):
         return {
             "datetime": self.datetime,
             "zoneKey": self.zoneKey,
-            "production": self.production.dict(exclude_none=True),
+            "production": self.production.dict(exclude_none=True) if self.production else {},
             "storage": self.storage.dict(exclude_none=True) if self.storage else {},
             "source": self.source,
             "sourceType": self.sourceType,

--- a/electricitymap/contrib/lib/models/events.py
+++ b/electricitymap/contrib/lib/models/events.py
@@ -290,7 +290,9 @@ class ProductionBreakdown(Event):
         return {
             "datetime": self.datetime,
             "zoneKey": self.zoneKey,
-            "production": self.production.dict(exclude_none=True) if self.production else {},
+            "production": self.production.dict(exclude_none=True)
+            if self.production
+            else {},
             "storage": self.storage.dict(exclude_none=True) if self.storage else {},
             "source": self.source,
             "sourceType": self.sourceType,

--- a/parsers/EIA.py
+++ b/parsers/EIA.py
@@ -10,7 +10,7 @@ https://www.eia.gov/opendata/register.php
 """
 from datetime import datetime, timedelta
 from logging import Logger, getLogger
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Tuple
 
 import arrow
 from dateutil import parser, tz
@@ -19,12 +19,12 @@ from requests import Session
 from electricitymap.contrib.config import ZoneKey
 from electricitymap.contrib.lib.models.event_lists import (
     ExchangeList,
+    ProductionBreakdownList,
     TotalConsumptionList,
 )
-from parsers.ENTSOE import merge_production_outputs
+from electricitymap.contrib.lib.models.events import ProductionMix, StorageMix
 from parsers.lib.config import refetch_frequency
 from parsers.lib.utils import get_token
-from parsers.lib.validation import validate
 
 # Reverse exchanges need to be multiplied by -1, since they are reported in the opposite direction
 REVERSE_EXCHANGES = [
@@ -415,17 +415,43 @@ def fetch_consumption_forecast(
     )
 
 
+def create_production_storage(
+    fuel_type: str, production_point: Dict[str, float], negative_threshold: float
+) -> Tuple[Optional[ProductionMix], Optional[StorageMix]]:
+    """Create a production mix or a storage mix from a production point
+    handling the special cases of hydro storage and self consumption"""
+    production_value = production_point["value"]
+    production_mix = ProductionMix()
+    storage_mix = StorageMix()
+    if production_value > 0:
+        production_mix.set_value(fuel_type, production_value)
+        return production_mix, None
+    if fuel_type == "hydro":
+        storage_mix.set_value("hydro", production_value)
+        return None, storage_mix
+    if production_value > negative_threshold:
+        # This is considered to be self consumption and should be reported as 0.
+        # Lower values are set to None as they are most likely outliers.
+        production_value = 0
+    production_mix.set_value(fuel_type, production_value)
+    return production_mix, None
+
+
 @refetch_frequency(timedelta(days=1))
 def fetch_production_mix(
-    zone_key: str,
+    zone_key: ZoneKey,
     session: Optional[Session] = None,
     target_datetime: Optional[datetime] = None,
     logger: Logger = getLogger(__name__),
 ):
-    mixes = []
-    for type, code in TYPES.items():
+    all_production_breakdowns: List[ProductionBreakdownList] = []
+    for production_mode, code in TYPES.items():
+        negative_threshold = NEGATIVE_PRODUCTION_THRESHOLDS_TYPE.get(
+            production_mode, NEGATIVE_PRODUCTION_THRESHOLDS_TYPE["default"]
+        )
+        production_breakdown = ProductionBreakdownList(logger)
         url_prefix = PRODUCTION_MIX.format(REGIONS[zone_key], code)
-        mix = _fetch(
+        production_values = _fetch(
             zone_key,
             url_prefix,
             session=session,
@@ -436,7 +462,11 @@ def fetch_production_mix(
         # As null values can cause problems in the estimation models if there's
         # only null values.
         # Integrate with data quality layer later.
-        mix = [datapoint for datapoint in mix if datapoint["value"] is not None]
+        production_values = [
+            datapoint
+            for datapoint in production_values
+            if datapoint["value"] is not None
+        ]
 
         # EIA does not currently split production from the Virgil Summer C
         # plant across the two owning/ utilizing BAs:
@@ -446,20 +476,33 @@ def fetch_production_mix(
         # This split can be found in the eGRID data,
         # https://www.epa.gov/energy/emissions-generation-resource-integrated-database-egrid
 
-        if zone_key == "US-CAR-SCEG" and type == "nuclear":
-            for point in mix:
+        if zone_key == "US-CAR-SCEG" and production_mode == "nuclear":
+            for point in production_values:
                 point.update({"value": point["value"] * (1 - SC_VIRGIL_OWNERSHIP)})
 
+        for point in production_values:
+            production_mix, storage_mix = create_production_storage(
+                production_mode, point, negative_threshold
+            )
+            production_breakdown.append(
+                zoneKey=zone_key,
+                datetime=point["datetime"],
+                production=production_mix,
+                storage=storage_mix,
+                source="eia.gov",
+            )
+        all_production_breakdowns.append(production_breakdown)
         # Integrate the supplier zones in the zones they supply
 
         supplying_zones = PRODUCTION_ZONES_TRANSFERS.get(zone_key, {})
         zones_to_integrate = {
             **supplying_zones.get("all", {}),
-            **supplying_zones.get(type, {}),
+            **supplying_zones.get(production_mode, {}),
         }
         for zone, percentage in zones_to_integrate.items():
             url_prefix = PRODUCTION_MIX.format(REGIONS[zone], code)
-            additional_mix = _fetch(
+            additional_breakdown = ProductionBreakdownList(logger)
+            additional_production = _fetch(
                 zone,
                 url_prefix,
                 session=session,
@@ -470,68 +513,50 @@ def fetch_production_mix(
             # As null values can cause problems in the estimation models if there's
             # only null values.
             # Integrate with data quality layer later.
-            additional_mix = [
+            additional_production = [
                 datapoint
-                for datapoint in additional_mix
+                for datapoint in additional_production
                 if datapoint["value"] is not None
             ]
-            for point in additional_mix:
+            for point in additional_production:
                 point.update({"value": point["value"] * percentage})
-            mix = _merge_production_mix([mix, additional_mix])
-        if not mix:
-            continue
-
-        for point in mix:
-            negative_threshold = NEGATIVE_PRODUCTION_THRESHOLDS_TYPE.get(
-                type, NEGATIVE_PRODUCTION_THRESHOLDS_TYPE["default"]
-            )
-
-            if (
-                type != "hydro"
-                and point["value"]
-                and 0 > point["value"] >= negative_threshold
-            ):
-                point["value"] = 0
-
-            if type == "hydro" and point["value"] and point["value"] < 0:
-                point.update(
-                    {
-                        "production": {},  # required by merge_production_outputs()
-                        "storage": {type: point.pop("value")},
-                    }
+                production_mix, storage_mix = create_production_storage(
+                    production_mode, point, negative_threshold
                 )
-            else:
-                point.update(
-                    {
-                        "production": {type: point.pop("value")},
-                        "storage": {},  # required by merge_production_outputs()
-                    }
+                additional_breakdown.append(
+                    zoneKey=zone_key,
+                    datetime=point["datetime"],
+                    production=production_mix,
+                    storage=storage_mix,
+                    source="eia.gov",
                 )
+            all_production_breakdowns.append(additional_breakdown)
 
-            # replace small negative values (>-5) with 0s This is necessary for solar
-            point = validate(point, logger=logger, remove_negative=True)
-        mixes.append(mix)
-
-    if not mixes:
+    if len(all_production_breakdowns) == 0:
         logger.warning(f"No production mix data found for {zone_key}")
-        return []
-
+        return ProductionBreakdownList(logger).to_list()
+    all_production_breakdowns = list(
+        filter(lambda x: len(x.events) > 0, all_production_breakdowns)
+    )
     # Some of the returned mixes could be for older timeframes.
     # Fx the latest oil data could be 6 months old.
     # In this case we want to discard the old data as we won't be able to merge it
-    timeframes = [sorted(map(lambda x: x["datetime"], mix)) for mix in mixes]
+    timeframes = [
+        sorted(map(lambda x: x.datetime, breakdowns.events))
+        for breakdowns in all_production_breakdowns
+        if len(breakdowns.events) > 0
+    ]
     latest_timeframe = max(timeframes, key=lambda x: x[-1])
 
-    correct_mixes = []
-    for mix in mixes:
+    for production_list in all_production_breakdowns:
         correct_mix = []
-        for production_in_mix in mix:
-            if production_in_mix["datetime"] in latest_timeframe:
-                correct_mix.append(production_in_mix)
-        if len(correct_mix) > 0:
-            correct_mixes.append(correct_mix)
-
-    return merge_production_outputs(correct_mixes, zone_key, merge_source="eia.gov")
+        for production_mix in production_list.events:
+            if production_mix.datetime in latest_timeframe:
+                correct_mix.append(production_mix)
+        production_list.events = correct_mix
+    return ProductionBreakdownList.merge_production_breakdowns(
+        all_production_breakdowns, logger
+    ).to_list()
 
 
 @refetch_frequency(timedelta(days=1))

--- a/parsers/EIA.py
+++ b/parsers/EIA.py
@@ -632,25 +632,6 @@ def _fetch(
     ]
 
 
-def _index_by_timestamp(datapoints: List[dict]) -> Dict[str, dict]:
-    indexed_data = {}
-    for datapoint in datapoints:
-        indexed_data[datapoint["datetime"]] = datapoint
-    return indexed_data
-
-
-def _merge_production_mix(mixes: List[List[Dict[str, Any]]]) -> List[Dict[str, Any]]:
-    merged_data = {}
-    for mix in mixes:
-        indexed_mix = _index_by_timestamp(mix)
-        for timestamp, mix_value in indexed_mix.items():
-            if not timestamp in merged_data.keys():
-                merged_data[timestamp] = mix_value
-            else:
-                merged_data[timestamp]["value"] += mix_value["value"]
-    return list(merged_data.values())
-
-
 def _conform_timestamp_convention(dt: datetime):
     # The timestamp given by EIA represents the end of the time interval.
     # ElectricityMap using another convention,

--- a/parsers/EIA.py
+++ b/parsers/EIA.py
@@ -532,12 +532,13 @@ def fetch_production_mix(
                 )
             all_production_breakdowns.append(additional_breakdown)
 
-    if len(all_production_breakdowns) == 0:
-        logger.warning(f"No production mix data found for {zone_key}")
-        return ProductionBreakdownList(logger).to_list()
     all_production_breakdowns = list(
         filter(lambda x: len(x.events) > 0, all_production_breakdowns)
     )
+
+    if len(all_production_breakdowns) == 0:
+        logger.warning(f"No production mix data found for {zone_key}")
+        return ProductionBreakdownList(logger).to_list()
     # Some of the returned mixes could be for older timeframes.
     # Fx the latest oil data could be 6 months old.
     # In this case we want to discard the old data as we won't be able to merge it

--- a/parsers/EIA.py
+++ b/parsers/EIA.py
@@ -427,6 +427,8 @@ def create_production_storage(
         production_mix.set_value(fuel_type, production_value)
         return production_mix, None
     if fuel_type == "hydro":
+        # Negative hydro is reported by some BAs, according to the EIA those are pumped storage.
+        # https://www.eia.gov/electricity/gridmonitor/about
         storage_mix.set_value("hydro", abs(production_value))
         return None, storage_mix
     if production_value > negative_threshold:

--- a/parsers/EIA.py
+++ b/parsers/EIA.py
@@ -427,7 +427,7 @@ def create_production_storage(
         production_mix.set_value(fuel_type, production_value)
         return production_mix, None
     if fuel_type == "hydro":
-        storage_mix.set_value("hydro", production_value)
+        storage_mix.set_value("hydro", abs(production_value))
         return None, storage_mix
     if production_value > negative_threshold:
         # This is considered to be self consumption and should be reported as 0.

--- a/parsers/examples/example_parser.py
+++ b/parsers/examples/example_parser.py
@@ -16,7 +16,7 @@ from electricitymap.contrib.lib.models.event_lists import (
     TotalProductionList,
 )
 from electricitymap.contrib.lib.models.events import ProductionMix, StorageMix
-from electricitymap.contrib.parsers.lib.exceptions import ParserException
+from parsers.lib.exceptions import ParserException
 
 
 def fetch_production(

--- a/parsers/test/mocks/EIA/US_SW_DEAA-hydro.json
+++ b/parsers/test/mocks/EIA/US_SW_DEAA-hydro.json
@@ -1,0 +1,31 @@
+{
+  "response": {
+    "query execution": 0.008633325,
+    "count query execution": 0.021634831,
+    "total": 3,
+    "dateFormat": "YYYY-MM-DD\"T\"HH24",
+    "frequency": "hourly",
+    "data": [
+      {
+        "period": "2022-10-31T11",
+        "respondent": "DEAA",
+        "respondent-name": "test",
+        "fueltype": "WAT",
+        "type-name": "Hydro generation",
+        "value": 3,
+        "value-units": "megawatthours"
+      },
+      {
+        "period": "2022-10-31T12",
+        "respondent": "DEAA",
+        "respondent-name": "test",
+        "fueltype": "WAT",
+        "type-name": "Hydro generation",
+        "value": -900,
+        "value-units": "megawatthours"
+      }
+    ],
+    "description": "Hourly net generation by balancing authority and energy source.  \n    Source: Form EIA-930\n    Product: Hourly Electric Grid Monitor"
+  },
+  "apiVersion": "2.0.3"
+}

--- a/parsers/test/mocks/EIA/US_SW_HGMA-hydro.json
+++ b/parsers/test/mocks/EIA/US_SW_HGMA-hydro.json
@@ -1,0 +1,31 @@
+{
+  "response": {
+    "query execution": 0.008633325,
+    "count query execution": 0.021634831,
+    "total": 3,
+    "dateFormat": "YYYY-MM-DD\"T\"HH24",
+    "frequency": "hourly",
+    "data": [
+      {
+        "period": "2022-10-31T11",
+        "respondent": "HGMA",
+        "respondent-name": "test",
+        "fueltype": "WAT",
+        "type-name": "Hydro generation",
+        "value": 4,
+        "value-units": "megawatthours"
+      },
+      {
+        "period": "2022-10-31T12",
+        "respondent": "HGMA",
+        "respondent-name": "test",
+        "fueltype": "WAT",
+        "type-name": "Hydro generation",
+        "value": 400,
+        "value-units": "megawatthours"
+      }
+    ],
+    "description": "Hourly net generation by balancing authority and energy source.  \n    Source: Form EIA-930\n    Product: Hourly Electric Grid Monitor"
+  },
+  "apiVersion": "2.0.3"
+}

--- a/parsers/test/mocks/EIA/US_SW_SRP-hydro.json
+++ b/parsers/test/mocks/EIA/US_SW_SRP-hydro.json
@@ -1,0 +1,31 @@
+{
+  "response": {
+    "query execution": 0.008633325,
+    "count query execution": 0.021634831,
+    "total": 3,
+    "dateFormat": "YYYY-MM-DD\"T\"HH24",
+    "frequency": "hourly",
+    "data": [
+      {
+        "period": "2022-10-31T11",
+        "respondent": "SRP",
+        "respondent-name": "test",
+        "fueltype": "WAT",
+        "type-name": "Hydro generation",
+        "value": -5,
+        "value-units": "megawatthours"
+      },
+      {
+        "period": "2022-10-31T12",
+        "respondent": "SRP",
+        "respondent-name": "test",
+        "fueltype": "WAT",
+        "type-name": "Hydro generation",
+        "value": 400,
+        "value-units": "megawatthours"
+      }
+    ],
+    "description": "Hourly net generation by balancing authority and energy source.  \n    Source: Form EIA-930\n    Product: Hourly Electric Grid Monitor"
+  },
+  "apiVersion": "2.0.3"
+}

--- a/parsers/test/test_EIA.py
+++ b/parsers/test/test_EIA.py
@@ -90,7 +90,7 @@ class TestEIAProduction(TestEIA):
             GET, gas_avrn_url, json=loads(gas_avrn_data.decode("utf-8"))
         )
 
-        data_list = EIA.fetch_production_mix("US-NW-PACW", self.session)
+        data_list = EIA.fetch_production_mix(ZoneKey("US-NW-PACW"), self.session)
         expected = [
             {
                 "zoneKey": "US-NW-PACW",
@@ -100,7 +100,7 @@ class TestEIAProduction(TestEIA):
             {"zoneKey": "US-NW-PACW", "source": "eia.gov", "production": {"gas": 450}},
         ]
         self.check_production_matches(data_list, expected)
-        data_list = EIA.fetch_production_mix("US-NW-BPAT", self.session)
+        data_list = EIA.fetch_production_mix(ZoneKey("US-NW-BPAT"), self.session)
         expected = [
             {
                 "zoneKey": "US-NW-BPAT",
@@ -133,7 +133,7 @@ class TestEIAProduction(TestEIA):
             GET, nuclear_sc_url, json=loads(nuclear_sc_data.decode("utf-8"))
         )
 
-        data_list = EIA.fetch_production_mix("US-CAR-SC", self.session)
+        data_list = EIA.fetch_production_mix(ZoneKey("US-CAR-SC"), self.session)
         expected = [
             {
                 "zoneKey": "US-CAR-SC",
@@ -147,7 +147,7 @@ class TestEIAProduction(TestEIA):
             },
         ]
         self.check_production_matches(data_list, expected)
-        data_list = EIA.fetch_production_mix("US-CAR-SCEG", self.session)
+        data_list = EIA.fetch_production_mix(ZoneKey("US-CAR-SCEG"), self.session)
         expected = [
             {
                 "zoneKey": "US-CAR-SCEG",
@@ -194,7 +194,7 @@ class TestEIAProduction(TestEIA):
             "parsers.test.mocks.EIA", "US-NW-PGE-with-nulls.json"
         )
         self.adapter.register_uri(GET, ANY, json=loads(null_avrn_data.decode("utf-8")))
-        data_list = EIA.fetch_production_mix("US-NW-PGE", self.session)
+        data_list = EIA.fetch_production_mix(ZoneKey("US-NW-PGE"), self.session)
         expected = [
             {
                 "zoneKey": "US-NW-PGE",
@@ -223,7 +223,9 @@ class TestEIAExchanges(TestEIA):
             "parsers.test.mocks.EIA", "US-NW-BPAT-US-NW-NWMT-exchange.json"
         )
         self.adapter.register_uri(GET, ANY, json=loads(data.decode("utf-8")))
-        data_list = EIA.fetch_exchange("US-NW-BPAT", "US-NW-NWMT", self.session)
+        data_list = EIA.fetch_exchange(
+            ZoneKey("US-NW-BPAT"), ZoneKey("US-NW-NWMT"), self.session
+        )
         expected = [
             {
                 "source": "eia.gov",

--- a/parsers/test/test_EIA.py
+++ b/parsers/test/test_EIA.py
@@ -4,13 +4,13 @@ from datetime import datetime
 from json import loads
 from typing import Dict, List, Union
 
-from parsers import EIA
 from pkg_resources import resource_string
 from pytz import utc
 from requests import Session
 from requests_mock import ANY, GET, Adapter
 
 from electricitymap.contrib.config import ZoneKey
+from parsers import EIA
 
 
 class TestEIA(unittest.TestCase):

--- a/parsers/test/test_EIA.py
+++ b/parsers/test/test_EIA.py
@@ -4,13 +4,13 @@ from datetime import datetime
 from json import loads
 from typing import Dict, List, Union
 
+from parsers import EIA
 from pkg_resources import resource_string
 from pytz import utc
 from requests import Session
 from requests_mock import ANY, GET, Adapter
 
 from electricitymap.contrib.config import ZoneKey
-from parsers import EIA
 
 
 class TestEIA(unittest.TestCase):
@@ -221,13 +221,13 @@ class TestEIAProduction(TestEIA):
                 "zoneKey": "US-SW-SRP",
                 "source": "eia.gov",
                 "production": {"hydro": 7.0},
-                "storage": {"hydro": -5.0},
+                "storage": {"hydro": 5.0},
             },
             {
                 "zoneKey": "US-SW-SRP",
                 "source": "eia.gov",
                 "production": {"hydro": 800.0},
-                "storage": {"hydro": -900.0},
+                "storage": {"hydro": 900.0},
             },
         ]
         self.check_production_matches(data, expected)

--- a/parsers/test/test_MX.py
+++ b/parsers/test/test_MX.py
@@ -7,7 +7,7 @@ from requests import Session
 from requests_mock import ANY, Adapter
 
 from electricitymap.contrib.config import ZoneKey
-from electricitymap.contrib.parsers.MX import fetch_consumption
+from parsers.MX import fetch_consumption
 
 
 class TestFetchConsumption(TestCase):

--- a/web/package.json
+++ b/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "electricitymaps-web",
-  "version": "1.29.0",
+  "version": "1.30.0",
   "description": "A real-time visualisation of the CO2 emissions of electricity consumption",
   "license": "AGPL-3.0-or-later",
   "engines": {


### PR DESCRIPTION
## Description

Use new Event datastructure for production mix EIA.

The reasoning behind the fetch production mix has been changed slightly. Zones with no consumption that feed all or part of their generation into other zones are being handled differently.

Previously, all the production mixes from supplying zones were merged together before determining if the hydro production might be negative and hence be a storage action. This had the side effect that merging together all those values might mean that a negative hydro production from a supplying zone might be rendered positive in case the main zone or another supplying zone has a higer absolute hydro production therefore nullifying the storage event.

This is not what would happen physically most likely. Most likely storage events would be handled in their own zone before supplying the surplus to another zone.

Now, we compute the storage event on a per zone basis and merging storage and production together at a later stage with the merge production output static method.

## Testing
Added a test to make sure the hydro transfer is executed as expected.

BTW in the EIA parser negative hydro production is mapped to negative hydro storage, does this make sense @pierresegonne, @FelixDQ @VIKTORVAV99 .