### PR TITLE
JP `Unknown` emission factor for regions without discrete sources

### DIFF
--- a/config/zones/JP-CG.yaml
+++ b/config/zones/JP-CG.yaml
@@ -14,9 +14,18 @@ capacity:
   solar: 55.9
   wind: 365
 disclaimer: The data provider (Chugoku Electric Power Co.,Inc.) provides live data only for solar and unknown. We are working on improving the data quality for this zone.
+emissionFactors:
+  lifecycle:
+    unknown:
+      _comment: 'Source: Enerdata 2022 Japanese National Average'
+      _url:
+        - https://www.climate-transparency.org/wp-content/uploads/2022/10/CT2022-Japan-Web.pdf
+      source: Enerdata 2022
+      value: 462
 contributors:
   - tmslaine
   - lorrieq
+  - PPsyrius
 parsers:
   consumptionForecast: JP.fetch_consumption_forecast
   price: JP.fetch_price

--- a/config/zones/JP-HKD.yaml
+++ b/config/zones/JP-HKD.yaml
@@ -20,7 +20,16 @@ contributors:
   - lorrieq
   - pierresegonne
   - wobniarin
+  - PPsyrius
 disclaimer: The data provider (Hokkaido Electric Power Network HEPCO) provides live data only for solar and unknown. We are working on improving the data quality for this zone.
+emissionFactors:
+  lifecycle:
+    unknown:
+      _comment: 'Source: Enerdata 2022 Japanese National Average'
+      _url:
+        - https://www.climate-transparency.org/wp-content/uploads/2022/10/CT2022-Japan-Web.pdf
+      source: Enerdata 2022
+      value: 462
 parsers:
   consumptionForecast: JP.fetch_consumption_forecast
   price: JP.fetch_price

--- a/config/zones/JP-HR.yaml
+++ b/config/zones/JP-HR.yaml
@@ -8,6 +8,7 @@ contributors:
   - lorrieq
   - pierresegonne
   - wobniarin
+  - PPsyrius
 capacity:
   biomass: 700
   geothermal: 0
@@ -18,6 +19,14 @@ capacity:
   oil: 1750
   wind: 229.6
 disclaimer: The data provider (Hokuriku Electric Power Co.,Inc.) provides live data only for solar and unknown. We are working on improving the data quality for this zone.
+emissionFactors:
+  lifecycle:
+    unknown:
+      _comment: 'Source: Enerdata 2022 Japanese National Average'
+      _url:
+        - https://www.climate-transparency.org/wp-content/uploads/2022/10/CT2022-Japan-Web.pdf
+      source: Enerdata 2022
+      value: 462
 parsers:
   consumptionForecast: JP.fetch_consumption_forecast
   price: JP.fetch_price

--- a/config/zones/JP-ON.yaml
+++ b/config/zones/JP-ON.yaml
@@ -6,6 +6,7 @@ bounding_box:
 contributors:
   - tmslaine
   - lorrieq
+  - PPsyrius
 capacity:
   biomass: 49
   geothermal: 0
@@ -16,6 +17,14 @@ capacity:
   oil: 189.78
   wind: 28
 disclaimer: The data provider (Okiden Electric Power Co.,Inc.) provides live data only for solar and unknown. We are working on improving the data quality for this zone.
+emissionFactors:
+  lifecycle:
+    unknown:
+      _comment: 'Source: Enerdata 2022 Japanese National Average'
+      _url:
+        - https://www.climate-transparency.org/wp-content/uploads/2022/10/CT2022-Japan-Web.pdf
+      source: Enerdata 2022
+      value: 462
 parsers:
   consumptionForecast: JP.fetch_consumption_forecast
   price: JP.fetch_price

--- a/config/zones/JP-SK.yaml
+++ b/config/zones/JP-SK.yaml
@@ -7,6 +7,7 @@ contributors:
   - tmslaine
   - lorrieq
   - wobniarin
+  - PPsyrius
 capacity:
   biomass: 406
   geothermal: 0
@@ -19,6 +20,14 @@ capacity:
   solar: 2230
   wind: 227
 disclaimer: The data provider (Yonden Shikoku Electric Power Co.,Inc.) provides live data only for solar and unknown. We are working on improving the data quality for this zone.
+emissionFactors:
+  lifecycle:
+    unknown:
+      _comment: 'Source: Enerdata 2022 Japanese National Average'
+      _url:
+        - https://www.climate-transparency.org/wp-content/uploads/2022/10/CT2022-Japan-Web.pdf
+      source: Enerdata 2022
+      value: 462
 parsers:
   consumptionForecast: JP.fetch_consumption_forecast
   price: JP.fetch_price

--- a/config/zones/JP-TH.yaml
+++ b/config/zones/JP-TH.yaml
@@ -18,7 +18,16 @@ capacity:
 contributors:
   - tmslaine
   - lorrieq
+  - PPsyrius
 disclaimer: The data provider (Tohoku Electric Power Co. Inc.) provides live data only for solar and unknown. We are working on improving the data quality for this zone.
+emissionFactors:
+  lifecycle:
+    unknown:
+      _comment: 'Source: Enerdata 2022 Japanese National Average'
+      _url:
+        - https://www.climate-transparency.org/wp-content/uploads/2022/10/CT2022-Japan-Web.pdf
+      source: Enerdata 2022
+      value: 462
 parsers:
   consumptionForecast: JP.fetch_consumption_forecast
   price: JP.fetch_price


### PR DESCRIPTION
## Issue

<!-- If you want to close an issue automatically when your PR is merged, write "Closes X" where X is the PR number. For example: Closes #000 -->
Closes #5361.

## Description

This adds `unknown` emission source data for Japanese zones without discrete sources, which are:
- Hokuriku (`JP-HR`)
- Chugoku (`JP-CG`)
- Shikoku (`JP-SK`)
- Okinawa (`JP-ON`)
- Tohoku (`JP-TH`)
- Hokkaido (`JP-HKD`)

which now defaults to `462gCO₂eq/kWh` as per `Enerdata 2022`'s Japanese National Average data cited in [`Climate Transparency`'s Japan, Country Profile 2022](https://www.climate-transparency.org/wp-content/uploads/2022/10/CT2022-Japan-Web.pdf) instead of the default `700gCO₂eq/kWh` .

### Preview

<!-- Please add screenshots and/or gif that shows visual changes (if applicable) -->
```yml
emissionFactors:
  lifecycle:
    unknown:
      _comment: 'Source: Enerdata 2022 Japanese National Average'
      _url:
        - https://www.climate-transparency.org/wp-content/uploads/2022/10/CT2022-Japan-Web.pdf
      source: Enerdata 2022
      value: 462
```

### Double check

- [ ] I have tested my parser changes locally with `poetry run test_parser "zone_key"`
- [ ] I have run `pnpx prettier --write .` and `poetry run format` to format my changes.
