### PR TITLE
Resolves #5352: Added overflowY: auto style to ZoneHeader component

### DIFF
--- a/web/src/features/panels/zone/ZoneHeader.tsx
+++ b/web/src/features/panels/zone/ZoneHeader.tsx
@@ -61,7 +61,7 @@ export function ZoneHeader({ zoneId, data, isAggregated }: ZoneHeaderProps) {
   const isEstimated = estimationMethod !== undefined;
 
   return (
-    <div className="mt-1 grid w-full gap-y-5 sm:pr-4">
+    <div className="mt-1 grid w-full gap-y-5 sm:pr-4" style={{ overflowY: 'auto' }}>
       <ZoneHeaderTitle
         zoneId={zoneId}
         isEstimated={isEstimated}


### PR DESCRIPTION
## Issue

<!-- If you want to close an issue automatically when your PR is merged, write "Closes X" where X is the PR number. For example: Closes #000 -->

## Description

To fix this issue, I just added a minor styling adjustment to the ZoneHeader Component: `style={{ overflowY: 'auto' }}`. I hope this is the change you're looking for. Also, this is my first OSS pull request so I'm sorry if I made any mistakes.

### Preview

![image](https://user-images.githubusercontent.com/98565804/236583350-74d3d530-03db-43e5-880c-0b43b0ee8d0a.png)
![image](https://user-images.githubusercontent.com/98565804/236583372-80e72d6a-c453-4c4f-b1dd-36e6a349b9cb.png)
As you can see, the piecharts and the USA header doesn't overflow anymore, even when the USA tag is lengthened. Not sure if you want the little scrolling bar at the bottom though.

### Double check

- [ ] I have tested my parser changes locally with `poetry run test_parser "zone_key"`
- [ ] I have run `pnpx prettier --write .` and `poetry run format` to format my changes.
