### PR TITLE
Use validation error in the event validation

### DIFF
--- a/electricitymap/contrib/lib/models/events.py
+++ b/electricitymap/contrib/lib/models/events.py
@@ -4,7 +4,7 @@ from enum import Enum
 from logging import Logger
 from typing import Any, Dict, Optional
 
-from pydantic import BaseModel, PrivateAttr, validator
+from pydantic import BaseModel, PrivateAttr, ValidationError, validator
 
 from electricitymap.contrib.config import EXCHANGES_CONFIG, ZONES_CONFIG, ZoneKey
 from electricitymap.contrib.config.constants import PRODUCTION_MODES
@@ -179,8 +179,8 @@ class Exchange(Event):
                 netFlow=netFlow,
                 sourceType=sourceType,
             )
-        except ValueError as e:
-            logger.error(f"Error creating exchange Event {datetime}: {e}")
+        except ValidationError as e:
+            logger.error(f"Error(s) creating exchange Event {datetime}: {e}")
 
     def to_dict(self) -> Dict[str, Any]:
         return {
@@ -223,8 +223,8 @@ class TotalProduction(Event):
                 value=value,
                 sourceType=sourceType,
             )
-        except ValueError as e:
-            logger.error(f"Error creating total production Event {datetime}: {e}")
+        except ValidationError as e:
+            logger.error(f"Error(s) creating total production Event {datetime}: {e}")
 
     def to_dict(self) -> Dict[str, Any]:
         return {
@@ -279,8 +279,8 @@ class ProductionBreakdown(Event):
                 storage=storage,
                 sourceType=sourceType,
             )
-        except ValueError as e:
-            logger.error(f"Error creating production breakdown Event {datetime}: {e}")
+        except ValidationError as e:
+            logger.error(f"Error(s) creating production breakdown Event {datetime}: {e}")
 
     def to_dict(self) -> Dict[str, Any]:
         return {
@@ -324,9 +324,9 @@ class TotalConsumption(Event):
                 consumption=consumption,
                 sourceType=sourceType,
             )
-        except ValueError as e:
+        except ValidationError as e:
             logger.error(
-                f"Error creating total consumption Event {datetime}: {e}",
+                f"Error(s) creating total consumption Event {datetime}: {e}",
                 extra={
                     "zoneKey": zoneKey,
                     "datetime": datetime,
@@ -373,8 +373,8 @@ class Price(Event):
                 currency=currency,
                 sourceType=sourceType,
             )
-        except ValueError as e:
-            logger.error(f"Error creating price Event {datetime}: {e}")
+        except ValidationError as e:
+            logger.error(f"Error(s) creating price Event {datetime}: {e}")
 
     def to_dict(self) -> Dict[str, Any]:
         return {

--- a/electricitymap/contrib/lib/models/events.py
+++ b/electricitymap/contrib/lib/models/events.py
@@ -280,7 +280,9 @@ class ProductionBreakdown(Event):
                 sourceType=sourceType,
             )
         except ValidationError as e:
-            logger.error(f"Error(s) creating production breakdown Event {datetime}: {e}")
+            logger.error(
+                f"Error(s) creating production breakdown Event {datetime}: {e}"
+            )
 
     def to_dict(self) -> Dict[str, Any]:
         return {

--- a/electricitymap/contrib/lib/tests/test_events.py
+++ b/electricitymap/contrib/lib/tests/test_events.py
@@ -82,6 +82,18 @@ class TestExchange(unittest.TestCase):
                 source="trust.me",
             )
 
+    def test_static_create_logs_error(self):
+        logger = logging.Logger("test")
+        with patch.object(logger, "error") as mock_error:
+            Exchange.create(
+                logger=logger,
+                zoneKey=ZoneKey("DER->FR"),
+                datetime=datetime(2023, 1, 1, tzinfo=timezone.utc),
+                netFlow=-1,
+                source="trust.me",
+            )
+            mock_error.assert_called_once()
+
 
 class TestConsumption(unittest.TestCase):
     def test_create_consumption(self):
@@ -118,6 +130,18 @@ class TestConsumption(unittest.TestCase):
                 consumption=-1,
                 source="trust.me",
             )
+
+    def test_static_create_logs_error(self):
+        logger = logging.Logger("test")
+        with patch.object(logger, "error") as mock_error:
+            TotalConsumption.create(
+                logger=logger,
+                zoneKey=ZoneKey("DE"),
+                datetime=datetime(2023, 1, 1, tzinfo=timezone.utc),
+                consumption=-1,
+                source="trust.me",
+            )
+            mock_error.assert_called_once()
 
 
 class TestPrice(unittest.TestCase):
@@ -270,6 +294,18 @@ class TestProductionBreakdown(unittest.TestCase):
                 source="trust.me",
             )
 
+    def test_static_create_logs_error(self):
+        logger = logging.Logger("test")
+        with patch.object(logger, "error") as mock_error:
+            ProductionBreakdown.create(
+                logger=logger,
+                zoneKey=ZoneKey("DE"),
+                datetime=datetime(2023, 1, 1, tzinfo=timezone.utc),
+                production=ProductionMix(wind=None),
+                source="trust.me",
+            )
+            mock_error.assert_called_once()
+
 
 class TestTotalProduction(unittest.TestCase):
     def test_create_generation(self):
@@ -283,6 +319,18 @@ class TestTotalProduction(unittest.TestCase):
         assert generation.datetime == datetime(2023, 1, 1, tzinfo=timezone.utc)
         assert generation.source == "trust.me"
         assert generation.value == 1
+
+    def test_static_create_logs_error(self):
+        logger = logging.Logger("test")
+        with patch.object(logger, "error") as mock_error:
+            TotalProduction.create(
+                logger=logger,
+                zoneKey=ZoneKey("DE"),
+                datetime=datetime(2023, 1, 1, tzinfo=timezone.utc),
+                value=-1,
+                source="trust.me",
+            )
+            mock_error.assert_called_once()
 
 
 class TestMixes(unittest.TestCase):


### PR DESCRIPTION
## Issue

The consumption parser for the EIA raised errors due to some zones returning None for the consumption, most likely Genration only zones. This is not the expected behavior, the expected behavior was that the error would be catched and logged and an not added to the list.

## Description

Turns out the issue is that actually Pydentic raises a Validation error in the end with all the validation errors. Therefore rewrite the create static method to correctly catch those errors and log them.

This will fix the issue we see with consumption data for the US as zones reporting null will only log the error and not raise an error.
