### PR TITLE
Update Chinese translation for gas

### DIFF
--- a/web/public/locales/zh-CN.json
+++ b/web/public/locales/zh-CN.json
@@ -98,7 +98,7 @@
   "biomass": "生物质",
   "nuclear": "核能",
   "geothermal": "地热",
-  "gas": "煤气",
+  "gas": "天然气",
   "coal": "煤炭",
   "oil": "石油",
   "unknown": "未知",

--- a/web/public/locales/zh-HK.json
+++ b/web/public/locales/zh-HK.json
@@ -48,7 +48,7 @@
   "biomass": "生物質",
   "nuclear": "核能",
   "geothermal": "地熱",
-  "gas": "煤氣",
+  "gas": "天然氣",
   "coal": "煤炭",
   "oil": "石油",
   "unknown": "未知",

--- a/web/public/locales/zh-TW.json
+++ b/web/public/locales/zh-TW.json
@@ -49,7 +49,7 @@
   "biomass": "生物質",
   "nuclear": "核能",
   "geothermal": "地熱",
-  "gas": "煤氣",
+  "gas": "天然氣",
   "coal": "煤炭",
   "oil": "石油",
   "unknown": "未知",


### PR DESCRIPTION
## Issue

Closes #5262

## Description

Updates the translation for gas (natural gas / fossil gas) from the colloquial 煤气 to the more specific 天然气. See for example that this is the term used in the wikipedia article https://zh.wikipedia.org/zh-tw/%E5%A4%A9%E7%84%B6%E6%B0%94 corresponding to the English "natural gas" article.

### Double check

- [n/a] I have tested my parser changes locally with `poetry run test_parser "zone_key"`
- [n/a] I have run `pnpx prettier --write .` and `poetry run format` to format my changes.
