### PR TITLE
Fix datetime not serializable error in error logging

### DIFF
--- a/electricitymap/contrib/lib/models/events.py
+++ b/electricitymap/contrib/lib/models/events.py
@@ -337,7 +337,7 @@ class TotalConsumption(Event):
                 f"Error(s) creating total consumption Event {datetime}: {e}",
                 extra={
                     "zoneKey": zoneKey,
-                    "datetime": datetime,
+                    "datetime": datetime.strftime("%Y-%m-%dT%H:%M:%SZ"),
                     "kind": "consumption",
                 },
             )


### PR DESCRIPTION
## Issue

We get this error sometimes when parsing consumption:
`TypeError: Object of type datetime is not JSON serializable `

## Description

Make sure the datetime becomes a proper string when logging the error.
