### PR TITLE
Remove unused imports from Python files and add flake8 lint check

### DIFF
--- a/electricitymap/contrib/lib/models/event_lists.py
+++ b/electricitymap/contrib/lib/models/event_lists.py
@@ -1,7 +1,7 @@
 from abc import ABC, abstractmethod
 from datetime import datetime
 from logging import Logger
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Dict, List, Optional
 
 import numpy as np
 import pandas as pd

--- a/parsers/CA_AB.py
+++ b/parsers/CA_AB.py
@@ -6,7 +6,6 @@
 
 # Standard library imports
 import csv
-import logging
 import re
 import urllib.parse
 from datetime import datetime

--- a/parsers/IE.py
+++ b/parsers/IE.py
@@ -2,7 +2,6 @@ from datetime import datetime, timedelta
 from logging import Logger, getLogger
 from typing import Optional
 
-import arrow
 import pytz
 from requests import Response, Session
 

--- a/parsers/MX.py
+++ b/parsers/MX.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 import urllib
-from datetime import datetime, timedelta, timezone
+from datetime import datetime, timedelta
 from io import StringIO
 from logging import Logger, getLogger
 from typing import Optional

--- a/parsers/MY_WM.py
+++ b/parsers/MY_WM.py
@@ -15,7 +15,6 @@ from typing import Optional
 
 # Third-party library imports
 import arrow
-import requests
 from requests import Session
 
 # Local library imports

--- a/parsers/NTESMO.py
+++ b/parsers/NTESMO.py
@@ -13,7 +13,7 @@ import pandas as pd
 from bs4 import BeautifulSoup
 from pytz import timezone
 from requests import Session
-from requests.adapters import HTTPAdapter, Retry
+from requests.adapters import Retry
 
 from parsers.lib.config import refetch_frequency, retry_policy
 from parsers.lib.exceptions import ParserException

--- a/parsers/US_CA.py
+++ b/parsers/US_CA.py
@@ -11,7 +11,6 @@ import pytz
 from bs4 import BeautifulSoup
 from requests import Session
 
-from electricitymap.contrib.config.constants import PRODUCTION_MODES
 from parsers.lib.config import refetch_frequency
 from parsers.lib.validation import validate_consumption
 

--- a/parsers/US_PJM.py
+++ b/parsers/US_PJM.py
@@ -10,7 +10,6 @@ from typing import List, Optional, Union
 import arrow
 import demjson3 as demjson
 import pandas as pd
-import pytz
 from bs4 import BeautifulSoup
 from dateutil import parser, tz
 from requests import Response, Session

--- a/parsers/archived/GB_NIR.py
+++ b/parsers/archived/GB_NIR.py
@@ -2,10 +2,8 @@
 # Archived reason: Data is no longer available.
 
 import logging
-from collections import defaultdict
 from datetime import datetime, timedelta
 from io import StringIO
-from operator import itemgetter
 
 import pandas as pd
 import requests

--- a/parsers/archived/IN_GJ.py
+++ b/parsers/archived/IN_GJ.py
@@ -11,7 +11,7 @@ from typing import Optional
 import arrow
 from requests import Session
 
-from ..lib import IN, web, zonekey
+from ..lib import web, zonekey
 from ..lib.validation import validate
 
 SLDCGUJ_URL = (

--- a/parsers/archived/JP_ISEP.py
+++ b/parsers/archived/JP_ISEP.py
@@ -2,9 +2,7 @@
 # Archive reason: No longer in use.
 
 import datetime
-import json
 import logging
-import os
 import re
 
 import pandas as pd

--- a/parsers/test/test_AU_TAS_FI.py
+++ b/parsers/test/test_AU_TAS_FI.py
@@ -4,10 +4,8 @@ import json
 import unittest
 from unittest.mock import patch
 
-from pkg_resources import resource_string
 from requests import Session
 from requests_mock import Adapter
-from testfixtures import LogCapture
 
 from parsers import ajenti
 

--- a/parsers/test/test_AU_TAS_KI.py
+++ b/parsers/test/test_AU_TAS_KI.py
@@ -4,10 +4,8 @@ import json
 import unittest
 from unittest.mock import patch
 
-from pkg_resources import resource_string
 from requests import Session
 from requests_mock import Adapter
-from testfixtures import LogCapture
 
 from parsers import ajenti
 

--- a/parsers/test/test_AU_WA_RI.py
+++ b/parsers/test/test_AU_WA_RI.py
@@ -4,10 +4,8 @@ import json
 import unittest
 from unittest.mock import patch
 
-from pkg_resources import resource_string
 from requests import Session
 from requests_mock import Adapter
-from testfixtures import LogCapture
 
 from parsers import ajenti
 

--- a/parsers/test/test_BR.py
+++ b/parsers/test/test_BR.py
@@ -4,7 +4,6 @@
 
 import json
 import unittest
-from datetime import datetime
 from unittest.mock import patch
 
 from arrow import get

--- a/parsers/test/test_ENTSOE.py
+++ b/parsers/test/test_ENTSOE.py
@@ -1,10 +1,7 @@
 import os
 import unittest
 from datetime import datetime
-from json import loads
-from typing import Dict, List, Union
 
-from pkg_resources import resource_string
 from pytz import utc
 from requests import Session
 from requests_mock import ANY, GET, Adapter

--- a/parsers/test/test_IN_HP.py
+++ b/parsers/test/test_IN_HP.py
@@ -3,7 +3,7 @@ import unittest
 
 from pkg_resources import resource_string
 from requests import Session
-from requests_mock import ANY, Adapter
+from requests_mock import Adapter
 from testfixtures import LogCapture
 
 from parsers import IN_HP

--- a/parsers/test/test_OPENNEM.py
+++ b/parsers/test/test_OPENNEM.py
@@ -1,5 +1,4 @@
 import unittest
-from datetime import datetime
 
 import arrow
 import numpy as np

--- a/parsers/test/test_US_MISO.py
+++ b/parsers/test/test_US_MISO.py
@@ -4,7 +4,6 @@
 
 import json
 import logging
-import os
 import unittest
 from datetime import datetime
 from unittest.mock import patch

--- a/scripts/tooling.py
+++ b/scripts/tooling.py
@@ -26,7 +26,7 @@ def format():
 
 def lint():
     _run(
-        "flake8 electricitymap tests parsers --count --select=E901,E999,F821,F822,F823 --show-source --statistics"
+        "flake8 electricitymap tests parsers --count --select=F401,E901,E999,F821,F822,F823 --show-source --statistics"
     )
     _run("black --check .")
     _run("isort -c .")

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,8 +1,5 @@
-import json
 import unittest
 from pathlib import Path
-
-from deepdiff import DeepDiff
 
 from electricitymap.contrib import config
 


### PR DESCRIPTION
## Description

In a recent PR (https://github.com/electricitymaps/electricitymaps-contrib/pull/5269) it was noted that I had unused imports that I hadn't noticed that hadn't been caught by the current lint process.

This adds linting for unused Python imports, and removes current unused imports.

### Double check

- [ ] I have tested my parser changes locally with `poetry run test_parser "zone_key"`
- [x] I have run `pnpx prettier --write .` and `poetry run format` to format my changes.
