### PR TITLE
5352 Fix layout of gauges in ZoneHeader

### DIFF
--- a/web/src/features/panels/zone/ZoneHeader.tsx
+++ b/web/src/features/panels/zone/ZoneHeader.tsx
@@ -2,11 +2,11 @@ import CarbonIntensitySquare from 'components/CarbonIntensitySquare';
 import { CircularGauge } from 'components/CircularGauge';
 import { useAtom } from 'jotai';
 import { useTranslation } from 'translation/translation';
+import { ZoneDetails } from 'types';
 import { Mode } from 'utils/constants';
 import { getCarbonIntensity, getFossilFuelRatio, getRenewableRatio } from 'utils/helpers';
 import { productionConsumptionAtom, selectedDatetimeIndexAtom } from 'utils/state/atoms';
 import ZoneHeaderTitle from './ZoneHeaderTitle';
-import { ZoneDetails } from 'types';
 
 function LowCarbonTooltip() {
   const { __ } = useTranslation();
@@ -61,12 +61,14 @@ export function ZoneHeader({ zoneId, data, isAggregated }: ZoneHeaderProps) {
   const isEstimated = estimationMethod !== undefined;
 
   return (
-    <div className="mt-1 grid w-full gap-y-5 sm:pr-4">
-      <ZoneHeaderTitle
-        zoneId={zoneId}
-        isEstimated={isEstimated}
-        isAggregated={isAggregated}
-      />
+    <div>
+      <div className="mt-1 mb-4 grid w-full sm:pr-4">
+        <ZoneHeaderTitle
+          zoneId={zoneId}
+          isEstimated={isEstimated}
+          isAggregated={isAggregated}
+        />
+      </div>
       <div className="flex flex-row justify-evenly">
         <CarbonIntensitySquare
           data-test-id="co2-square-value"


### PR DESCRIPTION
## Issue

Partial fix to #5352 reported by @madsnedergaard 

## Description

Extracted the gauges container from the zone title container.

### Preview

#### Before
![Screenshot from 2023-05-11 21-11-23](https://github.com/electricitymaps/electricitymaps-contrib/assets/3165655/59796052-9071-4108-b293-319bd59d100f)

#### Fix 
Gray country badge is hidden if it overflows
![Screenshot from 2023-05-11 21-25-54](https://github.com/electricitymaps/electricitymaps-contrib/assets/3165655/52c5d195-7549-452a-9da5-4409d1190e26)


#### Alternative Fix
Gray country badge is visible if it overflows
![Screenshot from 2023-05-11 21-29-54](https://github.com/electricitymaps/electricitymaps-contrib/assets/3165655/4df307e9-bfad-46f8-853f-bb07730b30ca)


### Double check

- [x] I have tested my parser changes locally with `poetry run test_parser "zone_key"`
- [x] I have run `pnpx prettier --write .` and `poetry run format` to format my changes.
