### PR TITLE
Production Breakdown correctly reports corrected negative values.

### DIFF
--- a/electricitymap/contrib/lib/models/events.py
+++ b/electricitymap/contrib/lib/models/events.py
@@ -77,7 +77,8 @@ class ProductionMix(Mix):
         )
         if keep_corrected_negative_values:
             for corrected_negative_mode in self._corrected_negative_values:
-                production_mix[corrected_negative_mode] = None
+                if corrected_negative_mode not in production_mix:
+                    production_mix[corrected_negative_mode] = None
         return production_mix
 
     def __setattr__(self, name: str, value: Optional[float]) -> None:
@@ -86,6 +87,9 @@ class ProductionMix(Mix):
                 self._corrected_negative_values.add(name)
                 return super().__setattr__(name, None)
         return super().__setattr__(name, value)
+
+    def report_corrected_negative_values(self, mode: str):
+        self._corrected_negative_values.add(mode)
 
     @property
     def has_corrected_negative_values(self) -> bool:

--- a/electricitymap/contrib/lib/tests/test_events.py
+++ b/electricitymap/contrib/lib/tests/test_events.py
@@ -267,6 +267,24 @@ class TestProductionBreakdown(unittest.TestCase):
             assert breakdown.production.hydro == None
             assert breakdown.production.wind == 10
 
+    def test_self_report_negative_value(self):
+        mix = ProductionMix(
+            wind=0,
+        )
+        # We have manually set a 0 to avoid reporting self consumption for instance.
+        mix.report_corrected_negative_values("wind")
+        logger = logging.Logger("test")
+        with patch.object(logger, "warning") as mock_warning:
+            breakdown = ProductionBreakdown.create(
+                logger=logger,
+                zoneKey=ZoneKey("DE"),
+                datetime=datetime(2023, 1, 1, tzinfo=timezone.utc),
+                production=mix,
+                source="trust.me",
+            )
+            mock_warning.assert_called_once()
+            assert breakdown.production.wind == 0
+
     @freezegun.freeze_time("2023-01-01")
     def test_forecasted_points(self):
         mix = ProductionMix(wind=10)

--- a/parsers/EIA.py
+++ b/parsers/EIA.py
@@ -449,6 +449,7 @@ def create_production_storage(
         # This is considered to be self consumption and should be reported as 0.
         # Lower values are set to None as they are most likely outliers.
         production_value = 0
+        production_mix.report_corrected_negative_values(fuel_type)
     production_mix.set_value(fuel_type, production_value)
     return production_mix, None
 


### PR DESCRIPTION
## Issue

When negative values were passed to a production breakdown, they were fixed by setting them to None. However when returning the dict those values were erased.

Furthermore, it would be great to be able to report values that have been corrected outside of the ProductionBreakdown.

## Description

- Fix None comming from corrected negative values being excluded from the resulting dictionary.

