### PR TITLE
fix CZ->SK exchange

### DIFF
--- a/parsers/CZ.py
+++ b/parsers/CZ.py
@@ -27,7 +27,7 @@ translate_table_gen = {
     "unknown": "unknown",
 }
 translate_table_dist = {
-    "SEPS": "SVK",
+    "SEPS": "SK",
     "APG": "AT",
     "PSE": "PL",
     "TenneT": "DE",


### PR DESCRIPTION
## Issue
Fixes: #5405 

## Description
There was a small configuration error that resulted in the data between CZ and SK always being reported as 0.

This can be avoided in the future by implementing the new parser classes and avoiding setting 0 as a starting point. This should be addressed in a future PR.

### Double check

- [x] I have tested my parser changes locally with `poetry run test_parser "zone_key"`
- [x] I have run `pnpx prettier --write .` and `poetry run format` to format my changes.
