### PR TITLE
Fix warnings from pandas surfaced in tests

### DIFF
--- a/parsers/test/test_OPENNEM.py
+++ b/parsers/test/test_OPENNEM.py
@@ -13,7 +13,7 @@ class TestOPENNEM(unittest.TestCase):
             start="2021-01-01 00:00:00+00:00",
             end="2021-01-01 01:00:00+00:00",
             freq="5T",
-            closed="left",
+            inclusive="left",
         )
         df = pd.DataFrame(index=idx)
         rdn_any_column = np.random.rand(len(idx)).astype(float)
@@ -31,7 +31,7 @@ class TestOPENNEM(unittest.TestCase):
                 start="2021-01-01 00:00:00+00:00",
                 end="2021-01-01 01:00:00+00:00",
                 freq="30T",
-                closed="left",
+                inclusive="left",
             )
         )
         assert processed_df.loc[:, "SOLAR_ROOFTOP"].iloc[0] == 84.0

--- a/validators/zone_specific_checks.py
+++ b/validators/zone_specific_checks.py
@@ -34,8 +34,8 @@ def validate_production_has_fossil_fuel(events: pd.DataFrame) -> pd.Series:
         "production.oil",
         "production.gas",
     ]
-    fossil_fuel_cols_in_event = set.intersection(
-        set(fossil_fuel_cols), set(events.columns)
+    fossil_fuel_cols_in_event = list(
+        set.intersection(set(fossil_fuel_cols), set(events.columns))
     )
 
     res = (events[fossil_fuel_cols_in_event] > 0).any(axis=1).astype(int)


### PR DESCRIPTION
## Description

When running the tests with `poetry run test`, I saw several warnings from pandas:

```

tests/validators/test_zone_specific_checks.py::test_validate_production_has_fossil_fuel
  /Users/qyearsley/electricitymaps-contrib/validators/zone_specific_checks.py:41: FutureWarning: Passing a set as an indexer is deprecated and will raise in a future version. Use a list instead.
    res = (events[fossil_fuel_cols_in_event] > 0).any(axis=1).astype(int)

parsers/test/test_OPENNEM.py::TestOPENNEM::test_process_solar_rooftop
  /Users/qyearsley/electricitymaps-contrib/parsers/test/test_OPENNEM.py:12: FutureWarning: Argument `closed` is deprecated in favor of `inclusive`.
    idx = pd.date_range(

parsers/test/test_OPENNEM.py::TestOPENNEM::test_process_solar_rooftop
  /Users/qyearsley/electricitymaps-contrib/parsers/test/test_OPENNEM.py:29: FutureWarning: Argument `closed` is deprecated in favor of `inclusive`.
    assert processed_df.index.equals(
```

It looks like these changes were made some time ago like version 1.40 (https://pandas.pydata.org/docs/whatsnew/v1.4.0.html) and poetry.lock has pandas version 1.5.3, so this is probably safe to do.

### Double check

- [ ] I have tested my parser changes locally with `poetry run test_parser "zone_key"`
- [X] I have run `pnpx prettier --write .` and `poetry run format` to format my changes.
