### PR TITLE
[WIP] Remove nuclear from validation for Germany

### DIFF
--- a/parsers/ENTSOE.py
+++ b/parsers/ENTSOE.py
@@ -359,7 +359,6 @@ VALIDATIONS: Dict[str, Dict[str, Any]] = {
         "required": [
             "coal",
             "gas",
-            "nuclear",
             "wind",
             "biomass",
             "hydro",


### PR DESCRIPTION
## Issue

Ever since a few days ago Germany is only ever showing "estimated" data. This seems to be because ENTSO-E is only reporting Geothermal, Wind (offshore), and Brown coal / Lignite.  In any case, it should no longer be required for the nuclear key to be present for German output.

## Description

Remove 'nuclear' as a required ENTSO-E output for Germany

<!-- ### Preview

Please add screenshots and/or gif that shows visual changes (if applicable) -->

### Double check

- [ ] I have tested my parser changes locally with `poetry run test_parser "zone_key"`
- [ ] I have run `pnpx prettier --write .` and `poetry run format` to format my changes.
