### PR TITLE
fix: IL parser

### DIFF
--- a/parsers/IL.py
+++ b/parsers/IL.py
@@ -115,7 +115,7 @@ def fetch_production(
     production = production.replace(',', '')
     reserve = reserve.replace(',', '')
 
-    production = float(production) + float(reserve)
+    production = float(production) * 1000 + float(reserve) * 1000
 
     # all mapped to unknown as there is no available breakdown
     return {
@@ -145,7 +145,7 @@ def fetch_consumption(
     return {
         "zoneKey": zone_key,
         "datetime": arrow.now(TZ).datetime,
-        "consumption": {"unknown": float(consumption)},
+        "consumption": float(consumption) * 1000,
         "source": NOGA_BASE_URL,
     }
 


### PR DESCRIPTION
## Issue

Closes #4288 

## Description
IL parser went down after the site redesign. I reached out to the person in charge of public information and was directed to [Noga](https://www.noga-iso.co.il/en/). this parser uses the API endpoint they use on their site.

**important to note**
currently, all of the consumption and production are labelled as `unknown` since there is no distribution map. *but* there is a consumption and production division between renewable energy and "regular energy" in MW [here](https://www.noga-iso.co.il/demandforecast). If you think this division is relevant, let me know, and I can add it.



### Double check

- [ X] I have tested my parser changes locally with `poetry run test_parser "zone_key"`
- [X ] I have run `pnpx prettier --write .` and `poetry run format` to format my changes.
