### PR TITLE
TH: Includes Float Time (Ft) rate for tariff pricing

### DIFF
--- a/parsers/TH.py
+++ b/parsers/TH.py
@@ -190,9 +190,9 @@ def fetch_price(
     price_ft = ft_rate_table.find_all("td")[curr_ft_month].text
 
     if price_ft == "\xa0":
-        price_ft = ft_rate_table.find_all("td")[curr_ft_month + 13]
+        price_ft = ft_rate_table.find_all("td")[curr_ft_month + 13].text
     if "\n" in price_ft:
-        price_ft = re.findall("\d+\.\d+", price_ft)[0]
+        price_ft = re.findall(r"\d+\.\d+", price_ft)[0]
 
     return {
         "zoneKey": zone_key,

--- a/parsers/TH.py
+++ b/parsers/TH.py
@@ -1,5 +1,6 @@
 import datetime as dt
 import json
+import re
 from logging import Logger, getLogger
 from typing import List, Optional
 
@@ -12,7 +13,8 @@ from parsers.lib.exceptions import ParserException
 
 EGAT_GENERATION_URL = "https://www.sothailand.com/sysgen/ws/sysgen"
 EGAT_URL = "www.egat.co.th"
-MEA_PRICE_URL = "https://www.mea.or.th/en/profile/109/111"
+MEA_BASEPRICE_URL = "https://www.mea.or.th/en/profile/109/111"
+MEA_FT_URL = "https://www.mea.or.th/content/detail/2985/2987/474"
 MEA_URL = "www.mea.or.th"
 TZ = "Asia/Bangkok"
 
@@ -86,7 +88,7 @@ def fetch_generation_forecast(
 
 def _as_localtime(datetime):
     """
-    If there is no datetime is given, returns the current datetime with timezone.
+    If there is no datetime given, returns the current datetime with timezone.
     Otherwise, it interprets the datetime as the representation of local time
     since the API server supposes the local timezone instead of UTC.
     """
@@ -154,23 +156,49 @@ def fetch_price(
     target_datetime: Optional[dt.datetime] = None,
     logger: Logger = getLogger(__name__),
 ) -> dict:
-    """Fetch the price data from the MEA."""
+    """
+    Fetch the base tariff data from the MEA (Unit in THB). This is then added up with
+    Float Time (Ft) rate from another MEA's webpage (Unit in Satang (THB/100)).
+
+    The Thai MEA/PEA Electicity Fee calculation are as follows:
+    AmountDue = (BasePrice** + FtRate) * UnitAmountInKWh
+    ActualDue = (AmountDue * 7%VAT) + FixedServiceFee
+
+    * Time-of-Use (TOU) rate is uncommon and thus left unimplemented.
+    **While actual BasePrice is done in a progressive manner, For Electricity Maps -
+      we use "AmountDue" at 1MWh calculated at the highest pricing bracket for simplification.
+    """
     if target_datetime is not None:
         raise NotImplementedError("This parser is not yet able to parse past dates")
 
     # Fetch price from MEA table.
-    with requests.get(MEA_PRICE_URL) as response:
-        soup = BeautifulSoup(response.content, "lxml")
+    # `price_base` is 'Over 400 kWh (up from 401st)' from Table 1.1
+    with requests.get(MEA_BASEPRICE_URL) as response:
+        soup_base = BeautifulSoup(response.content, "lxml")
 
-    # 'Over 400 kWh (up from 401st)' from Table 1.1
-    unit_price_table = soup.find_all("table")[1]
-    price = unit_price_table.find_all("td")[19]
+    unit_price_table = soup_base.find_all("table")[1]
+    price_base = unit_price_table.find_all("td")[19].text
+
+    # Available Ft pricing history dated back as far as September 2535 B.E. (1992 C.E.)
+    # `price_ft` slot's is 0+(month number), additional +13 is needed if that slot is " "
+    # For 2023 multi-Ft rates, we assumed the household rate.
+    with requests.get(MEA_FT_URL) as response:
+        soup_ft = BeautifulSoup(response.content, "lxml")
+
+    ft_rate_table = soup_ft.find_all("table")[1]
+    curr_ft_month = arrow.now(TZ).month
+    price_ft = ft_rate_table.find_all("td")[curr_ft_month].text
+
+    if price_ft == "\xa0":
+        price_ft = ft_rate_table.find_all("td")[curr_ft_month + 13]
+    if "\n" in price_ft:
+        price_ft = re.findall("\d+\.\d+", price_ft)[0]
 
     return {
         "zoneKey": zone_key,
         "currency": "THB",
         "datetime": arrow.now(TZ).datetime,
-        "price": float(price.text) * 1000,
+        "price": float(price_base) * 1000 + float(price_ft) * 10,
         "source": MEA_URL,
     }
 


### PR DESCRIPTION
## Description
This PR adds up `Float Time (Ft)`, an energy adjustment charge on top of the base tariff to better represents actual electricity cost in Thailand as billed by PEA/MEA (both organizations used the same unified rate nationwide). 

As per MEA's website (rephrased from the website's MTL) [[1]](https://www.mea.or.th/en/profile/109/111) [[2]](https://www.mea.or.th/en/content/detail/2985/2987/484):
```yml
Electricity charges billed for each month comprising the electricity base charge according to the tariffs herein; 
and an energy adjustment charge (Ft), which is the uncontrollable cost of the Power Sector. Such as the cost of 
fuels used in electricity generation that differ from the planned value, the impact from rate of exchange and 
inflation rate. The energy adjustment charge will also be shown on the electricity bill.
```
```yml
Ft is a variable tariff derived from the Automatic Tariff Adjustment Mechanism formula. It reflects the changing, 
unpredictable costs i.e. fuel cost (EGAT) and power purchasing cost (other entities) on top of the base tariff.

Ft is abbreviated(?) from "Fuel Adjustment Charge (at the given time)". This is mandated by the "Energy Policy 
and Planning Office (EPPO)" and reviewed every 4 months - in January, May, and September.
```

This PR utilizes an algorithm that automatically fetches the Ft rate for the current month that is resilient to changes in table content and covers all special cases in that specific table as of May 2023.

### Preview

<!-- Please add screenshots and/or gif that shows visual changes (if applicable) -->
```python
def fetch_price(
    zone_key: str = "TH",
    session: Optional[requests.Session] = None,
    target_datetime: Optional[dt.datetime] = None,
    logger: Logger = getLogger(__name__),
) -> dict:
    """
    Fetch the base tariff data from the MEA (Unit in THB). This is then added up with
    Float Time (Ft) rate from another MEA's webpage (Unit in Satang (THB/100)).

    The Thai MEA/PEA Electicity Fee calculation are as follows:
    AmountDue = (BasePrice** + FtRate) * UnitAmountInKWh
    ActualDue = (AmountDue * 7%VAT) + FixedServiceFee

    * Time-of-Use (TOU) rate is uncommon and thus left unimplemented.
    **While actual BasePrice is done in a progressive manner, For Electricity Maps -
      we use "AmountDue" at 1MWh calculated at the highest pricing bracket for simplification.
    """
    if target_datetime is not None:
        raise NotImplementedError("This parser is not yet able to parse past dates")

    # Fetch price from MEA table.
    # `price_base` is 'Over 400 kWh (up from 401st)' from Table 1.1
    with requests.get(MEA_BASEPRICE_URL) as response:
        soup_base = BeautifulSoup(response.content, "lxml")

    unit_price_table = soup_base.find_all("table")[1]
    price_base = unit_price_table.find_all("td")[19].text

    # Available Ft pricing history dated back as far as September 2535 B.E. (1992 C.E.)
    # `price_ft` slot's is 0+(month number), additional +13 is needed if that slot is " "
    # For 2023 multi-Ft rates, we assumed the household rate.
    with requests.get(MEA_FT_URL) as response:
        soup_ft = BeautifulSoup(response.content, "lxml")

    ft_rate_table = soup_ft.find_all("table")[1]
    curr_ft_month = arrow.now(TZ).month
    price_ft = ft_rate_table.find_all("td")[curr_ft_month].text

    if price_ft == "\xa0":
        price_ft = ft_rate_table.find_all("td")[curr_ft_month + 13]
    if "\n" in price_ft:
        price_ft = re.findall("\d+\.\d+", price_ft)[0]

    return {
        "zoneKey": zone_key,
        "currency": "THB",
        "datetime": arrow.now(TZ).datetime,
        "price": float(price_base) * 1000 + float(price_ft) * 10,
        "source": MEA_URL,
    }
```

### Double check

- [x] I have tested my parser changes locally with `poetry run test_parser "zone_key"`
- [x] I have run `pnpx prettier --write .` and `poetry run format` to format my changes.
