### PR TITLE
Temporarily disable SG certificate verification

### DIFF
--- a/parsers/SG.py
+++ b/parsers/SG.py
@@ -146,6 +146,8 @@ def fetch_production(
         raise NotImplementedError("This parser is not yet able to parse past dates")
 
     requests_obj = session or Session()
+    # TODO: restore verification when source fixes configuration or we manually install their chain
+    requests_obj.verify = False
 
     response = requests_obj.get(TICKER_URL)
     data = response.json()
@@ -229,6 +231,8 @@ def fetch_price(
         raise NotImplementedError("This parser is not yet able to parse past dates")
 
     requests_obj = session or Session()
+    # TODO: restore verification when source fixes configuration or we manually install their chain
+    requests_obj.verify = False
     response = requests_obj.get(TICKER_URL)
     data = response.json()
 


### PR DESCRIPTION
## Description

The SG parser currently fails with a certificate error:

```
~/code/electricitymaps-contrib [master] 🧨 poetry run test_parser SG                                                                                                                                                                                                     
2023-05-30 08:57:15,550 DEBUG    urllib3.connectionpool         Starting new HTTPS connection (1): www.emcsg.com:443                                                                                                                                                     
Traceback (most recent call last):                                                                                                                                                                                                                                       
  File "/Users/james/code/electricitymaps-contrib/.venv/lib/python3.8/site-packages/urllib3/connectionpool.py", line 703, in urlopen                                                                                                                                     
    httplib_response = self._make_request(                                                                                                                                                                                                                               
  File "/Users/james/code/electricitymaps-contrib/.venv/lib/python3.8/site-packages/urllib3/connectionpool.py", line 386, in _make_request                                                                                                                               
    self._validate_conn(conn)                                                                                                                                                                                                                                            
  File "/Users/james/code/electricitymaps-contrib/.venv/lib/python3.8/site-packages/urllib3/connectionpool.py", line 1042, in _validate_conn                                                                                                                             
    conn.connect()                                                                                                                                                                                                                                                       
  File "/Users/james/code/electricitymaps-contrib/.venv/lib/python3.8/site-packages/urllib3/connection.py", line 419, in connect                                                                                                                                         
    self.sock = ssl_wrap_socket(                                                                                                                                                                                                                                         
  File "/Users/james/code/electricitymaps-contrib/.venv/lib/python3.8/site-packages/urllib3/util/ssl_.py", line 449, in ssl_wrap_socket                                                                                                                                  
    ssl_sock = _ssl_wrap_socket_impl(                                                                                                                                                                                                                                    
  File "/Users/james/code/electricitymaps-contrib/.venv/lib/python3.8/site-packages/urllib3/util/ssl_.py", line 493, in _ssl_wrap_socket_impl                                                                                                                            
    return ssl_context.wrap_socket(sock, server_hostname=server_hostname)                                                                                                                                                                                                
  File "/Users/james/.pyenv/versions/3.8.12/lib/python3.8/ssl.py", line 500, in wrap_socket                                                                                                                                                                              
    return self.sslsocket_class._create(                                                                                                                                                                                                                                 
  File "/Users/james/.pyenv/versions/3.8.12/lib/python3.8/ssl.py", line 1040, in _create                                                                                                                                                                                 
    self.do_handshake()                                                                                                                                                                                                                                                  
  File "/Users/james/.pyenv/versions/3.8.12/lib/python3.8/ssl.py", line 1309, in do_handshake                                                                                                                                                                            
    self._sslobj.do_handshake()                                                                                                                                                                                                                                          
ssl.SSLCertVerificationError: [SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: unable to get local issuer certificate (_ssl.c:1131)                                                                                                                           
                                                                                                                                                                                                                                                                         
During handling of the above exception, another exception occurred:                                                                 
                                                                  
Traceback (most recent call last):                                                                                                                                                                                                                                       
  File "/Users/james/code/electricitymaps-contrib/.venv/lib/python3.8/site-packages/requests/adapters.py", line 439, in send                                                                                                                                             
    resp = conn.urlopen(                                                                                                                                                                                                                                                 
  File "/Users/james/code/electricitymaps-contrib/.venv/lib/python3.8/site-packages/urllib3/connectionpool.py", line 787, in urlopen                                                                                                                                     
    retries = retries.increment(                                  
  File "/Users/james/code/electricitymaps-contrib/.venv/lib/python3.8/site-packages/urllib3/util/retry.py", line 592, in increment                                                                                                                                       
    raise MaxRetryError(_pool, url, error or ResponseError(cause))                                                                  
urllib3.exceptions.MaxRetryError: HTTPSConnectionPool(host='www.emcsg.com', port=443): Max retries exceeded with url: /ChartServer/blue/ticker (Caused by SSLError(SSLCertVerificationError(1, '[SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: unable to get
 local issuer certificate (_ssl.c:1131)')))                       
                                                                                                                                    
During handling of the above exception, another exception occurred:                                                                 
                                                                                                                                    
Traceback (most recent call last):                                                                                                  
  File "<string>", line 1, in <module>                                                                                              
  File "/Users/james/code/electricitymaps-contrib/.venv/lib/python3.8/site-packages/click/core.py", line 1134, in __call__                                                                                                                                               
    return self.main(*args, **kwargs)                                                                                               
  File "/Users/james/code/electricitymaps-contrib/.venv/lib/python3.8/site-packages/click/core.py", line 1059, in main                                                                                                                                                   
    rv = self.invoke(ctx)                                         
  File "/Users/james/code/electricitymaps-contrib/.venv/lib/python3.8/site-packages/click/core.py", line 1401, in invoke                                                                                                                                                 
    return ctx.invoke(self.callback, **ctx.params)                                                                                  
  File "/Users/james/code/electricitymaps-contrib/.venv/lib/python3.8/site-packages/click/core.py", line 767, in invoke                                                                                                                                                  
    return __callback(*args, **kwargs)                                                                                              
  File "/Users/james/code/electricitymaps-contrib/test_parser.py", line 60, in test_parser                                                                                                                                                                               
    res = parser(*args, target_datetime=target_datetime, logger=getLogger(__name__))                                                                                                                                                                                     
  File "/Users/james/code/electricitymaps-contrib/parsers/SG.py", line 150, in fetch_production                                                                                                                                                                          
    response = requests_obj.get(TICKER_URL)                                                                                         
  File "/Users/james/code/electricitymaps-contrib/.venv/lib/python3.8/site-packages/requests/sessions.py", line 555, in get                                                                                                                                              
    return self.request('GET', url, **kwargs)                                                                                       
  File "/Users/james/code/electricitymaps-contrib/.venv/lib/python3.8/site-packages/requests/sessions.py", line 542, in request                                                                                                                                          
    resp = self.send(prep, **send_kwargs)                                                                                           
  File "/Users/james/code/electricitymaps-contrib/.venv/lib/python3.8/site-packages/requests/sessions.py", line 655, in send                                                                                                                                             
    r = adapter.send(request, **kwargs)                                                                                                                                                                                                                                  
  File "/Users/james/code/electricitymaps-contrib/.venv/lib/python3.8/site-packages/requests/adapters.py", line 514, in send                                                                                                                                             
    raise SSLError(e, request=request)                                                                                              
requests.exceptions.SSLError: HTTPSConnectionPool(host='www.emcsg.com', port=443): Max retries exceeded with url: /ChartServer/blue/ticker (Caused by SSLError(SSLCertVerificationError(1, '[SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: unable to get loc
al issuer certificate (_ssl.c:1131)')))
```

The root cause of the issue seems to be an missing intermediate certificate: 

<img width="1709" alt="Screenshot 2023-05-30 at 09 05 12" src="https://github.com/electricitymaps/electricitymaps-contrib/assets/1755162/8d965d23-ee8c-499e-945c-4cda90c69303">

The long term fix is either to get the server admin to send the intermediate certificate or to install the cert chain manually ourselves in the image that runs this parser in the cloud. For now, this will let us get the parser back up and running.

### Double check

- [x] I have tested my parser changes locally with `poetry run test_parser "zone_key"`
- [x] I have run `pnpx prettier --write .` and `poetry run format` to format my changes.
