### PR TITLE
Fetch production for IN-SO

### DIFF
--- a/config/zones/IN-SO.yaml
+++ b/config/zones/IN-SO.yaml
@@ -19,3 +19,4 @@ contributors:
 timezone: Asia/Kolkata
 parsers:
   consumption: IN.fetch_consumption
+  production: IN.fetch_production


### PR DESCRIPTION
## Issue

We are kickstarting the development of IN-SO. Therefore we should start fetching production data for IN-SO.

## Description

Activates fetch production for IN-SO.

## Additional notes
We will hide the zone data on the map until the estimation model is ready to be used.

### Double check

- [x] I have tested my parser changes locally with `poetry run test_parser "zone_key"`
- [x] I have run `pnpx prettier --write .` and `poetry run format` to format my changes.
