### PR TITLE
fix CO production parser

### DIFF
--- a/parsers/CO.py
+++ b/parsers/CO.py
@@ -176,7 +176,9 @@ def fetch_production(
         for col in df_generation_aggregated.columns:
             production_kw = df_generation_aggregated[col].to_dict()
             # convert to MW
-            production_mw = {mode: round(production_kw[mode] / 1000,3) for mode in production_kw}
+            production_mw = {
+                mode: round(production_kw[mode] / 1000, 3) for mode in production_kw
+            }
             # convert to ProductionMix
             production_mix = ProductionMix()
 

--- a/parsers/CO.py
+++ b/parsers/CO.py
@@ -132,9 +132,9 @@ def fetch_production(
     logger: Logger = getLogger(__name__),
 ) -> List[Dict[str, Any]]:
     if target_datetime is None:
-        target_arrow_in_tz = arrow.get(target_datetime).to(TZ)
-    else:
         target_arrow_in_tz = arrow.now().floor("day").to(TZ).shift(days=-XM_DELAY)
+    else:
+        target_arrow_in_tz = arrow.get(target_datetime).to(TZ)
 
     objetoAPI = pydataxm.ReadDB()
 
@@ -176,7 +176,7 @@ def fetch_production(
         for col in df_generation_aggregated.columns:
             production_kw = df_generation_aggregated[col].to_dict()
             # convert to MW
-            production_mw = {mode: production_kw[mode] / 1000 for mode in production_kw}
+            production_mw = {mode: round(production_kw[mode] / 1000,3) for mode in production_kw}
             # convert to ProductionMix
             production_mix = ProductionMix()
 


### PR DESCRIPTION
## Issue

production parser for CO was not returning any values because of mistake in `target_datetime` definition

## Description

change `target_datetime` definition in `fetch_production`

### Preview

<img width="569" alt="image" src="https://github.com/electricitymaps/electricitymaps-contrib/assets/107848894/846ac9cb-1eac-4dc3-919d-4e55794f30ea">

### Double check

- [ ] I have tested my parser changes locally with `poetry run test_parser "zone_key"`
- [ ] I have run `pnpx prettier --write .` and `poetry run format` to format my changes.
