### PR TITLE
fix IN-EA_IN-SO exchange config

### DIFF
--- a/config/exchanges/IN-EA_IN-SO.yaml
+++ b/config/exchanges/IN-EA_IN-SO.yaml
@@ -2,6 +2,5 @@ lonlat:
   - 81.073025
   - 17.788574
 parsers:
-  parsers:
   exchange: IN_EA.fetch_exchange
 rotation: 40


### PR DESCRIPTION
## Issue

There was a extra parser field which cause the tests to fail.

## Description

Removes the extra field.

