### PR TITLE
Update NL wind/solar based on 2023-06-02 CBS data

### DIFF
--- a/config/zones/NL.yaml
+++ b/config/zones/NL.yaml
@@ -12,8 +12,8 @@ capacity:
   hydro storage: 0
   nuclear: 486
   oil: 0
-  solar: 22590
-  wind: 9410
+  solar: 19142
+  wind: 8831
 contributors:
   - corradio
   - PaulCornelissen


### PR DESCRIPTION
I tried to find the current capacity numbers in the listed sources, but couldn't. The already-cited CBS source published an update to the table of installed capacities as of 2023-06-02, see here: https://opendata.cbs.nl/#/CBS/nl/dataset/82610NED. 

The numbers I'm including are the end-of-year ones for 2022. As far as I know there are no more up-to-date numbers than this, but happy to be pointed to them if they do exist.
