### PR TITLE
Fix points in timezones ahead of UTC are discarded

### DIFF
--- a/electricitymap/contrib/lib/models/events.py
+++ b/electricitymap/contrib/lib/models/events.py
@@ -178,14 +178,16 @@ class Event(BaseModel, ABC):
         return v
 
     @validator("datetime")
-    def _validate_datetime(cls, v, values: Dict[str, Any]):
+    def _validate_datetime(cls, v: datetime, values: Dict[str, Any]):
         if v.tzinfo is None:
             raise ValueError(f"Missing timezone: {v}")
         if v < LOWER_DATETIME_BOUND:
             raise ValueError(f"Date is before 2000, this is not plausible: {v}")
         if values.get(
             "sourceType", EventSourceType.measured
-        ) != EventSourceType.forecasted and v > datetime.now(timezone.utc) + timedelta(
+        ) != EventSourceType.forecasted and v.astimezone(timezone.utc) > datetime.now(
+            timezone.utc
+        ) + timedelta(
             days=1
         ):
             raise ValueError(

--- a/electricitymap/contrib/lib/models/events.py
+++ b/electricitymap/contrib/lib/models/events.py
@@ -1,3 +1,4 @@
+import datetime as dt
 from abc import ABC, abstractmethod
 from datetime import datetime, timedelta, timezone
 from enum import Enum
@@ -178,7 +179,7 @@ class Event(BaseModel, ABC):
         return v
 
     @validator("datetime")
-    def _validate_datetime(cls, v: datetime, values: Dict[str, Any]):
+    def _validate_datetime(cls, v: dt.datetime, values: Dict[str, Any]):
         if v.tzinfo is None:
             raise ValueError(f"Missing timezone: {v}")
         if v < LOWER_DATETIME_BOUND:

--- a/electricitymap/contrib/lib/tests/test_events.py
+++ b/electricitymap/contrib/lib/tests/test_events.py
@@ -3,6 +3,7 @@ import unittest
 from datetime import datetime, timezone
 
 import freezegun
+import pytz
 from mock import patch
 
 from electricitymap.contrib.config.constants import PRODUCTION_MODES, STORAGE_MODES
@@ -328,6 +329,20 @@ class TestProductionBreakdown(unittest.TestCase):
                 production=mix,
                 source="trust.me",
             )
+
+    @freezegun.freeze_time("2023-01-01")
+    def test_non_forecasted_point_with_timezone_forward(self):
+        """Test that points in a timezone that is ahead of UTC are accepted."""
+        mix = ProductionMix(wind=10)
+        breakdown = ProductionBreakdown(
+            zoneKey=ZoneKey("DE"),
+            datetime=datetime(2023, 1, 1, 5, tzinfo=pytz.timezone("Asia/Tokyo")),
+            production=mix,
+            source="trust.me",
+        )
+        assert breakdown.datetime == datetime(
+            2023, 1, 1, 5, tzinfo=pytz.timezone("Asia/Tokyo")
+        )
 
     def test_static_create_logs_error(self):
         logger = logging.Logger("test")


### PR DESCRIPTION
## Issue

We saw for IN-EA, some exchanges being discarded because they were in the future. This comes from the fact that we are comparing the date with utc.

## Description

Making sure the check compares UTC timestamps + add unit test.

### Double check

- [x] I have tested my parser changes locally with `poetry run test_parser "zone_key"`
- [x] I have run `pnpx prettier --write .` and `poetry run format` to format my changes.
