### PR TITLE
Restructure scheduled jobs

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -4,6 +4,8 @@ on:
     branches:
       - master
   pull_request:
+  schedule:
+    - cron: '0 7 * * 1'
 
 jobs:
   # This job is used to determine what files have changed and is used by later jobs to determine if they should run.

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -2,8 +2,6 @@ name: 'CodeQL'
 
 on:
   workflow_call:
-  schedule:
-    - cron: '0 7 * * 1'
 
 jobs:
   analyze:

--- a/.github/workflows/eslint.yml
+++ b/.github/workflows/eslint.yml
@@ -2,8 +2,6 @@ name: ESLint
 
 on:
   workflow_call:
-  schedule:
-    - cron: '0 7 * * 1'
 
 jobs:
   eslint:


### PR DESCRIPTION
## Issue

It looks like GitHub Security is picking up these as two diffrent jobs when they are run independently, this is not what we want.
<img width="744" alt="image" src="https://github.com/electricitymaps/electricitymaps-contrib/assets/30777521/2e0dcb19-de5d-46be-be89-e251eddc3962">


## Description

Removes the cron schedules on the individual CI jobs and moves it to the "master" CI.
This will make us consume a little more resources but everything besides the CodeQL jobs and perhaps some tests should be cached at this point.

>**Note**
>I have removed the extra configuration from the security panel for now but it will be recreated if we don't merge this.

### Double check

- [x] I have run `pnpx prettier --write .` and `poetry run format` to format my changes.
