### PR TITLE
add error checking on unknown zones + remove unused options params

### DIFF
--- a/web/src/api/getState.ts
+++ b/web/src/api/getState.ts
@@ -27,7 +27,7 @@ const getState = async (timeAverage: string): Promise<GridState> => {
   throw new Error(await response.text());
 };
 
-const useGetState = (options?: UseQueryOptions<GridState>): UseQueryResult<GridState> => {
+const useGetState = (): UseQueryResult<GridState> => {
   const [timeAverage] = useAtom(timeAverageAtom);
   return useQuery<GridState>(
     [QUERY_KEYS.STATE, timeAverage],
@@ -36,7 +36,6 @@ const useGetState = (options?: UseQueryOptions<GridState>): UseQueryResult<GridS
       refetchInterval: REFETCH_INTERVAL_FIVE_MINUTES,
       staleTime: REFETCH_INTERVAL_FIVE_MINUTES,
       refetchOnWindowFocus: true,
-      ...options,
     }
   );
 };

--- a/web/src/api/getZone.ts
+++ b/web/src/api/getZone.ts
@@ -29,6 +29,9 @@ const getZone = async (
 
   if (response.ok) {
     const { data } = (await response.json()) as { data: ZoneDetails };
+    if (!data.zoneStates) {
+      throw new Error('No data returned from API');
+    }
     return data;
   }
 
@@ -37,17 +40,14 @@ const getZone = async (
 
 // TODO: The frontend (graphs) expects that the datetimes in state are the same as in zone
 // should we add a check for this?
-const useGetZone = (
-  options?: UseQueryOptions<ZoneDetails>
-): UseQueryResult<ZoneDetails> => {
-  const [timeAverage] = useAtom(timeAverageAtom);
+const useGetZone = (): UseQueryResult<ZoneDetails> => {
   const { zoneId } = useParams();
+  const [timeAverage] = useAtom(timeAverageAtom);
   return useQuery<ZoneDetails>(
     [QUERY_KEYS.ZONE, zoneId, timeAverage],
     async () => getZone(timeAverage, zoneId),
     {
       staleTime: REFETCH_INTERVAL_FIVE_MINUTES,
-      ...options,
     }
   );
 };

--- a/web/src/components/Button.tsx
+++ b/web/src/components/Button.tsx
@@ -25,11 +25,11 @@ export function Button({
   textColor,
   href,
   className,
-  ...restProps
+  onClick,
 }: ButtonProps) {
   const renderAsLink = Boolean(href);
   const As = renderAsLink ? 'a' : 'button';
-
+  const type = renderAsLink ? undefined : 'button';
   const isIconOnly = !children && Boolean(icon);
 
   return (
@@ -43,8 +43,9 @@ export function Button({
       translate="no"
       disabled={disabled}
       style={{ color: textColor, background: background }}
-      {...(renderAsLink ? { href } : { type: 'button' })}
-      {...restProps}
+      href={href}
+      type={type}
+      onClick={onClick}
     >
       {icon}
       {children}

--- a/web/src/components/CarbonIntensitySquare.tsx
+++ b/web/src/components/CarbonIntensitySquare.tsx
@@ -32,7 +32,9 @@ interface CarbonIntensitySquareProps {
 function CarbonIntensitySquare({ intensity, withSubtext }: CarbonIntensitySquareProps) {
   const { __ } = useTranslation();
   const co2ColorScale = useCo2ColorScale();
-  const styles = useSpring({ backgroundColor: co2ColorScale(intensity) });
+  const backgroundColor = useSpring({
+    backgroundColor: co2ColorScale(intensity),
+  }).backgroundColor;
 
   return (
     <div>
@@ -40,7 +42,7 @@ function CarbonIntensitySquare({ intensity, withSubtext }: CarbonIntensitySquare
         <animated.div
           style={{
             color: getTextColor(co2ColorScale(intensity)),
-            ...styles,
+            backgroundColor,
           }}
           className="mx-auto flex h-[65px] w-[65px] flex-col items-center justify-center rounded-2xl"
         >

--- a/web/src/components/Flag.tsx
+++ b/web/src/components/Flag.tsx
@@ -13,9 +13,14 @@ interface CountryFlagProps
     React.SVGAttributes<HTMLSVGElement> {
   zoneId: string;
   size?: number;
+  className?: string;
 }
 
-export function CountryFlag({ zoneId, size = DEFAULT_FLAG_SIZE }: CountryFlagProps) {
+export function CountryFlag({
+  zoneId,
+  size = DEFAULT_FLAG_SIZE,
+  className,
+}: CountryFlagProps) {
   const countryName = getCountryName(zoneId) as keyof typeof flags;
   const FlagIcon = flags[countryName];
 
@@ -30,6 +35,7 @@ export function CountryFlag({ zoneId, size = DEFAULT_FLAG_SIZE }: CountryFlagPro
       style={{
         minWidth: size,
       }}
+      className={className}
     />
   );
 }

--- a/web/src/components/Flag.tsx
+++ b/web/src/components/Flag.tsx
@@ -15,11 +15,7 @@ interface CountryFlagProps
   size?: number;
 }
 
-export function CountryFlag({
-  zoneId,
-  size = DEFAULT_FLAG_SIZE,
-  ...props
-}: CountryFlagProps) {
+export function CountryFlag({ zoneId, size = DEFAULT_FLAG_SIZE }: CountryFlagProps) {
   const countryName = getCountryName(zoneId) as keyof typeof flags;
   const FlagIcon = flags[countryName];
 
@@ -34,7 +30,6 @@ export function CountryFlag({
       style={{
         minWidth: size,
       }}
-      {...props}
     />
   );
 }

--- a/web/src/features/map-controls/LanguageSelector.tsx
+++ b/web/src/features/map-controls/LanguageSelector.tsx
@@ -4,7 +4,6 @@ import { useTranslation } from 'translation/translation';
 import MapOptionSelector from './MapOptionSelector';
 import MapButton from './MapButton';
 import { HiLanguage } from 'react-icons/hi2';
-import { Button } from 'components/Button';
 
 type LanguageNamesKey = keyof typeof languageNames;
 

--- a/web/src/features/panels/zone/ZoneDetails.tsx
+++ b/web/src/features/panels/zone/ZoneDetails.tsx
@@ -19,19 +19,20 @@ import { ZoneDataStatus, getHasSubZones, getZoneDataStatus } from './util';
 
 export default function ZoneDetails(): JSX.Element {
   const { zoneId } = useParams();
+  if (!zoneId) {
+    return <Navigate to="/" replace />;
+  }
   const [timeAverage] = useAtom(timeAverageAtom);
   const [displayByEmissions] = useAtom(displayByEmissionsAtom);
   const [viewMode, setViewMode] = useAtom(spatialAggregateAtom);
   const isZoneView = viewMode === SpatialAggregate.ZONE;
   const hasSubZones = getHasSubZones(zoneId);
   const isSubZone = zoneId ? zoneId.includes('-') : true;
-  const { data, isError, isLoading } = useGetZone({
-    enabled: Boolean(zoneId),
-  });
+  const { data, isError, isLoading } = useGetZone();
 
   // TODO: App-backend should not return an empty array as "data" if the zone does not
   // exist.
-  if (!zoneId || Array.isArray(data)) {
+  if (Array.isArray(data)) {
     return <Navigate to="/" replace />;
   }
 


### PR DESCRIPTION
## Issue
Felt inspired to do some minor performance improvements and prevent the crash when zone param is not valid

## Description
- This PR checks the zone details api response and throws an error if it doesn't contain any zone states (when it's not in our list of zones). 

- Removes the options param from useQuery as we weren't using it for anything.

- Explicitly defines props in a couple of places instead of passing and spreading



### Double check

- [x] I have tested my parser changes locally with `poetry run test_parser "zone_key"`
- [x] I have run `pnpx prettier --write .` and `poetry run format` to format my changes.
