### PR TITLE
Updated FI renewable capacities per Fingrid

### DIFF
--- a/config/zones/FI.yaml
+++ b/config/zones/FI.yaml
@@ -11,9 +11,9 @@ capacity:
   hydro: 3178
   nuclear: 4394
   oil: 1051
-  solar: 697
+  solar: 734
   unknown: 828
-  wind: 5700
+  wind: 5772
 contributors:
   - corradio
   - nessie2013


### PR DESCRIPTION
Issue

New wind and solar capacity has been connected to the grid in Finland since the last update.
Description

This PR updates the capacities for wind and solar generation based on Fingrid data sources listed in DATA_SOURCES.md.