### PR TITLE
Fix for issue #5083 (Graph selector offset when missing data)

### DIFF
--- a/web/src/features/charts/elements/AreaGraph.tsx
+++ b/web/src/features/charts/elements/AreaGraph.tsx
@@ -263,6 +263,7 @@ function AreaGraph({
         timeScale={timeScale}
         valueScale={valueScale}
         datetimes={datetimes}
+        endTime={endTime}
         markerUpdateHandler={markerUpdateHandler}
         markerHideHandler={markerHideHandler}
         selectedLayerIndex={selectedLayerIndex}

--- a/web/src/features/charts/elements/GraphHoverline.tsx
+++ b/web/src/features/charts/elements/GraphHoverline.tsx
@@ -7,6 +7,7 @@ const GraphHoverLine = React.memo(
   ({
     layers,
     datetimes,
+    endTime,
     timeScale,
     valueScale,
     markerUpdateHandler,
@@ -18,9 +19,12 @@ const GraphHoverLine = React.memo(
     const layer = layers && layers[selectedLayerIndex];
     const fill = layer && layer.markerFill;
     const datapoint = layer && layer.datapoints && layer.datapoints[selectedTimeIndex];
+    const nextDateTime = datetimes
+      ? datetimes[selectedTimeIndex + 1] ?? endTime
+      : undefined;
     const interval =
-      datetimes && datetimes.length > 1
-        ? timeScale(datetimes[1]) - timeScale(datetimes[0])
+      nextDateTime && datetimes[selectedTimeIndex]
+        ? timeScale(nextDateTime) - timeScale(datetimes[selectedTimeIndex])
         : undefined;
     let x =
       datetimes &&


### PR DESCRIPTION
## Issue

Closes #5083 

## Description

This is my first contribution PR and I'm hoping to do many more in the future (as part of my degree), I'd love to hear any and all feedback!

Fixed the bug described in [issue 5083](https://github.com/electricitymaps/electricitymaps-contrib/issues/5083): "In yearly view when there is a datapoint missing the selector/marker gets offset causing a weird and unexpected behavior when hovering over the datapoints." It does seem that this issue should apply for all views, just most prominently viewed at the yearly timescale.

The issue with the current code is that the offset is calculated using the time difference between the first and second datetimes in the graph. This would only work if all datetimes have the same interval between them.

The fix for this is to compute the offset without the incorrect offset: for any given datetime, the interval is measured between said datetime and the next one. In the case where the datetime is the latest one, we use the value `endTime` that is used for the graph.

Speaking of `endTime`, there is a similar bug in the current code. The value is computed by examining the interval bewteen the last and second last datetimes (and then adding it to the last datetime). If there is a missing value in there, we will not get the proper time interval. The proper fix would be to define constants for the different time settings and then just add it to the last date time (ex. hour, day, year). I would be happy to add this to the PR as well, just not sure if you guys have conventions for hard-coded constants like these (or if these constants already exist somewhere)?

### Preview

![image](https://github.com/electricitymaps/electricitymaps-contrib/assets/55926479/64f15827-af1a-400d-a891-6808b9baf48c)

![image](https://github.com/electricitymaps/electricitymaps-contrib/assets/55926479/22b398cb-1d46-47af-b751-378d0f6cecac)

### Double check

- [ ] I have tested my parser changes locally with `poetry run test_parser "zone_key"`
- [x] I have run `pnpx prettier --write .` and `poetry run format` to format my changes.
