### PR TITLE
Fix India exchanges are rejected because their are in the future

### DIFF
--- a/parsers/IN_EA.py
+++ b/parsers/IN_EA.py
@@ -1,13 +1,13 @@
 from datetime import datetime, timedelta
 from logging import Logger, getLogger
-from typing import Optional
+from typing import Dict, List, Optional
 
 import arrow
 import pytz
 from requests import Response, Session
 
+from electricitymap.contrib.lib.models.event_lists import ExchangeList
 from parsers.lib.exceptions import ParserException
-from parsers.lib.quality import validate_datapoint_format
 
 IN_WE_PROXY = "https://in-proxy-jfnx5klx2a-el.a.run.app"
 IN_EA_TZ = pytz.timezone("Asia/Kolkata")
@@ -25,7 +25,7 @@ def fetch_exchange(
     session: Session = Session(),
     target_datetime: Optional[datetime] = None,
     logger: Logger = getLogger(__name__),
-) -> dict:
+) -> List[Dict]:
     """collects average daily exchanges for ERLC"""
     if target_datetime is None:
         # 1 day delay observed
@@ -36,27 +36,21 @@ def fetch_exchange(
     target_date = target_datetime.strftime("%Y-%m-%d")
     url_exchange = f"{IN_WE_PROXY}/api/pspreportpsp/Get/pspreport_psp_interregionalexchanges/GetByTwoDate?host=https://app.erldc.in&firstDate={target_date}&secondDate={target_date}"
     sorted_zone_keys = "->".join(sorted([zone_key1, zone_key2]))
-
+    exchanges = ExchangeList(logger)
     resp: Response = session.get(url=url_exchange)
-    if resp.status_code == 200:
-        data = resp.json()
-        zone_data = [
-            item for item in data if item["Type"] == EXCHANGE_MAPPING[zone_key2]
-        ]
-        imports = sum(float(item["ImportMW"]) for item in zone_data)
-        exports = sum(float(item["ExportMW"]) for item in zone_data)  # always negative
-        data_point = {
-            "datetime": target_datetime.replace(tzinfo=IN_EA_TZ),
-            "sortedZoneKeys": sorted_zone_keys,
-            "netFlow": imports + exports,
-            "source": "erldc.in",
-        }
-        validate_datapoint_format(
-            datapoint=data_point, zone_key=zone_key1, kind="exchange"
-        )
-        return data_point
-    else:
+    if not resp.ok:
         raise ParserException(
             parser="IN_EA.py",
             message=f"{target_datetime}: {sorted_zone_keys} data is not available : [{resp.status_code}]",
         )
+    data = resp.json()
+    zone_data = [item for item in data if item["Type"] == EXCHANGE_MAPPING[zone_key2]]
+    imports = sum(float(item["ImportMW"]) for item in zone_data)
+    exports = sum(float(item["ExportMW"]) for item in zone_data)  # always negative
+    exchanges.append(
+        sorted_zone_keys=sorted_zone_keys,
+        datetime=target_datetime.replace(tzinfo=IN_EA_TZ),
+        netFlow=imports + exports,
+        source="erldc.in",
+    )
+    return exchanges.to_list()

--- a/parsers/IN_EA.py
+++ b/parsers/IN_EA.py
@@ -1,6 +1,6 @@
 from datetime import datetime, timedelta
 from logging import Logger, getLogger
-from typing import Dict, List, Optional
+from typing import Any, Dict, List, Optional
 
 import arrow
 import pytz
@@ -25,7 +25,7 @@ def fetch_exchange(
     session: Session = Session(),
     target_datetime: Optional[datetime] = None,
     logger: Logger = getLogger(__name__),
-) -> List[Dict]:
+) -> List[Dict[str, Any]]:
     """collects average daily exchanges for ERLC"""
     if target_datetime is None:
         # 1 day delay observed

--- a/parsers/IN_EA.py
+++ b/parsers/IN_EA.py
@@ -48,7 +48,7 @@ def fetch_exchange(
     imports = sum(float(item["ImportMW"]) for item in zone_data)
     exports = sum(float(item["ExportMW"]) for item in zone_data)  # always negative
     exchanges.append(
-        sorted_zone_keys=sorted_zone_keys,
+        zoneKey=sorted_zone_keys,
         datetime=target_datetime.replace(tzinfo=IN_EA_TZ),
         netFlow=imports + exports,
         source="erldc.in",

--- a/parsers/lib/quality.py
+++ b/parsers/lib/quality.py
@@ -2,7 +2,7 @@
 This library contains validation functions applied to all parsers by the feeder.
 This is a higher level validation than validation.py
 """
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Any, Dict, List
 from warnings import warn
 
@@ -49,7 +49,7 @@ def validate_reasonable_time(item, k):
         )
 
     arrow_now = arrow.utcnow()
-    if data_time > arrow_now:
+    if data_time.astimezone(timezone.utc) > arrow_now:
         raise ValidationError(
             "Data from %s can't be in the future, data was %s, now is "
             "%s" % (k, data_time, arrow_now)


### PR DESCRIPTION
## Issue

Exchange data is still being rejected for India because located in another zone. Turns out that feeder electricity calls the validation functions for every parser event, so regardless of wether the function has been updated to EventList we also need to update the validation function.

## Description

- Update the validation function from to convert the datetime to UTC.
- Fit IN-EA parser to ExchangeList

### Preview


### Double check

- [ ] I have tested my parser changes locally with `poetry run test_parser "zone_key"`
- [ ] I have run `pnpx prettier --write .` and `poetry run format` to format my changes.
