### PR TITLE
include time-zone from config file

### DIFF
--- a/electricitymap/contrib/config/__init__.py
+++ b/electricitymap/contrib/config/__init__.py
@@ -17,7 +17,8 @@ from electricitymap.contrib.config.zones import (
     zone_bounding_boxes,
     zone_parents,
 )
-from electricitymap.contrib.lib.types import ZoneKey
+from electricitymap.contrib.lib.types import ZoneKey, TimeZone
+
 
 CONFIG_DIR = Path(__file__).parent.parent.parent.parent.joinpath("config").resolve()
 
@@ -40,6 +41,12 @@ ZONE_BOUNDING_BOXES: Dict[ZoneKey, BoundingBox] = zone_bounding_boxes(ZONES_CONF
 
 # Make a mapping from subzone to the parent zone (full zone).
 ZONE_PARENT: Dict[ZoneKey, ZoneKey] = zone_parents(ZONES_CONFIG)
+
+# Prepare zone time zone
+ZONE_TIME_ZONE: Dict[ZoneKey, TimeZone] = {}
+for zone_id, zone_config in ZONES_CONFIG.items():
+    if "timezone" in zone_config:
+        ZONE_TIME_ZONE[zone_id] = zone_config["timezone"]
 
 # Zone neighbours are zones that are connected by exchanges.
 ZONE_NEIGHBOURS: Dict[ZoneKey, List[ZoneKey]] = generate_zone_neighbours(

--- a/electricitymap/contrib/config/__init__.py
+++ b/electricitymap/contrib/config/__init__.py
@@ -10,14 +10,14 @@ from electricitymap.contrib.config.reading import (
     read_exchanges_config,
     read_zones_config,
 )
-from electricitymap.contrib.config.types import BoundingBox
+from electricitymap.contrib.config.types import BoundingBox, TimeZone
 from electricitymap.contrib.config.zones import (
     generate_all_neighbours,
     generate_zone_neighbours,
     zone_bounding_boxes,
     zone_parents,
 )
-from electricitymap.contrib.lib.types import ZoneKey, TimeZone
+from electricitymap.contrib.lib.types import ZoneKey
 
 
 CONFIG_DIR = Path(__file__).parent.parent.parent.parent.joinpath("config").resolve()

--- a/electricitymap/contrib/config/__init__.py
+++ b/electricitymap/contrib/config/__init__.py
@@ -19,7 +19,6 @@ from electricitymap.contrib.config.zones import (
 )
 from electricitymap.contrib.lib.types import ZoneKey
 
-
 CONFIG_DIR = Path(__file__).parent.parent.parent.parent.joinpath("config").resolve()
 
 ZONES_CONFIG = read_zones_config(CONFIG_DIR)

--- a/electricitymap/contrib/config/types.py
+++ b/electricitymap/contrib/config/types.py
@@ -5,3 +5,4 @@ from typing import List, NewType, Tuple
 # representing a box with corners at 140.46°E, 39.64°S and 150.47°E, 33.48°S.
 Point = NewType("Point", Tuple[float, float])
 BoundingBox = NewType("BoundingBox", List[Point])
+TimeZone = NewType("TimeZone", str)


### PR DESCRIPTION
## Issue

We want to add a new feature to compute daytime and night time into the forecast system. To do that, we need to know the local time zone in order to get sunrise and sunset. 

## Description
This PR is linked to this one: https://github.com/electricitymaps/electricitymaps/pull/3621 

We need to include the TimeZone configuration in order to localize the sunrise and sunset times and compute the daytime feature. 
