### PR TITLE
Fix: production history shows mt instead of kg

### DIFF
--- a/web/src/utils/formatting.ts
+++ b/web/src/utils/formatting.ts
@@ -27,7 +27,7 @@ export const formatCo2 = function (d: number, numberDigits: number = DEFAULT_NUM
     return d;
   }
 
-  return d >= 1
+  return value >= 1
     ? `${d3.format(`.${numberDigits}s`)(value)}t ${translate('ofCO2eqPerMinute')}` // a ton or more
     : `${d3.format(`.${numberDigits}s`)(value * 1e6)}g ${translate('ofCO2eqPerMinute')}`;
 };


### PR DESCRIPTION
## Issue

Closes #4317 

## Description

This should be the fix for [this open issue](https://github.com/electricitymaps/electricitymaps-contrib/issues/4317), just one simple change in the end. The issue seems to be that the value used for comparison in `formatCo2` is the parameter that uses units `gCO₂ / h` instead of the final calculated value (that is the number formatted) that uses units `tCO₂ / min`.

### Preview

![image](https://github.com/electricitymaps/electricitymaps-contrib/assets/55926479/03a3504d-1a8e-42ce-bad9-7ab5e85473af)

### Double check

- [ ] I have tested my parser changes locally with `poetry run test_parser "zone_key"`
- [x] I have run `pnpx prettier --write .` and `poetry run format` to format my changes.
