### PR TITLE
Changes to engines requirements to greater than X instead of strict major

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -4,8 +4,8 @@
   "description": "A real-time visualisation of the CO2 emissions of electricity consumption",
   "license": "AGPL-3.0-or-later",
   "engines": {
-    "node": "^18",
-    "pnpm": "^8"
+    "node": ">=18",
+    "pnpm": ">=8"
   },
   "type": "module",
   "repository": {


### PR DESCRIPTION
## Description

In #5467 versions were added, but I think pinning to a specific major is a bit too strict especially for Node :)
