### PR TITLE
include capacity changes for JP-HKD

### DIFF
--- a/config/zones/JP-HKD.yaml
+++ b/config/zones/JP-HKD.yaml
@@ -13,7 +13,7 @@ capacity:
   nuclear: 2070
   oil: 1815
   solar: 1880
-  wind: 530
+  wind: 577
   unknown: 0
 contributors:
   - tmslaine

--- a/parsers/JP.py
+++ b/parsers/JP.py
@@ -76,9 +76,7 @@ def fetch_production(
     datalist = []
 
     for i in df.index:
-        capacity = get_wind_capacity(
-                    df.loc[i, "datetime"].to_pydatetime(), zone_key
-                )
+        capacity = get_wind_capacity(df.loc[i, "datetime"].to_pydatetime(), zone_key)
         data = {
             "zoneKey": zone_key,
             "datetime": df.loc[i, "datetime"].to_pydatetime(),
@@ -94,9 +92,7 @@ def fetch_production(
                 "geothermal": None,
                 "unknown": df.loc[i, "unknown"],
             },
-            "capacity": {
-                "wind":capacity if capacity is not None else {}
-                            },
+            "capacity": {"wind": capacity if capacity is not None else {}},
             "source": "occtonet.or.jp, {}".format(sources[zone_key]),
         }
         datalist.append(data)

--- a/parsers/JP.py
+++ b/parsers/JP.py
@@ -9,8 +9,8 @@ import arrow
 import pandas as pd
 from requests import Session
 
-from parsers import occtonet
 from electricitymap.contrib.config import ZONES_CONFIG
+from parsers import occtonet
 from parsers.lib.config import refetch_frequency
 
 # Abbreviations
@@ -39,7 +39,8 @@ sources = {
 }
 ZONES_ONLY_LIVE = ["JP-TK", "JP-CB", "JP-SK"]
 
-def get_wind_capacity(datetime:datetime, zone_key):
+
+def get_wind_capacity(datetime: datetime, zone_key):
     assert zone_key == "JP-HKD"
     ZONE_CONFIG = ZONES_CONFIG[zone_key]
     capacity = ZONE_CONFIG["capacity"]["wind"]
@@ -53,6 +54,7 @@ def get_wind_capacity(datetime:datetime, zone_key):
     else:
         raise NotImplementedError("This parser can only fetch wind capacity for JP-HKD")
     return capacity
+
 
 @refetch_frequency(timedelta(days=1))
 def fetch_production(
@@ -86,15 +88,17 @@ def fetch_production(
                 "geothermal": None,
                 "unknown": df.loc[i, "unknown"],
             },
-            "capacity":
-            {"wind": get_wind_capacity(df.loc[i, "datetime"].to_pydatetime(), zone_key) if zone_key in ["JP-HKD"] else None},
+            "capacity": {
+                "wind": get_wind_capacity(
+                    df.loc[i, "datetime"].to_pydatetime(), zone_key
+                )
+                if zone_key in ["JP-HKD"]
+                else None
+            },
             "source": "occtonet.or.jp, {}".format(sources[zone_key]),
         }
         datalist.append(data)
-    breakpoint()
     return datalist
-
-
 
 
 def fetch_production_df(

--- a/parsers/JP.py
+++ b/parsers/JP.py
@@ -40,7 +40,7 @@ sources = {
 ZONES_ONLY_LIVE = ["JP-TK", "JP-CB", "JP-SK"]
 
 
-def get_wind_capacity(datetime: datetime, zone_key):
+def get_wind_capacity(datetime: datetime, zone_key, logger: Logger):
     ZONE_CONFIG = ZONES_CONFIG[zone_key]
     try:
         capacity = ZONE_CONFIG["capacity"]["wind"]
@@ -52,9 +52,7 @@ def get_wind_capacity(datetime: datetime, zone_key):
             elif datetime.year >= 2021:
                 capacity = 577
     except Exception as e:
-        Logger.error(f"Wind capacity not found in configuration file: {e.args}")
-        print(f"Wind capacity not found in configuration file: {e.args}")
-        # Logger.exception("Wind capacity not found in configuration file")
+        logger.error(f"Wind capacity not found in configuration file: {e.args}")
         capacity = None
     return capacity
 
@@ -76,7 +74,9 @@ def fetch_production(
     datalist = []
 
     for i in df.index:
-        capacity = get_wind_capacity(df.loc[i, "datetime"].to_pydatetime(), zone_key)
+        capacity = get_wind_capacity(
+            df.loc[i, "datetime"].to_pydatetime(), zone_key, logger
+        )
         data = {
             "zoneKey": zone_key,
             "datetime": df.loc[i, "datetime"].to_pydatetime(),

--- a/parsers/JP.py
+++ b/parsers/JP.py
@@ -10,6 +10,7 @@ import pandas as pd
 from requests import Session
 
 from parsers import occtonet
+from electricitymap.contrib.config import ZONES_CONFIG
 from parsers.lib.config import refetch_frequency
 
 # Abbreviations
@@ -38,6 +39,20 @@ sources = {
 }
 ZONES_ONLY_LIVE = ["JP-TK", "JP-CB", "JP-SK"]
 
+def get_wind_capacity(datetime:datetime, zone_key):
+    assert zone_key == "JP-HKD"
+    ZONE_CONFIG = ZONES_CONFIG[zone_key]
+    capacity = ZONE_CONFIG["capacity"]["wind"]
+    if zone_key == "JP-HKD":
+        if datetime.year <= 2019:
+            capacity = 480
+        elif datetime.year == 2020:
+            capacity = 520
+        elif datetime.year >= 2021:
+            capacity = 577
+    else:
+        raise NotImplementedError("This parser can only fetch wind capacity for JP-HKD")
+    return capacity
 
 @refetch_frequency(timedelta(days=1))
 def fetch_production(
@@ -71,11 +86,15 @@ def fetch_production(
                 "geothermal": None,
                 "unknown": df.loc[i, "unknown"],
             },
+            "capacity":
+            {"wind": get_wind_capacity(df.loc[i, "datetime"].to_pydatetime(), zone_key) if zone_key in ["JP-HKD"] else None},
             "source": "occtonet.or.jp, {}".format(sources[zone_key]),
         }
         datalist.append(data)
-
+    breakpoint()
     return datalist
+
+
 
 
 def fetch_production_df(
@@ -123,7 +142,6 @@ def fetch_production_df(
     # When there is solar, remove it from other production
     if "solar" in df.columns:
         df["unknown"] = df["unknown"] - df["solar"]
-
     return df
 
 


### PR DESCRIPTION
## Issue

We have different historical capacity values for JP-HKD. The parser does not retrieve installed capacity, but we can include manually from the data sources. The capacity is usually updated at the end of the fiscal year (in Japan, around March) 

## Description

We include a function that returns the capacity value for JP-HKD based on the year that is queried. The capacity value is included into the json blob returned. Right now we only include yearly values for wind. 

### Preview

![image](https://github.com/electricitymaps/electricitymaps-contrib/assets/50823290/fde97703-22e9-484a-9b69-60a06ebc19e4)


### Double check

- [X] I have tested my parser changes locally with `poetry run test_parser "zone_key"`
- [X] I have run `pnpx prettier --write .` and `poetry run format` to format my changes.
