### PR TITLE
bypass AU-WA-RI for Australia aggregation

### DIFF
--- a/config/zones/AU.yaml
+++ b/config/zones/AU.yaml
@@ -5,6 +5,7 @@ bounding_box:
     - -33.486452325214685
 bypassedSubZones:
   - AU-TAS-CBI
+  - AU-WA-RI
 capacity:
   battery storage: 157.2
   biomass: 384.1


### PR DESCRIPTION
## Issue

We can't get historical data for AU-WA-RI which means we can't create historical aggregations of AU if it is included.

## Description

This PR bypasses AU-WA-RI from AU aggregation to for us to be able to aggregate Australia.

### Double check

- [x] I have run `pnpx prettier --write .` and `poetry run format` to format my changes.
