### PR TITLE
update india zone name

### DIFF
--- a/web/public/locales/en.json
+++ b/web/public/locales/en.json
@@ -776,7 +776,7 @@
       "zoneName": "Isle of Man"
     },
     "IN": {
-      "zoneName": "Mainland India"
+      "zoneName": "India"
     },
     "IN-EA": {
       "countryName": "India",


### PR DESCRIPTION
## Issue
The data portal scripts depend on the zoneName of a parent country matching the countryName of a zone. 

## Description
This PR renames "Mainland India" to "India" to match the country name fields


### Double check

- [x] I have tested my parser changes locally with `poetry run test_parser "zone_key"`
- [x] I have run `pnpx prettier --write .` and `poetry run format` to format my changes.
