### PR TITLE
Adjust storage emission factors

### DIFF
--- a/config/defaults.yaml
+++ b/config/defaults.yaml
@@ -19,9 +19,9 @@ fallbackZoneMixes:
       wind: 0.047716
 isLowCarbon:
   battery charge:
-    _comment: Battery charge does not contribute to the production/consumption mix
+    _comment: Charge does not have any impact (we count emissions at discharge)
     source: Electricity Maps
-    value: 0
+    value: 1
   battery discharge:
     _comment: Battery discharge is assumed to be powered by low-carbon. Ideally this should be overriden per zone.
     source: Electricity Maps
@@ -47,9 +47,9 @@ isLowCarbon:
     source: Electricity Maps
     value: 1
   hydro charge:
-    _comment: Battery charge does not contribute to the production/consumption mix
+    _comment: Charge does not have any impact (we count emissions at discharge)
     source: Electricity Maps
-    value: 0
+    value: 1
   hydro discharge:
     _comment: Hydro discharge is assumed to be powered by low-carbon. Ideally this should be overriden per zone.
     source: Electricity Maps
@@ -77,9 +77,9 @@ isLowCarbon:
     value: 1
 isRenewable:
   battery charge:
-    _comment: Battery charge does not contribute to the production/consumption mix
+    _comment: Charge does not have any impact (we count emissions at discharge)
     source: Electricity Maps
-    value: 0
+    value: 1
   battery discharge:
     _comment: Battery discharge is assumed to be powered by renewables. Ideally this should be overriden per zone.
     source: Electricity Maps
@@ -105,9 +105,9 @@ isRenewable:
     source: Electricity Maps
     value: 1
   hydro charge:
-    _comment: Battery charge does not contribute to the production/consumption mix
+    _comment: Charge does not have any impact (we count emissions at discharge)
     source: Electricity Maps
-    value: 0
+    value: 1
   hydro discharge:
     _comment: Hydro discharge is assumed to be powered by renewables. Ideally this should be overriden per zone.
     source: Electricity Maps


### PR DESCRIPTION
## Issue
We don't count emissions at storage, and thus, we set emission factors of 0g/kWh for these activities.
For consistency, we also have to assume that charging is done with 100% low-carbon (and renewable) electricity (as opposed to 100% fossil fuel).

The storage factors are in theory never used because storage is not assigned to any zone (the *discharge* factors are the ones used to assign impact to zones). However, storage factors are used in marginal calculations when assessing the impact of using more storage. Right now the storage lowcarbon/renewable % is set to 0, which means 100% fossil-based storage impact. We should instead set it to 100% lowcarbon/renewable to ensure we treat storage activities as "free".