### PR TITLE
Fix for Mongolia parser

### DIFF
--- a/config/zones/MN.yaml
+++ b/config/zones/MN.yaml
@@ -11,6 +11,7 @@ capacity:
 contributors:
   - q--
   - alixunderplatz
+  - MuffinCompiler
 emissionFactors:
   direct:
     unknown:

--- a/parsers/IN_EA.py
+++ b/parsers/IN_EA.py
@@ -7,7 +7,7 @@ from requests import Session
 
 from electricitymap.contrib.config import ZoneKey
 from electricitymap.contrib.lib.models.event_lists import ExchangeList
-from electricitymap.contrib.parsers.lib.config import refetch_frequency
+from parsers.lib.config import refetch_frequency
 from parsers.lib.exceptions import ParserException
 
 IN_WE_PROXY = "https://in-proxy-jfnx5klx2a-el.a.run.app"

--- a/parsers/MN.py
+++ b/parsers/MN.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python3
 
-import json
 from datetime import datetime
 from logging import Logger, getLogger
 from typing import Any, Dict, Optional
@@ -74,7 +73,7 @@ def query(session: Session) -> Dict[str, Any]:
         )
 
     # Read as JSON
-    response_json = json.loads(target_response.text)
+    response_json = target_response.json()
     query_result = parse_json(response_json)
 
     return query_result
@@ -98,7 +97,7 @@ def fetch_production(
         - query_data["importMW"]
         - query_data["solarMW"]
         - query_data["windMW"],
-        2,
+        13,
     )
 
     dataset_production = {

--- a/parsers/MN.py
+++ b/parsers/MN.py
@@ -3,7 +3,7 @@
 import json
 from datetime import datetime
 from logging import Logger, getLogger
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, Optional
 
 import arrow
 from pytz import timezone

--- a/parsers/MN.py
+++ b/parsers/MN.py
@@ -4,7 +4,6 @@ from datetime import datetime
 from logging import Logger, getLogger
 from typing import Any, Dict, Optional
 
-import arrow
 from pytz import timezone
 from requests import Response, Session
 
@@ -53,11 +52,11 @@ def parse_json(web_json: dict) -> Dict[str, Any]:
     # Then we can safely parse them
     query_data = dict()
     for query_key, src_key in JSON_QUERY_TO_SRC.items():
-
         if query_key == "time":
             # convert to datetime
-            parsed_time = arrow.get(web_json[src_key], "YYYY-MM-DD HH:mm:ss", tzinfo=TZ)
-            query_data[query_key] = parsed_time.datetime
+            query_data[query_key] = datetime.fromisoformat(web_json[src_key]).replace(
+                tzinfo=TZ
+            )
         else:
             # or convert to float, might also be string
             query_data[query_key] = float(web_json[src_key])
@@ -147,6 +146,6 @@ def fetch_consumption(
 
 if __name__ == "__main__":
     print("fetch_production() ->")
-    print(fetch_production())
+    print(fetch_production(ZoneKey("MN")))
     print("fetch_consumption() ->")
-    print(fetch_consumption())
+    print(fetch_consumption(ZoneKey("MN")))


### PR DESCRIPTION
## Issue

Closes #5470

## Description

Endpoint for Mongolia data changed from table (parsed) from HTML, to JSON. Available data fields are still exactly the same as in previous data source (wind, solar, exchange, unknown which infered from total consumption). Changed general structure a bit to remove duplicated code in consumption and production methods.

Also changed a single import in the `IN-EA` parser. The present absolute import path yields runtime errors for me. All other parsers use the import I changed it to.

### Double check

- [x] I have tested my parser changes locally with `poetry run test_parser MN [production|consumption]`
- [x] I have run `pnpx prettier --write .` and `poetry run format` to format my changes.
