### PR TITLE
Add validation for RS hydro in ENTSOE.py

### DIFF
--- a/parsers/ENTSOE.py
+++ b/parsers/ENTSOE.py
@@ -425,6 +425,9 @@ VALIDATIONS: Dict[str, Dict[str, Any]] = {
     },
     "RS": {
         "required": ["coal"],
+        "expected_range": {
+            "hydro": (0, 5000), # 5 GW is double the production capacity of Serbia.
+        },
     },
     "SE": {
         "required": ["hydro", "nuclear", "wind", "unknown"],
@@ -921,7 +924,6 @@ def parse_prices(
     zoneKey: ZoneKey,
     logger: Logger,
 ) -> PriceList:
-
     if not xml_text:
         return PriceList(logger)
     soup = BeautifulSoup(xml_text, "html.parser")

--- a/parsers/ENTSOE.py
+++ b/parsers/ENTSOE.py
@@ -426,7 +426,7 @@ VALIDATIONS: Dict[str, Dict[str, Any]] = {
     "RS": {
         "required": ["coal"],
         "expected_range": {
-            "hydro": (0, 5000), # 5 GW is double the production capacity of Serbia.
+            "hydro": (0, 5000),  # 5 GW is double the production capacity of Serbia.
         },
     },
     "SE": {


### PR DESCRIPTION
## Issue

The Serbia production values for hydro have been over 6 times the installed capacity for several hours the last few days but are have been corrected in the ENTSO-E transparency platform. 

## Description

This PR adds validation for RS hydro production so it can never go over double it's installed capacity. Which means it should exclude all the erroneous values while still allowing it to increase without us having to adjust it.

### Double check

- [x] I have tested my parser changes locally with `poetry run test_parser "zone_key"`
- [x] I have run `pnpx prettier --write .` and `poetry run format` to format my changes.
