### PR TITLE
Use refetch token if specified datetime in ENTSOE parser

### DIFF
--- a/parsers/ENTSOE.py
+++ b/parsers/ENTSOE.py
@@ -483,7 +483,6 @@ def query_ENTSOE(
             message="target_datetime has to be a datetime in query_entsoe",
         )
 
-
     # make sure we have an arrow object
     params["periodStart"] = (target_datetime + timedelta(hours=span[0])).strftime(
         "%Y%m%d%H00"  # YYYYMMDDHH00

--- a/parsers/ENTSOE.py
+++ b/parsers/ENTSOE.py
@@ -472,24 +472,28 @@ def query_ENTSOE(
     Raises an exception if no API token is found.
     Returns a request object.
     """
+    env_var = "ENTSOE_REFETCH_TOKEN"
     if target_datetime is None:
         target_datetime = datetime.utcnow()
-    if isinstance(target_datetime, datetime):
-        # make sure we have an arrow object
-        params["periodStart"] = (target_datetime + timedelta(hours=span[0])).strftime(
-            "%Y%m%d%H00"  # YYYYMMDDHH00
-        )
-        params["periodEnd"] = (target_datetime + timedelta(hours=span[1])).strftime(
-            "%Y%m%d%H00"  # YYYYMMDDHH00
-        )
-    else:
+        env_var = "ENTSOE_TOKEN"
+
+    if not isinstance(target_datetime, datetime):
         raise ParserException(
             parser="ENTSOE.py",
             message="target_datetime has to be a datetime in query_entsoe",
         )
 
+
+    # make sure we have an arrow object
+    params["periodStart"] = (target_datetime + timedelta(hours=span[0])).strftime(
+        "%Y%m%d%H00"  # YYYYMMDDHH00
+    )
+    params["periodEnd"] = (target_datetime + timedelta(hours=span[1])).strftime(
+        "%Y%m%d%H00"  # YYYYMMDDHH00
+    )
+
     # Due to rate limiting, we need to spread our requests across different tokens
-    tokens = get_token("ENTSOE_TOKEN").split(",")
+    tokens = get_token(env_var).split(",")
     # Shuffle the tokens so that we don't always use the same one first.
     shuffle(tokens)
     last_response_if_all_fail = None

--- a/parsers/test/test_ENTSOE.py
+++ b/parsers/test/test_ENTSOE.py
@@ -9,7 +9,6 @@ from requests_mock import ANY, GET, Adapter
 
 from electricitymap.contrib.lib.types import ZoneKey
 from parsers import ENTSOE
-from parsers.lib.utils import get_token
 
 
 class TestENTSOE(unittest.TestCase):

--- a/parsers/test/test_ENTSOE.py
+++ b/parsers/test/test_ENTSOE.py
@@ -1,6 +1,7 @@
 import os
 import unittest
 from datetime import datetime
+from unittest import mock
 
 from pytz import utc
 from requests import Session
@@ -8,6 +9,7 @@ from requests_mock import ANY, GET, Adapter
 
 from electricitymap.contrib.lib.types import ZoneKey
 from parsers import ENTSOE
+from parsers.lib.utils import get_token
 
 
 class TestENTSOE(unittest.TestCase):
@@ -51,3 +53,25 @@ class TestFetchPrices(TestENTSOE):
             self.assertEqual(
                 prices[0]["datetime"], datetime(2023, 5, 6, 22, 0, tzinfo=utc)
             )
+
+
+class TestENTSOE_Refetch(unittest.TestCase):
+    def test_refetch_token(self) -> None:
+        token = mock.Mock(return_value="token")
+        with mock.patch("parsers.ENTSOE.get_token", token) as patched_get_token:
+            self.session = Session()
+            self.adapter = Adapter()
+            self.session.mount("https://", self.adapter)
+            with open("parsers/test/mocks/ENTSOE/FR_prices.xml", "rb") as price_fr_data:
+                self.adapter.register_uri(
+                    GET,
+                    ANY,
+                    content=price_fr_data.read(),
+                )
+                _ = ENTSOE.fetch_price(ZoneKey("DE"), self.session)
+                patched_get_token.assert_called_once_with("ENTSOE_TOKEN")
+                patched_get_token.reset_mock()
+                _ = ENTSOE.fetch_price(
+                    ZoneKey("DE"), self.session, datetime(2021, 1, 1)
+                )
+                patched_get_token.assert_called_once_with("ENTSOE_REFETCH_TOKEN")


### PR DESCRIPTION
## Issue

We are rolling out an automatic data refetch. For ENTSOE we risk hitting API rate limitations. Therefore when we are refetching data, we should be using a specific token.

## Description

When the target datetime is specified, we should use the refetch token as when the target datetime is specified it means this is a refetch.

### Double check

- [ ] I have tested my parser changes locally with `poetry run test_parser "zone_key"`
- [ ] I have run `pnpx prettier --write .` and `poetry run format` to format my changes.
