### PR TITLE
Use EU proxy for refetches

### DIFF
--- a/parsers/ENTSOE.py
+++ b/parsers/ENTSOE.py
@@ -39,10 +39,10 @@ ENDPOINT = "/api"
 ENTSOE_HOST = "https://web-api.tp.entsoe.eu"
 
 
-EU_PROXY = "https://eu-proxy-jfnx5klx2a-ew.a.run.app{enpoint}?host={host}"
+EU_PROXY = "https://eu-proxy-jfnx5klx2a-ew.a.run.app{endpoint}?host={host}"
 
 ENTSOE_ENDPOINT = ENTSOE_HOST + ENDPOINT
-ENTSOE_EU_PROXY_ENDPOINT = EU_PROXY.format(enpoint=ENDPOINT, host=ENTSOE_HOST)
+ENTSOE_EU_PROXY_ENDPOINT = EU_PROXY.format(endpoint=ENDPOINT, host=ENTSOE_HOST)
 
 ENTSOE_PARAMETER_DESC = {
     "B01": "Biomass",

--- a/parsers/ENTSOE.py
+++ b/parsers/ENTSOE.py
@@ -35,7 +35,15 @@ from .lib.exceptions import ParserException
 from .lib.utils import get_token, sum_production_dicts
 from .lib.validation import validate
 
-ENTSOE_ENDPOINT = "https://web-api.tp.entsoe.eu/api"
+ENDPOINT = "/api"
+ENTSOE_HOST = "https://web-api.tp.entsoe.eu"
+
+
+EU_PROXY = "https://eu-proxy-jfnx5klx2a-ew.a.run.app{enpoint}?host={host}"
+
+ENTSOE_ENDPOINT = ENTSOE_HOST + ENDPOINT
+ENTSOE_EU_PROXY_ENDPOINT = EU_PROXY.format(enpoint=ENDPOINT, host=ENTSOE_HOST)
+
 ENTSOE_PARAMETER_DESC = {
     "B01": "Biomass",
     "B02": "Fossil Brown coal/Lignite",
@@ -473,9 +481,11 @@ def query_ENTSOE(
     Returns a request object.
     """
     env_var = "ENTSOE_REFETCH_TOKEN"
+    url = ENTSOE_EU_PROXY_ENDPOINT
     if target_datetime is None:
         target_datetime = datetime.utcnow()
         env_var = "ENTSOE_TOKEN"
+        url = ENTSOE_ENDPOINT
 
     if not isinstance(target_datetime, datetime):
         raise ParserException(
@@ -499,7 +509,7 @@ def query_ENTSOE(
     # Try each token until we get a valid response
     for token in tokens:
         params["securityToken"] = token
-        response: Response = session.get(ENTSOE_ENDPOINT, params=params)
+        response: Response = session.get(url, params=params)
         if response.ok:
             return response.text
         else:

--- a/parsers/test/test_ENTSOE.py
+++ b/parsers/test/test_ENTSOE.py
@@ -74,3 +74,29 @@ class TestENTSOE_Refetch(unittest.TestCase):
                     ZoneKey("DE"), self.session, datetime(2021, 1, 1)
                 )
                 patched_get_token.assert_called_once_with("ENTSOE_REFETCH_TOKEN")
+
+    def test_refetch_uses_proxy(self):
+        os.environ["ENTSOE_REFETCH_TOKEN"] = "proxy"
+        self.session = Session()
+        self.adapter = Adapter()
+        self.session.mount("https://", self.adapter)
+        with open("parsers/test/mocks/ENTSOE/FR_prices.xml", "rb") as price_fr_data:
+            self.adapter.register_uri(
+                GET,
+                ENTSOE.ENTSOE_EU_PROXY_ENDPOINT,
+                content=price_fr_data.read(),
+            )
+            _ = ENTSOE.fetch_price(ZoneKey("DE"), self.session, datetime(2021, 1, 1))
+
+    def test_fetch_uses_normal_url(self):
+        os.environ["ENTSOE_TOKEN"] = "proxy"
+        self.session = Session()
+        self.adapter = Adapter()
+        self.session.mount("https://", self.adapter)
+        with open("parsers/test/mocks/ENTSOE/FR_prices.xml", "rb") as price_fr_data:
+            self.adapter.register_uri(
+                GET,
+                ENTSOE.ENTSOE_ENDPOINT,
+                content=price_fr_data.read(),
+            )
+            _ = ENTSOE.fetch_price(ZoneKey("DE"), self.session)


### PR DESCRIPTION
## Issue

We deployed our EU proxy to be able to use a different IP address when doing refetches on ENTSOE.

## Description

In case the target datetime is supplied, uses the proxied endpoint.


### Double check

- [ ] I have tested my parser changes locally with `poetry run test_parser "zone_key"`
- [ ] I have run `pnpx prettier --write .` and `poetry run format` to format my changes.
