### PR TITLE
`Mobile performance`:Hide exchange arrows on touch start

### DIFF
--- a/web/src/features/map/Map.tsx
+++ b/web/src/features/map/Map.tsx
@@ -335,6 +335,7 @@ export default function MapPage(): ReactElement {
       onError={onError}
       onMouseMove={onMouseMove}
       onMouseOut={onMouseOut}
+      onTouchStart={onDragStart}
       onDragStart={onDragStart}
       onDragEnd={onDragEnd}
       onZoomStart={onZoomStart}


### PR DESCRIPTION
## Issue
Slow performance on older android devices

## Description
This PR hides the exchange arrows when the onTouchStart event handler is triggered. 

As discussed in PR #5501 the main performance benefit was seen from hiding the arrows, this implementation should keep the same user experience on desktop.

### Double check

- [x] I have tested my parser changes locally with `poetry run test_parser "zone_key"`
- [x] I have run `pnpx prettier --write .` and `poetry run format` to format my changes.
