### PR TITLE
Automatic dependency updates for app dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -38,6 +38,7 @@ updates:
         patterns:
           - 'i18next'
           - 'i18next-*'
+          - 'react-i18next'
       topojson:
         patterns:
           - 'topojson-*'

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,22 +8,22 @@ updates:
     schedule:
       interval: 'weekly'
     reviewers:
-      - "VIKTORVAV99"
+      - 'VIKTORVAV99'
     ignore:
       - dependency-name: '*'
         update-types: ['version-update:semver-patch']
 
   # Maintain the web npm (pnpm) dependencies.
-  - package-ecosystem: "npm"
-    directory: "/web/"
+  - package-ecosystem: 'npm'
+    directory: '/web/'
     schedule:
-      interval: "monthly"
+      interval: 'monthly'
     open-pull-requests-limit: 10
     reviewers:
-      - "VIKTORVAV99"
+      - 'VIKTORVAV99'
     ignore:
-      - dependency-name: "*"
-        update-types: ["version-update:semver-major", "version-update:semver-patch"]
+      - dependency-name: '*'
+        update-types: ['version-update:semver-major', 'version-update:semver-patch']
     groups:
       radix-ui:
         patterns:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,10 +6,55 @@ updates:
   - package-ecosystem: 'github-actions'
     directory: '/'
     schedule:
-      interval: 'daily'
+      interval: 'weekly'
+    reviewers:
+      - "VIKTORVAV99"
     ignore:
       - dependency-name: '*'
         update-types: ['version-update:semver-patch']
+
+  # Maintain the web npm (pnpm) dependencies.
+  - package-ecosystem: "npm"
+    directory: "/web/"
+    schedule:
+      interval: "monthly"
+    open-pull-requests-limit: 10
+    reviewers:
+      - "VIKTORVAV99"
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major", "version-update:semver-patch"]
+    groups:
+      radix-ui:
+        patterns:
+          - '@radix-ui/*'
+      types:
+        patterns:
+          - '@types/*'
+      d3:
+        patterns:
+          - 'd3-*'
+      i18next:
+        patterns:
+          - 'i18next'
+          - 'i18next-*'
+      topojson:
+        patterns:
+          - 'topojson-*'
+      storybook:
+        patterns:
+          - '@storybook/*'
+      eslint:
+        patterns:
+          - 'eslint'
+          - 'eslint-*'
+      prettier:
+        patterns:
+          - 'prettier'
+          - 'prettier-*'
+      capacitor:
+        patterns:
+          - '@capacitor/*'
 #
 # CURRENTLY DISABLED
 # We had so many PRs being opened and not enough time to test each individual update,
@@ -25,22 +70,6 @@ updates:
 #    ignore:
 #      - dependency-name: "*"
 #        update-types: ["version-update:semver-major"]
-#
-#  # Maintain the web npm dependencies.
-#  - package-ecosystem: "npm"
-#    directory: "/web/"
-#    schedule:
-#      interval: "monthly"
-#    open-pull-requests-limit: 10
-#    ignore:
-#      - dependency-name: "*"
-#        update-types: ["version-update:semver-major"]
-#
-#  - package-ecosystem: "docker"
-#    directory: "/web/"
-#    schedule:
-#      interval: "monthly"
-#    open-pull-requests-limit: 5
 #
 #  # Maintain the mockserver npm dependencies.
 #  - package-ecosystem: "npm"


### PR DESCRIPTION
## Issue
Our dependencies have a tendency to drift.

## Description
This PR updates our dependabot config to allow dependabot to update all minor versions of our /web dependencies. I have grouped the major dependency groups to reduce the number of individual PRs and to ensure that dependencies that should be updated together are like ESLint configs or all the types packages.

### Double check

- [x] I have run `pnpx prettier --write .` and `poetry run format` to format my changes.
