### PR TITLE
Fix Alaska Bounding Box

### DIFF
--- a/config/zones/US-AK.yaml
+++ b/config/zones/US-AK.yaml
@@ -1,8 +1,8 @@
 bounding_box:
-  - - -179.64350338399993
-    - 50.71539948100022
-  - - 180.28093509200022
-    - 71.91250234600014
+  - - -188
+    - 51
+  - - -130
+    - 72
 emissionFactors:
   direct:
     coal:
@@ -20,8 +20,9 @@ emissionFactors:
   lifecycle:
     coal:
       datetime: '2020-01-01'
-      source: eGrid 2020; Oberschelp, Christopher, et al. "Global emission hotspots
-        of coal power generation."
+      source: >-
+        eGrid 2020; Oberschelp, Christopher, et al. "Global emission hotspots of
+        coal power generation."
       value: 1061.619377
     gas:
       datetime: '2021-01-01'
@@ -33,7 +34,9 @@ emissionFactors:
       value: 957.1828107
 sources:
   IPCC 2014:
-    link: https://www.ipcc.ch/site/assets/uploads/2018/02/ipcc_wg3_ar5_annex-iii.pdf#page=7
+    link: >-
+      https://www.ipcc.ch/site/assets/uploads/2018/02/ipcc_wg3_ar5_annex-iii.pdf#page=7
   eGrid 2020:
-    link: https://drive.google.com/file/d/1_FAAuTtIdMuORZKsqHnd9vMNHlQgYarh/view?usp=sharing
+    link: >-
+      https://drive.google.com/file/d/1_FAAuTtIdMuORZKsqHnd9vMNHlQgYarh/view?usp=sharing
 timezone: America/Anchorage

--- a/web/geo/generateZoneBoundingBoxes.ts
+++ b/web/geo/generateZoneBoundingBoxes.ts
@@ -103,7 +103,7 @@ if (isAggregate) {
 
 for (const [zoneKey, bbox] of Object.entries(boundingBoxes)) {
   // do not add new entries to zones/*.yaml, do not add RU because it crosses the 180th meridian
-  if (zoneKey === 'RU' || zoneKey === 'RU-FE') {
+  if (zoneKey === 'RU' || zoneKey === 'RU-FE' || zoneKey === 'US-AK') {
     console.log('IGNORING', zoneKey, 'because it is crossing the 180th meridian');
     continue;
   }


### PR DESCRIPTION
## Issue
Bo Dong alerted us on slack that the Alaska bounding box was incorrect. This is due to the fact it crosses the 180th meridian and our current script can't handle this.

## Description
I have manually updated the bounding box and added a override for it in the bounding box generation script.

### Double check

- [x] I have run `pnpx prettier --write .` and `poetry run format` to format my changes.
