### PR TITLE
Fix ENTSOE.py storage consumption

### DIFF
--- a/parsers/ENTSOE.py
+++ b/parsers/ENTSOE.py
@@ -810,9 +810,12 @@ def parse_production(
         for entry in timeseries.find_all("point"):
             quantity = float(entry.find_all("quantity")[0].contents[0])
             position = int(entry.find_all("position")[0].contents[0])
+            is_production = (
+                len(timeseries.find_all("inBiddingZone_Domain.mRID".lower())) > 0
+            )
             datetime = datetime_from_position(datetime_start, position, resolution)
             production, storage = create_production_storage(
-                fuel_code, quantity, logger, zoneKey
+                fuel_code, quantity if is_production else -quantity, logger, zoneKey
             )
             production_breakdowns.append(
                 zoneKey=zoneKey,

--- a/parsers/ENTSOE.py
+++ b/parsers/ENTSOE.py
@@ -810,6 +810,9 @@ def parse_production(
         for entry in timeseries.find_all("point"):
             quantity = float(entry.find_all("quantity")[0].contents[0])
             position = int(entry.find_all("position")[0].contents[0])
+            # Since all values in ENTSOE are positive, we need to check if
+            # the value is production or consumption so we can set the quantity
+            # to a negative value if it is consumption.
             is_production = (
                 len(timeseries.find_all("inBiddingZone_Domain.mRID".lower())) > 0
             )


### PR DESCRIPTION
## Issue
Fixes: #5589 

## Description

Adds back the is_production check and inverts the value if it's not true to fix the consumption values.

### Double check

- [x] I have tested my parser changes locally with `poetry run test_parser "zone_key"`
- [x] I have run `pnpx prettier --write .` and `poetry run format` to format my changes.
