### PR TITLE
Update disclaimer for JP-CB

### DIFF
--- a/config/zones/JP-CB.yaml
+++ b/config/zones/JP-CB.yaml
@@ -19,7 +19,7 @@ contributors:
   - lorrieq
   - pierresegonne
   - wobniarin
-disclaimer: The data provider (Chubu Electric Power Co.,Inc.) provides live data only for solar and unknown. We are working on improving the data quality for this zone.
+disclaimer: The data provided for solar power production is suspected to be too high (source; Chubu Electric Power Co.,Inc.). See https://github.com/electricitymaps/electricitymaps-contrib/issues/5616.
 emissionFactors:
   lifecycle:
     unknown:


### PR DESCRIPTION
## Issue

An estimation model was added for JP-CB, dividing unknown production in a more granular breakdown.
We also reported that solar production is suspiciously high

## Description

Update the zone disclaimer to reflect this

### Preview

<!-- Please add screenshots and/or gif that shows visual changes (if applicable) -->

### Double check

- [x] I have tested my parser changes locally with `poetry run test_parser "zone_key"`
- [x] I have run `pnpx prettier --write .` and `poetry run format` to format my changes.
