### PR TITLE
Add disclaimers to zones

### DIFF
--- a/config/zones/AR.yaml
+++ b/config/zones/AR.yaml
@@ -161,4 +161,5 @@ fallbackZoneMixes:
         wind: 0.0772943608308855
 parsers:
   production: AR.fetch_production
+disclaimer: Unknown production is the aggregation of thermal production, mainly gas.
 timezone: America/Argentina/Buenos_Aires

--- a/config/zones/AU-NT.yaml
+++ b/config/zones/AU-NT.yaml
@@ -17,4 +17,5 @@ parsers:
   consumption: NTESMO.fetch_consumption
   price: NTESMO.fetch_price
   production: NTESMO.fetch_production_mix
+disclaimer: The Northern Territory power grid is not connected to the (Australian) National Electricity Market or Western Australia's grid.
 timezone: Australia/Darwin

--- a/config/zones/AU-WA.yaml
+++ b/config/zones/AU-WA.yaml
@@ -211,4 +211,5 @@ fallbackZoneMixes:
 parsers:
   price: OPENNEM.fetch_price
   production: OPENNEM.fetch_production
+disclaimer: Western Australia's power grid is not connected to the (Australian) National Electricity Market or the Northern Territory grid.
 timezone: Australia/Perth

--- a/config/zones/BO.yaml
+++ b/config/zones/BO.yaml
@@ -165,4 +165,5 @@ fallbackZoneMixes:
 parsers:
   generationForecast: BO.fetch_generation_forecast
   production: BO.fetch_production
+disclaimer: Unknown production is the aggregation of thermal production, mainly gas, coal and oil.
 timezone: America/La_Paz

--- a/config/zones/BR-CS.yaml
+++ b/config/zones/BR-CS.yaml
@@ -199,4 +199,5 @@ fallbackZoneMixes:
         wind: 0.030407074126448184
 parsers:
   production: BR.fetch_production
+disclaimer: Unknown production is the aggregation of thermal production, mainly gas, coal and oil.
 timezone: null

--- a/config/zones/BR-N.yaml
+++ b/config/zones/BR-N.yaml
@@ -198,4 +198,5 @@ fallbackZoneMixes:
         wind: 0.12396047613175017
 parsers:
   production: BR.fetch_production
+disclaimer: Unknown production is the aggregation of thermal production, mainly gas, coal and oil.
 timezone: null

--- a/config/zones/BR-NE.yaml
+++ b/config/zones/BR-NE.yaml
@@ -183,4 +183,5 @@ fallbackZoneMixes:
         wind: 0.48304371118414346
 parsers:
   production: BR.fetch_production
+disclaimer: Unknown production is the aggregation of thermal production, mainly gas, coal and oil.
 timezone: null

--- a/config/zones/BR-S.yaml
+++ b/config/zones/BR-S.yaml
@@ -198,4 +198,5 @@ fallbackZoneMixes:
         wind: 0.07201483333379087
 parsers:
   production: BR.fetch_production
+disclaimer: Unknown production is the aggregation of thermal production, mainly gas, coal and oil.
 timezone: null

--- a/config/zones/CL-SEN.yaml
+++ b/config/zones/CL-SEN.yaml
@@ -252,4 +252,5 @@ fallbackZoneMixes:
         wind: 0.08868521298423133
 parsers:
   production: CL.fetch_production
+disclaimer: Unknown production is the aggregation of thermal production, mainly gas, coal and oil.
 timezone: America/Santiago

--- a/config/zones/GB-NIR.yaml
+++ b/config/zones/GB-NIR.yaml
@@ -223,4 +223,5 @@ parsers:
   price: ENTSOE.fetch_price
   production: IE.fetch_production
   productionPerModeForecast: IE.fetch_wind_forecasts
+disclaimer: The complete generation mix is unavailable. It is therefore estimated by Electricity Maps.
 timezone: Europe/London

--- a/config/zones/HK.yaml
+++ b/config/zones/HK.yaml
@@ -208,4 +208,5 @@ fallbackZoneMixes:
         solar: 0.0
         unknown: 0.0
         wind: 0.0
+disclaimer: Real-time consumption and generation mix data is not available and is fully estimated.
 timezone: Asia/Hong_Kong

--- a/config/zones/ID.yaml
+++ b/config/zones/ID.yaml
@@ -214,4 +214,5 @@ fallbackZoneMixes:
         solar: 0.0
         unknown: 0.0
         wind: 0.0
+disclaimer: Real-time consumption and generation mix data is not available and is fully estimated.
 timezone: Asia/Jakarta

--- a/config/zones/IE.yaml
+++ b/config/zones/IE.yaml
@@ -285,4 +285,5 @@ sources:
   : link:
       https://unece.org/sites/default/files/2022-04/LCA_3_FINAL%20March%202022.pdf#page=37,
       https://proceedings.windeurope.org/biplatform/rails/active_storage/disk/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdDRG9JYTJWNVNTSWhORFJ0ZDJJMWVUbG9OMll6TVRaaGEza3lkamgxZG1aM056WnZZZ1k2QmtWVU9oQmthWE53YjNOcGRHbHZia2tpQVk1cGJteHBibVU3SUdacGJHVnVZVzFsUFNKWGFXNWtaWFZ5YjNCbExWZHBibVF0Wlc1bGNtZDVMV2x1TFVWMWNtOXdaUzB5TURJeExYTjBZWFJwYzNScFkzTXVjR1JtSWpzZ1ptbHNaVzVoYldVcVBWVlVSaTA0SnlkWGFXNWtaWFZ5YjNCbExWZHBibVF0Wlc1bGNtZDVMV2x1TFVWMWNtOXdaUzB5TURJeExYTjBZWFJwYzNScFkzTXVjR1JtQmpzR1ZEb1JZMjl1ZEdWdWRGOTBlWEJsU1NJVVlYQndiR2xqWVhScGIyNHZjR1JtQmpzR1ZBPT0iLCJleHAiOiIyMDIyLTExLTAyVDE1OjU0OjAzLjEyNFoiLCJwdXIiOiJibG9iX2tleSJ9fQ==--c25280a7345257bd91bfaf6d64ddb75c55eef799/Windeurope-Wind-energy-in-Europe-2021-statistics.pdf?content_type=application%2Fpdf&disposition=inline%3B+filename%3D%22Windeurope-Wind-energy-in-Europe-2021-statistics.pdf%22%3B+filename%2A%3DUTF-8%27%27Windeurope-Wind-energy-in-Europe-2021-statistics.pdf
+disclaimer: The complete generation mix is unavailable. It is therefore estimated by Electricity Maps.
 timezone: Europe/Dublin

--- a/config/zones/JP-CB.yaml
+++ b/config/zones/JP-CB.yaml
@@ -19,7 +19,7 @@ contributors:
   - lorrieq
   - pierresegonne
   - wobniarin
-disclaimer: The data provided for solar power production is suspected to be too high (source; Chubu Electric Power Co.,Inc.). See https://github.com/electricitymaps/electricitymaps-contrib/issues/5616.
+disclaimer: The data provided for solar power production is suspected to be too high (source; Chubu Electric Power Co.,Inc.).
 emissionFactors:
   lifecycle:
     unknown:

--- a/config/zones/NL.yaml
+++ b/config/zones/NL.yaml
@@ -18,7 +18,6 @@ contributors:
   - corradio
   - PaulCornelissen
   - nessie2013
-disclaimer: The data provider (ENTSO-E) underreports production and consumption data.
 emissionFactors:
   direct:
     battery discharge:
@@ -290,4 +289,5 @@ sources:
   : link:
       https://unece.org/sites/default/files/2022-04/LCA_3_FINAL%20March%202022.pdf#page=37,
       https://proceedings.windeurope.org/biplatform/rails/active_storage/disk/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdDRG9JYTJWNVNTSWhORFJ0ZDJJMWVUbG9OMll6TVRaaGEza3lkamgxZG1aM056WnZZZ1k2QmtWVU9oQmthWE53YjNOcGRHbHZia2tpQVk1cGJteHBibVU3SUdacGJHVnVZVzFsUFNKWGFXNWtaWFZ5YjNCbExWZHBibVF0Wlc1bGNtZDVMV2x1TFVWMWNtOXdaUzB5TURJeExYTjBZWFJwYzNScFkzTXVjR1JtSWpzZ1ptbHNaVzVoYldVcVBWVlVSaTA0SnlkWGFXNWtaWFZ5YjNCbExWZHBibVF0Wlc1bGNtZDVMV2x1TFVWMWNtOXdaUzB5TURJeExYTjBZWFJwYzNScFkzTXVjR1JtQmpzR1ZEb1JZMjl1ZEdWdWRGOTBlWEJsU1NJVVlYQndiR2xqWVhScGIyNHZjR1JtQmpzR1ZBPT0iLCJleHAiOiIyMDIyLTExLTAyVDE1OjU0OjAzLjEyNFoiLCJwdXIiOiJibG9iX2tleSJ9fQ==--c25280a7345257bd91bfaf6d64ddb75c55eef799/Windeurope-Wind-energy-in-Europe-2021-statistics.pdf?content_type=application%2Fpdf&disposition=inline%3B+filename%3D%22Windeurope-Wind-energy-in-Europe-2021-statistics.pdf%22%3B+filename%2A%3DUTF-8%27%27Windeurope-Wind-energy-in-Europe-2021-statistics.pdf
+disclaimer: The generation mix served by our source is incomplete. It is therefore improved through an Electricity Maps estimation model.
 timezone: Europe/Amsterdam

--- a/config/zones/NL.yaml
+++ b/config/zones/NL.yaml
@@ -289,5 +289,5 @@ sources:
   : link:
       https://unece.org/sites/default/files/2022-04/LCA_3_FINAL%20March%202022.pdf#page=37,
       https://proceedings.windeurope.org/biplatform/rails/active_storage/disk/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdDRG9JYTJWNVNTSWhORFJ0ZDJJMWVUbG9OMll6TVRaaGEza3lkamgxZG1aM056WnZZZ1k2QmtWVU9oQmthWE53YjNOcGRHbHZia2tpQVk1cGJteHBibVU3SUdacGJHVnVZVzFsUFNKWGFXNWtaWFZ5YjNCbExWZHBibVF0Wlc1bGNtZDVMV2x1TFVWMWNtOXdaUzB5TURJeExYTjBZWFJwYzNScFkzTXVjR1JtSWpzZ1ptbHNaVzVoYldVcVBWVlVSaTA0SnlkWGFXNWtaWFZ5YjNCbExWZHBibVF0Wlc1bGNtZDVMV2x1TFVWMWNtOXdaUzB5TURJeExYTjBZWFJwYzNScFkzTXVjR1JtQmpzR1ZEb1JZMjl1ZEdWdWRGOTBlWEJsU1NJVVlYQndiR2xqWVhScGIyNHZjR1JtQmpzR1ZBPT0iLCJleHAiOiIyMDIyLTExLTAyVDE1OjU0OjAzLjEyNFoiLCJwdXIiOiJibG9iX2tleSJ9fQ==--c25280a7345257bd91bfaf6d64ddb75c55eef799/Windeurope-Wind-energy-in-Europe-2021-statistics.pdf?content_type=application%2Fpdf&disposition=inline%3B+filename%3D%22Windeurope-Wind-energy-in-Europe-2021-statistics.pdf%22%3B+filename%2A%3DUTF-8%27%27Windeurope-Wind-energy-in-Europe-2021-statistics.pdf
-disclaimer: The generation mix served by our source is incomplete. It is therefore improved through an Electricity Maps estimation model.
+disclaimer: The generation mix served by the source is incomplete. It is therefore improved through an Electricity Maps estimation model.
 timezone: Europe/Amsterdam

--- a/config/zones/US-CAL-BANC.yaml
+++ b/config/zones/US-CAL-BANC.yaml
@@ -25,6 +25,8 @@ delays:
   consumption: 30
   consumptionForecast: 30
   production: 30
+disclaimer: Data for real-time consumption and generation mix is estimated. Real-time
+  exchanges are not available.
 emissionFactors:
   direct:
     battery discharge:

--- a/config/zones/US-CAL-IID.yaml
+++ b/config/zones/US-CAL-IID.yaml
@@ -25,6 +25,8 @@ delays:
   consumption: 30
   consumptionForecast: 30
   production: 30
+disclaimer: Data for real-time consumption and generation mix is estimated. Real-time
+  exchanges are not available.
 emissionFactors:
   direct:
     battery discharge:

--- a/config/zones/US-CAL-LDWP.yaml
+++ b/config/zones/US-CAL-LDWP.yaml
@@ -25,6 +25,8 @@ delays:
   consumption: 30
   consumptionForecast: 30
   production: 30
+disclaimer: Data for real-time consumption and generation mix is estimated. Real-time
+  exchanges are not available.
 emissionFactors:
   direct:
     battery discharge:

--- a/config/zones/US-CAL-TIDC.yaml
+++ b/config/zones/US-CAL-TIDC.yaml
@@ -25,6 +25,8 @@ delays:
   consumption: 30
   consumptionForecast: 30
   production: 30
+disclaimer: Data for real-time consumption and generation mix is estimated. Real-time
+  exchanges are not available.
 emissionFactors:
   direct:
     battery discharge:

--- a/config/zones/US-CAR-CPLE.yaml
+++ b/config/zones/US-CAR-CPLE.yaml
@@ -25,6 +25,8 @@ delays:
   consumption: 30
   consumptionForecast: 30
   production: 30
+disclaimer: Data for real-time consumption and generation mix is estimated. Real-time
+  exchanges are not available.
 emissionFactors:
   direct:
     battery discharge:

--- a/config/zones/US-CAR-CPLW.yaml
+++ b/config/zones/US-CAR-CPLW.yaml
@@ -25,6 +25,8 @@ delays:
   consumption: 30
   consumptionForecast: 30
   production: 30
+disclaimer: Data for real-time consumption and generation mix is estimated. Real-time
+  exchanges are not available.
 emissionFactors:
   direct:
     battery discharge:

--- a/config/zones/US-CAR-DUK.yaml
+++ b/config/zones/US-CAR-DUK.yaml
@@ -25,6 +25,8 @@ delays:
   consumption: 30
   consumptionForecast: 30
   production: 30
+disclaimer: Data for real-time consumption and generation mix is estimated. Real-time
+  exchanges are not available.
 emissionFactors:
   direct:
     battery discharge:

--- a/config/zones/US-CAR-SC.yaml
+++ b/config/zones/US-CAR-SC.yaml
@@ -25,6 +25,8 @@ delays:
   consumption: 30
   consumptionForecast: 30
   production: 30
+disclaimer: Data for real-time consumption and generation mix is estimated. Real-time
+  exchanges are not available.
 emissionFactors:
   direct:
     battery discharge:

--- a/config/zones/US-CAR-SCEG.yaml
+++ b/config/zones/US-CAR-SCEG.yaml
@@ -25,6 +25,8 @@ delays:
   consumption: 30
   consumptionForecast: 30
   production: 30
+disclaimer: Data for real-time consumption and generation mix is estimated. Real-time
+  exchanges are not available.
 emissionFactors:
   direct:
     battery discharge:

--- a/config/zones/US-CAR-YAD.yaml
+++ b/config/zones/US-CAR-YAD.yaml
@@ -23,6 +23,8 @@ contributors:
   - KabelWlan
 delays:
   production: 30
+disclaimer: Data for real-time consumption and generation mix is estimated. Real-time
+  exchanges are not available.
 emissionFactors:
   direct:
     battery discharge:

--- a/config/zones/US-CENT-SPA.yaml
+++ b/config/zones/US-CENT-SPA.yaml
@@ -25,6 +25,8 @@ delays:
   consumption: 30
   consumptionForecast: 30
   production: 30
+disclaimer: Data for real-time consumption and generation mix is estimated. Real-time
+  exchanges are not available.
 emissionFactors:
   direct:
     battery discharge:

--- a/config/zones/US-FLA-FMPP.yaml
+++ b/config/zones/US-FLA-FMPP.yaml
@@ -25,6 +25,8 @@ delays:
   consumption: 30
   consumptionForecast: 30
   production: 30
+disclaimer: Data for real-time consumption and generation mix is estimated. Real-time
+  exchanges are not available.
 emissionFactors:
   direct:
     battery discharge:

--- a/config/zones/US-FLA-FPC.yaml
+++ b/config/zones/US-FLA-FPC.yaml
@@ -25,6 +25,8 @@ delays:
   consumption: 30
   consumptionForecast: 30
   production: 30
+disclaimer: Data for real-time consumption and generation mix is estimated. Real-time
+  exchanges are not available.
 emissionFactors:
   direct:
     battery discharge:

--- a/config/zones/US-FLA-FPL.yaml
+++ b/config/zones/US-FLA-FPL.yaml
@@ -25,6 +25,8 @@ delays:
   consumption: 30
   consumptionForecast: 30
   production: 30
+disclaimer: Data for real-time consumption and generation mix is estimated. Real-time
+  exchanges are not available.
 emissionFactors:
   direct:
     battery discharge:

--- a/config/zones/US-FLA-GVL.yaml
+++ b/config/zones/US-FLA-GVL.yaml
@@ -25,6 +25,8 @@ delays:
   consumption: 30
   consumptionForecast: 30
   production: 30
+disclaimer: Data for real-time consumption and generation mix is estimated. Real-time
+  exchanges are not available.
 emissionFactors:
   direct:
     battery discharge:

--- a/config/zones/US-FLA-JEA.yaml
+++ b/config/zones/US-FLA-JEA.yaml
@@ -25,6 +25,8 @@ delays:
   consumption: 30
   consumptionForecast: 30
   production: 30
+disclaimer: Data for real-time consumption and generation mix is estimated. Real-time
+  exchanges are not available.
 emissionFactors:
   direct:
     battery discharge:

--- a/config/zones/US-FLA-NSB.yaml
+++ b/config/zones/US-FLA-NSB.yaml
@@ -11,6 +11,8 @@ delays:
   consumption: 30
   consumptionForecast: 30
   production: 30
+disclaimer: Data for real-time consumption and generation mix is estimated. Real-time
+  exchanges are not available.
 emissionFactors:
   lifecycle:
     coal:

--- a/config/zones/US-FLA-SEC.yaml
+++ b/config/zones/US-FLA-SEC.yaml
@@ -25,6 +25,8 @@ delays:
   consumption: 30
   consumptionForecast: 30
   production: 30
+disclaimer: Data for real-time consumption and generation mix is estimated. Real-time
+  exchanges are not available.
 emissionFactors:
   direct:
     battery discharge:

--- a/config/zones/US-FLA-TAL.yaml
+++ b/config/zones/US-FLA-TAL.yaml
@@ -25,6 +25,8 @@ delays:
   consumption: 30
   consumptionForecast: 30
   production: 30
+disclaimer: Data for real-time consumption and generation mix is estimated. Real-time
+  exchanges are not available.
 emissionFactors:
   direct:
     battery discharge:

--- a/config/zones/US-FLA-TEC.yaml
+++ b/config/zones/US-FLA-TEC.yaml
@@ -26,6 +26,8 @@ delays:
   consumption: 30
   consumptionForecast: 30
   production: 30
+disclaimer: Data for real-time consumption and generation mix is estimated. Real-time
+  exchanges are not available.
 emissionFactors:
   direct:
     battery discharge:

--- a/config/zones/US-HI-OA.yaml
+++ b/config/zones/US-HI-OA.yaml
@@ -20,6 +20,8 @@ contributors:
   - KabelWlan
   - danielmatsuda
   - brandongalbraith
+disclaimer: Data for real-time consumption and generation mix is estimated. Real-time
+  exchanges are not available.
 emissionFactors:
   direct:
     battery discharge:

--- a/config/zones/US-MIDW-AECI.yaml
+++ b/config/zones/US-MIDW-AECI.yaml
@@ -25,6 +25,8 @@ delays:
   consumption: 30
   consumptionForecast: 30
   production: 30
+disclaimer: Data for real-time consumption and generation mix is estimated. Real-time
+  exchanges are not available.
 emissionFactors:
   direct:
     battery discharge:

--- a/config/zones/US-MIDW-LGEE.yaml
+++ b/config/zones/US-MIDW-LGEE.yaml
@@ -25,6 +25,8 @@ delays:
   consumption: 30
   consumptionForecast: 30
   production: 30
+disclaimer: Data for real-time consumption and generation mix is estimated. Real-time
+  exchanges are not available.
 emissionFactors:
   direct:
     battery discharge:

--- a/config/zones/US-MIDW-MISO.yaml
+++ b/config/zones/US-MIDW-MISO.yaml
@@ -25,6 +25,8 @@ delays:
   consumption: 30
   consumptionForecast: 30
   production: 30
+disclaimer: Data for real-time consumption and generation mix is estimated. Real-time
+  exchanges are not available.
 emissionFactors:
   direct:
     battery discharge:

--- a/config/zones/US-NW-AVA.yaml
+++ b/config/zones/US-NW-AVA.yaml
@@ -25,6 +25,8 @@ delays:
   consumption: 30
   consumptionForecast: 30
   production: 30
+disclaimer: Data for real-time consumption and generation mix is estimated. Real-time
+  exchanges are not available.
 emissionFactors:
   direct:
     battery discharge:

--- a/config/zones/US-NW-AVRN.yaml
+++ b/config/zones/US-NW-AVRN.yaml
@@ -18,6 +18,8 @@ contributors:
   - KabelWlan
 delays:
   production: 30
+disclaimer: Data for real-time consumption and generation mix is estimated. Real-time
+  exchanges are not available.
 emissionFactors:
   direct:
     battery discharge:

--- a/config/zones/US-NW-BPAT.yaml
+++ b/config/zones/US-NW-BPAT.yaml
@@ -25,6 +25,8 @@ delays:
   consumption: 30
   consumptionForecast: 30
   production: 30
+disclaimer: Data for real-time consumption and generation mix is estimated. Real-time
+  exchanges are not available.
 emissionFactors:
   direct:
     battery discharge:

--- a/config/zones/US-NW-CHPD.yaml
+++ b/config/zones/US-NW-CHPD.yaml
@@ -25,6 +25,8 @@ delays:
   consumption: 30
   consumptionForecast: 30
   production: 30
+disclaimer: Data for real-time consumption and generation mix is estimated. Real-time
+  exchanges are not available.
 emissionFactors:
   direct:
     battery discharge:

--- a/config/zones/US-NW-DOPD.yaml
+++ b/config/zones/US-NW-DOPD.yaml
@@ -25,6 +25,8 @@ delays:
   consumption: 30
   consumptionForecast: 30
   production: 30
+disclaimer: Data for real-time consumption and generation mix is estimated. Real-time
+  exchanges are not available.
 emissionFactors:
   direct:
     battery discharge:

--- a/config/zones/US-NW-GCPD.yaml
+++ b/config/zones/US-NW-GCPD.yaml
@@ -25,6 +25,8 @@ delays:
   consumption: 30
   consumptionForecast: 30
   production: 30
+disclaimer: Data for real-time consumption and generation mix is estimated. Real-time
+  exchanges are not available.
 emissionFactors:
   direct:
     battery discharge:

--- a/config/zones/US-NW-GRID.yaml
+++ b/config/zones/US-NW-GRID.yaml
@@ -22,6 +22,8 @@ contributors:
   - robertahunt
 delays:
   production: 30
+disclaimer: Data for real-time consumption and generation mix is estimated. Real-time
+  exchanges are not available.
 emissionFactors:
   direct:
     battery discharge:

--- a/config/zones/US-NW-GWA.yaml
+++ b/config/zones/US-NW-GWA.yaml
@@ -23,6 +23,8 @@ contributors:
   - KabelWlan
 delays:
   production: 30
+disclaimer: Data for real-time consumption and generation mix is estimated. Real-time
+  exchanges are not available.
 emissionFactors:
   direct:
     battery discharge:

--- a/config/zones/US-NW-IPCO.yaml
+++ b/config/zones/US-NW-IPCO.yaml
@@ -25,6 +25,8 @@ delays:
   consumption: 30
   consumptionForecast: 30
   production: 30
+disclaimer: Data for real-time consumption and generation mix is estimated. Real-time
+  exchanges are not available.
 emissionFactors:
   direct:
     battery discharge:

--- a/config/zones/US-NW-NEVP.yaml
+++ b/config/zones/US-NW-NEVP.yaml
@@ -25,6 +25,8 @@ delays:
   consumption: 30
   consumptionForecast: 30
   production: 30
+disclaimer: Data for real-time consumption and generation mix is estimated. Real-time
+  exchanges are not available.
 emissionFactors:
   direct:
     battery discharge:

--- a/config/zones/US-NW-NWMT.yaml
+++ b/config/zones/US-NW-NWMT.yaml
@@ -25,6 +25,8 @@ delays:
   consumption: 30
   consumptionForecast: 30
   production: 30
+disclaimer: Data for real-time consumption and generation mix is estimated. Real-time
+  exchanges are not available.
 emissionFactors:
   direct:
     battery discharge:

--- a/config/zones/US-NW-PACE.yaml
+++ b/config/zones/US-NW-PACE.yaml
@@ -25,6 +25,8 @@ delays:
   consumption: 30
   consumptionForecast: 30
   production: 30
+disclaimer: Data for real-time consumption and generation mix is estimated. Real-time
+  exchanges are not available.
 emissionFactors:
   direct:
     battery discharge:

--- a/config/zones/US-NW-PACW.yaml
+++ b/config/zones/US-NW-PACW.yaml
@@ -25,6 +25,8 @@ delays:
   consumption: 30
   consumptionForecast: 30
   production: 30
+disclaimer: Data for real-time consumption and generation mix is estimated. Real-time
+  exchanges are not available.
 emissionFactors:
   direct:
     battery discharge:

--- a/config/zones/US-NW-PGE.yaml
+++ b/config/zones/US-NW-PGE.yaml
@@ -25,6 +25,8 @@ delays:
   consumption: 30
   consumptionForecast: 30
   production: 30
+disclaimer: Data for real-time consumption and generation mix is estimated. Real-time
+  exchanges are not available.
 emissionFactors:
   direct:
     battery discharge:

--- a/config/zones/US-NW-PSCO.yaml
+++ b/config/zones/US-NW-PSCO.yaml
@@ -25,6 +25,8 @@ delays:
   consumption: 30
   consumptionForecast: 30
   production: 30
+disclaimer: Data for real-time consumption and generation mix is estimated. Real-time
+  exchanges are not available.
 emissionFactors:
   direct:
     battery discharge:

--- a/config/zones/US-NW-PSEI.yaml
+++ b/config/zones/US-NW-PSEI.yaml
@@ -25,6 +25,8 @@ delays:
   consumption: 30
   consumptionForecast: 30
   production: 30
+disclaimer: Data for real-time consumption and generation mix is estimated. Real-time
+  exchanges are not available.
 emissionFactors:
   direct:
     battery discharge:

--- a/config/zones/US-NW-SCL.yaml
+++ b/config/zones/US-NW-SCL.yaml
@@ -25,6 +25,8 @@ delays:
   consumption: 30
   consumptionForecast: 30
   production: 30
+disclaimer: Data for real-time consumption and generation mix is estimated. Real-time
+  exchanges are not available.
 emissionFactors:
   direct:
     battery discharge:

--- a/config/zones/US-NW-TPWR.yaml
+++ b/config/zones/US-NW-TPWR.yaml
@@ -25,6 +25,8 @@ delays:
   consumption: 30
   consumptionForecast: 30
   production: 30
+disclaimer: Data for real-time consumption and generation mix is estimated. Real-time
+  exchanges are not available.
 emissionFactors:
   direct:
     battery discharge:

--- a/config/zones/US-NW-WACM.yaml
+++ b/config/zones/US-NW-WACM.yaml
@@ -1,8 +1,8 @@
 bounding_box:
-- - -114.55
-  - 35.43059
-- - -95.95176
-  - 48.07463
+  - - -114.55
+    - 35.43059
+  - - -95.95176
+    - 48.07463
 capacity:
   battery storage: 8.2
   biomass: 3.2
@@ -18,9 +18,9 @@ capacity:
   wind: 1236.9
 comment: Western Area Power Administration - Rocky Mountain Region
 contributors:
-- systemcatch
-- robertahunt
-- KabelWlan
+  - systemcatch
+  - robertahunt
+  - KabelWlan
 delays:
   consumption: 30
   consumptionForecast: 30
@@ -30,27 +30,27 @@ disclaimer: Data for real-time consumption and generation mix is estimated. Real
 emissionFactors:
   direct:
     battery discharge:
-    - datetime: '2015-01-01'
-      source: Electricity Maps, 2015 average
-      value: 522.328946727275
-    - datetime: '2016-01-01'
-      source: Electricity Maps, 2016 average
-      value: 600.24085171663
-    - datetime: '2017-01-01'
-      source: Electricity Maps, 2017 average
-      value: 599.9171704894312
-    - datetime: '2018-01-01'
-      source: Electricity Maps, 2018 average
-      value: 636.8362049769621
-    - datetime: '2019-01-01'
-      source: Electricity Maps, 2019 average
-      value: 727.5689224678046
-    - datetime: '2020-01-01'
-      source: Electricity Maps, 2020 average
-      value: 713.3386200996066
-    - datetime: '2021-01-01'
-      source: Electricity Maps, 2021 average
-      value: 745.1015602237039
+      - datetime: '2015-01-01'
+        source: Electricity Maps, 2015 average
+        value: 522.328946727275
+      - datetime: '2016-01-01'
+        source: Electricity Maps, 2016 average
+        value: 600.24085171663
+      - datetime: '2017-01-01'
+        source: Electricity Maps, 2017 average
+        value: 599.9171704894312
+      - datetime: '2018-01-01'
+        source: Electricity Maps, 2018 average
+        value: 636.8362049769621
+      - datetime: '2019-01-01'
+        source: Electricity Maps, 2019 average
+        value: 727.5689224678046
+      - datetime: '2020-01-01'
+        source: Electricity Maps, 2020 average
+        value: 713.3386200996066
+      - datetime: '2021-01-01'
+        source: Electricity Maps, 2021 average
+        value: 745.1015602237039
     coal:
       datetime: '2020-01-01'
       source: eGrid 2020
@@ -60,54 +60,54 @@ emissionFactors:
       source: eGrid 2020
       value: 451.7150314
     hydro discharge:
-    - datetime: '2015-01-01'
-      source: Electricity Maps, 2015 average
-      value: 522.328946727275
-    - datetime: '2016-01-01'
-      source: Electricity Maps, 2016 average
-      value: 600.24085171663
-    - datetime: '2017-01-01'
-      source: Electricity Maps, 2017 average
-      value: 599.9171704894312
-    - datetime: '2018-01-01'
-      source: Electricity Maps, 2018 average
-      value: 636.8362049769621
-    - datetime: '2019-01-01'
-      source: Electricity Maps, 2019 average
-      value: 727.5689224678046
-    - datetime: '2020-01-01'
-      source: Electricity Maps, 2020 average
-      value: 713.3386200996066
-    - datetime: '2021-01-01'
-      source: Electricity Maps, 2021 average
-      value: 745.1015602237039
+      - datetime: '2015-01-01'
+        source: Electricity Maps, 2015 average
+        value: 522.328946727275
+      - datetime: '2016-01-01'
+        source: Electricity Maps, 2016 average
+        value: 600.24085171663
+      - datetime: '2017-01-01'
+        source: Electricity Maps, 2017 average
+        value: 599.9171704894312
+      - datetime: '2018-01-01'
+        source: Electricity Maps, 2018 average
+        value: 636.8362049769621
+      - datetime: '2019-01-01'
+        source: Electricity Maps, 2019 average
+        value: 727.5689224678046
+      - datetime: '2020-01-01'
+        source: Electricity Maps, 2020 average
+        value: 713.3386200996066
+      - datetime: '2021-01-01'
+        source: Electricity Maps, 2021 average
+        value: 745.1015602237039
     oil:
       datetime: '2021-01-01'
       source: eGrid 2020
       value: 953.0188558
   lifecycle:
     battery discharge:
-    - datetime: '2015-01-01'
-      source: Electricity Maps, 2015 average
-      value: 578.8785062604765
-    - datetime: '2016-01-01'
-      source: Electricity Maps, 2016 average
-      value: 647.5129689052843
-    - datetime: '2017-01-01'
-      source: Electricity Maps, 2017 average
-      value: 647.1636603946245
-    - datetime: '2018-01-01'
-      source: Electricity Maps, 2018 average
-      value: 682.9063010555286
-    - datetime: '2019-01-01'
-      source: Electricity Maps, 2019 average
-      value: 754.313794649862
-    - datetime: '2020-01-01'
-      source: Electricity Maps, 2020 average
-      value: 738.5041430582977
-    - datetime: '2021-01-01'
-      source: Electricity Maps, 2021 average
-      value: 766.9391259296401
+      - datetime: '2015-01-01'
+        source: Electricity Maps, 2015 average
+        value: 578.8785062604765
+      - datetime: '2016-01-01'
+        source: Electricity Maps, 2016 average
+        value: 647.5129689052843
+      - datetime: '2017-01-01'
+        source: Electricity Maps, 2017 average
+        value: 647.1636603946245
+      - datetime: '2018-01-01'
+        source: Electricity Maps, 2018 average
+        value: 682.9063010555286
+      - datetime: '2019-01-01'
+        source: Electricity Maps, 2019 average
+        value: 754.313794649862
+      - datetime: '2020-01-01'
+        source: Electricity Maps, 2020 average
+        value: 738.5041430582977
+      - datetime: '2021-01-01'
+        source: Electricity Maps, 2021 average
+        value: 766.9391259296401
     coal:
       datetime: '2020-01-01'
       source: eGrid 2020; Oberschelp, Christopher, et al. "Global emission hotspots
@@ -118,27 +118,27 @@ emissionFactors:
       source: eGrid 2020; IPCC 2014
       value: 571.7150314
     hydro discharge:
-    - datetime: '2015-01-01'
-      source: Electricity Maps, 2015 average
-      value: 578.8785062604765
-    - datetime: '2016-01-01'
-      source: Electricity Maps, 2016 average
-      value: 647.5129689052843
-    - datetime: '2017-01-01'
-      source: Electricity Maps, 2017 average
-      value: 647.1636603946245
-    - datetime: '2018-01-01'
-      source: Electricity Maps, 2018 average
-      value: 682.9063010555286
-    - datetime: '2019-01-01'
-      source: Electricity Maps, 2019 average
-      value: 754.313794649862
-    - datetime: '2020-01-01'
-      source: Electricity Maps, 2020 average
-      value: 738.5041430582977
-    - datetime: '2021-01-01'
-      source: Electricity Maps, 2021 average
-      value: 766.9391259296401
+      - datetime: '2015-01-01'
+        source: Electricity Maps, 2015 average
+        value: 578.8785062604765
+      - datetime: '2016-01-01'
+        source: Electricity Maps, 2016 average
+        value: 647.5129689052843
+      - datetime: '2017-01-01'
+        source: Electricity Maps, 2017 average
+        value: 647.1636603946245
+      - datetime: '2018-01-01'
+        source: Electricity Maps, 2018 average
+        value: 682.9063010555286
+      - datetime: '2019-01-01'
+        source: Electricity Maps, 2019 average
+        value: 754.313794649862
+      - datetime: '2020-01-01'
+        source: Electricity Maps, 2020 average
+        value: 738.5041430582977
+      - datetime: '2021-01-01'
+        source: Electricity Maps, 2021 average
+        value: 766.9391259296401
     oil:
       datetime: '2021-01-01'
       source: eGrid 2020; IPCC 2014
@@ -149,111 +149,111 @@ emissionFactors:
       value: 25.6
 fallbackZoneMixes:
   powerOriginRatios:
-  - _source: Electricity Maps, 2015 average
-    datetime: '2015-01-01'
-    value:
-      battery discharge: 0.0
-      biomass: 0.0
-      coal: 0.2206717959267389
-      gas: 0.01471379089719616
-      geothermal: 0.0
-      hydro: 0.06296408881644881
-      hydro discharge: 0.669613498708566
-      nuclear: 0.0
-      oil: 0.0
-      solar: 0.0016737800965772663
-      unknown: 0.0
-      wind: 0.03036316468062711
-  - _source: Electricity Maps, 2016 average
-    datetime: '2016-01-01'
-    value:
-      battery discharge: 0.0
-      biomass: 0.0
-      coal: 0.22067183986329889
-      gas: 0.014713793826765627
-      geothermal: 0.0
-      hydro: 0.06296410135282869
-      hydro discharge: 0.6696136320310574
-      nuclear: 0.0
-      oil: 0.0
-      solar: 0.001673581276554992
-      unknown: 0.0
-      wind: 0.03036317072604401
-  - _source: Electricity Maps, 2017 average
-    datetime: '2017-01-01'
-    value:
-      battery discharge: 0.0
-      biomass: 1.1554882652213175e-06
-      coal: 0.22117309534990356
-      gas: 0.015133381668101924
-      geothermal: 0.0
-      hydro: 0.06289815496973643
-      hydro discharge: 0.6677432889151635
-      nuclear: 0.00020584033408480135
-      oil: 5.486563363898268e-06
-      solar: 0.0016704008212679005
-      unknown: 6.432516204218729e-06
-      wind: 0.031162823781348256
-  - _source: Electricity Maps, 2018 average
-    datetime: '2018-01-01'
-    value:
-      battery discharge: 0.0
-      biomass: 1.992850084285126e-06
-      coal: 0.3130600221178869
-      gas: 0.07086360311720846
-      geothermal: 1.1004882494821965e-07
-      hydro: 0.08518813207060041
-      hydro discharge: 0.4948411655112337
-      nuclear: 0.001265270138770325
-      oil: 3.9003293959793586e-05
-      solar: 0.0017713050687814054
-      unknown: 4.557362708127615e-05
-      wind: 0.03292386066544561
-  - _source: Electricity Maps, 2019 average
-    datetime: '2019-01-01'
-    value:
-      battery discharge: 0.0
-      biomass: 2.1785827384790743e-06
-      coal: 0.6082642037284738
-      gas: 0.05776796233424209
-      geothermal: 1.9662299083746158e-08
-      hydro: 0.19912160752322175
-      hydro discharge: 0.05390412143882069
-      nuclear: 0.002858390284467637
-      oil: 7.80146403191001e-05
-      solar: 0.004500349556353111
-      unknown: 0.00013024986156132712
-      wind: 0.07337282052083943
-  - _source: Electricity Maps, 2020 average
-    datetime: '2020-01-01'
-    value:
-      battery discharge: 0.0
-      biomass: 4.645406952969902e-06
-      coal: 0.5734706496087112
-      gas: 0.020694222275304777
-      geothermal: 4.4557609299196044e-08
-      hydro: 0.18292314739157337
-      hydro discharge: 0.1335041018562262
-      nuclear: 0.0008652472757246601
-      oil: 8.672788817618806e-05
-      solar: 0.006476660988832901
-      unknown: 0.0001472371216044963
-      wind: 0.08182929420808369
-  - _source: Electricity Maps, 2021 average
-    datetime: '2021-01-01'
-    value:
-      battery discharge: 1.1646032008790393e-08
-      biomass: 1.5047089285071788e-05
-      coal: 0.6611531269097868
-      gas: 0.02937752917631008
-      geothermal: 3.5437211683890764e-07
-      hydro: 0.17463885493567977
-      hydro discharge: 1.2029935135365874e-05
-      nuclear: 0.003174585210400739
-      oil: 5.671076879651942e-05
-      solar: 0.0077608075889321225
-      unknown: 0.0003080433696485103
-      wind: 0.12350465671685011
+    - _source: Electricity Maps, 2015 average
+      datetime: '2015-01-01'
+      value:
+        battery discharge: 0.0
+        biomass: 0.0
+        coal: 0.2206717959267389
+        gas: 0.01471379089719616
+        geothermal: 0.0
+        hydro: 0.06296408881644881
+        hydro discharge: 0.669613498708566
+        nuclear: 0.0
+        oil: 0.0
+        solar: 0.0016737800965772663
+        unknown: 0.0
+        wind: 0.03036316468062711
+    - _source: Electricity Maps, 2016 average
+      datetime: '2016-01-01'
+      value:
+        battery discharge: 0.0
+        biomass: 0.0
+        coal: 0.22067183986329889
+        gas: 0.014713793826765627
+        geothermal: 0.0
+        hydro: 0.06296410135282869
+        hydro discharge: 0.6696136320310574
+        nuclear: 0.0
+        oil: 0.0
+        solar: 0.001673581276554992
+        unknown: 0.0
+        wind: 0.03036317072604401
+    - _source: Electricity Maps, 2017 average
+      datetime: '2017-01-01'
+      value:
+        battery discharge: 0.0
+        biomass: 1.1554882652213175e-06
+        coal: 0.22117309534990356
+        gas: 0.015133381668101924
+        geothermal: 0.0
+        hydro: 0.06289815496973643
+        hydro discharge: 0.6677432889151635
+        nuclear: 0.00020584033408480135
+        oil: 5.486563363898268e-06
+        solar: 0.0016704008212679005
+        unknown: 6.432516204218729e-06
+        wind: 0.031162823781348256
+    - _source: Electricity Maps, 2018 average
+      datetime: '2018-01-01'
+      value:
+        battery discharge: 0.0
+        biomass: 1.992850084285126e-06
+        coal: 0.3130600221178869
+        gas: 0.07086360311720846
+        geothermal: 1.1004882494821965e-07
+        hydro: 0.08518813207060041
+        hydro discharge: 0.4948411655112337
+        nuclear: 0.001265270138770325
+        oil: 3.9003293959793586e-05
+        solar: 0.0017713050687814054
+        unknown: 4.557362708127615e-05
+        wind: 0.03292386066544561
+    - _source: Electricity Maps, 2019 average
+      datetime: '2019-01-01'
+      value:
+        battery discharge: 0.0
+        biomass: 2.1785827384790743e-06
+        coal: 0.6082642037284738
+        gas: 0.05776796233424209
+        geothermal: 1.9662299083746158e-08
+        hydro: 0.19912160752322175
+        hydro discharge: 0.05390412143882069
+        nuclear: 0.002858390284467637
+        oil: 7.80146403191001e-05
+        solar: 0.004500349556353111
+        unknown: 0.00013024986156132712
+        wind: 0.07337282052083943
+    - _source: Electricity Maps, 2020 average
+      datetime: '2020-01-01'
+      value:
+        battery discharge: 0.0
+        biomass: 4.645406952969902e-06
+        coal: 0.5734706496087112
+        gas: 0.020694222275304777
+        geothermal: 4.4557609299196044e-08
+        hydro: 0.18292314739157337
+        hydro discharge: 0.1335041018562262
+        nuclear: 0.0008652472757246601
+        oil: 8.672788817618806e-05
+        solar: 0.006476660988832901
+        unknown: 0.0001472371216044963
+        wind: 0.08182929420808369
+    - _source: Electricity Maps, 2021 average
+      datetime: '2021-01-01'
+      value:
+        battery discharge: 1.1646032008790393e-08
+        biomass: 1.5047089285071788e-05
+        coal: 0.6611531269097868
+        gas: 0.02937752917631008
+        geothermal: 3.5437211683890764e-07
+        hydro: 0.17463885493567977
+        hydro discharge: 1.2029935135365874e-05
+        nuclear: 0.003174585210400739
+        oil: 5.671076879651942e-05
+        solar: 0.0077608075889321225
+        unknown: 0.0003080433696485103
+        wind: 0.12350465671685011
 parsers:
   consumption: EIA.fetch_consumption
   consumptionForecast: EIA.fetch_consumption_forecast

--- a/config/zones/US-NW-WACM.yaml
+++ b/config/zones/US-NW-WACM.yaml
@@ -1,8 +1,8 @@
 bounding_box:
-  - - -114.55
-    - 35.43059
-  - - -95.95176
-    - 48.07463
+- - -114.55
+  - 35.43059
+- - -95.95176
+  - 48.07463
 capacity:
   battery storage: 8.2
   biomass: 3.2
@@ -18,37 +18,39 @@ capacity:
   wind: 1236.9
 comment: Western Area Power Administration - Rocky Mountain Region
 contributors:
-  - systemcatch
-  - robertahunt
-  - KabelWlan
+- systemcatch
+- robertahunt
+- KabelWlan
 delays:
   consumption: 30
   consumptionForecast: 30
   production: 30
+disclaimer: Data for real-time consumption and generation mix is estimated. Real-time
+  exchanges are not available.
 emissionFactors:
   direct:
     battery discharge:
-      - datetime: '2015-01-01'
-        source: Electricity Maps, 2015 average
-        value: 522.328946727275
-      - datetime: '2016-01-01'
-        source: Electricity Maps, 2016 average
-        value: 600.24085171663
-      - datetime: '2017-01-01'
-        source: Electricity Maps, 2017 average
-        value: 599.9171704894312
-      - datetime: '2018-01-01'
-        source: Electricity Maps, 2018 average
-        value: 636.8362049769621
-      - datetime: '2019-01-01'
-        source: Electricity Maps, 2019 average
-        value: 727.5689224678046
-      - datetime: '2020-01-01'
-        source: Electricity Maps, 2020 average
-        value: 713.3386200996066
-      - datetime: '2021-01-01'
-        source: Electricity Maps, 2021 average
-        value: 745.1015602237039
+    - datetime: '2015-01-01'
+      source: Electricity Maps, 2015 average
+      value: 522.328946727275
+    - datetime: '2016-01-01'
+      source: Electricity Maps, 2016 average
+      value: 600.24085171663
+    - datetime: '2017-01-01'
+      source: Electricity Maps, 2017 average
+      value: 599.9171704894312
+    - datetime: '2018-01-01'
+      source: Electricity Maps, 2018 average
+      value: 636.8362049769621
+    - datetime: '2019-01-01'
+      source: Electricity Maps, 2019 average
+      value: 727.5689224678046
+    - datetime: '2020-01-01'
+      source: Electricity Maps, 2020 average
+      value: 713.3386200996066
+    - datetime: '2021-01-01'
+      source: Electricity Maps, 2021 average
+      value: 745.1015602237039
     coal:
       datetime: '2020-01-01'
       source: eGrid 2020
@@ -58,54 +60,54 @@ emissionFactors:
       source: eGrid 2020
       value: 451.7150314
     hydro discharge:
-      - datetime: '2015-01-01'
-        source: Electricity Maps, 2015 average
-        value: 522.328946727275
-      - datetime: '2016-01-01'
-        source: Electricity Maps, 2016 average
-        value: 600.24085171663
-      - datetime: '2017-01-01'
-        source: Electricity Maps, 2017 average
-        value: 599.9171704894312
-      - datetime: '2018-01-01'
-        source: Electricity Maps, 2018 average
-        value: 636.8362049769621
-      - datetime: '2019-01-01'
-        source: Electricity Maps, 2019 average
-        value: 727.5689224678046
-      - datetime: '2020-01-01'
-        source: Electricity Maps, 2020 average
-        value: 713.3386200996066
-      - datetime: '2021-01-01'
-        source: Electricity Maps, 2021 average
-        value: 745.1015602237039
+    - datetime: '2015-01-01'
+      source: Electricity Maps, 2015 average
+      value: 522.328946727275
+    - datetime: '2016-01-01'
+      source: Electricity Maps, 2016 average
+      value: 600.24085171663
+    - datetime: '2017-01-01'
+      source: Electricity Maps, 2017 average
+      value: 599.9171704894312
+    - datetime: '2018-01-01'
+      source: Electricity Maps, 2018 average
+      value: 636.8362049769621
+    - datetime: '2019-01-01'
+      source: Electricity Maps, 2019 average
+      value: 727.5689224678046
+    - datetime: '2020-01-01'
+      source: Electricity Maps, 2020 average
+      value: 713.3386200996066
+    - datetime: '2021-01-01'
+      source: Electricity Maps, 2021 average
+      value: 745.1015602237039
     oil:
       datetime: '2021-01-01'
       source: eGrid 2020
       value: 953.0188558
   lifecycle:
     battery discharge:
-      - datetime: '2015-01-01'
-        source: Electricity Maps, 2015 average
-        value: 578.8785062604765
-      - datetime: '2016-01-01'
-        source: Electricity Maps, 2016 average
-        value: 647.5129689052843
-      - datetime: '2017-01-01'
-        source: Electricity Maps, 2017 average
-        value: 647.1636603946245
-      - datetime: '2018-01-01'
-        source: Electricity Maps, 2018 average
-        value: 682.9063010555286
-      - datetime: '2019-01-01'
-        source: Electricity Maps, 2019 average
-        value: 754.313794649862
-      - datetime: '2020-01-01'
-        source: Electricity Maps, 2020 average
-        value: 738.5041430582977
-      - datetime: '2021-01-01'
-        source: Electricity Maps, 2021 average
-        value: 766.9391259296401
+    - datetime: '2015-01-01'
+      source: Electricity Maps, 2015 average
+      value: 578.8785062604765
+    - datetime: '2016-01-01'
+      source: Electricity Maps, 2016 average
+      value: 647.5129689052843
+    - datetime: '2017-01-01'
+      source: Electricity Maps, 2017 average
+      value: 647.1636603946245
+    - datetime: '2018-01-01'
+      source: Electricity Maps, 2018 average
+      value: 682.9063010555286
+    - datetime: '2019-01-01'
+      source: Electricity Maps, 2019 average
+      value: 754.313794649862
+    - datetime: '2020-01-01'
+      source: Electricity Maps, 2020 average
+      value: 738.5041430582977
+    - datetime: '2021-01-01'
+      source: Electricity Maps, 2021 average
+      value: 766.9391259296401
     coal:
       datetime: '2020-01-01'
       source: eGrid 2020; Oberschelp, Christopher, et al. "Global emission hotspots
@@ -116,27 +118,27 @@ emissionFactors:
       source: eGrid 2020; IPCC 2014
       value: 571.7150314
     hydro discharge:
-      - datetime: '2015-01-01'
-        source: Electricity Maps, 2015 average
-        value: 578.8785062604765
-      - datetime: '2016-01-01'
-        source: Electricity Maps, 2016 average
-        value: 647.5129689052843
-      - datetime: '2017-01-01'
-        source: Electricity Maps, 2017 average
-        value: 647.1636603946245
-      - datetime: '2018-01-01'
-        source: Electricity Maps, 2018 average
-        value: 682.9063010555286
-      - datetime: '2019-01-01'
-        source: Electricity Maps, 2019 average
-        value: 754.313794649862
-      - datetime: '2020-01-01'
-        source: Electricity Maps, 2020 average
-        value: 738.5041430582977
-      - datetime: '2021-01-01'
-        source: Electricity Maps, 2021 average
-        value: 766.9391259296401
+    - datetime: '2015-01-01'
+      source: Electricity Maps, 2015 average
+      value: 578.8785062604765
+    - datetime: '2016-01-01'
+      source: Electricity Maps, 2016 average
+      value: 647.5129689052843
+    - datetime: '2017-01-01'
+      source: Electricity Maps, 2017 average
+      value: 647.1636603946245
+    - datetime: '2018-01-01'
+      source: Electricity Maps, 2018 average
+      value: 682.9063010555286
+    - datetime: '2019-01-01'
+      source: Electricity Maps, 2019 average
+      value: 754.313794649862
+    - datetime: '2020-01-01'
+      source: Electricity Maps, 2020 average
+      value: 738.5041430582977
+    - datetime: '2021-01-01'
+      source: Electricity Maps, 2021 average
+      value: 766.9391259296401
     oil:
       datetime: '2021-01-01'
       source: eGrid 2020; IPCC 2014
@@ -147,111 +149,111 @@ emissionFactors:
       value: 25.6
 fallbackZoneMixes:
   powerOriginRatios:
-    - _source: Electricity Maps, 2015 average
-      datetime: '2015-01-01'
-      value:
-        battery discharge: 0.0
-        biomass: 0.0
-        coal: 0.2206717959267389
-        gas: 0.01471379089719616
-        geothermal: 0.0
-        hydro: 0.06296408881644881
-        hydro discharge: 0.669613498708566
-        nuclear: 0.0
-        oil: 0.0
-        solar: 0.0016737800965772663
-        unknown: 0.0
-        wind: 0.03036316468062711
-    - _source: Electricity Maps, 2016 average
-      datetime: '2016-01-01'
-      value:
-        battery discharge: 0.0
-        biomass: 0.0
-        coal: 0.22067183986329889
-        gas: 0.014713793826765627
-        geothermal: 0.0
-        hydro: 0.06296410135282869
-        hydro discharge: 0.6696136320310574
-        nuclear: 0.0
-        oil: 0.0
-        solar: 0.001673581276554992
-        unknown: 0.0
-        wind: 0.03036317072604401
-    - _source: Electricity Maps, 2017 average
-      datetime: '2017-01-01'
-      value:
-        battery discharge: 0.0
-        biomass: 1.1554882652213175e-06
-        coal: 0.22117309534990356
-        gas: 0.015133381668101924
-        geothermal: 0.0
-        hydro: 0.06289815496973643
-        hydro discharge: 0.6677432889151635
-        nuclear: 0.00020584033408480135
-        oil: 5.486563363898268e-06
-        solar: 0.0016704008212679005
-        unknown: 6.432516204218729e-06
-        wind: 0.031162823781348256
-    - _source: Electricity Maps, 2018 average
-      datetime: '2018-01-01'
-      value:
-        battery discharge: 0.0
-        biomass: 1.992850084285126e-06
-        coal: 0.3130600221178869
-        gas: 0.07086360311720846
-        geothermal: 1.1004882494821965e-07
-        hydro: 0.08518813207060041
-        hydro discharge: 0.4948411655112337
-        nuclear: 0.001265270138770325
-        oil: 3.9003293959793586e-05
-        solar: 0.0017713050687814054
-        unknown: 4.557362708127615e-05
-        wind: 0.03292386066544561
-    - _source: Electricity Maps, 2019 average
-      datetime: '2019-01-01'
-      value:
-        battery discharge: 0.0
-        biomass: 2.1785827384790743e-06
-        coal: 0.6082642037284738
-        gas: 0.05776796233424209
-        geothermal: 1.9662299083746158e-08
-        hydro: 0.19912160752322175
-        hydro discharge: 0.05390412143882069
-        nuclear: 0.002858390284467637
-        oil: 7.80146403191001e-05
-        solar: 0.004500349556353111
-        unknown: 0.00013024986156132712
-        wind: 0.07337282052083943
-    - _source: Electricity Maps, 2020 average
-      datetime: '2020-01-01'
-      value:
-        battery discharge: 0.0
-        biomass: 4.645406952969902e-06
-        coal: 0.5734706496087112
-        gas: 0.020694222275304777
-        geothermal: 4.4557609299196044e-08
-        hydro: 0.18292314739157337
-        hydro discharge: 0.1335041018562262
-        nuclear: 0.0008652472757246601
-        oil: 8.672788817618806e-05
-        solar: 0.006476660988832901
-        unknown: 0.0001472371216044963
-        wind: 0.08182929420808369
-    - _source: Electricity Maps, 2021 average
-      datetime: '2021-01-01'
-      value:
-        battery discharge: 1.1646032008790393e-08
-        biomass: 1.5047089285071788e-05
-        coal: 0.6611531269097868
-        gas: 0.02937752917631008
-        geothermal: 3.5437211683890764e-07
-        hydro: 0.17463885493567977
-        hydro discharge: 1.2029935135365874e-05
-        nuclear: 0.003174585210400739
-        oil: 5.671076879651942e-05
-        solar: 0.0077608075889321225
-        unknown: 0.0003080433696485103
-        wind: 0.12350465671685011
+  - _source: Electricity Maps, 2015 average
+    datetime: '2015-01-01'
+    value:
+      battery discharge: 0.0
+      biomass: 0.0
+      coal: 0.2206717959267389
+      gas: 0.01471379089719616
+      geothermal: 0.0
+      hydro: 0.06296408881644881
+      hydro discharge: 0.669613498708566
+      nuclear: 0.0
+      oil: 0.0
+      solar: 0.0016737800965772663
+      unknown: 0.0
+      wind: 0.03036316468062711
+  - _source: Electricity Maps, 2016 average
+    datetime: '2016-01-01'
+    value:
+      battery discharge: 0.0
+      biomass: 0.0
+      coal: 0.22067183986329889
+      gas: 0.014713793826765627
+      geothermal: 0.0
+      hydro: 0.06296410135282869
+      hydro discharge: 0.6696136320310574
+      nuclear: 0.0
+      oil: 0.0
+      solar: 0.001673581276554992
+      unknown: 0.0
+      wind: 0.03036317072604401
+  - _source: Electricity Maps, 2017 average
+    datetime: '2017-01-01'
+    value:
+      battery discharge: 0.0
+      biomass: 1.1554882652213175e-06
+      coal: 0.22117309534990356
+      gas: 0.015133381668101924
+      geothermal: 0.0
+      hydro: 0.06289815496973643
+      hydro discharge: 0.6677432889151635
+      nuclear: 0.00020584033408480135
+      oil: 5.486563363898268e-06
+      solar: 0.0016704008212679005
+      unknown: 6.432516204218729e-06
+      wind: 0.031162823781348256
+  - _source: Electricity Maps, 2018 average
+    datetime: '2018-01-01'
+    value:
+      battery discharge: 0.0
+      biomass: 1.992850084285126e-06
+      coal: 0.3130600221178869
+      gas: 0.07086360311720846
+      geothermal: 1.1004882494821965e-07
+      hydro: 0.08518813207060041
+      hydro discharge: 0.4948411655112337
+      nuclear: 0.001265270138770325
+      oil: 3.9003293959793586e-05
+      solar: 0.0017713050687814054
+      unknown: 4.557362708127615e-05
+      wind: 0.03292386066544561
+  - _source: Electricity Maps, 2019 average
+    datetime: '2019-01-01'
+    value:
+      battery discharge: 0.0
+      biomass: 2.1785827384790743e-06
+      coal: 0.6082642037284738
+      gas: 0.05776796233424209
+      geothermal: 1.9662299083746158e-08
+      hydro: 0.19912160752322175
+      hydro discharge: 0.05390412143882069
+      nuclear: 0.002858390284467637
+      oil: 7.80146403191001e-05
+      solar: 0.004500349556353111
+      unknown: 0.00013024986156132712
+      wind: 0.07337282052083943
+  - _source: Electricity Maps, 2020 average
+    datetime: '2020-01-01'
+    value:
+      battery discharge: 0.0
+      biomass: 4.645406952969902e-06
+      coal: 0.5734706496087112
+      gas: 0.020694222275304777
+      geothermal: 4.4557609299196044e-08
+      hydro: 0.18292314739157337
+      hydro discharge: 0.1335041018562262
+      nuclear: 0.0008652472757246601
+      oil: 8.672788817618806e-05
+      solar: 0.006476660988832901
+      unknown: 0.0001472371216044963
+      wind: 0.08182929420808369
+  - _source: Electricity Maps, 2021 average
+    datetime: '2021-01-01'
+    value:
+      battery discharge: 1.1646032008790393e-08
+      biomass: 1.5047089285071788e-05
+      coal: 0.6611531269097868
+      gas: 0.02937752917631008
+      geothermal: 3.5437211683890764e-07
+      hydro: 0.17463885493567977
+      hydro discharge: 1.2029935135365874e-05
+      nuclear: 0.003174585210400739
+      oil: 5.671076879651942e-05
+      solar: 0.0077608075889321225
+      unknown: 0.0003080433696485103
+      wind: 0.12350465671685011
 parsers:
   consumption: EIA.fetch_consumption
   consumptionForecast: EIA.fetch_consumption_forecast

--- a/config/zones/US-NW-WAUW.yaml
+++ b/config/zones/US-NW-WAUW.yaml
@@ -1,8 +1,8 @@
 bounding_box:
-- - -113.348433684
-  - 43.730745552
-- - -102.051328941
-  - 49.1340949710001
+  - - -113.348433684
+    - 43.730745552
+  - - -102.051328941
+    - 49.1340949710001
 capacity:
   battery storage: 0
   biomass: 0
@@ -18,9 +18,9 @@ capacity:
   wind: 77.6
 comment: Western Area Power Administration Ugp West
 contributors:
-- systemcatch
-- robertahunt
-- KabelWlan
+  - systemcatch
+  - robertahunt
+  - KabelWlan
 delays:
   consumption: 30
   consumptionForecast: 30
@@ -30,72 +30,72 @@ disclaimer: Data for real-time consumption and generation mix is estimated. Real
 emissionFactors:
   direct:
     battery discharge:
-    - datetime: '2015-01-01'
-      source: Electricity Maps, 2015 average
-      value: 0.0
-    - datetime: '2016-01-01'
-      source: Electricity Maps, 2016 average
-      value: 0.0
-    - datetime: '2017-01-01'
-      source: Electricity Maps, 2017 average
-      value: 91.81161464621788
-    - datetime: '2018-01-01'
-      source: Electricity Maps, 2018 average
-      value: 417.7480805008109
-    - datetime: '2019-01-01'
-      source: Electricity Maps, 2019 average
-      value: 395.20735394186596
-    - datetime: '2020-01-01'
-      source: Electricity Maps, 2020 average
-      value: 336.5823773479149
-    - datetime: '2021-01-01'
-      source: Electricity Maps, 2021 average
-      value: 320.03251964724365
+      - datetime: '2015-01-01'
+        source: Electricity Maps, 2015 average
+        value: 0.0
+      - datetime: '2016-01-01'
+        source: Electricity Maps, 2016 average
+        value: 0.0
+      - datetime: '2017-01-01'
+        source: Electricity Maps, 2017 average
+        value: 91.81161464621788
+      - datetime: '2018-01-01'
+        source: Electricity Maps, 2018 average
+        value: 417.7480805008109
+      - datetime: '2019-01-01'
+        source: Electricity Maps, 2019 average
+        value: 395.20735394186596
+      - datetime: '2020-01-01'
+        source: Electricity Maps, 2020 average
+        value: 336.5823773479149
+      - datetime: '2021-01-01'
+        source: Electricity Maps, 2021 average
+        value: 320.03251964724365
     hydro discharge:
-    - datetime: '2015-01-01'
-      source: Electricity Maps, 2015 average
-      value: 0.0
-    - datetime: '2016-01-01'
-      source: Electricity Maps, 2016 average
-      value: 0.0
-    - datetime: '2017-01-01'
-      source: Electricity Maps, 2017 average
-      value: 91.81161464621788
-    - datetime: '2018-01-01'
-      source: Electricity Maps, 2018 average
-      value: 417.7480805008109
-    - datetime: '2019-01-01'
-      source: Electricity Maps, 2019 average
-      value: 395.20735394186596
-    - datetime: '2020-01-01'
-      source: Electricity Maps, 2020 average
-      value: 336.5823773479149
-    - datetime: '2021-01-01'
-      source: Electricity Maps, 2021 average
-      value: 320.03251964724365
+      - datetime: '2015-01-01'
+        source: Electricity Maps, 2015 average
+        value: 0.0
+      - datetime: '2016-01-01'
+        source: Electricity Maps, 2016 average
+        value: 0.0
+      - datetime: '2017-01-01'
+        source: Electricity Maps, 2017 average
+        value: 91.81161464621788
+      - datetime: '2018-01-01'
+        source: Electricity Maps, 2018 average
+        value: 417.7480805008109
+      - datetime: '2019-01-01'
+        source: Electricity Maps, 2019 average
+        value: 395.20735394186596
+      - datetime: '2020-01-01'
+        source: Electricity Maps, 2020 average
+        value: 336.5823773479149
+      - datetime: '2021-01-01'
+        source: Electricity Maps, 2021 average
+        value: 320.03251964724365
   lifecycle:
     battery discharge:
-    - datetime: '2015-01-01'
-      source: Electricity Maps, 2015 average
-      value: 23.999999999999996
-    - datetime: '2016-01-01'
-      source: Electricity Maps, 2016 average
-      value: 24.0
-    - datetime: '2017-01-01'
-      source: Electricity Maps, 2017 average
-      value: 118.60457186489754
-    - datetime: '2018-01-01'
-      source: Electricity Maps, 2018 average
-      value: 443.5870690432486
-    - datetime: '2019-01-01'
-      source: Electricity Maps, 2019 average
-      value: 420.80054953499655
-    - datetime: '2020-01-01'
-      source: Electricity Maps, 2020 average
-      value: 363.02739669674816
-    - datetime: '2021-01-01'
-      source: Electricity Maps, 2021 average
-      value: 350.86841690436955
+      - datetime: '2015-01-01'
+        source: Electricity Maps, 2015 average
+        value: 23.999999999999996
+      - datetime: '2016-01-01'
+        source: Electricity Maps, 2016 average
+        value: 24.0
+      - datetime: '2017-01-01'
+        source: Electricity Maps, 2017 average
+        value: 118.60457186489754
+      - datetime: '2018-01-01'
+        source: Electricity Maps, 2018 average
+        value: 443.5870690432486
+      - datetime: '2019-01-01'
+        source: Electricity Maps, 2019 average
+        value: 420.80054953499655
+      - datetime: '2020-01-01'
+        source: Electricity Maps, 2020 average
+        value: 363.02739669674816
+      - datetime: '2021-01-01'
+        source: Electricity Maps, 2021 average
+        value: 350.86841690436955
     coal:
       datetime: '2012-01-01'
       source: IPCC 2014; Oberschelp, Christopher, et al. "Global emission hotspots
@@ -106,123 +106,123 @@ emissionFactors:
       source: IPCC 2014
       value: 490.0
     hydro discharge:
-    - datetime: '2015-01-01'
-      source: Electricity Maps, 2015 average
-      value: 23.999999999999996
-    - datetime: '2016-01-01'
-      source: Electricity Maps, 2016 average
-      value: 24.0
-    - datetime: '2017-01-01'
-      source: Electricity Maps, 2017 average
-      value: 118.60457186489754
-    - datetime: '2018-01-01'
-      source: Electricity Maps, 2018 average
-      value: 443.5870690432486
-    - datetime: '2019-01-01'
-      source: Electricity Maps, 2019 average
-      value: 420.80054953499655
-    - datetime: '2020-01-01'
-      source: Electricity Maps, 2020 average
-      value: 363.02739669674816
-    - datetime: '2021-01-01'
-      source: Electricity Maps, 2021 average
-      value: 350.86841690436955
+      - datetime: '2015-01-01'
+        source: Electricity Maps, 2015 average
+        value: 23.999999999999996
+      - datetime: '2016-01-01'
+        source: Electricity Maps, 2016 average
+        value: 24.0
+      - datetime: '2017-01-01'
+        source: Electricity Maps, 2017 average
+        value: 118.60457186489754
+      - datetime: '2018-01-01'
+        source: Electricity Maps, 2018 average
+        value: 443.5870690432486
+      - datetime: '2019-01-01'
+        source: Electricity Maps, 2019 average
+        value: 420.80054953499655
+      - datetime: '2020-01-01'
+        source: Electricity Maps, 2020 average
+        value: 363.02739669674816
+      - datetime: '2021-01-01'
+        source: Electricity Maps, 2021 average
+        value: 350.86841690436955
     oil:
       datetime: '2014-01-01'
       source: IPCC 2014; EIA 2020/BEIS 2021
       value: 650.0
 fallbackZoneMixes:
   powerOriginRatios:
-  - _source: Electricity Maps, 2015 average
-    datetime: '2015-01-01'
-    value:
-      battery discharge: 0.0
-      biomass: 0.0
-      coal: 0.0
-      gas: 0.0
-      geothermal: 0.0
-      hydro: 1.0
-      hydro discharge: 0.0
-      nuclear: 0.0
-      oil: 0.0
-      solar: 0.0
-      unknown: 0.0
-      wind: 0.0
-  - _source: Electricity Maps, 2016 average
-    datetime: '2016-01-01'
-    value:
-      battery discharge: 0.0
-      biomass: 0.0
-      coal: 0.0
-      gas: 0.0
-      geothermal: 0.0
-      hydro: 1.0
-      hydro discharge: 0.0
-      nuclear: 0.0
-      oil: 0.0
-      solar: 0.0
-      unknown: 0.0
-      wind: 0.0
-  - _source: Electricity Maps, 2018 average
-    datetime: '2018-01-01'
-    value:
-      battery discharge: 0.0
-      biomass: 0.00022912154956575775
-      coal: 0.35698600672013564
-      gas: 0.043489650296816965
-      geothermal: 2.9276327604667432e-05
-      hydro: 0.5094604078132364
-      hydro discharge: 0.019296420822171995
-      nuclear: 0.007327061202225197
-      oil: 0.010875889350624193
-      solar: 0.001275090042275448
-      unknown: 0.0004639215505949063
-      wind: 0.05059770008661282
-  - _source: Electricity Maps, 2019 average
-    datetime: '2019-01-01'
-    value:
-      battery discharge: 0.0
-      biomass: 6.440677135167201e-05
-      coal: 0.3424395029831795
-      gas: 0.05264892610441374
-      geothermal: 2.279668786186678e-06
-      hydro: 0.4882978718188815
-      hydro discharge: 0.0002622354481142482
-      nuclear: 0.011605389333111086
-      oil: 0.009254597332052143
-      solar: 0.0013815037969967206
-      unknown: 0.0008167219833608691
-      wind: 0.09374342450374308
-  - _source: Electricity Maps, 2020 average
-    datetime: '2020-01-01'
-    value:
-      battery discharge: 0.0
-      biomass: 0.00015673310184084098
-      coal: 0.2851784136171661
-      gas: 0.051775186074399716
-      geothermal: 1.1891737620701137e-06
-      hydro: 0.5078761732137984
-      hydro discharge: 0.0012634407929160295
-      nuclear: 0.014053129780165584
-      oil: 0.011281966868367228
-      solar: 0.0019460515675813709
-      unknown: 0.0010438442107265978
-      wind: 0.12606369715374388
-  - _source: Electricity Maps, 2021 average
-    datetime: '2021-01-01'
-    value:
-      battery discharge: 0.0
-      biomass: 0.0001739541570315472
-      coal: 0.26307923818255347
-      gas: 0.0942631368628971
-      geothermal: 6.480080352996378e-07
-      hydro: 0.42025759519418043
-      hydro discharge: 0.0
-      nuclear: 0.027869637583506034
-      oil: 0.004197916054159072
-      solar: 0.0015858676647590429
-      unknown: 0.0014880184514287978
-      wind: 0.18743901224375184
+    - _source: Electricity Maps, 2015 average
+      datetime: '2015-01-01'
+      value:
+        battery discharge: 0.0
+        biomass: 0.0
+        coal: 0.0
+        gas: 0.0
+        geothermal: 0.0
+        hydro: 1.0
+        hydro discharge: 0.0
+        nuclear: 0.0
+        oil: 0.0
+        solar: 0.0
+        unknown: 0.0
+        wind: 0.0
+    - _source: Electricity Maps, 2016 average
+      datetime: '2016-01-01'
+      value:
+        battery discharge: 0.0
+        biomass: 0.0
+        coal: 0.0
+        gas: 0.0
+        geothermal: 0.0
+        hydro: 1.0
+        hydro discharge: 0.0
+        nuclear: 0.0
+        oil: 0.0
+        solar: 0.0
+        unknown: 0.0
+        wind: 0.0
+    - _source: Electricity Maps, 2018 average
+      datetime: '2018-01-01'
+      value:
+        battery discharge: 0.0
+        biomass: 0.00022912154956575775
+        coal: 0.35698600672013564
+        gas: 0.043489650296816965
+        geothermal: 2.9276327604667432e-05
+        hydro: 0.5094604078132364
+        hydro discharge: 0.019296420822171995
+        nuclear: 0.007327061202225197
+        oil: 0.010875889350624193
+        solar: 0.001275090042275448
+        unknown: 0.0004639215505949063
+        wind: 0.05059770008661282
+    - _source: Electricity Maps, 2019 average
+      datetime: '2019-01-01'
+      value:
+        battery discharge: 0.0
+        biomass: 6.440677135167201e-05
+        coal: 0.3424395029831795
+        gas: 0.05264892610441374
+        geothermal: 2.279668786186678e-06
+        hydro: 0.4882978718188815
+        hydro discharge: 0.0002622354481142482
+        nuclear: 0.011605389333111086
+        oil: 0.009254597332052143
+        solar: 0.0013815037969967206
+        unknown: 0.0008167219833608691
+        wind: 0.09374342450374308
+    - _source: Electricity Maps, 2020 average
+      datetime: '2020-01-01'
+      value:
+        battery discharge: 0.0
+        biomass: 0.00015673310184084098
+        coal: 0.2851784136171661
+        gas: 0.051775186074399716
+        geothermal: 1.1891737620701137e-06
+        hydro: 0.5078761732137984
+        hydro discharge: 0.0012634407929160295
+        nuclear: 0.014053129780165584
+        oil: 0.011281966868367228
+        solar: 0.0019460515675813709
+        unknown: 0.0010438442107265978
+        wind: 0.12606369715374388
+    - _source: Electricity Maps, 2021 average
+      datetime: '2021-01-01'
+      value:
+        battery discharge: 0.0
+        biomass: 0.0001739541570315472
+        coal: 0.26307923818255347
+        gas: 0.0942631368628971
+        geothermal: 6.480080352996378e-07
+        hydro: 0.42025759519418043
+        hydro discharge: 0.0
+        nuclear: 0.027869637583506034
+        oil: 0.004197916054159072
+        solar: 0.0015858676647590429
+        unknown: 0.0014880184514287978
+        wind: 0.18743901224375184
 parsers:
   consumption: EIA.fetch_consumption
   consumptionForecast: EIA.fetch_consumption_forecast

--- a/config/zones/US-NW-WAUW.yaml
+++ b/config/zones/US-NW-WAUW.yaml
@@ -1,8 +1,8 @@
 bounding_box:
-  - - -113.348433684
-    - 43.730745552
-  - - -102.051328941
-    - 49.1340949710001
+- - -113.348433684
+  - 43.730745552
+- - -102.051328941
+  - 49.1340949710001
 capacity:
   battery storage: 0
   biomass: 0
@@ -18,82 +18,84 @@ capacity:
   wind: 77.6
 comment: Western Area Power Administration Ugp West
 contributors:
-  - systemcatch
-  - robertahunt
-  - KabelWlan
+- systemcatch
+- robertahunt
+- KabelWlan
 delays:
   consumption: 30
   consumptionForecast: 30
   production: 30
+disclaimer: Data for real-time consumption and generation mix is estimated. Real-time
+  exchanges are not available.
 emissionFactors:
   direct:
     battery discharge:
-      - datetime: '2015-01-01'
-        source: Electricity Maps, 2015 average
-        value: 0.0
-      - datetime: '2016-01-01'
-        source: Electricity Maps, 2016 average
-        value: 0.0
-      - datetime: '2017-01-01'
-        source: Electricity Maps, 2017 average
-        value: 91.81161464621788
-      - datetime: '2018-01-01'
-        source: Electricity Maps, 2018 average
-        value: 417.7480805008109
-      - datetime: '2019-01-01'
-        source: Electricity Maps, 2019 average
-        value: 395.20735394186596
-      - datetime: '2020-01-01'
-        source: Electricity Maps, 2020 average
-        value: 336.5823773479149
-      - datetime: '2021-01-01'
-        source: Electricity Maps, 2021 average
-        value: 320.03251964724365
+    - datetime: '2015-01-01'
+      source: Electricity Maps, 2015 average
+      value: 0.0
+    - datetime: '2016-01-01'
+      source: Electricity Maps, 2016 average
+      value: 0.0
+    - datetime: '2017-01-01'
+      source: Electricity Maps, 2017 average
+      value: 91.81161464621788
+    - datetime: '2018-01-01'
+      source: Electricity Maps, 2018 average
+      value: 417.7480805008109
+    - datetime: '2019-01-01'
+      source: Electricity Maps, 2019 average
+      value: 395.20735394186596
+    - datetime: '2020-01-01'
+      source: Electricity Maps, 2020 average
+      value: 336.5823773479149
+    - datetime: '2021-01-01'
+      source: Electricity Maps, 2021 average
+      value: 320.03251964724365
     hydro discharge:
-      - datetime: '2015-01-01'
-        source: Electricity Maps, 2015 average
-        value: 0.0
-      - datetime: '2016-01-01'
-        source: Electricity Maps, 2016 average
-        value: 0.0
-      - datetime: '2017-01-01'
-        source: Electricity Maps, 2017 average
-        value: 91.81161464621788
-      - datetime: '2018-01-01'
-        source: Electricity Maps, 2018 average
-        value: 417.7480805008109
-      - datetime: '2019-01-01'
-        source: Electricity Maps, 2019 average
-        value: 395.20735394186596
-      - datetime: '2020-01-01'
-        source: Electricity Maps, 2020 average
-        value: 336.5823773479149
-      - datetime: '2021-01-01'
-        source: Electricity Maps, 2021 average
-        value: 320.03251964724365
+    - datetime: '2015-01-01'
+      source: Electricity Maps, 2015 average
+      value: 0.0
+    - datetime: '2016-01-01'
+      source: Electricity Maps, 2016 average
+      value: 0.0
+    - datetime: '2017-01-01'
+      source: Electricity Maps, 2017 average
+      value: 91.81161464621788
+    - datetime: '2018-01-01'
+      source: Electricity Maps, 2018 average
+      value: 417.7480805008109
+    - datetime: '2019-01-01'
+      source: Electricity Maps, 2019 average
+      value: 395.20735394186596
+    - datetime: '2020-01-01'
+      source: Electricity Maps, 2020 average
+      value: 336.5823773479149
+    - datetime: '2021-01-01'
+      source: Electricity Maps, 2021 average
+      value: 320.03251964724365
   lifecycle:
     battery discharge:
-      - datetime: '2015-01-01'
-        source: Electricity Maps, 2015 average
-        value: 23.999999999999996
-      - datetime: '2016-01-01'
-        source: Electricity Maps, 2016 average
-        value: 24.0
-      - datetime: '2017-01-01'
-        source: Electricity Maps, 2017 average
-        value: 118.60457186489754
-      - datetime: '2018-01-01'
-        source: Electricity Maps, 2018 average
-        value: 443.5870690432486
-      - datetime: '2019-01-01'
-        source: Electricity Maps, 2019 average
-        value: 420.80054953499655
-      - datetime: '2020-01-01'
-        source: Electricity Maps, 2020 average
-        value: 363.02739669674816
-      - datetime: '2021-01-01'
-        source: Electricity Maps, 2021 average
-        value: 350.86841690436955
+    - datetime: '2015-01-01'
+      source: Electricity Maps, 2015 average
+      value: 23.999999999999996
+    - datetime: '2016-01-01'
+      source: Electricity Maps, 2016 average
+      value: 24.0
+    - datetime: '2017-01-01'
+      source: Electricity Maps, 2017 average
+      value: 118.60457186489754
+    - datetime: '2018-01-01'
+      source: Electricity Maps, 2018 average
+      value: 443.5870690432486
+    - datetime: '2019-01-01'
+      source: Electricity Maps, 2019 average
+      value: 420.80054953499655
+    - datetime: '2020-01-01'
+      source: Electricity Maps, 2020 average
+      value: 363.02739669674816
+    - datetime: '2021-01-01'
+      source: Electricity Maps, 2021 average
+      value: 350.86841690436955
     coal:
       datetime: '2012-01-01'
       source: IPCC 2014; Oberschelp, Christopher, et al. "Global emission hotspots
@@ -104,123 +106,123 @@ emissionFactors:
       source: IPCC 2014
       value: 490.0
     hydro discharge:
-      - datetime: '2015-01-01'
-        source: Electricity Maps, 2015 average
-        value: 23.999999999999996
-      - datetime: '2016-01-01'
-        source: Electricity Maps, 2016 average
-        value: 24.0
-      - datetime: '2017-01-01'
-        source: Electricity Maps, 2017 average
-        value: 118.60457186489754
-      - datetime: '2018-01-01'
-        source: Electricity Maps, 2018 average
-        value: 443.5870690432486
-      - datetime: '2019-01-01'
-        source: Electricity Maps, 2019 average
-        value: 420.80054953499655
-      - datetime: '2020-01-01'
-        source: Electricity Maps, 2020 average
-        value: 363.02739669674816
-      - datetime: '2021-01-01'
-        source: Electricity Maps, 2021 average
-        value: 350.86841690436955
+    - datetime: '2015-01-01'
+      source: Electricity Maps, 2015 average
+      value: 23.999999999999996
+    - datetime: '2016-01-01'
+      source: Electricity Maps, 2016 average
+      value: 24.0
+    - datetime: '2017-01-01'
+      source: Electricity Maps, 2017 average
+      value: 118.60457186489754
+    - datetime: '2018-01-01'
+      source: Electricity Maps, 2018 average
+      value: 443.5870690432486
+    - datetime: '2019-01-01'
+      source: Electricity Maps, 2019 average
+      value: 420.80054953499655
+    - datetime: '2020-01-01'
+      source: Electricity Maps, 2020 average
+      value: 363.02739669674816
+    - datetime: '2021-01-01'
+      source: Electricity Maps, 2021 average
+      value: 350.86841690436955
     oil:
       datetime: '2014-01-01'
       source: IPCC 2014; EIA 2020/BEIS 2021
       value: 650.0
 fallbackZoneMixes:
   powerOriginRatios:
-    - _source: Electricity Maps, 2015 average
-      datetime: '2015-01-01'
-      value:
-        battery discharge: 0.0
-        biomass: 0.0
-        coal: 0.0
-        gas: 0.0
-        geothermal: 0.0
-        hydro: 1.0
-        hydro discharge: 0.0
-        nuclear: 0.0
-        oil: 0.0
-        solar: 0.0
-        unknown: 0.0
-        wind: 0.0
-    - _source: Electricity Maps, 2016 average
-      datetime: '2016-01-01'
-      value:
-        battery discharge: 0.0
-        biomass: 0.0
-        coal: 0.0
-        gas: 0.0
-        geothermal: 0.0
-        hydro: 1.0
-        hydro discharge: 0.0
-        nuclear: 0.0
-        oil: 0.0
-        solar: 0.0
-        unknown: 0.0
-        wind: 0.0
-    - _source: Electricity Maps, 2018 average
-      datetime: '2018-01-01'
-      value:
-        battery discharge: 0.0
-        biomass: 0.00022912154956575775
-        coal: 0.35698600672013564
-        gas: 0.043489650296816965
-        geothermal: 2.9276327604667432e-05
-        hydro: 0.5094604078132364
-        hydro discharge: 0.019296420822171995
-        nuclear: 0.007327061202225197
-        oil: 0.010875889350624193
-        solar: 0.001275090042275448
-        unknown: 0.0004639215505949063
-        wind: 0.05059770008661282
-    - _source: Electricity Maps, 2019 average
-      datetime: '2019-01-01'
-      value:
-        battery discharge: 0.0
-        biomass: 6.440677135167201e-05
-        coal: 0.3424395029831795
-        gas: 0.05264892610441374
-        geothermal: 2.279668786186678e-06
-        hydro: 0.4882978718188815
-        hydro discharge: 0.0002622354481142482
-        nuclear: 0.011605389333111086
-        oil: 0.009254597332052143
-        solar: 0.0013815037969967206
-        unknown: 0.0008167219833608691
-        wind: 0.09374342450374308
-    - _source: Electricity Maps, 2020 average
-      datetime: '2020-01-01'
-      value:
-        battery discharge: 0.0
-        biomass: 0.00015673310184084098
-        coal: 0.2851784136171661
-        gas: 0.051775186074399716
-        geothermal: 1.1891737620701137e-06
-        hydro: 0.5078761732137984
-        hydro discharge: 0.0012634407929160295
-        nuclear: 0.014053129780165584
-        oil: 0.011281966868367228
-        solar: 0.0019460515675813709
-        unknown: 0.0010438442107265978
-        wind: 0.12606369715374388
-    - _source: Electricity Maps, 2021 average
-      datetime: '2021-01-01'
-      value:
-        battery discharge: 0.0
-        biomass: 0.0001739541570315472
-        coal: 0.26307923818255347
-        gas: 0.0942631368628971
-        geothermal: 6.480080352996378e-07
-        hydro: 0.42025759519418043
-        hydro discharge: 0.0
-        nuclear: 0.027869637583506034
-        oil: 0.004197916054159072
-        solar: 0.0015858676647590429
-        unknown: 0.0014880184514287978
-        wind: 0.18743901224375184
+  - _source: Electricity Maps, 2015 average
+    datetime: '2015-01-01'
+    value:
+      battery discharge: 0.0
+      biomass: 0.0
+      coal: 0.0
+      gas: 0.0
+      geothermal: 0.0
+      hydro: 1.0
+      hydro discharge: 0.0
+      nuclear: 0.0
+      oil: 0.0
+      solar: 0.0
+      unknown: 0.0
+      wind: 0.0
+  - _source: Electricity Maps, 2016 average
+    datetime: '2016-01-01'
+    value:
+      battery discharge: 0.0
+      biomass: 0.0
+      coal: 0.0
+      gas: 0.0
+      geothermal: 0.0
+      hydro: 1.0
+      hydro discharge: 0.0
+      nuclear: 0.0
+      oil: 0.0
+      solar: 0.0
+      unknown: 0.0
+      wind: 0.0
+  - _source: Electricity Maps, 2018 average
+    datetime: '2018-01-01'
+    value:
+      battery discharge: 0.0
+      biomass: 0.00022912154956575775
+      coal: 0.35698600672013564
+      gas: 0.043489650296816965
+      geothermal: 2.9276327604667432e-05
+      hydro: 0.5094604078132364
+      hydro discharge: 0.019296420822171995
+      nuclear: 0.007327061202225197
+      oil: 0.010875889350624193
+      solar: 0.001275090042275448
+      unknown: 0.0004639215505949063
+      wind: 0.05059770008661282
+  - _source: Electricity Maps, 2019 average
+    datetime: '2019-01-01'
+    value:
+      battery discharge: 0.0
+      biomass: 6.440677135167201e-05
+      coal: 0.3424395029831795
+      gas: 0.05264892610441374
+      geothermal: 2.279668786186678e-06
+      hydro: 0.4882978718188815
+      hydro discharge: 0.0002622354481142482
+      nuclear: 0.011605389333111086
+      oil: 0.009254597332052143
+      solar: 0.0013815037969967206
+      unknown: 0.0008167219833608691
+      wind: 0.09374342450374308
+  - _source: Electricity Maps, 2020 average
+    datetime: '2020-01-01'
+    value:
+      battery discharge: 0.0
+      biomass: 0.00015673310184084098
+      coal: 0.2851784136171661
+      gas: 0.051775186074399716
+      geothermal: 1.1891737620701137e-06
+      hydro: 0.5078761732137984
+      hydro discharge: 0.0012634407929160295
+      nuclear: 0.014053129780165584
+      oil: 0.011281966868367228
+      solar: 0.0019460515675813709
+      unknown: 0.0010438442107265978
+      wind: 0.12606369715374388
+  - _source: Electricity Maps, 2021 average
+    datetime: '2021-01-01'
+    value:
+      battery discharge: 0.0
+      biomass: 0.0001739541570315472
+      coal: 0.26307923818255347
+      gas: 0.0942631368628971
+      geothermal: 6.480080352996378e-07
+      hydro: 0.42025759519418043
+      hydro discharge: 0.0
+      nuclear: 0.027869637583506034
+      oil: 0.004197916054159072
+      solar: 0.0015858676647590429
+      unknown: 0.0014880184514287978
+      wind: 0.18743901224375184
 parsers:
   consumption: EIA.fetch_consumption
   consumptionForecast: EIA.fetch_consumption_forecast

--- a/config/zones/US-NW-WWA.yaml
+++ b/config/zones/US-NW-WWA.yaml
@@ -1,8 +1,8 @@
 bounding_box:
-  - - -113.662527277
-    - 48.163057327
-  - - -110.887711776
-    - 49.498921
+- - -113.662527277
+  - 48.163057327
+- - -110.887711776
+  - 49.498921
 capacity:
   battery storage: 0
   biomass: 0
@@ -18,53 +18,55 @@ capacity:
   wind: 189
 comment: Naturener Wind Watch, Llc
 contributors:
-  - systemcatch
-  - robertahunt
-  - KabelWlan
+- systemcatch
+- robertahunt
+- KabelWlan
 delays:
   production: 30
+disclaimer: Data for real-time consumption and generation mix is estimated. Real-time
+  exchanges are not available.
 emissionFactors:
   direct:
     battery discharge:
-      - datetime: '2018-01-01'
-        source: Electricity Maps, 2018 average
-        value: 7.802466429699843
-      - datetime: '2019-01-01'
-        source: Electricity Maps, 2019 average
-        value: 2.6026810985847924
-      - datetime: '2020-01-01'
-        source: Electricity Maps, 2020 average
-        value: 11.606070372560616
-      - datetime: '2021-01-01'
-        source: Electricity Maps, 2021 average
-        value: 6.978356391809629
+    - datetime: '2018-01-01'
+      source: Electricity Maps, 2018 average
+      value: 7.802466429699843
+    - datetime: '2019-01-01'
+      source: Electricity Maps, 2019 average
+      value: 2.6026810985847924
+    - datetime: '2020-01-01'
+      source: Electricity Maps, 2020 average
+      value: 11.606070372560616
+    - datetime: '2021-01-01'
+      source: Electricity Maps, 2021 average
+      value: 6.978356391809629
     hydro discharge:
-      - datetime: '2018-01-01'
-        source: Electricity Maps, 2018 average
-        value: 7.802466429699843
-      - datetime: '2019-01-01'
-        source: Electricity Maps, 2019 average
-        value: 2.6026810985847924
-      - datetime: '2020-01-01'
-        source: Electricity Maps, 2020 average
-        value: 11.606070372560616
-      - datetime: '2021-01-01'
-        source: Electricity Maps, 2021 average
-        value: 6.978356391809629
+    - datetime: '2018-01-01'
+      source: Electricity Maps, 2018 average
+      value: 7.802466429699843
+    - datetime: '2019-01-01'
+      source: Electricity Maps, 2019 average
+      value: 2.6026810985847924
+    - datetime: '2020-01-01'
+      source: Electricity Maps, 2020 average
+      value: 11.606070372560616
+    - datetime: '2021-01-01'
+      source: Electricity Maps, 2021 average
+      value: 6.978356391809629
   lifecycle:
     battery discharge:
-      - datetime: '2018-01-01'
-        source: Electricity Maps, 2018 average
-        value: 15.942928515007898
-      - datetime: '2019-01-01'
-        source: Electricity Maps, 2019 average
-        value: 11.531889541856561
-      - datetime: '2020-01-01'
-        source: Electricity Maps, 2020 average
-        value: 16.11851862803075
-      - datetime: '2021-01-01'
-        source: Electricity Maps, 2021 average
-        value: 11.538837852794687
+    - datetime: '2018-01-01'
+      source: Electricity Maps, 2018 average
+      value: 15.942928515007898
+    - datetime: '2019-01-01'
+      source: Electricity Maps, 2019 average
+      value: 11.531889541856561
+    - datetime: '2020-01-01'
+      source: Electricity Maps, 2020 average
+      value: 16.11851862803075
+    - datetime: '2021-01-01'
+      source: Electricity Maps, 2021 average
+      value: 11.538837852794687
     coal:
       datetime: '2014-01-01'
       source: IPCC 2014
@@ -74,18 +76,18 @@ emissionFactors:
       source: IPCC 2014
       value: 490.0
     hydro discharge:
-      - datetime: '2018-01-01'
-        source: Electricity Maps, 2018 average
-        value: 15.942928515007898
-      - datetime: '2019-01-01'
-        source: Electricity Maps, 2019 average
-        value: 11.531889541856561
-      - datetime: '2020-01-01'
-        source: Electricity Maps, 2020 average
-        value: 16.11851862803075
-      - datetime: '2021-01-01'
-        source: Electricity Maps, 2021 average
-        value: 11.538837852794687
+    - datetime: '2018-01-01'
+      source: Electricity Maps, 2018 average
+      value: 15.942928515007898
+    - datetime: '2019-01-01'
+      source: Electricity Maps, 2019 average
+      value: 11.531889541856561
+    - datetime: '2020-01-01'
+      source: Electricity Maps, 2020 average
+      value: 16.11851862803075
+    - datetime: '2021-01-01'
+      source: Electricity Maps, 2021 average
+      value: 11.538837852794687
     oil:
       datetime: '2014-01-01'
       source: IPCC 2014; EIA 2020/BEIS 2021

--- a/config/zones/US-NW-WWA.yaml
+++ b/config/zones/US-NW-WWA.yaml
@@ -1,8 +1,8 @@
 bounding_box:
-- - -113.662527277
-  - 48.163057327
-- - -110.887711776
-  - 49.498921
+  - - -113.662527277
+    - 48.163057327
+  - - -110.887711776
+    - 49.498921
 capacity:
   battery storage: 0
   biomass: 0
@@ -18,9 +18,9 @@ capacity:
   wind: 189
 comment: Naturener Wind Watch, Llc
 contributors:
-- systemcatch
-- robertahunt
-- KabelWlan
+  - systemcatch
+  - robertahunt
+  - KabelWlan
 delays:
   production: 30
 disclaimer: Data for real-time consumption and generation mix is estimated. Real-time
@@ -28,45 +28,45 @@ disclaimer: Data for real-time consumption and generation mix is estimated. Real
 emissionFactors:
   direct:
     battery discharge:
-    - datetime: '2018-01-01'
-      source: Electricity Maps, 2018 average
-      value: 7.802466429699843
-    - datetime: '2019-01-01'
-      source: Electricity Maps, 2019 average
-      value: 2.6026810985847924
-    - datetime: '2020-01-01'
-      source: Electricity Maps, 2020 average
-      value: 11.606070372560616
-    - datetime: '2021-01-01'
-      source: Electricity Maps, 2021 average
-      value: 6.978356391809629
+      - datetime: '2018-01-01'
+        source: Electricity Maps, 2018 average
+        value: 7.802466429699843
+      - datetime: '2019-01-01'
+        source: Electricity Maps, 2019 average
+        value: 2.6026810985847924
+      - datetime: '2020-01-01'
+        source: Electricity Maps, 2020 average
+        value: 11.606070372560616
+      - datetime: '2021-01-01'
+        source: Electricity Maps, 2021 average
+        value: 6.978356391809629
     hydro discharge:
-    - datetime: '2018-01-01'
-      source: Electricity Maps, 2018 average
-      value: 7.802466429699843
-    - datetime: '2019-01-01'
-      source: Electricity Maps, 2019 average
-      value: 2.6026810985847924
-    - datetime: '2020-01-01'
-      source: Electricity Maps, 2020 average
-      value: 11.606070372560616
-    - datetime: '2021-01-01'
-      source: Electricity Maps, 2021 average
-      value: 6.978356391809629
+      - datetime: '2018-01-01'
+        source: Electricity Maps, 2018 average
+        value: 7.802466429699843
+      - datetime: '2019-01-01'
+        source: Electricity Maps, 2019 average
+        value: 2.6026810985847924
+      - datetime: '2020-01-01'
+        source: Electricity Maps, 2020 average
+        value: 11.606070372560616
+      - datetime: '2021-01-01'
+        source: Electricity Maps, 2021 average
+        value: 6.978356391809629
   lifecycle:
     battery discharge:
-    - datetime: '2018-01-01'
-      source: Electricity Maps, 2018 average
-      value: 15.942928515007898
-    - datetime: '2019-01-01'
-      source: Electricity Maps, 2019 average
-      value: 11.531889541856561
-    - datetime: '2020-01-01'
-      source: Electricity Maps, 2020 average
-      value: 16.11851862803075
-    - datetime: '2021-01-01'
-      source: Electricity Maps, 2021 average
-      value: 11.538837852794687
+      - datetime: '2018-01-01'
+        source: Electricity Maps, 2018 average
+        value: 15.942928515007898
+      - datetime: '2019-01-01'
+        source: Electricity Maps, 2019 average
+        value: 11.531889541856561
+      - datetime: '2020-01-01'
+        source: Electricity Maps, 2020 average
+        value: 16.11851862803075
+      - datetime: '2021-01-01'
+        source: Electricity Maps, 2021 average
+        value: 11.538837852794687
     coal:
       datetime: '2014-01-01'
       source: IPCC 2014
@@ -76,18 +76,18 @@ emissionFactors:
       source: IPCC 2014
       value: 490.0
     hydro discharge:
-    - datetime: '2018-01-01'
-      source: Electricity Maps, 2018 average
-      value: 15.942928515007898
-    - datetime: '2019-01-01'
-      source: Electricity Maps, 2019 average
-      value: 11.531889541856561
-    - datetime: '2020-01-01'
-      source: Electricity Maps, 2020 average
-      value: 16.11851862803075
-    - datetime: '2021-01-01'
-      source: Electricity Maps, 2021 average
-      value: 11.538837852794687
+      - datetime: '2018-01-01'
+        source: Electricity Maps, 2018 average
+        value: 15.942928515007898
+      - datetime: '2019-01-01'
+        source: Electricity Maps, 2019 average
+        value: 11.531889541856561
+      - datetime: '2020-01-01'
+        source: Electricity Maps, 2020 average
+        value: 16.11851862803075
+      - datetime: '2021-01-01'
+        source: Electricity Maps, 2021 average
+        value: 11.538837852794687
     oil:
       datetime: '2014-01-01'
       source: IPCC 2014; EIA 2020/BEIS 2021

--- a/config/zones/US-SE-AEC.yaml
+++ b/config/zones/US-SE-AEC.yaml
@@ -1,8 +1,8 @@
 bounding_box:
-  - - -88.9596785776442
-    - 29.339638675596
-  - - -84.3581394658229
-    - 34.4502982778481
+- - -88.9596785776442
+  - 29.339638675596
+- - -84.3581394658229
+  - 34.4502982778481
 capacity:
   battery storage: 0
   biomass: 4.8
@@ -18,28 +18,30 @@ capacity:
   wind: 0
 comment: Powersouth Energy Cooperative
 contributors:
-  - systemcatch
-  - robertahunt
-  - KabelWlan
+- systemcatch
+- robertahunt
+- KabelWlan
 delays:
   consumption: 30
   consumptionForecast: 30
   production: 30
+disclaimer: Data for real-time consumption and generation mix is estimated. Real-time
+  exchanges are not available.
 emissionFactors:
   direct:
     battery discharge:
-      - datetime: '2018-01-01'
-        source: Electricity Maps, 2018 average
-        value: 637.5461428543931
-      - datetime: '2019-01-01'
-        source: Electricity Maps, 2019 average
-        value: 552.3948407547141
-      - datetime: '2020-01-01'
-        source: Electricity Maps, 2020 average
-        value: 459.2089741767484
-      - datetime: '2021-01-01'
-        source: Electricity Maps, 2021 average
-        value: 401.9975251542462
+    - datetime: '2018-01-01'
+      source: Electricity Maps, 2018 average
+      value: 637.5461428543931
+    - datetime: '2019-01-01'
+      source: Electricity Maps, 2019 average
+      value: 552.3948407547141
+    - datetime: '2020-01-01'
+      source: Electricity Maps, 2020 average
+      value: 459.2089741767484
+    - datetime: '2021-01-01'
+      source: Electricity Maps, 2021 average
+      value: 401.9975251542462
     coal:
       datetime: '2020-01-01'
       source: eGrid 2020
@@ -49,32 +51,32 @@ emissionFactors:
       source: eGrid 2020
       value: 404.1054386
     hydro discharge:
-      - datetime: '2018-01-01'
-        source: Electricity Maps, 2018 average
-        value: 637.5461428543931
-      - datetime: '2019-01-01'
-        source: Electricity Maps, 2019 average
-        value: 552.3948407547141
-      - datetime: '2020-01-01'
-        source: Electricity Maps, 2020 average
-        value: 459.2089741767484
-      - datetime: '2021-01-01'
-        source: Electricity Maps, 2021 average
-        value: 401.9975251542462
+    - datetime: '2018-01-01'
+      source: Electricity Maps, 2018 average
+      value: 637.5461428543931
+    - datetime: '2019-01-01'
+      source: Electricity Maps, 2019 average
+      value: 552.3948407547141
+    - datetime: '2020-01-01'
+      source: Electricity Maps, 2020 average
+      value: 459.2089741767484
+    - datetime: '2021-01-01'
+      source: Electricity Maps, 2021 average
+      value: 401.9975251542462
   lifecycle:
     battery discharge:
-      - datetime: '2018-01-01'
-        source: Electricity Maps, 2018 average
-        value: 755.4345979007286
-      - datetime: '2019-01-01'
-        source: Electricity Maps, 2019 average
-        value: 670.921113609942
-      - datetime: '2020-01-01'
-        source: Electricity Maps, 2020 average
-        value: 578.5336295237561
-      - datetime: '2021-01-01'
-        source: Electricity Maps, 2021 average
-        value: 521.2200312142762
+    - datetime: '2018-01-01'
+      source: Electricity Maps, 2018 average
+      value: 755.4345979007286
+    - datetime: '2019-01-01'
+      source: Electricity Maps, 2019 average
+      value: 670.921113609942
+    - datetime: '2020-01-01'
+      source: Electricity Maps, 2020 average
+      value: 578.5336295237561
+    - datetime: '2021-01-01'
+      source: Electricity Maps, 2021 average
+      value: 521.2200312142762
     coal:
       datetime: '2020-01-01'
       source: eGrid 2020; Oberschelp, Christopher, et al. "Global emission hotspots
@@ -85,84 +87,84 @@ emissionFactors:
       source: eGrid 2020; IPCC 2014
       value: 524.1054386000001
     hydro discharge:
-      - datetime: '2018-01-01'
-        source: Electricity Maps, 2018 average
-        value: 755.4345979007286
-      - datetime: '2019-01-01'
-        source: Electricity Maps, 2019 average
-        value: 670.921113609942
-      - datetime: '2020-01-01'
-        source: Electricity Maps, 2020 average
-        value: 578.5336295237561
-      - datetime: '2021-01-01'
-        source: Electricity Maps, 2021 average
-        value: 521.2200312142762
+    - datetime: '2018-01-01'
+      source: Electricity Maps, 2018 average
+      value: 755.4345979007286
+    - datetime: '2019-01-01'
+      source: Electricity Maps, 2019 average
+      value: 670.921113609942
+    - datetime: '2020-01-01'
+      source: Electricity Maps, 2020 average
+      value: 578.5336295237561
+    - datetime: '2021-01-01'
+      source: Electricity Maps, 2021 average
+      value: 521.2200312142762
     oil:
       datetime: '2014-01-01'
       source: IPCC 2014; EIA 2020/BEIS 2021
       value: 650.0
 fallbackZoneMixes:
   powerOriginRatios:
-    - _source: Electricity Maps, 2018 average
-      datetime: '2018-01-01'
-      value:
-        battery discharge: 0.0
-        biomass: 0.0
-        coal: 0.29474525062092716
-        gas: 0.6970662105457389
-        geothermal: 0.0
-        hydro: 0.0025829374134651254
-        hydro discharge: 0.0008280134712315929
-        nuclear: 0.0
-        oil: 0.0
-        solar: 0.0
-        unknown: 0.004777587948637279
-        wind: 0.0
-    - _source: Electricity Maps, 2019 average
-      datetime: '2019-01-01'
-      value:
-        battery discharge: 0.0
-        biomass: 0.0
-        coal: 0.18734852087481615
-        gas: 0.8026600045354034
-        geothermal: 0.0
-        hydro: 0.003308356720003904
-        hydro discharge: 0.0
-        nuclear: 0.0
-        oil: 0.0
-        solar: 0.0
-        unknown: 0.006683117869776512
-        wind: 0.0
-    - _source: Electricity Maps, 2020 average
-      datetime: '2020-01-01'
-      value:
-        battery discharge: 0.0
-        biomass: 0.0
-        coal: 0.069255336108549
-        gas: 0.9198139987343975
-        geothermal: 0.0
-        hydro: 0.0028750567325007688
-        hydro discharge: 0.0
-        nuclear: 0.0
-        oil: 0.0
-        solar: 0.0
-        unknown: 0.008055608424552687
-        wind: 0.0
-    - _source: Electricity Maps, 2021 average
-      datetime: '2021-01-01'
-      value:
-        battery discharge: 0.0
-        biomass: 0.0
-        coal: 0.0
-        gas: 0.9837240945072053
-        geothermal: 0.0
-        hydro: 0.008503295011414636
-        hydro discharge: 0.0
-        nuclear: 0.0
-        oil: 0.0
-        solar: 0.0
-        unknown: 0.00777261048138002
-        wind: 0.0
+  - _source: Electricity Maps, 2018 average
+    datetime: '2018-01-01'
+    value:
+      battery discharge: 0.0
+      biomass: 0.0
+      coal: 0.29474525062092716
+      gas: 0.6970662105457389
+      geothermal: 0.0
+      hydro: 0.0025829374134651254
+      hydro discharge: 0.0008280134712315929
+      nuclear: 0.0
+      oil: 0.0
+      solar: 0.0
+      unknown: 0.004777587948637279
+      wind: 0.0
+  - _source: Electricity Maps, 2019 average
+    datetime: '2019-01-01'
+    value:
+      battery discharge: 0.0
+      biomass: 0.0
+      coal: 0.18734852087481615
+      gas: 0.8026600045354034
+      geothermal: 0.0
+      hydro: 0.003308356720003904
+      hydro discharge: 0.0
+      nuclear: 0.0
+      oil: 0.0
+      solar: 0.0
+      unknown: 0.006683117869776512
+      wind: 0.0
+  - _source: Electricity Maps, 2020 average
+    datetime: '2020-01-01'
+    value:
+      battery discharge: 0.0
+      biomass: 0.0
+      coal: 0.069255336108549
+      gas: 0.9198139987343975
+      geothermal: 0.0
+      hydro: 0.0028750567325007688
+      hydro discharge: 0.0
+      nuclear: 0.0
+      oil: 0.0
+      solar: 0.0
+      unknown: 0.008055608424552687
+      wind: 0.0
+  - _source: Electricity Maps, 2021 average
+    datetime: '2021-01-01'
+    value:
+      battery discharge: 0.0
+      biomass: 0.0
+      coal: 0.0
+      gas: 0.9837240945072053
+      geothermal: 0.0
+      hydro: 0.008503295011414636
+      hydro discharge: 0.0
+      nuclear: 0.0
+      oil: 0.0
+      solar: 0.0
+      unknown: 0.00777261048138002
+      wind: 0.0
 parsers:
   consumption: EIA.fetch_consumption
   consumptionForecast: EIA.fetch_consumption_forecast

--- a/config/zones/US-SE-AEC.yaml
+++ b/config/zones/US-SE-AEC.yaml
@@ -1,8 +1,8 @@
 bounding_box:
-- - -88.9596785776442
-  - 29.339638675596
-- - -84.3581394658229
-  - 34.4502982778481
+  - - -88.9596785776442
+    - 29.339638675596
+  - - -84.3581394658229
+    - 34.4502982778481
 capacity:
   battery storage: 0
   biomass: 4.8
@@ -18,9 +18,9 @@ capacity:
   wind: 0
 comment: Powersouth Energy Cooperative
 contributors:
-- systemcatch
-- robertahunt
-- KabelWlan
+  - systemcatch
+  - robertahunt
+  - KabelWlan
 delays:
   consumption: 30
   consumptionForecast: 30
@@ -30,18 +30,18 @@ disclaimer: Data for real-time consumption and generation mix is estimated. Real
 emissionFactors:
   direct:
     battery discharge:
-    - datetime: '2018-01-01'
-      source: Electricity Maps, 2018 average
-      value: 637.5461428543931
-    - datetime: '2019-01-01'
-      source: Electricity Maps, 2019 average
-      value: 552.3948407547141
-    - datetime: '2020-01-01'
-      source: Electricity Maps, 2020 average
-      value: 459.2089741767484
-    - datetime: '2021-01-01'
-      source: Electricity Maps, 2021 average
-      value: 401.9975251542462
+      - datetime: '2018-01-01'
+        source: Electricity Maps, 2018 average
+        value: 637.5461428543931
+      - datetime: '2019-01-01'
+        source: Electricity Maps, 2019 average
+        value: 552.3948407547141
+      - datetime: '2020-01-01'
+        source: Electricity Maps, 2020 average
+        value: 459.2089741767484
+      - datetime: '2021-01-01'
+        source: Electricity Maps, 2021 average
+        value: 401.9975251542462
     coal:
       datetime: '2020-01-01'
       source: eGrid 2020
@@ -51,32 +51,32 @@ emissionFactors:
       source: eGrid 2020
       value: 404.1054386
     hydro discharge:
-    - datetime: '2018-01-01'
-      source: Electricity Maps, 2018 average
-      value: 637.5461428543931
-    - datetime: '2019-01-01'
-      source: Electricity Maps, 2019 average
-      value: 552.3948407547141
-    - datetime: '2020-01-01'
-      source: Electricity Maps, 2020 average
-      value: 459.2089741767484
-    - datetime: '2021-01-01'
-      source: Electricity Maps, 2021 average
-      value: 401.9975251542462
+      - datetime: '2018-01-01'
+        source: Electricity Maps, 2018 average
+        value: 637.5461428543931
+      - datetime: '2019-01-01'
+        source: Electricity Maps, 2019 average
+        value: 552.3948407547141
+      - datetime: '2020-01-01'
+        source: Electricity Maps, 2020 average
+        value: 459.2089741767484
+      - datetime: '2021-01-01'
+        source: Electricity Maps, 2021 average
+        value: 401.9975251542462
   lifecycle:
     battery discharge:
-    - datetime: '2018-01-01'
-      source: Electricity Maps, 2018 average
-      value: 755.4345979007286
-    - datetime: '2019-01-01'
-      source: Electricity Maps, 2019 average
-      value: 670.921113609942
-    - datetime: '2020-01-01'
-      source: Electricity Maps, 2020 average
-      value: 578.5336295237561
-    - datetime: '2021-01-01'
-      source: Electricity Maps, 2021 average
-      value: 521.2200312142762
+      - datetime: '2018-01-01'
+        source: Electricity Maps, 2018 average
+        value: 755.4345979007286
+      - datetime: '2019-01-01'
+        source: Electricity Maps, 2019 average
+        value: 670.921113609942
+      - datetime: '2020-01-01'
+        source: Electricity Maps, 2020 average
+        value: 578.5336295237561
+      - datetime: '2021-01-01'
+        source: Electricity Maps, 2021 average
+        value: 521.2200312142762
     coal:
       datetime: '2020-01-01'
       source: eGrid 2020; Oberschelp, Christopher, et al. "Global emission hotspots
@@ -87,84 +87,84 @@ emissionFactors:
       source: eGrid 2020; IPCC 2014
       value: 524.1054386000001
     hydro discharge:
-    - datetime: '2018-01-01'
-      source: Electricity Maps, 2018 average
-      value: 755.4345979007286
-    - datetime: '2019-01-01'
-      source: Electricity Maps, 2019 average
-      value: 670.921113609942
-    - datetime: '2020-01-01'
-      source: Electricity Maps, 2020 average
-      value: 578.5336295237561
-    - datetime: '2021-01-01'
-      source: Electricity Maps, 2021 average
-      value: 521.2200312142762
+      - datetime: '2018-01-01'
+        source: Electricity Maps, 2018 average
+        value: 755.4345979007286
+      - datetime: '2019-01-01'
+        source: Electricity Maps, 2019 average
+        value: 670.921113609942
+      - datetime: '2020-01-01'
+        source: Electricity Maps, 2020 average
+        value: 578.5336295237561
+      - datetime: '2021-01-01'
+        source: Electricity Maps, 2021 average
+        value: 521.2200312142762
     oil:
       datetime: '2014-01-01'
       source: IPCC 2014; EIA 2020/BEIS 2021
       value: 650.0
 fallbackZoneMixes:
   powerOriginRatios:
-  - _source: Electricity Maps, 2018 average
-    datetime: '2018-01-01'
-    value:
-      battery discharge: 0.0
-      biomass: 0.0
-      coal: 0.29474525062092716
-      gas: 0.6970662105457389
-      geothermal: 0.0
-      hydro: 0.0025829374134651254
-      hydro discharge: 0.0008280134712315929
-      nuclear: 0.0
-      oil: 0.0
-      solar: 0.0
-      unknown: 0.004777587948637279
-      wind: 0.0
-  - _source: Electricity Maps, 2019 average
-    datetime: '2019-01-01'
-    value:
-      battery discharge: 0.0
-      biomass: 0.0
-      coal: 0.18734852087481615
-      gas: 0.8026600045354034
-      geothermal: 0.0
-      hydro: 0.003308356720003904
-      hydro discharge: 0.0
-      nuclear: 0.0
-      oil: 0.0
-      solar: 0.0
-      unknown: 0.006683117869776512
-      wind: 0.0
-  - _source: Electricity Maps, 2020 average
-    datetime: '2020-01-01'
-    value:
-      battery discharge: 0.0
-      biomass: 0.0
-      coal: 0.069255336108549
-      gas: 0.9198139987343975
-      geothermal: 0.0
-      hydro: 0.0028750567325007688
-      hydro discharge: 0.0
-      nuclear: 0.0
-      oil: 0.0
-      solar: 0.0
-      unknown: 0.008055608424552687
-      wind: 0.0
-  - _source: Electricity Maps, 2021 average
-    datetime: '2021-01-01'
-    value:
-      battery discharge: 0.0
-      biomass: 0.0
-      coal: 0.0
-      gas: 0.9837240945072053
-      geothermal: 0.0
-      hydro: 0.008503295011414636
-      hydro discharge: 0.0
-      nuclear: 0.0
-      oil: 0.0
-      solar: 0.0
-      unknown: 0.00777261048138002
-      wind: 0.0
+    - _source: Electricity Maps, 2018 average
+      datetime: '2018-01-01'
+      value:
+        battery discharge: 0.0
+        biomass: 0.0
+        coal: 0.29474525062092716
+        gas: 0.6970662105457389
+        geothermal: 0.0
+        hydro: 0.0025829374134651254
+        hydro discharge: 0.0008280134712315929
+        nuclear: 0.0
+        oil: 0.0
+        solar: 0.0
+        unknown: 0.004777587948637279
+        wind: 0.0
+    - _source: Electricity Maps, 2019 average
+      datetime: '2019-01-01'
+      value:
+        battery discharge: 0.0
+        biomass: 0.0
+        coal: 0.18734852087481615
+        gas: 0.8026600045354034
+        geothermal: 0.0
+        hydro: 0.003308356720003904
+        hydro discharge: 0.0
+        nuclear: 0.0
+        oil: 0.0
+        solar: 0.0
+        unknown: 0.006683117869776512
+        wind: 0.0
+    - _source: Electricity Maps, 2020 average
+      datetime: '2020-01-01'
+      value:
+        battery discharge: 0.0
+        biomass: 0.0
+        coal: 0.069255336108549
+        gas: 0.9198139987343975
+        geothermal: 0.0
+        hydro: 0.0028750567325007688
+        hydro discharge: 0.0
+        nuclear: 0.0
+        oil: 0.0
+        solar: 0.0
+        unknown: 0.008055608424552687
+        wind: 0.0
+    - _source: Electricity Maps, 2021 average
+      datetime: '2021-01-01'
+      value:
+        battery discharge: 0.0
+        biomass: 0.0
+        coal: 0.0
+        gas: 0.9837240945072053
+        geothermal: 0.0
+        hydro: 0.008503295011414636
+        hydro discharge: 0.0
+        nuclear: 0.0
+        oil: 0.0
+        solar: 0.0
+        unknown: 0.00777261048138002
+        wind: 0.0
 parsers:
   consumption: EIA.fetch_consumption
   consumptionForecast: EIA.fetch_consumption_forecast

--- a/config/zones/US-SE-SEPA.yaml
+++ b/config/zones/US-SE-SEPA.yaml
@@ -1,8 +1,8 @@
 bounding_box:
-  - - -85.61569
-    - 30.211187
-  - - -83.357543
-    - 33.075117
+- - -85.61569
+  - 30.211187
+- - -83.357543
+  - 33.075117
 capacity:
   battery storage: 0
   biomass: 1.7
@@ -18,53 +18,55 @@ capacity:
   wind: 0
 comment: Southeastern Power Administration
 contributors:
-  - systemcatch
-  - robertahunt
-  - KabelWlan
+- systemcatch
+- robertahunt
+- KabelWlan
 delays:
   production: 30
+disclaimer: Data for real-time consumption and generation mix is estimated. Real-time
+  exchanges are not available.
 emissionFactors:
   direct:
     battery discharge:
-      - datetime: '2018-01-01'
-        source: Electricity Maps, 2018 average
-        value: 39.27545260848999
-      - datetime: '2019-01-01'
-        source: Electricity Maps, 2019 average
-        value: 29.03130733174335
-      - datetime: '2020-01-01'
-        source: Electricity Maps, 2020 average
-        value: 33.929216863681155
-      - datetime: '2021-01-01'
-        source: Electricity Maps, 2021 average
-        value: 15.685873662533016
+    - datetime: '2018-01-01'
+      source: Electricity Maps, 2018 average
+      value: 39.27545260848999
+    - datetime: '2019-01-01'
+      source: Electricity Maps, 2019 average
+      value: 29.03130733174335
+    - datetime: '2020-01-01'
+      source: Electricity Maps, 2020 average
+      value: 33.929216863681155
+    - datetime: '2021-01-01'
+      source: Electricity Maps, 2021 average
+      value: 15.685873662533016
     hydro discharge:
-      - datetime: '2018-01-01'
-        source: Electricity Maps, 2018 average
-        value: 39.27545260848999
-      - datetime: '2019-01-01'
-        source: Electricity Maps, 2019 average
-        value: 29.03130733174335
-      - datetime: '2020-01-01'
-        source: Electricity Maps, 2020 average
-        value: 33.929216863681155
-      - datetime: '2021-01-01'
-        source: Electricity Maps, 2021 average
-        value: 15.685873662533016
+    - datetime: '2018-01-01'
+      source: Electricity Maps, 2018 average
+      value: 39.27545260848999
+    - datetime: '2019-01-01'
+      source: Electricity Maps, 2019 average
+      value: 29.03130733174335
+    - datetime: '2020-01-01'
+      source: Electricity Maps, 2020 average
+      value: 33.929216863681155
+    - datetime: '2021-01-01'
+      source: Electricity Maps, 2021 average
+      value: 15.685873662533016
   lifecycle:
     battery discharge:
-      - datetime: '2018-01-01'
-        source: Electricity Maps, 2018 average
-        value: 54.86135357670589
-      - datetime: '2019-01-01'
-        source: Electricity Maps, 2019 average
-        value: 42.345445480566745
-      - datetime: '2020-01-01'
-        source: Electricity Maps, 2020 average
-        value: 53.856801986217484
-      - datetime: '2021-01-01'
-        source: Electricity Maps, 2021 average
-        value: 21.009397412365136
+    - datetime: '2018-01-01'
+      source: Electricity Maps, 2018 average
+      value: 54.86135357670589
+    - datetime: '2019-01-01'
+      source: Electricity Maps, 2019 average
+      value: 42.345445480566745
+    - datetime: '2020-01-01'
+      source: Electricity Maps, 2020 average
+      value: 53.856801986217484
+    - datetime: '2021-01-01'
+      source: Electricity Maps, 2021 average
+      value: 21.009397412365136
     coal:
       datetime: '2014-01-01'
       source: IPCC 2014
@@ -74,84 +76,84 @@ emissionFactors:
       source: IPCC 2014
       value: 490.0
     hydro discharge:
-      - datetime: '2018-01-01'
-        source: Electricity Maps, 2018 average
-        value: 54.86135357670589
-      - datetime: '2019-01-01'
-        source: Electricity Maps, 2019 average
-        value: 42.345445480566745
-      - datetime: '2020-01-01'
-        source: Electricity Maps, 2020 average
-        value: 53.856801986217484
-      - datetime: '2021-01-01'
-        source: Electricity Maps, 2021 average
-        value: 21.009397412365136
+    - datetime: '2018-01-01'
+      source: Electricity Maps, 2018 average
+      value: 54.86135357670589
+    - datetime: '2019-01-01'
+      source: Electricity Maps, 2019 average
+      value: 42.345445480566745
+    - datetime: '2020-01-01'
+      source: Electricity Maps, 2020 average
+      value: 53.856801986217484
+    - datetime: '2021-01-01'
+      source: Electricity Maps, 2021 average
+      value: 21.009397412365136
     oil:
       datetime: '2014-01-01'
       source: IPCC 2014; EIA 2020/BEIS 2021
       value: 650.0
 fallbackZoneMixes:
   powerOriginRatios:
-    - _source: Electricity Maps, 2018 average
-      datetime: '2018-01-01'
-      value:
-        battery discharge: 0.0
-        biomass: 0.0
-        coal: 0.060453434748225086
-        gas: 0.0568994410925796
-        geothermal: 0.0
-        hydro: 0.8342596031668459
-        hydro discharge: 0.0003168622990732267
-        nuclear: 0.04397099723656268
-        oil: 3.5542602251623856e-06
-        solar: 0.0016444673496770065
-        unknown: 0.002437778231933251
-        wind: 4.79825130396922e-06
-    - _source: Electricity Maps, 2019 average
-      datetime: '2019-01-01'
-      value:
-        battery discharge: 0.0
-        biomass: 0.0
-        coal: 0.04531111347272776
-        gas: 0.05517512863430662
-        geothermal: 0.0
-        hydro: 0.8485255098877937
-        hydro discharge: 0.00041251538740845044
-        nuclear: 0.04466581648467458
-        oil: 1.8154927955932234e-06
-        solar: 0.002554885446832629
-        unknown: 0.003335148826128926
-        wind: 1.0582994588945863e-05
-    - _source: Electricity Maps, 2020 average
-      datetime: '2020-01-01'
-      value:
-        battery discharge: 0.0
-        biomass: 0.0
-        coal: 0.03195456856331742
-        gas: 0.04332817441928475
-        geothermal: 0.0
-        hydro: 0.8672386612618044
-        hydro discharge: 0.0006467838519991542
-        nuclear: 0.05058321223382478
-        oil: 3.5542518299897877e-06
-        solar: 0.00357067337325493
-        unknown: 0.002648502490225808
-        wind: 1.759129703197477e-05
-    - _source: Electricity Maps, 2021 average
-      datetime: '2021-01-01'
-      value:
-        battery discharge: 0.0
-        biomass: 0.0
-        coal: 0.07337740561187013
-        gas: 0.07838695460555312
-        geothermal: 0.0
-        hydro: 0.7011488173938593
-        hydro discharge: 0.00288379609225797
-        nuclear: 0.13393565447333627
-        oil: 1.4690759512266785e-06
-        solar: 0.007555457617158807
-        unknown: 0.0025165271044512998
-        wind: 1.4690759512266785e-05
+  - _source: Electricity Maps, 2018 average
+    datetime: '2018-01-01'
+    value:
+      battery discharge: 0.0
+      biomass: 0.0
+      coal: 0.060453434748225086
+      gas: 0.0568994410925796
+      geothermal: 0.0
+      hydro: 0.8342596031668459
+      hydro discharge: 0.0003168622990732267
+      nuclear: 0.04397099723656268
+      oil: 3.5542602251623856e-06
+      solar: 0.0016444673496770065
+      unknown: 0.002437778231933251
+      wind: 4.79825130396922e-06
+  - _source: Electricity Maps, 2019 average
+    datetime: '2019-01-01'
+    value:
+      battery discharge: 0.0
+      biomass: 0.0
+      coal: 0.04531111347272776
+      gas: 0.05517512863430662
+      geothermal: 0.0
+      hydro: 0.8485255098877937
+      hydro discharge: 0.00041251538740845044
+      nuclear: 0.04466581648467458
+      oil: 1.8154927955932234e-06
+      solar: 0.002554885446832629
+      unknown: 0.003335148826128926
+      wind: 1.0582994588945863e-05
+  - _source: Electricity Maps, 2020 average
+    datetime: '2020-01-01'
+    value:
+      battery discharge: 0.0
+      biomass: 0.0
+      coal: 0.03195456856331742
+      gas: 0.04332817441928475
+      geothermal: 0.0
+      hydro: 0.8672386612618044
+      hydro discharge: 0.0006467838519991542
+      nuclear: 0.05058321223382478
+      oil: 3.5542518299897877e-06
+      solar: 0.00357067337325493
+      unknown: 0.002648502490225808
+      wind: 1.759129703197477e-05
+  - _source: Electricity Maps, 2021 average
+    datetime: '2021-01-01'
+    value:
+      battery discharge: 0.0
+      biomass: 0.0
+      coal: 0.07337740561187013
+      gas: 0.07838695460555312
+      geothermal: 0.0
+      hydro: 0.7011488173938593
+      hydro discharge: 0.00288379609225797
+      nuclear: 0.13393565447333627
+      oil: 1.4690759512266785e-06
+      solar: 0.007555457617158807
+      unknown: 0.0025165271044512998
+      wind: 1.4690759512266785e-05
 parsers:
   production: EIA.fetch_production_mix
 sources:

--- a/config/zones/US-SE-SEPA.yaml
+++ b/config/zones/US-SE-SEPA.yaml
@@ -1,8 +1,8 @@
 bounding_box:
-- - -85.61569
-  - 30.211187
-- - -83.357543
-  - 33.075117
+  - - -85.61569
+    - 30.211187
+  - - -83.357543
+    - 33.075117
 capacity:
   battery storage: 0
   biomass: 1.7
@@ -18,9 +18,9 @@ capacity:
   wind: 0
 comment: Southeastern Power Administration
 contributors:
-- systemcatch
-- robertahunt
-- KabelWlan
+  - systemcatch
+  - robertahunt
+  - KabelWlan
 delays:
   production: 30
 disclaimer: Data for real-time consumption and generation mix is estimated. Real-time
@@ -28,45 +28,45 @@ disclaimer: Data for real-time consumption and generation mix is estimated. Real
 emissionFactors:
   direct:
     battery discharge:
-    - datetime: '2018-01-01'
-      source: Electricity Maps, 2018 average
-      value: 39.27545260848999
-    - datetime: '2019-01-01'
-      source: Electricity Maps, 2019 average
-      value: 29.03130733174335
-    - datetime: '2020-01-01'
-      source: Electricity Maps, 2020 average
-      value: 33.929216863681155
-    - datetime: '2021-01-01'
-      source: Electricity Maps, 2021 average
-      value: 15.685873662533016
+      - datetime: '2018-01-01'
+        source: Electricity Maps, 2018 average
+        value: 39.27545260848999
+      - datetime: '2019-01-01'
+        source: Electricity Maps, 2019 average
+        value: 29.03130733174335
+      - datetime: '2020-01-01'
+        source: Electricity Maps, 2020 average
+        value: 33.929216863681155
+      - datetime: '2021-01-01'
+        source: Electricity Maps, 2021 average
+        value: 15.685873662533016
     hydro discharge:
-    - datetime: '2018-01-01'
-      source: Electricity Maps, 2018 average
-      value: 39.27545260848999
-    - datetime: '2019-01-01'
-      source: Electricity Maps, 2019 average
-      value: 29.03130733174335
-    - datetime: '2020-01-01'
-      source: Electricity Maps, 2020 average
-      value: 33.929216863681155
-    - datetime: '2021-01-01'
-      source: Electricity Maps, 2021 average
-      value: 15.685873662533016
+      - datetime: '2018-01-01'
+        source: Electricity Maps, 2018 average
+        value: 39.27545260848999
+      - datetime: '2019-01-01'
+        source: Electricity Maps, 2019 average
+        value: 29.03130733174335
+      - datetime: '2020-01-01'
+        source: Electricity Maps, 2020 average
+        value: 33.929216863681155
+      - datetime: '2021-01-01'
+        source: Electricity Maps, 2021 average
+        value: 15.685873662533016
   lifecycle:
     battery discharge:
-    - datetime: '2018-01-01'
-      source: Electricity Maps, 2018 average
-      value: 54.86135357670589
-    - datetime: '2019-01-01'
-      source: Electricity Maps, 2019 average
-      value: 42.345445480566745
-    - datetime: '2020-01-01'
-      source: Electricity Maps, 2020 average
-      value: 53.856801986217484
-    - datetime: '2021-01-01'
-      source: Electricity Maps, 2021 average
-      value: 21.009397412365136
+      - datetime: '2018-01-01'
+        source: Electricity Maps, 2018 average
+        value: 54.86135357670589
+      - datetime: '2019-01-01'
+        source: Electricity Maps, 2019 average
+        value: 42.345445480566745
+      - datetime: '2020-01-01'
+        source: Electricity Maps, 2020 average
+        value: 53.856801986217484
+      - datetime: '2021-01-01'
+        source: Electricity Maps, 2021 average
+        value: 21.009397412365136
     coal:
       datetime: '2014-01-01'
       source: IPCC 2014
@@ -76,84 +76,84 @@ emissionFactors:
       source: IPCC 2014
       value: 490.0
     hydro discharge:
-    - datetime: '2018-01-01'
-      source: Electricity Maps, 2018 average
-      value: 54.86135357670589
-    - datetime: '2019-01-01'
-      source: Electricity Maps, 2019 average
-      value: 42.345445480566745
-    - datetime: '2020-01-01'
-      source: Electricity Maps, 2020 average
-      value: 53.856801986217484
-    - datetime: '2021-01-01'
-      source: Electricity Maps, 2021 average
-      value: 21.009397412365136
+      - datetime: '2018-01-01'
+        source: Electricity Maps, 2018 average
+        value: 54.86135357670589
+      - datetime: '2019-01-01'
+        source: Electricity Maps, 2019 average
+        value: 42.345445480566745
+      - datetime: '2020-01-01'
+        source: Electricity Maps, 2020 average
+        value: 53.856801986217484
+      - datetime: '2021-01-01'
+        source: Electricity Maps, 2021 average
+        value: 21.009397412365136
     oil:
       datetime: '2014-01-01'
       source: IPCC 2014; EIA 2020/BEIS 2021
       value: 650.0
 fallbackZoneMixes:
   powerOriginRatios:
-  - _source: Electricity Maps, 2018 average
-    datetime: '2018-01-01'
-    value:
-      battery discharge: 0.0
-      biomass: 0.0
-      coal: 0.060453434748225086
-      gas: 0.0568994410925796
-      geothermal: 0.0
-      hydro: 0.8342596031668459
-      hydro discharge: 0.0003168622990732267
-      nuclear: 0.04397099723656268
-      oil: 3.5542602251623856e-06
-      solar: 0.0016444673496770065
-      unknown: 0.002437778231933251
-      wind: 4.79825130396922e-06
-  - _source: Electricity Maps, 2019 average
-    datetime: '2019-01-01'
-    value:
-      battery discharge: 0.0
-      biomass: 0.0
-      coal: 0.04531111347272776
-      gas: 0.05517512863430662
-      geothermal: 0.0
-      hydro: 0.8485255098877937
-      hydro discharge: 0.00041251538740845044
-      nuclear: 0.04466581648467458
-      oil: 1.8154927955932234e-06
-      solar: 0.002554885446832629
-      unknown: 0.003335148826128926
-      wind: 1.0582994588945863e-05
-  - _source: Electricity Maps, 2020 average
-    datetime: '2020-01-01'
-    value:
-      battery discharge: 0.0
-      biomass: 0.0
-      coal: 0.03195456856331742
-      gas: 0.04332817441928475
-      geothermal: 0.0
-      hydro: 0.8672386612618044
-      hydro discharge: 0.0006467838519991542
-      nuclear: 0.05058321223382478
-      oil: 3.5542518299897877e-06
-      solar: 0.00357067337325493
-      unknown: 0.002648502490225808
-      wind: 1.759129703197477e-05
-  - _source: Electricity Maps, 2021 average
-    datetime: '2021-01-01'
-    value:
-      battery discharge: 0.0
-      biomass: 0.0
-      coal: 0.07337740561187013
-      gas: 0.07838695460555312
-      geothermal: 0.0
-      hydro: 0.7011488173938593
-      hydro discharge: 0.00288379609225797
-      nuclear: 0.13393565447333627
-      oil: 1.4690759512266785e-06
-      solar: 0.007555457617158807
-      unknown: 0.0025165271044512998
-      wind: 1.4690759512266785e-05
+    - _source: Electricity Maps, 2018 average
+      datetime: '2018-01-01'
+      value:
+        battery discharge: 0.0
+        biomass: 0.0
+        coal: 0.060453434748225086
+        gas: 0.0568994410925796
+        geothermal: 0.0
+        hydro: 0.8342596031668459
+        hydro discharge: 0.0003168622990732267
+        nuclear: 0.04397099723656268
+        oil: 3.5542602251623856e-06
+        solar: 0.0016444673496770065
+        unknown: 0.002437778231933251
+        wind: 4.79825130396922e-06
+    - _source: Electricity Maps, 2019 average
+      datetime: '2019-01-01'
+      value:
+        battery discharge: 0.0
+        biomass: 0.0
+        coal: 0.04531111347272776
+        gas: 0.05517512863430662
+        geothermal: 0.0
+        hydro: 0.8485255098877937
+        hydro discharge: 0.00041251538740845044
+        nuclear: 0.04466581648467458
+        oil: 1.8154927955932234e-06
+        solar: 0.002554885446832629
+        unknown: 0.003335148826128926
+        wind: 1.0582994588945863e-05
+    - _source: Electricity Maps, 2020 average
+      datetime: '2020-01-01'
+      value:
+        battery discharge: 0.0
+        biomass: 0.0
+        coal: 0.03195456856331742
+        gas: 0.04332817441928475
+        geothermal: 0.0
+        hydro: 0.8672386612618044
+        hydro discharge: 0.0006467838519991542
+        nuclear: 0.05058321223382478
+        oil: 3.5542518299897877e-06
+        solar: 0.00357067337325493
+        unknown: 0.002648502490225808
+        wind: 1.759129703197477e-05
+    - _source: Electricity Maps, 2021 average
+      datetime: '2021-01-01'
+      value:
+        battery discharge: 0.0
+        biomass: 0.0
+        coal: 0.07337740561187013
+        gas: 0.07838695460555312
+        geothermal: 0.0
+        hydro: 0.7011488173938593
+        hydro discharge: 0.00288379609225797
+        nuclear: 0.13393565447333627
+        oil: 1.4690759512266785e-06
+        solar: 0.007555457617158807
+        unknown: 0.0025165271044512998
+        wind: 1.4690759512266785e-05
 parsers:
   production: EIA.fetch_production_mix
 sources:

--- a/config/zones/US-SE-SOCO.yaml
+++ b/config/zones/US-SE-SOCO.yaml
@@ -1,8 +1,8 @@
 bounding_box:
-- - -90.5406
-  - 29.42398
-- - -80.251429
-  - 35.5013030000001
+  - - -90.5406
+    - 29.42398
+  - - -80.251429
+    - 35.5013030000001
 capacity:
   battery storage: 82.2
   biomass: 1923.2
@@ -18,9 +18,9 @@ capacity:
   wind: 0
 comment: Southern Company Services, Inc. - Trans
 contributors:
-- systemcatch
-- robertahunt
-- KabelWlan
+  - systemcatch
+  - robertahunt
+  - KabelWlan
 delays:
   consumption: 30
   consumptionForecast: 30
@@ -30,27 +30,27 @@ disclaimer: Data for real-time consumption and generation mix is estimated. Real
 emissionFactors:
   direct:
     battery discharge:
-    - datetime: '2015-01-01'
-      source: Electricity Maps, 2015 average
-      value: 356.58538124958676
-    - datetime: '2016-01-01'
-      source: Electricity Maps, 2016 average
-      value: 395.87585698070444
-    - datetime: '2017-01-01'
-      source: Electricity Maps, 2017 average
-      value: 390.4120200382159
-    - datetime: '2018-01-01'
-      source: Electricity Maps, 2018 average
-      value: 430.9875307935109
-    - datetime: '2019-01-01'
-      source: Electricity Maps, 2019 average
-      value: 402.93609098694236
-    - datetime: '2020-01-01'
-      source: Electricity Maps, 2020 average
-      value: 363.30442521652844
-    - datetime: '2021-01-01'
-      source: Electricity Maps, 2021 average
-      value: 385.44064889984975
+      - datetime: '2015-01-01'
+        source: Electricity Maps, 2015 average
+        value: 356.58538124958676
+      - datetime: '2016-01-01'
+        source: Electricity Maps, 2016 average
+        value: 395.87585698070444
+      - datetime: '2017-01-01'
+        source: Electricity Maps, 2017 average
+        value: 390.4120200382159
+      - datetime: '2018-01-01'
+        source: Electricity Maps, 2018 average
+        value: 430.9875307935109
+      - datetime: '2019-01-01'
+        source: Electricity Maps, 2019 average
+        value: 402.93609098694236
+      - datetime: '2020-01-01'
+        source: Electricity Maps, 2020 average
+        value: 363.30442521652844
+      - datetime: '2021-01-01'
+        source: Electricity Maps, 2021 average
+        value: 385.44064889984975
     biomass:
       datetime: '2020-01-01'
       source: eGrid 2020
@@ -64,54 +64,54 @@ emissionFactors:
       source: eGrid 2020
       value: 403.2500634
     hydro discharge:
-    - datetime: '2015-01-01'
-      source: Electricity Maps, 2015 average
-      value: 356.58538124958676
-    - datetime: '2016-01-01'
-      source: Electricity Maps, 2016 average
-      value: 395.87585698070444
-    - datetime: '2017-01-01'
-      source: Electricity Maps, 2017 average
-      value: 390.4120200382159
-    - datetime: '2018-01-01'
-      source: Electricity Maps, 2018 average
-      value: 430.9875307935109
-    - datetime: '2019-01-01'
-      source: Electricity Maps, 2019 average
-      value: 402.93609098694236
-    - datetime: '2020-01-01'
-      source: Electricity Maps, 2020 average
-      value: 363.30442521652844
-    - datetime: '2021-01-01'
-      source: Electricity Maps, 2021 average
-      value: 385.44064889984975
+      - datetime: '2015-01-01'
+        source: Electricity Maps, 2015 average
+        value: 356.58538124958676
+      - datetime: '2016-01-01'
+        source: Electricity Maps, 2016 average
+        value: 395.87585698070444
+      - datetime: '2017-01-01'
+        source: Electricity Maps, 2017 average
+        value: 390.4120200382159
+      - datetime: '2018-01-01'
+        source: Electricity Maps, 2018 average
+        value: 430.9875307935109
+      - datetime: '2019-01-01'
+        source: Electricity Maps, 2019 average
+        value: 402.93609098694236
+      - datetime: '2020-01-01'
+        source: Electricity Maps, 2020 average
+        value: 363.30442521652844
+      - datetime: '2021-01-01'
+        source: Electricity Maps, 2021 average
+        value: 385.44064889984975
     oil:
       datetime: '2021-01-01'
       source: eGrid 2020
       value: 569.2843708
   lifecycle:
     battery discharge:
-    - datetime: '2015-01-01'
-      source: Electricity Maps, 2015 average
-      value: 436.84809804697466
-    - datetime: '2016-01-01'
-      source: Electricity Maps, 2016 average
-      value: 479.48803925651623
-    - datetime: '2017-01-01'
-      source: Electricity Maps, 2017 average
-      value: 472.6838709992727
-    - datetime: '2018-01-01'
-      source: Electricity Maps, 2018 average
-      value: 512.5043417150439
-    - datetime: '2019-01-01'
-      source: Electricity Maps, 2019 average
-      value: 485.3957688187578
-    - datetime: '2020-01-01'
-      source: Electricity Maps, 2020 average
-      value: 445.39577281719005
-    - datetime: '2021-01-01'
-      source: Electricity Maps, 2021 average
-      value: 466.40479434576497
+      - datetime: '2015-01-01'
+        source: Electricity Maps, 2015 average
+        value: 436.84809804697466
+      - datetime: '2016-01-01'
+        source: Electricity Maps, 2016 average
+        value: 479.48803925651623
+      - datetime: '2017-01-01'
+        source: Electricity Maps, 2017 average
+        value: 472.6838709992727
+      - datetime: '2018-01-01'
+        source: Electricity Maps, 2018 average
+        value: 512.5043417150439
+      - datetime: '2019-01-01'
+        source: Electricity Maps, 2019 average
+        value: 485.3957688187578
+      - datetime: '2020-01-01'
+        source: Electricity Maps, 2020 average
+        value: 445.39577281719005
+      - datetime: '2021-01-01'
+        source: Electricity Maps, 2021 average
+        value: 466.40479434576497
     biomass:
       datetime: '2020-01-01'
       source: eGrid 2020
@@ -126,27 +126,27 @@ emissionFactors:
       source: eGrid 2020; IPCC 2014
       value: 523.2500634
     hydro discharge:
-    - datetime: '2015-01-01'
-      source: Electricity Maps, 2015 average
-      value: 436.84809804697466
-    - datetime: '2016-01-01'
-      source: Electricity Maps, 2016 average
-      value: 479.48803925651623
-    - datetime: '2017-01-01'
-      source: Electricity Maps, 2017 average
-      value: 472.6838709992727
-    - datetime: '2018-01-01'
-      source: Electricity Maps, 2018 average
-      value: 512.5043417150439
-    - datetime: '2019-01-01'
-      source: Electricity Maps, 2019 average
-      value: 485.3957688187578
-    - datetime: '2020-01-01'
-      source: Electricity Maps, 2020 average
-      value: 445.39577281719005
-    - datetime: '2021-01-01'
-      source: Electricity Maps, 2021 average
-      value: 466.40479434576497
+      - datetime: '2015-01-01'
+        source: Electricity Maps, 2015 average
+        value: 436.84809804697466
+      - datetime: '2016-01-01'
+        source: Electricity Maps, 2016 average
+        value: 479.48803925651623
+      - datetime: '2017-01-01'
+        source: Electricity Maps, 2017 average
+        value: 472.6838709992727
+      - datetime: '2018-01-01'
+        source: Electricity Maps, 2018 average
+        value: 512.5043417150439
+      - datetime: '2019-01-01'
+        source: Electricity Maps, 2019 average
+        value: 485.3957688187578
+      - datetime: '2020-01-01'
+        source: Electricity Maps, 2020 average
+        value: 445.39577281719005
+      - datetime: '2021-01-01'
+        source: Electricity Maps, 2021 average
+        value: 466.40479434576497
     oil:
       datetime: '2021-01-01'
       source: eGrid 2020; IPCC 2014
@@ -157,111 +157,111 @@ emissionFactors:
       value: 25.6
 fallbackZoneMixes:
   powerOriginRatios:
-  - _source: Electricity Maps, 2015 average
-    datetime: '2015-01-01'
-    value:
-      battery discharge: 0.0
-      biomass: 0.0
-      coal: 0.20991751771719439
-      gas: 0.5170751263531372
-      geothermal: 0.0
-      hydro: 0.04433604659129754
-      hydro discharge: 0.0
-      nuclear: 0.19818868985985666
-      oil: 5.219349322086551e-05
-      solar: 0.020476561670608413
-      unknown: 0.00992882226058571
-      wind: 2.4930033104630298e-05
-  - _source: Electricity Maps, 2016 average
-    datetime: '2016-01-01'
-    value:
-      battery discharge: 0.0
-      biomass: 0.0
-      coal: 0.20991766424731897
-      gas: 0.5170754872905354
-      geothermal: 0.0
-      hydro: 0.04433607753948376
-      hydro discharge: 0.0
-      nuclear: 0.1981888282028293
-      oil: 5.219352965383759e-05
-      solar: 0.020475877945474875
-      unknown: 0.009928829191267714
-      wind: 2.493005050670753e-05
-  - _source: Electricity Maps, 2017 average
-    datetime: '2017-01-01'
-    value:
-      battery discharge: 0.0
-      biomass: 3.449866954240067e-10
-      coal: 0.20780856509947299
-      gas: 0.5057984664953191
-      geothermal: 0.0
-      hydro: 0.05043551825712503
-      hydro discharge: 0.00095009650720131
-      nuclear: 0.2050536570681865
-      oil: 0.00011120051024943249
-      solar: 0.01986985189846094
-      unknown: 0.0097423261300591
-      wind: 0.00024084047312260428
-  - _source: Electricity Maps, 2018 average
-    datetime: '2018-01-01'
-    value:
-      battery discharge: 0.0
-      biomass: 3.7543818872682154e-08
-      coal: 0.27723073621128475
-      gas: 0.4622373251972723
-      geothermal: 0.0
-      hydro: 0.04706900185168267
-      hydro discharge: 0.0005492427808934938
-      nuclear: 0.19721761034932728
-      oil: 0.00010721221717131393
-      solar: 0.009310065048084893
-      unknown: 0.0060981551649378395
-      wind: 0.0001879191406795858
-  - _source: Electricity Maps, 2019 average
-    datetime: '2019-01-01'
-    value:
-      battery discharge: 0.0
-      biomass: 1.5036405086413762e-07
-      coal: 0.22684586127765632
-      gas: 0.4982013597986002
-      geothermal: 0.0
-      hydro: 0.05268095830961946
-      hydro discharge: 0.0003183858324634775
-      nuclear: 0.20178384137151378
-      oil: 5.967129201895421e-05
-      solar: 0.011476226100914361
-      unknown: 0.008449969014584896
-      wind: 0.00019436757655325886
-  - _source: Electricity Maps, 2020 average
-    datetime: '2020-01-01'
-    value:
-      battery discharge: 0.0
-      biomass: 1.5059648548982626e-07
-      coal: 0.16649994128144918
-      gas: 0.5262339353134904
-      geothermal: 0.0
-      hydro: 0.06165667009718391
-      hydro discharge: 0.0003822278267363985
-      nuclear: 0.21362473056680711
-      oil: 2.938386886207628e-05
-      solar: 0.01989544653114018
-      unknown: 0.011508124460414838
-      wind: 0.00018030068535127486
-  - _source: Electricity Maps, 2021 average
-    datetime: '2021-01-01'
-    value:
-      battery discharge: 0.0
-      biomass: 1.6197169371510176e-07
-      coal: 0.2080956584114764
-      gas: 0.49148314652948866
-      geothermal: 0.0
-      hydro: 0.05149190112101555
-      hydro discharge: 0.00033576422771279914
-      nuclear: 0.2136947001302248
-      oil: 2.4946863080674378e-05
-      solar: 0.023465308513822107
-      unknown: 0.011075544332621392
-      wind: 0.00034126769934405204
+    - _source: Electricity Maps, 2015 average
+      datetime: '2015-01-01'
+      value:
+        battery discharge: 0.0
+        biomass: 0.0
+        coal: 0.20991751771719439
+        gas: 0.5170751263531372
+        geothermal: 0.0
+        hydro: 0.04433604659129754
+        hydro discharge: 0.0
+        nuclear: 0.19818868985985666
+        oil: 5.219349322086551e-05
+        solar: 0.020476561670608413
+        unknown: 0.00992882226058571
+        wind: 2.4930033104630298e-05
+    - _source: Electricity Maps, 2016 average
+      datetime: '2016-01-01'
+      value:
+        battery discharge: 0.0
+        biomass: 0.0
+        coal: 0.20991766424731897
+        gas: 0.5170754872905354
+        geothermal: 0.0
+        hydro: 0.04433607753948376
+        hydro discharge: 0.0
+        nuclear: 0.1981888282028293
+        oil: 5.219352965383759e-05
+        solar: 0.020475877945474875
+        unknown: 0.009928829191267714
+        wind: 2.493005050670753e-05
+    - _source: Electricity Maps, 2017 average
+      datetime: '2017-01-01'
+      value:
+        battery discharge: 0.0
+        biomass: 3.449866954240067e-10
+        coal: 0.20780856509947299
+        gas: 0.5057984664953191
+        geothermal: 0.0
+        hydro: 0.05043551825712503
+        hydro discharge: 0.00095009650720131
+        nuclear: 0.2050536570681865
+        oil: 0.00011120051024943249
+        solar: 0.01986985189846094
+        unknown: 0.0097423261300591
+        wind: 0.00024084047312260428
+    - _source: Electricity Maps, 2018 average
+      datetime: '2018-01-01'
+      value:
+        battery discharge: 0.0
+        biomass: 3.7543818872682154e-08
+        coal: 0.27723073621128475
+        gas: 0.4622373251972723
+        geothermal: 0.0
+        hydro: 0.04706900185168267
+        hydro discharge: 0.0005492427808934938
+        nuclear: 0.19721761034932728
+        oil: 0.00010721221717131393
+        solar: 0.009310065048084893
+        unknown: 0.0060981551649378395
+        wind: 0.0001879191406795858
+    - _source: Electricity Maps, 2019 average
+      datetime: '2019-01-01'
+      value:
+        battery discharge: 0.0
+        biomass: 1.5036405086413762e-07
+        coal: 0.22684586127765632
+        gas: 0.4982013597986002
+        geothermal: 0.0
+        hydro: 0.05268095830961946
+        hydro discharge: 0.0003183858324634775
+        nuclear: 0.20178384137151378
+        oil: 5.967129201895421e-05
+        solar: 0.011476226100914361
+        unknown: 0.008449969014584896
+        wind: 0.00019436757655325886
+    - _source: Electricity Maps, 2020 average
+      datetime: '2020-01-01'
+      value:
+        battery discharge: 0.0
+        biomass: 1.5059648548982626e-07
+        coal: 0.16649994128144918
+        gas: 0.5262339353134904
+        geothermal: 0.0
+        hydro: 0.06165667009718391
+        hydro discharge: 0.0003822278267363985
+        nuclear: 0.21362473056680711
+        oil: 2.938386886207628e-05
+        solar: 0.01989544653114018
+        unknown: 0.011508124460414838
+        wind: 0.00018030068535127486
+    - _source: Electricity Maps, 2021 average
+      datetime: '2021-01-01'
+      value:
+        battery discharge: 0.0
+        biomass: 1.6197169371510176e-07
+        coal: 0.2080956584114764
+        gas: 0.49148314652948866
+        geothermal: 0.0
+        hydro: 0.05149190112101555
+        hydro discharge: 0.00033576422771279914
+        nuclear: 0.2136947001302248
+        oil: 2.4946863080674378e-05
+        solar: 0.023465308513822107
+        unknown: 0.011075544332621392
+        wind: 0.00034126769934405204
 parsers:
   consumption: EIA.fetch_consumption
   consumptionForecast: EIA.fetch_consumption_forecast

--- a/config/zones/US-SE-SOCO.yaml
+++ b/config/zones/US-SE-SOCO.yaml
@@ -1,8 +1,8 @@
 bounding_box:
-  - - -90.5406
-    - 29.42398
-  - - -80.251429
-    - 35.5013030000001
+- - -90.5406
+  - 29.42398
+- - -80.251429
+  - 35.5013030000001
 capacity:
   battery storage: 82.2
   biomass: 1923.2
@@ -18,37 +18,39 @@ capacity:
   wind: 0
 comment: Southern Company Services, Inc. - Trans
 contributors:
-  - systemcatch
-  - robertahunt
-  - KabelWlan
+- systemcatch
+- robertahunt
+- KabelWlan
 delays:
   consumption: 30
   consumptionForecast: 30
   production: 30
+disclaimer: Data for real-time consumption and generation mix is estimated. Real-time
+  exchanges are not available.
 emissionFactors:
   direct:
     battery discharge:
-      - datetime: '2015-01-01'
-        source: Electricity Maps, 2015 average
-        value: 356.58538124958676
-      - datetime: '2016-01-01'
-        source: Electricity Maps, 2016 average
-        value: 395.87585698070444
-      - datetime: '2017-01-01'
-        source: Electricity Maps, 2017 average
-        value: 390.4120200382159
-      - datetime: '2018-01-01'
-        source: Electricity Maps, 2018 average
-        value: 430.9875307935109
-      - datetime: '2019-01-01'
-        source: Electricity Maps, 2019 average
-        value: 402.93609098694236
-      - datetime: '2020-01-01'
-        source: Electricity Maps, 2020 average
-        value: 363.30442521652844
-      - datetime: '2021-01-01'
-        source: Electricity Maps, 2021 average
-        value: 385.44064889984975
+    - datetime: '2015-01-01'
+      source: Electricity Maps, 2015 average
+      value: 356.58538124958676
+    - datetime: '2016-01-01'
+      source: Electricity Maps, 2016 average
+      value: 395.87585698070444
+    - datetime: '2017-01-01'
+      source: Electricity Maps, 2017 average
+      value: 390.4120200382159
+    - datetime: '2018-01-01'
+      source: Electricity Maps, 2018 average
+      value: 430.9875307935109
+    - datetime: '2019-01-01'
+      source: Electricity Maps, 2019 average
+      value: 402.93609098694236
+    - datetime: '2020-01-01'
+      source: Electricity Maps, 2020 average
+      value: 363.30442521652844
+    - datetime: '2021-01-01'
+      source: Electricity Maps, 2021 average
+      value: 385.44064889984975
     biomass:
       datetime: '2020-01-01'
       source: eGrid 2020
@@ -62,54 +64,54 @@ emissionFactors:
       source: eGrid 2020
       value: 403.2500634
     hydro discharge:
-      - datetime: '2015-01-01'
-        source: Electricity Maps, 2015 average
-        value: 356.58538124958676
-      - datetime: '2016-01-01'
-        source: Electricity Maps, 2016 average
-        value: 395.87585698070444
-      - datetime: '2017-01-01'
-        source: Electricity Maps, 2017 average
-        value: 390.4120200382159
-      - datetime: '2018-01-01'
-        source: Electricity Maps, 2018 average
-        value: 430.9875307935109
-      - datetime: '2019-01-01'
-        source: Electricity Maps, 2019 average
-        value: 402.93609098694236
-      - datetime: '2020-01-01'
-        source: Electricity Maps, 2020 average
-        value: 363.30442521652844
-      - datetime: '2021-01-01'
-        source: Electricity Maps, 2021 average
-        value: 385.44064889984975
+    - datetime: '2015-01-01'
+      source: Electricity Maps, 2015 average
+      value: 356.58538124958676
+    - datetime: '2016-01-01'
+      source: Electricity Maps, 2016 average
+      value: 395.87585698070444
+    - datetime: '2017-01-01'
+      source: Electricity Maps, 2017 average
+      value: 390.4120200382159
+    - datetime: '2018-01-01'
+      source: Electricity Maps, 2018 average
+      value: 430.9875307935109
+    - datetime: '2019-01-01'
+      source: Electricity Maps, 2019 average
+      value: 402.93609098694236
+    - datetime: '2020-01-01'
+      source: Electricity Maps, 2020 average
+      value: 363.30442521652844
+    - datetime: '2021-01-01'
+      source: Electricity Maps, 2021 average
+      value: 385.44064889984975
     oil:
       datetime: '2021-01-01'
       source: eGrid 2020
       value: 569.2843708
   lifecycle:
     battery discharge:
-      - datetime: '2015-01-01'
-        source: Electricity Maps, 2015 average
-        value: 436.84809804697466
-      - datetime: '2016-01-01'
-        source: Electricity Maps, 2016 average
-        value: 479.48803925651623
-      - datetime: '2017-01-01'
-        source: Electricity Maps, 2017 average
-        value: 472.6838709992727
-      - datetime: '2018-01-01'
-        source: Electricity Maps, 2018 average
-        value: 512.5043417150439
-      - datetime: '2019-01-01'
-        source: Electricity Maps, 2019 average
-        value: 485.3957688187578
-      - datetime: '2020-01-01'
-        source: Electricity Maps, 2020 average
-        value: 445.39577281719005
-      - datetime: '2021-01-01'
-        source: Electricity Maps, 2021 average
-        value: 466.40479434576497
+    - datetime: '2015-01-01'
+      source: Electricity Maps, 2015 average
+      value: 436.84809804697466
+    - datetime: '2016-01-01'
+      source: Electricity Maps, 2016 average
+      value: 479.48803925651623
+    - datetime: '2017-01-01'
+      source: Electricity Maps, 2017 average
+      value: 472.6838709992727
+    - datetime: '2018-01-01'
+      source: Electricity Maps, 2018 average
+      value: 512.5043417150439
+    - datetime: '2019-01-01'
+      source: Electricity Maps, 2019 average
+      value: 485.3957688187578
+    - datetime: '2020-01-01'
+      source: Electricity Maps, 2020 average
+      value: 445.39577281719005
+    - datetime: '2021-01-01'
+      source: Electricity Maps, 2021 average
+      value: 466.40479434576497
     biomass:
       datetime: '2020-01-01'
       source: eGrid 2020
@@ -124,27 +126,27 @@ emissionFactors:
       source: eGrid 2020; IPCC 2014
       value: 523.2500634
     hydro discharge:
-      - datetime: '2015-01-01'
-        source: Electricity Maps, 2015 average
-        value: 436.84809804697466
-      - datetime: '2016-01-01'
-        source: Electricity Maps, 2016 average
-        value: 479.48803925651623
-      - datetime: '2017-01-01'
-        source: Electricity Maps, 2017 average
-        value: 472.6838709992727
-      - datetime: '2018-01-01'
-        source: Electricity Maps, 2018 average
-        value: 512.5043417150439
-      - datetime: '2019-01-01'
-        source: Electricity Maps, 2019 average
-        value: 485.3957688187578
-      - datetime: '2020-01-01'
-        source: Electricity Maps, 2020 average
-        value: 445.39577281719005
-      - datetime: '2021-01-01'
-        source: Electricity Maps, 2021 average
-        value: 466.40479434576497
+    - datetime: '2015-01-01'
+      source: Electricity Maps, 2015 average
+      value: 436.84809804697466
+    - datetime: '2016-01-01'
+      source: Electricity Maps, 2016 average
+      value: 479.48803925651623
+    - datetime: '2017-01-01'
+      source: Electricity Maps, 2017 average
+      value: 472.6838709992727
+    - datetime: '2018-01-01'
+      source: Electricity Maps, 2018 average
+      value: 512.5043417150439
+    - datetime: '2019-01-01'
+      source: Electricity Maps, 2019 average
+      value: 485.3957688187578
+    - datetime: '2020-01-01'
+      source: Electricity Maps, 2020 average
+      value: 445.39577281719005
+    - datetime: '2021-01-01'
+      source: Electricity Maps, 2021 average
+      value: 466.40479434576497
     oil:
       datetime: '2021-01-01'
       source: eGrid 2020; IPCC 2014
@@ -155,111 +157,111 @@ emissionFactors:
       value: 25.6
 fallbackZoneMixes:
   powerOriginRatios:
-    - _source: Electricity Maps, 2015 average
-      datetime: '2015-01-01'
-      value:
-        battery discharge: 0.0
-        biomass: 0.0
-        coal: 0.20991751771719439
-        gas: 0.5170751263531372
-        geothermal: 0.0
-        hydro: 0.04433604659129754
-        hydro discharge: 0.0
-        nuclear: 0.19818868985985666
-        oil: 5.219349322086551e-05
-        solar: 0.020476561670608413
-        unknown: 0.00992882226058571
-        wind: 2.4930033104630298e-05
-    - _source: Electricity Maps, 2016 average
-      datetime: '2016-01-01'
-      value:
-        battery discharge: 0.0
-        biomass: 0.0
-        coal: 0.20991766424731897
-        gas: 0.5170754872905354
-        geothermal: 0.0
-        hydro: 0.04433607753948376
-        hydro discharge: 0.0
-        nuclear: 0.1981888282028293
-        oil: 5.219352965383759e-05
-        solar: 0.020475877945474875
-        unknown: 0.009928829191267714
-        wind: 2.493005050670753e-05
-    - _source: Electricity Maps, 2017 average
-      datetime: '2017-01-01'
-      value:
-        battery discharge: 0.0
-        biomass: 3.449866954240067e-10
-        coal: 0.20780856509947299
-        gas: 0.5057984664953191
-        geothermal: 0.0
-        hydro: 0.05043551825712503
-        hydro discharge: 0.00095009650720131
-        nuclear: 0.2050536570681865
-        oil: 0.00011120051024943249
-        solar: 0.01986985189846094
-        unknown: 0.0097423261300591
-        wind: 0.00024084047312260428
-    - _source: Electricity Maps, 2018 average
-      datetime: '2018-01-01'
-      value:
-        battery discharge: 0.0
-        biomass: 3.7543818872682154e-08
-        coal: 0.27723073621128475
-        gas: 0.4622373251972723
-        geothermal: 0.0
-        hydro: 0.04706900185168267
-        hydro discharge: 0.0005492427808934938
-        nuclear: 0.19721761034932728
-        oil: 0.00010721221717131393
-        solar: 0.009310065048084893
-        unknown: 0.0060981551649378395
-        wind: 0.0001879191406795858
-    - _source: Electricity Maps, 2019 average
-      datetime: '2019-01-01'
-      value:
-        battery discharge: 0.0
-        biomass: 1.5036405086413762e-07
-        coal: 0.22684586127765632
-        gas: 0.4982013597986002
-        geothermal: 0.0
-        hydro: 0.05268095830961946
-        hydro discharge: 0.0003183858324634775
-        nuclear: 0.20178384137151378
-        oil: 5.967129201895421e-05
-        solar: 0.011476226100914361
-        unknown: 0.008449969014584896
-        wind: 0.00019436757655325886
-    - _source: Electricity Maps, 2020 average
-      datetime: '2020-01-01'
-      value:
-        battery discharge: 0.0
-        biomass: 1.5059648548982626e-07
-        coal: 0.16649994128144918
-        gas: 0.5262339353134904
-        geothermal: 0.0
-        hydro: 0.06165667009718391
-        hydro discharge: 0.0003822278267363985
-        nuclear: 0.21362473056680711
-        oil: 2.938386886207628e-05
-        solar: 0.01989544653114018
-        unknown: 0.011508124460414838
-        wind: 0.00018030068535127486
-    - _source: Electricity Maps, 2021 average
-      datetime: '2021-01-01'
-      value:
-        battery discharge: 0.0
-        biomass: 1.6197169371510176e-07
-        coal: 0.2080956584114764
-        gas: 0.49148314652948866
-        geothermal: 0.0
-        hydro: 0.05149190112101555
-        hydro discharge: 0.00033576422771279914
-        nuclear: 0.2136947001302248
-        oil: 2.4946863080674378e-05
-        solar: 0.023465308513822107
-        unknown: 0.011075544332621392
-        wind: 0.00034126769934405204
+  - _source: Electricity Maps, 2015 average
+    datetime: '2015-01-01'
+    value:
+      battery discharge: 0.0
+      biomass: 0.0
+      coal: 0.20991751771719439
+      gas: 0.5170751263531372
+      geothermal: 0.0
+      hydro: 0.04433604659129754
+      hydro discharge: 0.0
+      nuclear: 0.19818868985985666
+      oil: 5.219349322086551e-05
+      solar: 0.020476561670608413
+      unknown: 0.00992882226058571
+      wind: 2.4930033104630298e-05
+  - _source: Electricity Maps, 2016 average
+    datetime: '2016-01-01'
+    value:
+      battery discharge: 0.0
+      biomass: 0.0
+      coal: 0.20991766424731897
+      gas: 0.5170754872905354
+      geothermal: 0.0
+      hydro: 0.04433607753948376
+      hydro discharge: 0.0
+      nuclear: 0.1981888282028293
+      oil: 5.219352965383759e-05
+      solar: 0.020475877945474875
+      unknown: 0.009928829191267714
+      wind: 2.493005050670753e-05
+  - _source: Electricity Maps, 2017 average
+    datetime: '2017-01-01'
+    value:
+      battery discharge: 0.0
+      biomass: 3.449866954240067e-10
+      coal: 0.20780856509947299
+      gas: 0.5057984664953191
+      geothermal: 0.0
+      hydro: 0.05043551825712503
+      hydro discharge: 0.00095009650720131
+      nuclear: 0.2050536570681865
+      oil: 0.00011120051024943249
+      solar: 0.01986985189846094
+      unknown: 0.0097423261300591
+      wind: 0.00024084047312260428
+  - _source: Electricity Maps, 2018 average
+    datetime: '2018-01-01'
+    value:
+      battery discharge: 0.0
+      biomass: 3.7543818872682154e-08
+      coal: 0.27723073621128475
+      gas: 0.4622373251972723
+      geothermal: 0.0
+      hydro: 0.04706900185168267
+      hydro discharge: 0.0005492427808934938
+      nuclear: 0.19721761034932728
+      oil: 0.00010721221717131393
+      solar: 0.009310065048084893
+      unknown: 0.0060981551649378395
+      wind: 0.0001879191406795858
+  - _source: Electricity Maps, 2019 average
+    datetime: '2019-01-01'
+    value:
+      battery discharge: 0.0
+      biomass: 1.5036405086413762e-07
+      coal: 0.22684586127765632
+      gas: 0.4982013597986002
+      geothermal: 0.0
+      hydro: 0.05268095830961946
+      hydro discharge: 0.0003183858324634775
+      nuclear: 0.20178384137151378
+      oil: 5.967129201895421e-05
+      solar: 0.011476226100914361
+      unknown: 0.008449969014584896
+      wind: 0.00019436757655325886
+  - _source: Electricity Maps, 2020 average
+    datetime: '2020-01-01'
+    value:
+      battery discharge: 0.0
+      biomass: 1.5059648548982626e-07
+      coal: 0.16649994128144918
+      gas: 0.5262339353134904
+      geothermal: 0.0
+      hydro: 0.06165667009718391
+      hydro discharge: 0.0003822278267363985
+      nuclear: 0.21362473056680711
+      oil: 2.938386886207628e-05
+      solar: 0.01989544653114018
+      unknown: 0.011508124460414838
+      wind: 0.00018030068535127486
+  - _source: Electricity Maps, 2021 average
+    datetime: '2021-01-01'
+    value:
+      battery discharge: 0.0
+      biomass: 1.6197169371510176e-07
+      coal: 0.2080956584114764
+      gas: 0.49148314652948866
+      geothermal: 0.0
+      hydro: 0.05149190112101555
+      hydro discharge: 0.00033576422771279914
+      nuclear: 0.2136947001302248
+      oil: 2.4946863080674378e-05
+      solar: 0.023465308513822107
+      unknown: 0.011075544332621392
+      wind: 0.00034126769934405204
 parsers:
   consumption: EIA.fetch_consumption
   consumptionForecast: EIA.fetch_consumption_forecast

--- a/config/zones/US-SW-AZPS.yaml
+++ b/config/zones/US-SW-AZPS.yaml
@@ -1,8 +1,8 @@
 bounding_box:
-  - - -115.31829
-    - 30.8336654
-  - - -108.777145881
-    - 36.784585904
+- - -115.31829
+  - 30.8336654
+- - -108.777145881
+  - 36.784585904
 capacity:
   battery storage: 200
   biomass: 33.4
@@ -18,37 +18,39 @@ capacity:
   wind: 557.5
 comment: Arizona Public Service Company
 contributors:
-  - systemcatch
-  - robertahunt
-  - KabelWlan
+- systemcatch
+- robertahunt
+- KabelWlan
 delays:
   consumption: 30
   consumptionForecast: 30
   production: 30
+disclaimer: Data for real-time consumption and generation mix is estimated. Real-time
+  exchanges are not available.
 emissionFactors:
   direct:
     battery discharge:
-      - datetime: '2015-01-01'
-        source: Electricity Maps, 2015 average
-        value: 287.4394383608348
-      - datetime: '2016-01-01'
-        source: Electricity Maps, 2016 average
-        value: 358.99917192529836
-      - datetime: '2017-01-01'
-        source: Electricity Maps, 2017 average
-        value: 358.7864539742484
-      - datetime: '2018-01-01'
-        source: Electricity Maps, 2018 average
-        value: 333.39391247326176
-      - datetime: '2019-01-01'
-        source: Electricity Maps, 2019 average
-        value: 295.81849021123355
-      - datetime: '2020-01-01'
-        source: Electricity Maps, 2020 average
-        value: 433.19170627807307
-      - datetime: '2021-01-01'
-        source: Electricity Maps, 2021 average
-        value: 394.89508781910087
+    - datetime: '2015-01-01'
+      source: Electricity Maps, 2015 average
+      value: 287.4394383608348
+    - datetime: '2016-01-01'
+      source: Electricity Maps, 2016 average
+      value: 358.99917192529836
+    - datetime: '2017-01-01'
+      source: Electricity Maps, 2017 average
+      value: 358.7864539742484
+    - datetime: '2018-01-01'
+      source: Electricity Maps, 2018 average
+      value: 333.39391247326176
+    - datetime: '2019-01-01'
+      source: Electricity Maps, 2019 average
+      value: 295.81849021123355
+    - datetime: '2020-01-01'
+      source: Electricity Maps, 2020 average
+      value: 433.19170627807307
+    - datetime: '2021-01-01'
+      source: Electricity Maps, 2021 average
+      value: 394.89508781910087
     biomass:
       datetime: '2020-01-01'
       source: eGrid 2020
@@ -62,50 +64,50 @@ emissionFactors:
       source: eGrid 2020
       value: 371.3656203
     hydro discharge:
-      - datetime: '2015-01-01'
-        source: Electricity Maps, 2015 average
-        value: 287.4394383608348
-      - datetime: '2016-01-01'
-        source: Electricity Maps, 2016 average
-        value: 358.99917192529836
-      - datetime: '2017-01-01'
-        source: Electricity Maps, 2017 average
-        value: 358.7864539742484
-      - datetime: '2018-01-01'
-        source: Electricity Maps, 2018 average
-        value: 333.39391247326176
-      - datetime: '2019-01-01'
-        source: Electricity Maps, 2019 average
-        value: 295.81849021123355
-      - datetime: '2020-01-01'
-        source: Electricity Maps, 2020 average
-        value: 433.19170627807307
-      - datetime: '2021-01-01'
-        source: Electricity Maps, 2021 average
-        value: 394.89508781910087
+    - datetime: '2015-01-01'
+      source: Electricity Maps, 2015 average
+      value: 287.4394383608348
+    - datetime: '2016-01-01'
+      source: Electricity Maps, 2016 average
+      value: 358.99917192529836
+    - datetime: '2017-01-01'
+      source: Electricity Maps, 2017 average
+      value: 358.7864539742484
+    - datetime: '2018-01-01'
+      source: Electricity Maps, 2018 average
+      value: 333.39391247326176
+    - datetime: '2019-01-01'
+      source: Electricity Maps, 2019 average
+      value: 295.81849021123355
+    - datetime: '2020-01-01'
+      source: Electricity Maps, 2020 average
+      value: 433.19170627807307
+    - datetime: '2021-01-01'
+      source: Electricity Maps, 2021 average
+      value: 394.89508781910087
   lifecycle:
     battery discharge:
-      - datetime: '2015-01-01'
-        source: Electricity Maps, 2015 average
-        value: 342.4822573202384
-      - datetime: '2016-01-01'
-        source: Electricity Maps, 2016 average
-        value: 402.78963651897595
-      - datetime: '2017-01-01'
-        source: Electricity Maps, 2017 average
-        value: 402.59777898407856
-      - datetime: '2018-01-01'
-        source: Electricity Maps, 2018 average
-        value: 369.57115985375964
-      - datetime: '2019-01-01'
-        source: Electricity Maps, 2019 average
-        value: 331.58551761975286
-      - datetime: '2020-01-01'
-        source: Electricity Maps, 2020 average
-        value: 500.6289690693686
-      - datetime: '2021-01-01'
-        source: Electricity Maps, 2021 average
-        value: 455.61015068419204
+    - datetime: '2015-01-01'
+      source: Electricity Maps, 2015 average
+      value: 342.4822573202384
+    - datetime: '2016-01-01'
+      source: Electricity Maps, 2016 average
+      value: 402.78963651897595
+    - datetime: '2017-01-01'
+      source: Electricity Maps, 2017 average
+      value: 402.59777898407856
+    - datetime: '2018-01-01'
+      source: Electricity Maps, 2018 average
+      value: 369.57115985375964
+    - datetime: '2019-01-01'
+      source: Electricity Maps, 2019 average
+      value: 331.58551761975286
+    - datetime: '2020-01-01'
+      source: Electricity Maps, 2020 average
+      value: 500.6289690693686
+    - datetime: '2021-01-01'
+      source: Electricity Maps, 2021 average
+      value: 455.61015068419204
     biomass:
       datetime: '2020-01-01'
       source: eGrid 2020
@@ -120,27 +122,27 @@ emissionFactors:
       source: eGrid 2020; IPCC 2014
       value: 491.3656203
     hydro discharge:
-      - datetime: '2015-01-01'
-        source: Electricity Maps, 2015 average
-        value: 342.4822573202384
-      - datetime: '2016-01-01'
-        source: Electricity Maps, 2016 average
-        value: 402.78963651897595
-      - datetime: '2017-01-01'
-        source: Electricity Maps, 2017 average
-        value: 402.59777898407856
-      - datetime: '2018-01-01'
-        source: Electricity Maps, 2018 average
-        value: 369.57115985375964
-      - datetime: '2019-01-01'
-        source: Electricity Maps, 2019 average
-        value: 331.58551761975286
-      - datetime: '2020-01-01'
-        source: Electricity Maps, 2020 average
-        value: 500.6289690693686
-      - datetime: '2021-01-01'
-        source: Electricity Maps, 2021 average
-        value: 455.61015068419204
+    - datetime: '2015-01-01'
+      source: Electricity Maps, 2015 average
+      value: 342.4822573202384
+    - datetime: '2016-01-01'
+      source: Electricity Maps, 2016 average
+      value: 402.78963651897595
+    - datetime: '2017-01-01'
+      source: Electricity Maps, 2017 average
+      value: 402.59777898407856
+    - datetime: '2018-01-01'
+      source: Electricity Maps, 2018 average
+      value: 369.57115985375964
+    - datetime: '2019-01-01'
+      source: Electricity Maps, 2019 average
+      value: 331.58551761975286
+    - datetime: '2020-01-01'
+      source: Electricity Maps, 2020 average
+      value: 500.6289690693686
+    - datetime: '2021-01-01'
+      source: Electricity Maps, 2021 average
+      value: 455.61015068419204
     oil:
       datetime: '2014-01-01'
       source: IPCC 2014; EIA 2020/BEIS 2021
@@ -151,111 +153,111 @@ emissionFactors:
       value: 25.6
 fallbackZoneMixes:
   powerOriginRatios:
-    - _source: Electricity Maps, 2015 average
-      datetime: '2015-01-01'
-      value:
-        battery discharge: 0.0
-        biomass: 0.0
-        coal: 0.24099398394415494
-        gas: 0.27045967294492
-        geothermal: 0.0
-        hydro: 0.00017026247081268955
-        hydro discharge: 0.0
-        nuclear: 0.43044470620782926
-        oil: 0.00017170188783646834
-        solar: 0.042855302210168866
-        unknown: 0.007209834241104496
-        wind: 0.007693478361094166
-    - _source: Electricity Maps, 2016 average
-      datetime: '2016-01-01'
-      value:
-        battery discharge: 0.0
-        biomass: 0.0
-        coal: 0.24099524605429917
-        gas: 0.2704610893698915
-        geothermal: 0.0
-        hydro: 0.00017026336249466466
-        hydro discharge: 0.0
-        nuclear: 0.43044696049078424
-        oil: 0.00017170278705681765
-        solar: 0.04285028934537776
-        unknown: 0.007209871999743883
-        wind: 0.0076935186526272785
-    - _source: Electricity Maps, 2017 average
-      datetime: '2017-01-01'
-      value:
-        battery discharge: 3.378043869684813e-07
-        biomass: 9.896889534349113e-07
-        coal: 0.24074781571513942
-        gas: 0.2705952701694139
-        geothermal: 1.978315628923381e-06
-        hydro: 0.00017856750642626545
-        hydro discharge: 4.0472789759431256e-07
-        nuclear: 0.4299888434364903
-        oil: 0.00017214461986942976
-        solar: 0.04341791995667617
-        unknown: 0.0072054801755000305
-        wind: 0.007690218493927688
-    - _source: Electricity Maps, 2018 average
-      datetime: '2018-01-01'
-      value:
-        battery discharge: 2.909762800587874e-08
-        biomass: 9.17862292654671e-06
-        coal: 0.24049113025692823
-        gas: 0.1928954403857158
-        geothermal: 4.946316976114715e-06
-        hydro: 0.006321999389319688
-        hydro discharge: 0.005974547970720107
-        nuclear: 0.51423123199895
-        oil: 8.026412814490848e-05
-        solar: 0.02932239319297992
-        unknown: 0.005304458695372724
-        wind: 0.005374580901233162
-    - _source: Electricity Maps, 2019 average
-      datetime: '2019-01-01'
-      value:
-        battery discharge: 1.942326867438576e-08
-        biomass: 4.989621908353319e-06
-        coal: 0.20720698132502677
-        gas: 0.19316517274711834
-        geothermal: 6.362918941664518e-07
-        hydro: 0.008505832422534602
-        hydro discharge: 0.0002786415364306498
-        nuclear: 0.5436494565040488
-        oil: 1.29132364570208e-05
-        solar: 0.03503707612259516
-        unknown: 0.006398705954506915
-        wind: 0.005770362133820053
-    - _source: Electricity Maps, 2020 average
-      datetime: '2020-01-01'
-      value:
-        battery discharge: 3.443074962936133e-07
-        biomass: 4.173519447699479e-05
-        coal: 0.2335282127141345
-        gas: 0.46420313953492487
-        geothermal: 2.2056957192337477e-05
-        hydro: 0.019532070048077672
-        hydro discharge: 0.002629168310043848
-        nuclear: 0.20838540393846702
-        oil: 3.847491197697858e-05
-        solar: 0.048925239773939096
-        unknown: 0.010712859844994671
-        wind: 0.012175497915945653
-    - _source: Electricity Maps, 2021 average
-      datetime: '2021-01-01'
-      value:
-        battery discharge: 1.184207731843033e-06
-        biomass: 2.6021598027496122e-05
-        coal: 0.21699578887260643
-        gas: 0.4049420657892342
-        geothermal: 3.541056074369383e-05
-        hydro: 0.017074653251840124
-        hydro discharge: 0.0008175941475170763
-        nuclear: 0.2795163713953564
-        oil: 8.968627439082357e-06
-        solar: 0.04625073953725447
-        unknown: 0.010039607592683613
-        wind: 0.024298130475104016
+  - _source: Electricity Maps, 2015 average
+    datetime: '2015-01-01'
+    value:
+      battery discharge: 0.0
+      biomass: 0.0
+      coal: 0.24099398394415494
+      gas: 0.27045967294492
+      geothermal: 0.0
+      hydro: 0.00017026247081268955
+      hydro discharge: 0.0
+      nuclear: 0.43044470620782926
+      oil: 0.00017170188783646834
+      solar: 0.042855302210168866
+      unknown: 0.007209834241104496
+      wind: 0.007693478361094166
+  - _source: Electricity Maps, 2016 average
+    datetime: '2016-01-01'
+    value:
+      battery discharge: 0.0
+      biomass: 0.0
+      coal: 0.24099524605429917
+      gas: 0.2704610893698915
+      geothermal: 0.0
+      hydro: 0.00017026336249466466
+      hydro discharge: 0.0
+      nuclear: 0.43044696049078424
+      oil: 0.00017170278705681765
+      solar: 0.04285028934537776
+      unknown: 0.007209871999743883
+      wind: 0.0076935186526272785
+  - _source: Electricity Maps, 2017 average
+    datetime: '2017-01-01'
+    value:
+      battery discharge: 3.378043869684813e-07
+      biomass: 9.896889534349113e-07
+      coal: 0.24074781571513942
+      gas: 0.2705952701694139
+      geothermal: 1.978315628923381e-06
+      hydro: 0.00017856750642626545
+      hydro discharge: 4.0472789759431256e-07
+      nuclear: 0.4299888434364903
+      oil: 0.00017214461986942976
+      solar: 0.04341791995667617
+      unknown: 0.0072054801755000305
+      wind: 0.007690218493927688
+  - _source: Electricity Maps, 2018 average
+    datetime: '2018-01-01'
+    value:
+      battery discharge: 2.909762800587874e-08
+      biomass: 9.17862292654671e-06
+      coal: 0.24049113025692823
+      gas: 0.1928954403857158
+      geothermal: 4.946316976114715e-06
+      hydro: 0.006321999389319688
+      hydro discharge: 0.005974547970720107
+      nuclear: 0.51423123199895
+      oil: 8.026412814490848e-05
+      solar: 0.02932239319297992
+      unknown: 0.005304458695372724
+      wind: 0.005374580901233162
+  - _source: Electricity Maps, 2019 average
+    datetime: '2019-01-01'
+    value:
+      battery discharge: 1.942326867438576e-08
+      biomass: 4.989621908353319e-06
+      coal: 0.20720698132502677
+      gas: 0.19316517274711834
+      geothermal: 6.362918941664518e-07
+      hydro: 0.008505832422534602
+      hydro discharge: 0.0002786415364306498
+      nuclear: 0.5436494565040488
+      oil: 1.29132364570208e-05
+      solar: 0.03503707612259516
+      unknown: 0.006398705954506915
+      wind: 0.005770362133820053
+  - _source: Electricity Maps, 2020 average
+    datetime: '2020-01-01'
+    value:
+      battery discharge: 3.443074962936133e-07
+      biomass: 4.173519447699479e-05
+      coal: 0.2335282127141345
+      gas: 0.46420313953492487
+      geothermal: 2.2056957192337477e-05
+      hydro: 0.019532070048077672
+      hydro discharge: 0.002629168310043848
+      nuclear: 0.20838540393846702
+      oil: 3.847491197697858e-05
+      solar: 0.048925239773939096
+      unknown: 0.010712859844994671
+      wind: 0.012175497915945653
+  - _source: Electricity Maps, 2021 average
+    datetime: '2021-01-01'
+    value:
+      battery discharge: 1.184207731843033e-06
+      biomass: 2.6021598027496122e-05
+      coal: 0.21699578887260643
+      gas: 0.4049420657892342
+      geothermal: 3.541056074369383e-05
+      hydro: 0.017074653251840124
+      hydro discharge: 0.0008175941475170763
+      nuclear: 0.2795163713953564
+      oil: 8.968627439082357e-06
+      solar: 0.04625073953725447
+      unknown: 0.010039607592683613
+      wind: 0.024298130475104016
 parsers:
   consumption: EIA.fetch_consumption
   consumptionForecast: EIA.fetch_consumption_forecast

--- a/config/zones/US-SW-AZPS.yaml
+++ b/config/zones/US-SW-AZPS.yaml
@@ -1,8 +1,8 @@
 bounding_box:
-- - -115.31829
-  - 30.8336654
-- - -108.777145881
-  - 36.784585904
+  - - -115.31829
+    - 30.8336654
+  - - -108.777145881
+    - 36.784585904
 capacity:
   battery storage: 200
   biomass: 33.4
@@ -18,9 +18,9 @@ capacity:
   wind: 557.5
 comment: Arizona Public Service Company
 contributors:
-- systemcatch
-- robertahunt
-- KabelWlan
+  - systemcatch
+  - robertahunt
+  - KabelWlan
 delays:
   consumption: 30
   consumptionForecast: 30
@@ -30,27 +30,27 @@ disclaimer: Data for real-time consumption and generation mix is estimated. Real
 emissionFactors:
   direct:
     battery discharge:
-    - datetime: '2015-01-01'
-      source: Electricity Maps, 2015 average
-      value: 287.4394383608348
-    - datetime: '2016-01-01'
-      source: Electricity Maps, 2016 average
-      value: 358.99917192529836
-    - datetime: '2017-01-01'
-      source: Electricity Maps, 2017 average
-      value: 358.7864539742484
-    - datetime: '2018-01-01'
-      source: Electricity Maps, 2018 average
-      value: 333.39391247326176
-    - datetime: '2019-01-01'
-      source: Electricity Maps, 2019 average
-      value: 295.81849021123355
-    - datetime: '2020-01-01'
-      source: Electricity Maps, 2020 average
-      value: 433.19170627807307
-    - datetime: '2021-01-01'
-      source: Electricity Maps, 2021 average
-      value: 394.89508781910087
+      - datetime: '2015-01-01'
+        source: Electricity Maps, 2015 average
+        value: 287.4394383608348
+      - datetime: '2016-01-01'
+        source: Electricity Maps, 2016 average
+        value: 358.99917192529836
+      - datetime: '2017-01-01'
+        source: Electricity Maps, 2017 average
+        value: 358.7864539742484
+      - datetime: '2018-01-01'
+        source: Electricity Maps, 2018 average
+        value: 333.39391247326176
+      - datetime: '2019-01-01'
+        source: Electricity Maps, 2019 average
+        value: 295.81849021123355
+      - datetime: '2020-01-01'
+        source: Electricity Maps, 2020 average
+        value: 433.19170627807307
+      - datetime: '2021-01-01'
+        source: Electricity Maps, 2021 average
+        value: 394.89508781910087
     biomass:
       datetime: '2020-01-01'
       source: eGrid 2020
@@ -64,50 +64,50 @@ emissionFactors:
       source: eGrid 2020
       value: 371.3656203
     hydro discharge:
-    - datetime: '2015-01-01'
-      source: Electricity Maps, 2015 average
-      value: 287.4394383608348
-    - datetime: '2016-01-01'
-      source: Electricity Maps, 2016 average
-      value: 358.99917192529836
-    - datetime: '2017-01-01'
-      source: Electricity Maps, 2017 average
-      value: 358.7864539742484
-    - datetime: '2018-01-01'
-      source: Electricity Maps, 2018 average
-      value: 333.39391247326176
-    - datetime: '2019-01-01'
-      source: Electricity Maps, 2019 average
-      value: 295.81849021123355
-    - datetime: '2020-01-01'
-      source: Electricity Maps, 2020 average
-      value: 433.19170627807307
-    - datetime: '2021-01-01'
-      source: Electricity Maps, 2021 average
-      value: 394.89508781910087
+      - datetime: '2015-01-01'
+        source: Electricity Maps, 2015 average
+        value: 287.4394383608348
+      - datetime: '2016-01-01'
+        source: Electricity Maps, 2016 average
+        value: 358.99917192529836
+      - datetime: '2017-01-01'
+        source: Electricity Maps, 2017 average
+        value: 358.7864539742484
+      - datetime: '2018-01-01'
+        source: Electricity Maps, 2018 average
+        value: 333.39391247326176
+      - datetime: '2019-01-01'
+        source: Electricity Maps, 2019 average
+        value: 295.81849021123355
+      - datetime: '2020-01-01'
+        source: Electricity Maps, 2020 average
+        value: 433.19170627807307
+      - datetime: '2021-01-01'
+        source: Electricity Maps, 2021 average
+        value: 394.89508781910087
   lifecycle:
     battery discharge:
-    - datetime: '2015-01-01'
-      source: Electricity Maps, 2015 average
-      value: 342.4822573202384
-    - datetime: '2016-01-01'
-      source: Electricity Maps, 2016 average
-      value: 402.78963651897595
-    - datetime: '2017-01-01'
-      source: Electricity Maps, 2017 average
-      value: 402.59777898407856
-    - datetime: '2018-01-01'
-      source: Electricity Maps, 2018 average
-      value: 369.57115985375964
-    - datetime: '2019-01-01'
-      source: Electricity Maps, 2019 average
-      value: 331.58551761975286
-    - datetime: '2020-01-01'
-      source: Electricity Maps, 2020 average
-      value: 500.6289690693686
-    - datetime: '2021-01-01'
-      source: Electricity Maps, 2021 average
-      value: 455.61015068419204
+      - datetime: '2015-01-01'
+        source: Electricity Maps, 2015 average
+        value: 342.4822573202384
+      - datetime: '2016-01-01'
+        source: Electricity Maps, 2016 average
+        value: 402.78963651897595
+      - datetime: '2017-01-01'
+        source: Electricity Maps, 2017 average
+        value: 402.59777898407856
+      - datetime: '2018-01-01'
+        source: Electricity Maps, 2018 average
+        value: 369.57115985375964
+      - datetime: '2019-01-01'
+        source: Electricity Maps, 2019 average
+        value: 331.58551761975286
+      - datetime: '2020-01-01'
+        source: Electricity Maps, 2020 average
+        value: 500.6289690693686
+      - datetime: '2021-01-01'
+        source: Electricity Maps, 2021 average
+        value: 455.61015068419204
     biomass:
       datetime: '2020-01-01'
       source: eGrid 2020
@@ -122,27 +122,27 @@ emissionFactors:
       source: eGrid 2020; IPCC 2014
       value: 491.3656203
     hydro discharge:
-    - datetime: '2015-01-01'
-      source: Electricity Maps, 2015 average
-      value: 342.4822573202384
-    - datetime: '2016-01-01'
-      source: Electricity Maps, 2016 average
-      value: 402.78963651897595
-    - datetime: '2017-01-01'
-      source: Electricity Maps, 2017 average
-      value: 402.59777898407856
-    - datetime: '2018-01-01'
-      source: Electricity Maps, 2018 average
-      value: 369.57115985375964
-    - datetime: '2019-01-01'
-      source: Electricity Maps, 2019 average
-      value: 331.58551761975286
-    - datetime: '2020-01-01'
-      source: Electricity Maps, 2020 average
-      value: 500.6289690693686
-    - datetime: '2021-01-01'
-      source: Electricity Maps, 2021 average
-      value: 455.61015068419204
+      - datetime: '2015-01-01'
+        source: Electricity Maps, 2015 average
+        value: 342.4822573202384
+      - datetime: '2016-01-01'
+        source: Electricity Maps, 2016 average
+        value: 402.78963651897595
+      - datetime: '2017-01-01'
+        source: Electricity Maps, 2017 average
+        value: 402.59777898407856
+      - datetime: '2018-01-01'
+        source: Electricity Maps, 2018 average
+        value: 369.57115985375964
+      - datetime: '2019-01-01'
+        source: Electricity Maps, 2019 average
+        value: 331.58551761975286
+      - datetime: '2020-01-01'
+        source: Electricity Maps, 2020 average
+        value: 500.6289690693686
+      - datetime: '2021-01-01'
+        source: Electricity Maps, 2021 average
+        value: 455.61015068419204
     oil:
       datetime: '2014-01-01'
       source: IPCC 2014; EIA 2020/BEIS 2021
@@ -153,111 +153,111 @@ emissionFactors:
       value: 25.6
 fallbackZoneMixes:
   powerOriginRatios:
-  - _source: Electricity Maps, 2015 average
-    datetime: '2015-01-01'
-    value:
-      battery discharge: 0.0
-      biomass: 0.0
-      coal: 0.24099398394415494
-      gas: 0.27045967294492
-      geothermal: 0.0
-      hydro: 0.00017026247081268955
-      hydro discharge: 0.0
-      nuclear: 0.43044470620782926
-      oil: 0.00017170188783646834
-      solar: 0.042855302210168866
-      unknown: 0.007209834241104496
-      wind: 0.007693478361094166
-  - _source: Electricity Maps, 2016 average
-    datetime: '2016-01-01'
-    value:
-      battery discharge: 0.0
-      biomass: 0.0
-      coal: 0.24099524605429917
-      gas: 0.2704610893698915
-      geothermal: 0.0
-      hydro: 0.00017026336249466466
-      hydro discharge: 0.0
-      nuclear: 0.43044696049078424
-      oil: 0.00017170278705681765
-      solar: 0.04285028934537776
-      unknown: 0.007209871999743883
-      wind: 0.0076935186526272785
-  - _source: Electricity Maps, 2017 average
-    datetime: '2017-01-01'
-    value:
-      battery discharge: 3.378043869684813e-07
-      biomass: 9.896889534349113e-07
-      coal: 0.24074781571513942
-      gas: 0.2705952701694139
-      geothermal: 1.978315628923381e-06
-      hydro: 0.00017856750642626545
-      hydro discharge: 4.0472789759431256e-07
-      nuclear: 0.4299888434364903
-      oil: 0.00017214461986942976
-      solar: 0.04341791995667617
-      unknown: 0.0072054801755000305
-      wind: 0.007690218493927688
-  - _source: Electricity Maps, 2018 average
-    datetime: '2018-01-01'
-    value:
-      battery discharge: 2.909762800587874e-08
-      biomass: 9.17862292654671e-06
-      coal: 0.24049113025692823
-      gas: 0.1928954403857158
-      geothermal: 4.946316976114715e-06
-      hydro: 0.006321999389319688
-      hydro discharge: 0.005974547970720107
-      nuclear: 0.51423123199895
-      oil: 8.026412814490848e-05
-      solar: 0.02932239319297992
-      unknown: 0.005304458695372724
-      wind: 0.005374580901233162
-  - _source: Electricity Maps, 2019 average
-    datetime: '2019-01-01'
-    value:
-      battery discharge: 1.942326867438576e-08
-      biomass: 4.989621908353319e-06
-      coal: 0.20720698132502677
-      gas: 0.19316517274711834
-      geothermal: 6.362918941664518e-07
-      hydro: 0.008505832422534602
-      hydro discharge: 0.0002786415364306498
-      nuclear: 0.5436494565040488
-      oil: 1.29132364570208e-05
-      solar: 0.03503707612259516
-      unknown: 0.006398705954506915
-      wind: 0.005770362133820053
-  - _source: Electricity Maps, 2020 average
-    datetime: '2020-01-01'
-    value:
-      battery discharge: 3.443074962936133e-07
-      biomass: 4.173519447699479e-05
-      coal: 0.2335282127141345
-      gas: 0.46420313953492487
-      geothermal: 2.2056957192337477e-05
-      hydro: 0.019532070048077672
-      hydro discharge: 0.002629168310043848
-      nuclear: 0.20838540393846702
-      oil: 3.847491197697858e-05
-      solar: 0.048925239773939096
-      unknown: 0.010712859844994671
-      wind: 0.012175497915945653
-  - _source: Electricity Maps, 2021 average
-    datetime: '2021-01-01'
-    value:
-      battery discharge: 1.184207731843033e-06
-      biomass: 2.6021598027496122e-05
-      coal: 0.21699578887260643
-      gas: 0.4049420657892342
-      geothermal: 3.541056074369383e-05
-      hydro: 0.017074653251840124
-      hydro discharge: 0.0008175941475170763
-      nuclear: 0.2795163713953564
-      oil: 8.968627439082357e-06
-      solar: 0.04625073953725447
-      unknown: 0.010039607592683613
-      wind: 0.024298130475104016
+    - _source: Electricity Maps, 2015 average
+      datetime: '2015-01-01'
+      value:
+        battery discharge: 0.0
+        biomass: 0.0
+        coal: 0.24099398394415494
+        gas: 0.27045967294492
+        geothermal: 0.0
+        hydro: 0.00017026247081268955
+        hydro discharge: 0.0
+        nuclear: 0.43044470620782926
+        oil: 0.00017170188783646834
+        solar: 0.042855302210168866
+        unknown: 0.007209834241104496
+        wind: 0.007693478361094166
+    - _source: Electricity Maps, 2016 average
+      datetime: '2016-01-01'
+      value:
+        battery discharge: 0.0
+        biomass: 0.0
+        coal: 0.24099524605429917
+        gas: 0.2704610893698915
+        geothermal: 0.0
+        hydro: 0.00017026336249466466
+        hydro discharge: 0.0
+        nuclear: 0.43044696049078424
+        oil: 0.00017170278705681765
+        solar: 0.04285028934537776
+        unknown: 0.007209871999743883
+        wind: 0.0076935186526272785
+    - _source: Electricity Maps, 2017 average
+      datetime: '2017-01-01'
+      value:
+        battery discharge: 3.378043869684813e-07
+        biomass: 9.896889534349113e-07
+        coal: 0.24074781571513942
+        gas: 0.2705952701694139
+        geothermal: 1.978315628923381e-06
+        hydro: 0.00017856750642626545
+        hydro discharge: 4.0472789759431256e-07
+        nuclear: 0.4299888434364903
+        oil: 0.00017214461986942976
+        solar: 0.04341791995667617
+        unknown: 0.0072054801755000305
+        wind: 0.007690218493927688
+    - _source: Electricity Maps, 2018 average
+      datetime: '2018-01-01'
+      value:
+        battery discharge: 2.909762800587874e-08
+        biomass: 9.17862292654671e-06
+        coal: 0.24049113025692823
+        gas: 0.1928954403857158
+        geothermal: 4.946316976114715e-06
+        hydro: 0.006321999389319688
+        hydro discharge: 0.005974547970720107
+        nuclear: 0.51423123199895
+        oil: 8.026412814490848e-05
+        solar: 0.02932239319297992
+        unknown: 0.005304458695372724
+        wind: 0.005374580901233162
+    - _source: Electricity Maps, 2019 average
+      datetime: '2019-01-01'
+      value:
+        battery discharge: 1.942326867438576e-08
+        biomass: 4.989621908353319e-06
+        coal: 0.20720698132502677
+        gas: 0.19316517274711834
+        geothermal: 6.362918941664518e-07
+        hydro: 0.008505832422534602
+        hydro discharge: 0.0002786415364306498
+        nuclear: 0.5436494565040488
+        oil: 1.29132364570208e-05
+        solar: 0.03503707612259516
+        unknown: 0.006398705954506915
+        wind: 0.005770362133820053
+    - _source: Electricity Maps, 2020 average
+      datetime: '2020-01-01'
+      value:
+        battery discharge: 3.443074962936133e-07
+        biomass: 4.173519447699479e-05
+        coal: 0.2335282127141345
+        gas: 0.46420313953492487
+        geothermal: 2.2056957192337477e-05
+        hydro: 0.019532070048077672
+        hydro discharge: 0.002629168310043848
+        nuclear: 0.20838540393846702
+        oil: 3.847491197697858e-05
+        solar: 0.048925239773939096
+        unknown: 0.010712859844994671
+        wind: 0.012175497915945653
+    - _source: Electricity Maps, 2021 average
+      datetime: '2021-01-01'
+      value:
+        battery discharge: 1.184207731843033e-06
+        biomass: 2.6021598027496122e-05
+        coal: 0.21699578887260643
+        gas: 0.4049420657892342
+        geothermal: 3.541056074369383e-05
+        hydro: 0.017074653251840124
+        hydro discharge: 0.0008175941475170763
+        nuclear: 0.2795163713953564
+        oil: 8.968627439082357e-06
+        solar: 0.04625073953725447
+        unknown: 0.010039607592683613
+        wind: 0.024298130475104016
 parsers:
   consumption: EIA.fetch_consumption
   consumptionForecast: EIA.fetch_consumption_forecast

--- a/config/zones/US-SW-DEAA.yaml
+++ b/config/zones/US-SW-DEAA.yaml
@@ -1,8 +1,8 @@
 bounding_box:
-- - -113.397006989
-  - 32.8262615200001
-- - -112.375976563
-  - 33.877473831
+  - - -113.397006989
+    - 32.8262615200001
+  - - -112.375976563
+    - 33.877473831
 capacity:
   battery storage: 0
   biomass: 0
@@ -18,9 +18,9 @@ capacity:
   wind: 0
 comment: Arlington Valley, Llc - Avba
 contributors:
-- systemcatch
-- robertahunt
-- KabelWlan
+  - systemcatch
+  - robertahunt
+  - KabelWlan
 delays:
   production: 30
 disclaimer: Data for real-time consumption and generation mix is estimated. Real-time

--- a/config/zones/US-SW-DEAA.yaml
+++ b/config/zones/US-SW-DEAA.yaml
@@ -1,8 +1,8 @@
 bounding_box:
-  - - -113.397006989
-    - 32.8262615200001
-  - - -112.375976563
-    - 33.877473831
+- - -113.397006989
+  - 32.8262615200001
+- - -112.375976563
+  - 33.877473831
 capacity:
   battery storage: 0
   biomass: 0
@@ -18,11 +18,13 @@ capacity:
   wind: 0
 comment: Arlington Valley, Llc - Avba
 contributors:
-  - systemcatch
-  - robertahunt
-  - KabelWlan
+- systemcatch
+- robertahunt
+- KabelWlan
 delays:
   production: 30
+disclaimer: Data for real-time consumption and generation mix is estimated. Real-time
+  exchanges are not available.
 emissionFactors:
   direct:
     gas:

--- a/config/zones/US-SW-EPE.yaml
+++ b/config/zones/US-SW-EPE.yaml
@@ -174,29 +174,29 @@ fallbackZoneMixes:
       datetime: '2017-01-01'
       value:
         battery discharge: 0
-        biomass: 3.853100112863885e-06
+        biomass: 0.000003853100112863885
         coal: 0.004455496495232723
         gas: 0.9350013068108511
         geothermal: 0
         hydro: 0.0005030464226245364
-        hydro discharge: 7.930803046377121e-06
+        hydro discharge: 0.000007930803046377121
         nuclear: 0.000575670582942777
-        oil: 1.966436419409328e-05
+        oil: 0.00001966436419409328
         solar: 0.05770207363295614
-        unknown: 2.5687979496163404e-05
+        unknown: 0.000025687979496163404
         wind: 0.0017040499828793595
     - _source: Electricity Maps, 2018 average
       datetime: '2018-01-01'
       value:
         battery discharge: 0
-        biomass: 4.498960916079481e-06
+        biomass: 0.000004498960916079481
         coal: 0.1653765018743752
         gas: 0.7113547792199667
-        geothermal: 2.2185749365357598e-07
+        geothermal: 2.2185749365357598e-7
         hydro: 0.003809699352885953
         hydro discharge: 0.013431676512939545
         nuclear: 0.026001466464787827
-        oil: 1.859629379639527e-05
+        oil: 0.00001859629379639527
         solar: 0.040548058562214856
         unknown: 0.0006523791345844036
         wind: 0.0388017321357148
@@ -204,44 +204,44 @@ fallbackZoneMixes:
       datetime: '2019-01-01'
       value:
         battery discharge: 0
-        biomass: 3.459819791272405e-06
+        biomass: 0.000003459819791272405
         coal: 0.16402899418179895
         gas: 0.6914645283384239
-        geothermal: 1.929424605444991e-06
+        geothermal: 0.000001929424605444991
         hydro: 0.007446336117737151
         hydro discharge: 0.00012762838624874202
         nuclear: 0.03022800658398542
-        oil: 3.571313305577317e-06
+        oil: 0.000003571313305577317
         solar: 0.05055243627998956
         unknown: 0.0014149242871016674
         wind: 0.054727555035252486
     - _source: Electricity Maps, 2020 average
       datetime: '2020-01-01'
       value:
-        battery discharge: 1.0403200301831518e-08
-        biomass: 4.782004405408555e-06
+        battery discharge: 1.0403200301831518e-8
+        biomass: 0.000004782004405408555
         coal: 0.17358368519268577
         gas: 0.6774887599200294
-        geothermal: 3.268916717064393e-06
+        geothermal: 0.000003268916717064393
         hydro: 0.007078332861721585
         hydro discharge: 0.0009837786365426973
         nuclear: 0.009804178248896336
-        oil: 5.328750376827034e-06
+        oil: 0.000005328750376827034
         solar: 0.06169993610123192
         unknown: 0.0019220941318552466
         wind: 0.06742601706309795
     - _source: Electricity Maps, 2021 average
       datetime: '2021-01-01'
       value:
-        battery discharge: 9.025386290669875e-08
-        biomass: 8.96405994792558e-06
+        battery discharge: 9.025386290669875e-8
+        biomass: 0.00000896405994792558
         coal: 0.18330897545496094
         gas: 0.6527233928988425
-        geothermal: 1.1751515790774776e-05
+        geothermal: 0.000011751515790774776
         hydro: 0.00629894784464964
         hydro discharge: 0.00010040626538289588
         nuclear: 0.01932987809687284
-        oil: 3.31972221383742e-06
+        oil: 0.00000331972221383742
         solar: 0.059661301297065907
         unknown: 0.0014996790138722235
         wind: 0.07705298347352142
@@ -251,9 +251,12 @@ parsers:
   production: EIA.fetch_production_mix
 sources:
   INCER ACV:
-    link: https://docs.google.com/spreadsheets/d/1w5DJ7sPen6axIHU8TCVcuzNCjlct4I6JAbhUlw-ZXu8/edit?usp=sharing
+    link: >-
+      https://docs.google.com/spreadsheets/d/1w5DJ7sPen6axIHU8TCVcuzNCjlct4I6JAbhUlw-ZXu8/edit?usp=sharing
   IPCC 2014:
-    link: https://www.ipcc.ch/site/assets/uploads/2018/02/ipcc_wg3_ar5_annex-iii.pdf#page=7
+    link: >-
+      https://www.ipcc.ch/site/assets/uploads/2018/02/ipcc_wg3_ar5_annex-iii.pdf#page=7
   eGrid 2020:
-    link: https://drive.google.com/file/d/1_FAAuTtIdMuORZKsqHnd9vMNHlQgYarh/view?usp=sharing
+    link: >-
+      https://drive.google.com/file/d/1_FAAuTtIdMuORZKsqHnd9vMNHlQgYarh/view?usp=sharing
 timezone: US/Mountain

--- a/config/zones/US-SW-EPE.yaml
+++ b/config/zones/US-SW-EPE.yaml
@@ -1,8 +1,8 @@
 bounding_box:
-- - -108.7296822968229
-  - 30.130950309039566
-- - -104.41562479630723
-  - 33.98037168914246
+  - - -108.7296822968229
+    - 30.130950309039566
+  - - -104.41562479630723
+    - 33.98037168914246
 capacity:
   battery storage: 51
   biomass: 3.2
@@ -18,9 +18,9 @@ capacity:
   wind: 0
 comment: El Paso Electric Company
 contributors:
-- systemcatch
-- robertahunt
-- KabelWlan
+  - systemcatch
+  - robertahunt
+  - KabelWlan
 delays:
   consumption: 30
   consumptionForecast: 30
@@ -30,76 +30,76 @@ disclaimer: Data for real-time consumption and generation mix is estimated. Real
 emissionFactors:
   direct:
     battery discharge:
-    - datetime: '2015-01-01'
-      source: Electricity Maps, 2015 average
-      value: 348.45428701670295
-    - datetime: '2016-01-01'
-      source: Electricity Maps, 2016 average
-      value: 514.101895165611
-    - datetime: '2017-01-01'
-      source: Electricity Maps, 2017 average
-      value: 514.7859055431869
-    - datetime: '2018-01-01'
-      source: Electricity Maps, 2018 average
-      value: 571.3437609438619
-    - datetime: '2019-01-01'
-      source: Electricity Maps, 2019 average
-      value: 552.4641741282234
-    - datetime: '2020-01-01'
-      source: Electricity Maps, 2020 average
-      value: 554.2767863427711
-    - datetime: '2021-01-01'
-      source: Electricity Maps, 2021 average
-      value: 552.3879131999372
+      - datetime: '2015-01-01'
+        source: Electricity Maps, 2015 average
+        value: 348.45428701670295
+      - datetime: '2016-01-01'
+        source: Electricity Maps, 2016 average
+        value: 514.101895165611
+      - datetime: '2017-01-01'
+        source: Electricity Maps, 2017 average
+        value: 514.7859055431869
+      - datetime: '2018-01-01'
+        source: Electricity Maps, 2018 average
+        value: 571.3437609438619
+      - datetime: '2019-01-01'
+        source: Electricity Maps, 2019 average
+        value: 552.4641741282234
+      - datetime: '2020-01-01'
+        source: Electricity Maps, 2020 average
+        value: 554.2767863427711
+      - datetime: '2021-01-01'
+        source: Electricity Maps, 2021 average
+        value: 552.3879131999372
     gas:
       datetime: '2021-01-01'
       source: eGrid 2020
       value: 545.8860298
     hydro discharge:
-    - datetime: '2015-01-01'
-      source: Electricity Maps, 2015 average
-      value: 348.45428701670295
-    - datetime: '2016-01-01'
-      source: Electricity Maps, 2016 average
-      value: 514.101895165611
-    - datetime: '2017-01-01'
-      source: Electricity Maps, 2017 average
-      value: 514.7859055431869
-    - datetime: '2018-01-01'
-      source: Electricity Maps, 2018 average
-      value: 571.3437609438619
-    - datetime: '2019-01-01'
-      source: Electricity Maps, 2019 average
-      value: 552.4641741282234
-    - datetime: '2020-01-01'
-      source: Electricity Maps, 2020 average
-      value: 554.2767863427711
-    - datetime: '2021-01-01'
-      source: Electricity Maps, 2021 average
-      value: 552.3879131999372
+      - datetime: '2015-01-01'
+        source: Electricity Maps, 2015 average
+        value: 348.45428701670295
+      - datetime: '2016-01-01'
+        source: Electricity Maps, 2016 average
+        value: 514.101895165611
+      - datetime: '2017-01-01'
+        source: Electricity Maps, 2017 average
+        value: 514.7859055431869
+      - datetime: '2018-01-01'
+        source: Electricity Maps, 2018 average
+        value: 571.3437609438619
+      - datetime: '2019-01-01'
+        source: Electricity Maps, 2019 average
+        value: 552.4641741282234
+      - datetime: '2020-01-01'
+        source: Electricity Maps, 2020 average
+        value: 554.2767863427711
+      - datetime: '2021-01-01'
+        source: Electricity Maps, 2021 average
+        value: 552.3879131999372
   lifecycle:
     battery discharge:
-    - datetime: '2015-01-01'
-      source: Electricity Maps, 2015 average
-      value: 464.088753652298
-    - datetime: '2016-01-01'
-      source: Electricity Maps, 2016 average
-      value: 628.6048672222605
-    - datetime: '2017-01-01'
-      source: Electricity Maps, 2017 average
-      value: 628.6437923889442
-    - datetime: '2018-01-01'
-      source: Electricity Maps, 2018 average
-      value: 666.5124144683374
-    - datetime: '2019-01-01'
-      source: Electricity Maps, 2019 average
-      value: 645.2149203085437
-    - datetime: '2020-01-01'
-      source: Electricity Maps, 2020 average
-      value: 645.9915486874397
-    - datetime: '2021-01-01'
-      source: Electricity Maps, 2021 average
-      value: 641.9435707652311
+      - datetime: '2015-01-01'
+        source: Electricity Maps, 2015 average
+        value: 464.088753652298
+      - datetime: '2016-01-01'
+        source: Electricity Maps, 2016 average
+        value: 628.6048672222605
+      - datetime: '2017-01-01'
+        source: Electricity Maps, 2017 average
+        value: 628.6437923889442
+      - datetime: '2018-01-01'
+        source: Electricity Maps, 2018 average
+        value: 666.5124144683374
+      - datetime: '2019-01-01'
+        source: Electricity Maps, 2019 average
+        value: 645.2149203085437
+      - datetime: '2020-01-01'
+        source: Electricity Maps, 2020 average
+        value: 645.9915486874397
+      - datetime: '2021-01-01'
+        source: Electricity Maps, 2021 average
+        value: 641.9435707652311
     coal:
       datetime: '2014-01-01'
       source: IPCC 2014
@@ -109,27 +109,27 @@ emissionFactors:
       source: eGrid 2020; IPCC 2014
       value: 665.8860298
     hydro discharge:
-    - datetime: '2015-01-01'
-      source: Electricity Maps, 2015 average
-      value: 464.088753652298
-    - datetime: '2016-01-01'
-      source: Electricity Maps, 2016 average
-      value: 628.6048672222605
-    - datetime: '2017-01-01'
-      source: Electricity Maps, 2017 average
-      value: 628.6437923889442
-    - datetime: '2018-01-01'
-      source: Electricity Maps, 2018 average
-      value: 666.5124144683374
-    - datetime: '2019-01-01'
-      source: Electricity Maps, 2019 average
-      value: 645.2149203085437
-    - datetime: '2020-01-01'
-      source: Electricity Maps, 2020 average
-      value: 645.9915486874397
-    - datetime: '2021-01-01'
-      source: Electricity Maps, 2021 average
-      value: 641.9435707652311
+      - datetime: '2015-01-01'
+        source: Electricity Maps, 2015 average
+        value: 464.088753652298
+      - datetime: '2016-01-01'
+        source: Electricity Maps, 2016 average
+        value: 628.6048672222605
+      - datetime: '2017-01-01'
+        source: Electricity Maps, 2017 average
+        value: 628.6437923889442
+      - datetime: '2018-01-01'
+        source: Electricity Maps, 2018 average
+        value: 666.5124144683374
+      - datetime: '2019-01-01'
+        source: Electricity Maps, 2019 average
+        value: 645.2149203085437
+      - datetime: '2020-01-01'
+        source: Electricity Maps, 2020 average
+        value: 645.9915486874397
+      - datetime: '2021-01-01'
+        source: Electricity Maps, 2021 average
+        value: 641.9435707652311
     oil:
       datetime: '2014-01-01'
       source: IPCC 2014; EIA 2020/BEIS 2021
@@ -140,111 +140,111 @@ emissionFactors:
       value: 25.6
 fallbackZoneMixes:
   powerOriginRatios:
-  - _source: Electricity Maps, 2015 average
-    datetime: '2015-01-01'
-    value:
-      battery discharge: 0
-      biomass: 0
-      coal: 0
-      gas: 0.9417706321553654
-      geothermal: 0
-      hydro: 0
-      hydro discharge: 0
-      nuclear: 0
-      oil: 0
-      solar: 0.058227941075081995
-      unknown: 0
-      wind: 0
-  - _source: Electricity Maps, 2016 average
-    datetime: '2016-01-01'
-    value:
-      battery discharge: 0
-      biomass: 0
-      coal: 0
-      gas: 0.9417707828037308
-      geothermal: 0
-      hydro: 0
-      hydro discharge: 0
-      nuclear: 0
-      oil: 0
-      solar: 0.05822779042648821
-      unknown: 0
-      wind: 0
-  - _source: Electricity Maps, 2017 average
-    datetime: '2017-01-01'
-    value:
-      battery discharge: 0
-      biomass: 3.853100112863885e-06
-      coal: 0.004455496495232723
-      gas: 0.9350013068108511
-      geothermal: 0
-      hydro: 0.0005030464226245364
-      hydro discharge: 7.930803046377121e-06
-      nuclear: 0.000575670582942777
-      oil: 1.966436419409328e-05
-      solar: 0.05770207363295614
-      unknown: 2.5687979496163404e-05
-      wind: 0.0017040499828793595
-  - _source: Electricity Maps, 2018 average
-    datetime: '2018-01-01'
-    value:
-      battery discharge: 0
-      biomass: 4.498960916079481e-06
-      coal: 0.1653765018743752
-      gas: 0.7113547792199667
-      geothermal: 2.2185749365357598e-07
-      hydro: 0.003809699352885953
-      hydro discharge: 0.013431676512939545
-      nuclear: 0.026001466464787827
-      oil: 1.859629379639527e-05
-      solar: 0.040548058562214856
-      unknown: 0.0006523791345844036
-      wind: 0.0388017321357148
-  - _source: Electricity Maps, 2019 average
-    datetime: '2019-01-01'
-    value:
-      battery discharge: 0
-      biomass: 3.459819791272405e-06
-      coal: 0.16402899418179895
-      gas: 0.6914645283384239
-      geothermal: 1.929424605444991e-06
-      hydro: 0.007446336117737151
-      hydro discharge: 0.00012762838624874202
-      nuclear: 0.03022800658398542
-      oil: 3.571313305577317e-06
-      solar: 0.05055243627998956
-      unknown: 0.0014149242871016674
-      wind: 0.054727555035252486
-  - _source: Electricity Maps, 2020 average
-    datetime: '2020-01-01'
-    value:
-      battery discharge: 1.0403200301831518e-08
-      biomass: 4.782004405408555e-06
-      coal: 0.17358368519268577
-      gas: 0.6774887599200294
-      geothermal: 3.268916717064393e-06
-      hydro: 0.007078332861721585
-      hydro discharge: 0.0009837786365426973
-      nuclear: 0.009804178248896336
-      oil: 5.328750376827034e-06
-      solar: 0.06169993610123192
-      unknown: 0.0019220941318552466
-      wind: 0.06742601706309795
-  - _source: Electricity Maps, 2021 average
-    datetime: '2021-01-01'
-    value:
-      battery discharge: 9.025386290669875e-08
-      biomass: 8.96405994792558e-06
-      coal: 0.18330897545496094
-      gas: 0.6527233928988425
-      geothermal: 1.1751515790774776e-05
-      hydro: 0.00629894784464964
-      hydro discharge: 0.00010040626538289588
-      nuclear: 0.01932987809687284
-      oil: 3.31972221383742e-06
-      solar: 0.059661301297065907
-      unknown: 0.0014996790138722235
-      wind: 0.07705298347352142
+    - _source: Electricity Maps, 2015 average
+      datetime: '2015-01-01'
+      value:
+        battery discharge: 0
+        biomass: 0
+        coal: 0
+        gas: 0.9417706321553654
+        geothermal: 0
+        hydro: 0
+        hydro discharge: 0
+        nuclear: 0
+        oil: 0
+        solar: 0.058227941075081995
+        unknown: 0
+        wind: 0
+    - _source: Electricity Maps, 2016 average
+      datetime: '2016-01-01'
+      value:
+        battery discharge: 0
+        biomass: 0
+        coal: 0
+        gas: 0.9417707828037308
+        geothermal: 0
+        hydro: 0
+        hydro discharge: 0
+        nuclear: 0
+        oil: 0
+        solar: 0.05822779042648821
+        unknown: 0
+        wind: 0
+    - _source: Electricity Maps, 2017 average
+      datetime: '2017-01-01'
+      value:
+        battery discharge: 0
+        biomass: 3.853100112863885e-06
+        coal: 0.004455496495232723
+        gas: 0.9350013068108511
+        geothermal: 0
+        hydro: 0.0005030464226245364
+        hydro discharge: 7.930803046377121e-06
+        nuclear: 0.000575670582942777
+        oil: 1.966436419409328e-05
+        solar: 0.05770207363295614
+        unknown: 2.5687979496163404e-05
+        wind: 0.0017040499828793595
+    - _source: Electricity Maps, 2018 average
+      datetime: '2018-01-01'
+      value:
+        battery discharge: 0
+        biomass: 4.498960916079481e-06
+        coal: 0.1653765018743752
+        gas: 0.7113547792199667
+        geothermal: 2.2185749365357598e-07
+        hydro: 0.003809699352885953
+        hydro discharge: 0.013431676512939545
+        nuclear: 0.026001466464787827
+        oil: 1.859629379639527e-05
+        solar: 0.040548058562214856
+        unknown: 0.0006523791345844036
+        wind: 0.0388017321357148
+    - _source: Electricity Maps, 2019 average
+      datetime: '2019-01-01'
+      value:
+        battery discharge: 0
+        biomass: 3.459819791272405e-06
+        coal: 0.16402899418179895
+        gas: 0.6914645283384239
+        geothermal: 1.929424605444991e-06
+        hydro: 0.007446336117737151
+        hydro discharge: 0.00012762838624874202
+        nuclear: 0.03022800658398542
+        oil: 3.571313305577317e-06
+        solar: 0.05055243627998956
+        unknown: 0.0014149242871016674
+        wind: 0.054727555035252486
+    - _source: Electricity Maps, 2020 average
+      datetime: '2020-01-01'
+      value:
+        battery discharge: 1.0403200301831518e-08
+        biomass: 4.782004405408555e-06
+        coal: 0.17358368519268577
+        gas: 0.6774887599200294
+        geothermal: 3.268916717064393e-06
+        hydro: 0.007078332861721585
+        hydro discharge: 0.0009837786365426973
+        nuclear: 0.009804178248896336
+        oil: 5.328750376827034e-06
+        solar: 0.06169993610123192
+        unknown: 0.0019220941318552466
+        wind: 0.06742601706309795
+    - _source: Electricity Maps, 2021 average
+      datetime: '2021-01-01'
+      value:
+        battery discharge: 9.025386290669875e-08
+        biomass: 8.96405994792558e-06
+        coal: 0.18330897545496094
+        gas: 0.6527233928988425
+        geothermal: 1.1751515790774776e-05
+        hydro: 0.00629894784464964
+        hydro discharge: 0.00010040626538289588
+        nuclear: 0.01932987809687284
+        oil: 3.31972221383742e-06
+        solar: 0.059661301297065907
+        unknown: 0.0014996790138722235
+        wind: 0.07705298347352142
 parsers:
   consumption: EIA.fetch_consumption
   consumptionForecast: EIA.fetch_consumption_forecast

--- a/config/zones/US-SW-EPE.yaml
+++ b/config/zones/US-SW-EPE.yaml
@@ -1,8 +1,8 @@
 bounding_box:
-  - - -108.7296822968229
-    - 30.130950309039566
-  - - -104.41562479630723
-    - 33.98037168914246
+- - -108.7296822968229
+  - 30.130950309039566
+- - -104.41562479630723
+  - 33.98037168914246
 capacity:
   battery storage: 51
   biomass: 3.2
@@ -18,86 +18,88 @@ capacity:
   wind: 0
 comment: El Paso Electric Company
 contributors:
-  - systemcatch
-  - robertahunt
-  - KabelWlan
+- systemcatch
+- robertahunt
+- KabelWlan
 delays:
   consumption: 30
   consumptionForecast: 30
   production: 30
+disclaimer: Data for real-time consumption and generation mix is estimated. Real-time
+  exchanges are not available.
 emissionFactors:
   direct:
     battery discharge:
-      - datetime: '2015-01-01'
-        source: Electricity Maps, 2015 average
-        value: 348.45428701670295
-      - datetime: '2016-01-01'
-        source: Electricity Maps, 2016 average
-        value: 514.101895165611
-      - datetime: '2017-01-01'
-        source: Electricity Maps, 2017 average
-        value: 514.7859055431869
-      - datetime: '2018-01-01'
-        source: Electricity Maps, 2018 average
-        value: 571.3437609438619
-      - datetime: '2019-01-01'
-        source: Electricity Maps, 2019 average
-        value: 552.4641741282234
-      - datetime: '2020-01-01'
-        source: Electricity Maps, 2020 average
-        value: 554.2767863427711
-      - datetime: '2021-01-01'
-        source: Electricity Maps, 2021 average
-        value: 552.3879131999372
+    - datetime: '2015-01-01'
+      source: Electricity Maps, 2015 average
+      value: 348.45428701670295
+    - datetime: '2016-01-01'
+      source: Electricity Maps, 2016 average
+      value: 514.101895165611
+    - datetime: '2017-01-01'
+      source: Electricity Maps, 2017 average
+      value: 514.7859055431869
+    - datetime: '2018-01-01'
+      source: Electricity Maps, 2018 average
+      value: 571.3437609438619
+    - datetime: '2019-01-01'
+      source: Electricity Maps, 2019 average
+      value: 552.4641741282234
+    - datetime: '2020-01-01'
+      source: Electricity Maps, 2020 average
+      value: 554.2767863427711
+    - datetime: '2021-01-01'
+      source: Electricity Maps, 2021 average
+      value: 552.3879131999372
     gas:
       datetime: '2021-01-01'
       source: eGrid 2020
       value: 545.8860298
     hydro discharge:
-      - datetime: '2015-01-01'
-        source: Electricity Maps, 2015 average
-        value: 348.45428701670295
-      - datetime: '2016-01-01'
-        source: Electricity Maps, 2016 average
-        value: 514.101895165611
-      - datetime: '2017-01-01'
-        source: Electricity Maps, 2017 average
-        value: 514.7859055431869
-      - datetime: '2018-01-01'
-        source: Electricity Maps, 2018 average
-        value: 571.3437609438619
-      - datetime: '2019-01-01'
-        source: Electricity Maps, 2019 average
-        value: 552.4641741282234
-      - datetime: '2020-01-01'
-        source: Electricity Maps, 2020 average
-        value: 554.2767863427711
-      - datetime: '2021-01-01'
-        source: Electricity Maps, 2021 average
-        value: 552.3879131999372
+    - datetime: '2015-01-01'
+      source: Electricity Maps, 2015 average
+      value: 348.45428701670295
+    - datetime: '2016-01-01'
+      source: Electricity Maps, 2016 average
+      value: 514.101895165611
+    - datetime: '2017-01-01'
+      source: Electricity Maps, 2017 average
+      value: 514.7859055431869
+    - datetime: '2018-01-01'
+      source: Electricity Maps, 2018 average
+      value: 571.3437609438619
+    - datetime: '2019-01-01'
+      source: Electricity Maps, 2019 average
+      value: 552.4641741282234
+    - datetime: '2020-01-01'
+      source: Electricity Maps, 2020 average
+      value: 554.2767863427711
+    - datetime: '2021-01-01'
+      source: Electricity Maps, 2021 average
+      value: 552.3879131999372
   lifecycle:
     battery discharge:
-      - datetime: '2015-01-01'
-        source: Electricity Maps, 2015 average
-        value: 464.088753652298
-      - datetime: '2016-01-01'
-        source: Electricity Maps, 2016 average
-        value: 628.6048672222605
-      - datetime: '2017-01-01'
-        source: Electricity Maps, 2017 average
-        value: 628.6437923889442
-      - datetime: '2018-01-01'
-        source: Electricity Maps, 2018 average
-        value: 666.5124144683374
-      - datetime: '2019-01-01'
-        source: Electricity Maps, 2019 average
-        value: 645.2149203085437
-      - datetime: '2020-01-01'
-        source: Electricity Maps, 2020 average
-        value: 645.9915486874397
-      - datetime: '2021-01-01'
-        source: Electricity Maps, 2021 average
-        value: 641.9435707652311
+    - datetime: '2015-01-01'
+      source: Electricity Maps, 2015 average
+      value: 464.088753652298
+    - datetime: '2016-01-01'
+      source: Electricity Maps, 2016 average
+      value: 628.6048672222605
+    - datetime: '2017-01-01'
+      source: Electricity Maps, 2017 average
+      value: 628.6437923889442
+    - datetime: '2018-01-01'
+      source: Electricity Maps, 2018 average
+      value: 666.5124144683374
+    - datetime: '2019-01-01'
+      source: Electricity Maps, 2019 average
+      value: 645.2149203085437
+    - datetime: '2020-01-01'
+      source: Electricity Maps, 2020 average
+      value: 645.9915486874397
+    - datetime: '2021-01-01'
+      source: Electricity Maps, 2021 average
+      value: 641.9435707652311
     coal:
       datetime: '2014-01-01'
       source: IPCC 2014
@@ -107,27 +109,27 @@ emissionFactors:
       source: eGrid 2020; IPCC 2014
       value: 665.8860298
     hydro discharge:
-      - datetime: '2015-01-01'
-        source: Electricity Maps, 2015 average
-        value: 464.088753652298
-      - datetime: '2016-01-01'
-        source: Electricity Maps, 2016 average
-        value: 628.6048672222605
-      - datetime: '2017-01-01'
-        source: Electricity Maps, 2017 average
-        value: 628.6437923889442
-      - datetime: '2018-01-01'
-        source: Electricity Maps, 2018 average
-        value: 666.5124144683374
-      - datetime: '2019-01-01'
-        source: Electricity Maps, 2019 average
-        value: 645.2149203085437
-      - datetime: '2020-01-01'
-        source: Electricity Maps, 2020 average
-        value: 645.9915486874397
-      - datetime: '2021-01-01'
-        source: Electricity Maps, 2021 average
-        value: 641.9435707652311
+    - datetime: '2015-01-01'
+      source: Electricity Maps, 2015 average
+      value: 464.088753652298
+    - datetime: '2016-01-01'
+      source: Electricity Maps, 2016 average
+      value: 628.6048672222605
+    - datetime: '2017-01-01'
+      source: Electricity Maps, 2017 average
+      value: 628.6437923889442
+    - datetime: '2018-01-01'
+      source: Electricity Maps, 2018 average
+      value: 666.5124144683374
+    - datetime: '2019-01-01'
+      source: Electricity Maps, 2019 average
+      value: 645.2149203085437
+    - datetime: '2020-01-01'
+      source: Electricity Maps, 2020 average
+      value: 645.9915486874397
+    - datetime: '2021-01-01'
+      source: Electricity Maps, 2021 average
+      value: 641.9435707652311
     oil:
       datetime: '2014-01-01'
       source: IPCC 2014; EIA 2020/BEIS 2021
@@ -138,123 +140,120 @@ emissionFactors:
       value: 25.6
 fallbackZoneMixes:
   powerOriginRatios:
-    - _source: Electricity Maps, 2015 average
-      datetime: '2015-01-01'
-      value:
-        battery discharge: 0
-        biomass: 0
-        coal: 0
-        gas: 0.9417706321553654
-        geothermal: 0
-        hydro: 0
-        hydro discharge: 0
-        nuclear: 0
-        oil: 0
-        solar: 0.058227941075081995
-        unknown: 0
-        wind: 0
-    - _source: Electricity Maps, 2016 average
-      datetime: '2016-01-01'
-      value:
-        battery discharge: 0
-        biomass: 0
-        coal: 0
-        gas: 0.9417707828037308
-        geothermal: 0
-        hydro: 0
-        hydro discharge: 0
-        nuclear: 0
-        oil: 0
-        solar: 0.05822779042648821
-        unknown: 0
-        wind: 0
-    - _source: Electricity Maps, 2017 average
-      datetime: '2017-01-01'
-      value:
-        battery discharge: 0
-        biomass: 0.000003853100112863885
-        coal: 0.004455496495232723
-        gas: 0.9350013068108511
-        geothermal: 0
-        hydro: 0.0005030464226245364
-        hydro discharge: 0.000007930803046377121
-        nuclear: 0.000575670582942777
-        oil: 0.00001966436419409328
-        solar: 0.05770207363295614
-        unknown: 0.000025687979496163404
-        wind: 0.0017040499828793595
-    - _source: Electricity Maps, 2018 average
-      datetime: '2018-01-01'
-      value:
-        battery discharge: 0
-        biomass: 0.000004498960916079481
-        coal: 0.1653765018743752
-        gas: 0.7113547792199667
-        geothermal: 2.2185749365357598e-7
-        hydro: 0.003809699352885953
-        hydro discharge: 0.013431676512939545
-        nuclear: 0.026001466464787827
-        oil: 0.00001859629379639527
-        solar: 0.040548058562214856
-        unknown: 0.0006523791345844036
-        wind: 0.0388017321357148
-    - _source: Electricity Maps, 2019 average
-      datetime: '2019-01-01'
-      value:
-        battery discharge: 0
-        biomass: 0.000003459819791272405
-        coal: 0.16402899418179895
-        gas: 0.6914645283384239
-        geothermal: 0.000001929424605444991
-        hydro: 0.007446336117737151
-        hydro discharge: 0.00012762838624874202
-        nuclear: 0.03022800658398542
-        oil: 0.000003571313305577317
-        solar: 0.05055243627998956
-        unknown: 0.0014149242871016674
-        wind: 0.054727555035252486
-    - _source: Electricity Maps, 2020 average
-      datetime: '2020-01-01'
-      value:
-        battery discharge: 1.0403200301831518e-8
-        biomass: 0.000004782004405408555
-        coal: 0.17358368519268577
-        gas: 0.6774887599200294
-        geothermal: 0.000003268916717064393
-        hydro: 0.007078332861721585
-        hydro discharge: 0.0009837786365426973
-        nuclear: 0.009804178248896336
-        oil: 0.000005328750376827034
-        solar: 0.06169993610123192
-        unknown: 0.0019220941318552466
-        wind: 0.06742601706309795
-    - _source: Electricity Maps, 2021 average
-      datetime: '2021-01-01'
-      value:
-        battery discharge: 9.025386290669875e-8
-        biomass: 0.00000896405994792558
-        coal: 0.18330897545496094
-        gas: 0.6527233928988425
-        geothermal: 0.000011751515790774776
-        hydro: 0.00629894784464964
-        hydro discharge: 0.00010040626538289588
-        nuclear: 0.01932987809687284
-        oil: 0.00000331972221383742
-        solar: 0.059661301297065907
-        unknown: 0.0014996790138722235
-        wind: 0.07705298347352142
+  - _source: Electricity Maps, 2015 average
+    datetime: '2015-01-01'
+    value:
+      battery discharge: 0
+      biomass: 0
+      coal: 0
+      gas: 0.9417706321553654
+      geothermal: 0
+      hydro: 0
+      hydro discharge: 0
+      nuclear: 0
+      oil: 0
+      solar: 0.058227941075081995
+      unknown: 0
+      wind: 0
+  - _source: Electricity Maps, 2016 average
+    datetime: '2016-01-01'
+    value:
+      battery discharge: 0
+      biomass: 0
+      coal: 0
+      gas: 0.9417707828037308
+      geothermal: 0
+      hydro: 0
+      hydro discharge: 0
+      nuclear: 0
+      oil: 0
+      solar: 0.05822779042648821
+      unknown: 0
+      wind: 0
+  - _source: Electricity Maps, 2017 average
+    datetime: '2017-01-01'
+    value:
+      battery discharge: 0
+      biomass: 3.853100112863885e-06
+      coal: 0.004455496495232723
+      gas: 0.9350013068108511
+      geothermal: 0
+      hydro: 0.0005030464226245364
+      hydro discharge: 7.930803046377121e-06
+      nuclear: 0.000575670582942777
+      oil: 1.966436419409328e-05
+      solar: 0.05770207363295614
+      unknown: 2.5687979496163404e-05
+      wind: 0.0017040499828793595
+  - _source: Electricity Maps, 2018 average
+    datetime: '2018-01-01'
+    value:
+      battery discharge: 0
+      biomass: 4.498960916079481e-06
+      coal: 0.1653765018743752
+      gas: 0.7113547792199667
+      geothermal: 2.2185749365357598e-07
+      hydro: 0.003809699352885953
+      hydro discharge: 0.013431676512939545
+      nuclear: 0.026001466464787827
+      oil: 1.859629379639527e-05
+      solar: 0.040548058562214856
+      unknown: 0.0006523791345844036
+      wind: 0.0388017321357148
+  - _source: Electricity Maps, 2019 average
+    datetime: '2019-01-01'
+    value:
+      battery discharge: 0
+      biomass: 3.459819791272405e-06
+      coal: 0.16402899418179895
+      gas: 0.6914645283384239
+      geothermal: 1.929424605444991e-06
+      hydro: 0.007446336117737151
+      hydro discharge: 0.00012762838624874202
+      nuclear: 0.03022800658398542
+      oil: 3.571313305577317e-06
+      solar: 0.05055243627998956
+      unknown: 0.0014149242871016674
+      wind: 0.054727555035252486
+  - _source: Electricity Maps, 2020 average
+    datetime: '2020-01-01'
+    value:
+      battery discharge: 1.0403200301831518e-08
+      biomass: 4.782004405408555e-06
+      coal: 0.17358368519268577
+      gas: 0.6774887599200294
+      geothermal: 3.268916717064393e-06
+      hydro: 0.007078332861721585
+      hydro discharge: 0.0009837786365426973
+      nuclear: 0.009804178248896336
+      oil: 5.328750376827034e-06
+      solar: 0.06169993610123192
+      unknown: 0.0019220941318552466
+      wind: 0.06742601706309795
+  - _source: Electricity Maps, 2021 average
+    datetime: '2021-01-01'
+    value:
+      battery discharge: 9.025386290669875e-08
+      biomass: 8.96405994792558e-06
+      coal: 0.18330897545496094
+      gas: 0.6527233928988425
+      geothermal: 1.1751515790774776e-05
+      hydro: 0.00629894784464964
+      hydro discharge: 0.00010040626538289588
+      nuclear: 0.01932987809687284
+      oil: 3.31972221383742e-06
+      solar: 0.059661301297065907
+      unknown: 0.0014996790138722235
+      wind: 0.07705298347352142
 parsers:
   consumption: EIA.fetch_consumption
   consumptionForecast: EIA.fetch_consumption_forecast
   production: EIA.fetch_production_mix
 sources:
   INCER ACV:
-    link: >-
-      https://docs.google.com/spreadsheets/d/1w5DJ7sPen6axIHU8TCVcuzNCjlct4I6JAbhUlw-ZXu8/edit?usp=sharing
+    link: https://docs.google.com/spreadsheets/d/1w5DJ7sPen6axIHU8TCVcuzNCjlct4I6JAbhUlw-ZXu8/edit?usp=sharing
   IPCC 2014:
-    link: >-
-      https://www.ipcc.ch/site/assets/uploads/2018/02/ipcc_wg3_ar5_annex-iii.pdf#page=7
+    link: https://www.ipcc.ch/site/assets/uploads/2018/02/ipcc_wg3_ar5_annex-iii.pdf#page=7
   eGrid 2020:
-    link: >-
-      https://drive.google.com/file/d/1_FAAuTtIdMuORZKsqHnd9vMNHlQgYarh/view?usp=sharing
+    link: https://drive.google.com/file/d/1_FAAuTtIdMuORZKsqHnd9vMNHlQgYarh/view?usp=sharing
 timezone: US/Mountain

--- a/config/zones/US-SW-GRIF.yaml
+++ b/config/zones/US-SW-GRIF.yaml
@@ -1,8 +1,8 @@
 bounding_box:
-  - - -114.764827728
-    - 34.168836594
-  - - -112.998666763
-    - 35.717744827
+- - -114.764827728
+  - 34.168836594
+- - -112.998666763
+  - 35.717744827
 capacity:
   battery storage: 0
   biomass: 0
@@ -18,57 +18,59 @@ capacity:
   wind: 0
 comment: Griffith Energy, Llc
 contributors:
-  - systemcatch
-  - robertahunt
-  - KabelWlan
+- systemcatch
+- robertahunt
+- KabelWlan
 delays:
   production: 30
+disclaimer: Data for real-time consumption and generation mix is estimated. Real-time
+  exchanges are not available.
 emissionFactors:
   direct:
     battery discharge:
-      - datetime: '2018-01-01'
-        source: Electricity Maps, 2018 average
-        value: 390.18
-      - datetime: '2019-01-01'
-        source: Electricity Maps, 2019 average
-        value: 390.17999999999995
-      - datetime: '2020-01-01'
-        source: Electricity Maps, 2020 average
-        value: 390.18
-      - datetime: '2021-01-01'
-        source: Electricity Maps, 2021 average
-        value: 390.18
+    - datetime: '2018-01-01'
+      source: Electricity Maps, 2018 average
+      value: 390.18
+    - datetime: '2019-01-01'
+      source: Electricity Maps, 2019 average
+      value: 390.17999999999995
+    - datetime: '2020-01-01'
+      source: Electricity Maps, 2020 average
+      value: 390.18
+    - datetime: '2021-01-01'
+      source: Electricity Maps, 2021 average
+      value: 390.18
     gas:
       datetime: '2021-01-01'
       source: eGrid 2020
       value: 390.1784429
     hydro discharge:
-      - datetime: '2018-01-01'
-        source: Electricity Maps, 2018 average
-        value: 390.18
-      - datetime: '2019-01-01'
-        source: Electricity Maps, 2019 average
-        value: 390.17999999999995
-      - datetime: '2020-01-01'
-        source: Electricity Maps, 2020 average
-        value: 390.18
-      - datetime: '2021-01-01'
-        source: Electricity Maps, 2021 average
-        value: 390.18
+    - datetime: '2018-01-01'
+      source: Electricity Maps, 2018 average
+      value: 390.18
+    - datetime: '2019-01-01'
+      source: Electricity Maps, 2019 average
+      value: 390.17999999999995
+    - datetime: '2020-01-01'
+      source: Electricity Maps, 2020 average
+      value: 390.18
+    - datetime: '2021-01-01'
+      source: Electricity Maps, 2021 average
+      value: 390.18
   lifecycle:
     battery discharge:
-      - datetime: '2018-01-01'
-        source: Electricity Maps, 2018 average
-        value: 510.18
-      - datetime: '2019-01-01'
-        source: Electricity Maps, 2019 average
-        value: 510.17999999999995
-      - datetime: '2020-01-01'
-        source: Electricity Maps, 2020 average
-        value: 510.18
-      - datetime: '2021-01-01'
-        source: Electricity Maps, 2021 average
-        value: 510.18
+    - datetime: '2018-01-01'
+      source: Electricity Maps, 2018 average
+      value: 510.18
+    - datetime: '2019-01-01'
+      source: Electricity Maps, 2019 average
+      value: 510.17999999999995
+    - datetime: '2020-01-01'
+      source: Electricity Maps, 2020 average
+      value: 510.18
+    - datetime: '2021-01-01'
+      source: Electricity Maps, 2021 average
+      value: 510.18
     coal:
       datetime: '2014-01-01'
       source: IPCC 2014
@@ -78,84 +80,84 @@ emissionFactors:
       source: eGrid 2020; IPCC 2014
       value: 510.1784429
     hydro discharge:
-      - datetime: '2018-01-01'
-        source: Electricity Maps, 2018 average
-        value: 510.18
-      - datetime: '2019-01-01'
-        source: Electricity Maps, 2019 average
-        value: 510.17999999999995
-      - datetime: '2020-01-01'
-        source: Electricity Maps, 2020 average
-        value: 510.18
-      - datetime: '2021-01-01'
-        source: Electricity Maps, 2021 average
-        value: 510.18
+    - datetime: '2018-01-01'
+      source: Electricity Maps, 2018 average
+      value: 510.18
+    - datetime: '2019-01-01'
+      source: Electricity Maps, 2019 average
+      value: 510.17999999999995
+    - datetime: '2020-01-01'
+      source: Electricity Maps, 2020 average
+      value: 510.18
+    - datetime: '2021-01-01'
+      source: Electricity Maps, 2021 average
+      value: 510.18
     oil:
       datetime: '2014-01-01'
       source: IPCC 2014; EIA 2020/BEIS 2021
       value: 650.0
 fallbackZoneMixes:
   powerOriginRatios:
-    - _source: Electricity Maps, 2018 average
-      datetime: '2018-01-01'
-      value:
-        battery discharge: 0.0
-        biomass: 0.0
-        coal: 0.0
-        gas: 1.0
-        geothermal: 0.0
-        hydro: 0.0
-        hydro discharge: 0.0
-        nuclear: 0.0
-        oil: 0.0
-        solar: 0.0
-        unknown: 0.0
-        wind: 0.0
-    - _source: Electricity Maps, 2019 average
-      datetime: '2019-01-01'
-      value:
-        battery discharge: 0.0
-        biomass: 0.0
-        coal: 0.0
-        gas: 1.0
-        geothermal: 0.0
-        hydro: 0.0
-        hydro discharge: 0.0
-        nuclear: 0.0
-        oil: 0.0
-        solar: 0.0
-        unknown: 0.0
-        wind: 0.0
-    - _source: Electricity Maps, 2020 average
-      datetime: '2020-01-01'
-      value:
-        battery discharge: 0.0
-        biomass: 0.0
-        coal: 0.0
-        gas: 1.0
-        geothermal: 0.0
-        hydro: 0.0
-        hydro discharge: 0.0
-        nuclear: 0.0
-        oil: 0.0
-        solar: 0.0
-        unknown: 0.0
-        wind: 0.0
-    - _source: Electricity Maps, 2021 average
-      datetime: '2021-01-01'
-      value:
-        battery discharge: 0.0
-        biomass: 0.0
-        coal: 0.0
-        gas: 1.0
-        geothermal: 0.0
-        hydro: 0.0
-        hydro discharge: 0.0
-        nuclear: 0.0
-        oil: 0.0
-        solar: 0.0
-        unknown: 0.0
-        wind: 0.0
+  - _source: Electricity Maps, 2018 average
+    datetime: '2018-01-01'
+    value:
+      battery discharge: 0.0
+      biomass: 0.0
+      coal: 0.0
+      gas: 1.0
+      geothermal: 0.0
+      hydro: 0.0
+      hydro discharge: 0.0
+      nuclear: 0.0
+      oil: 0.0
+      solar: 0.0
+      unknown: 0.0
+      wind: 0.0
+  - _source: Electricity Maps, 2019 average
+    datetime: '2019-01-01'
+    value:
+      battery discharge: 0.0
+      biomass: 0.0
+      coal: 0.0
+      gas: 1.0
+      geothermal: 0.0
+      hydro: 0.0
+      hydro discharge: 0.0
+      nuclear: 0.0
+      oil: 0.0
+      solar: 0.0
+      unknown: 0.0
+      wind: 0.0
+  - _source: Electricity Maps, 2020 average
+    datetime: '2020-01-01'
+    value:
+      battery discharge: 0.0
+      biomass: 0.0
+      coal: 0.0
+      gas: 1.0
+      geothermal: 0.0
+      hydro: 0.0
+      hydro discharge: 0.0
+      nuclear: 0.0
+      oil: 0.0
+      solar: 0.0
+      unknown: 0.0
+      wind: 0.0
+  - _source: Electricity Maps, 2021 average
+    datetime: '2021-01-01'
+    value:
+      battery discharge: 0.0
+      biomass: 0.0
+      coal: 0.0
+      gas: 1.0
+      geothermal: 0.0
+      hydro: 0.0
+      hydro discharge: 0.0
+      nuclear: 0.0
+      oil: 0.0
+      solar: 0.0
+      unknown: 0.0
+      wind: 0.0
 parsers:
   production: EIA.fetch_production_mix
 sources:

--- a/config/zones/US-SW-GRIF.yaml
+++ b/config/zones/US-SW-GRIF.yaml
@@ -1,8 +1,8 @@
 bounding_box:
-- - -114.764827728
-  - 34.168836594
-- - -112.998666763
-  - 35.717744827
+  - - -114.764827728
+    - 34.168836594
+  - - -112.998666763
+    - 35.717744827
 capacity:
   battery storage: 0
   biomass: 0
@@ -18,9 +18,9 @@ capacity:
   wind: 0
 comment: Griffith Energy, Llc
 contributors:
-- systemcatch
-- robertahunt
-- KabelWlan
+  - systemcatch
+  - robertahunt
+  - KabelWlan
 delays:
   production: 30
 disclaimer: Data for real-time consumption and generation mix is estimated. Real-time
@@ -28,49 +28,49 @@ disclaimer: Data for real-time consumption and generation mix is estimated. Real
 emissionFactors:
   direct:
     battery discharge:
-    - datetime: '2018-01-01'
-      source: Electricity Maps, 2018 average
-      value: 390.18
-    - datetime: '2019-01-01'
-      source: Electricity Maps, 2019 average
-      value: 390.17999999999995
-    - datetime: '2020-01-01'
-      source: Electricity Maps, 2020 average
-      value: 390.18
-    - datetime: '2021-01-01'
-      source: Electricity Maps, 2021 average
-      value: 390.18
+      - datetime: '2018-01-01'
+        source: Electricity Maps, 2018 average
+        value: 390.18
+      - datetime: '2019-01-01'
+        source: Electricity Maps, 2019 average
+        value: 390.17999999999995
+      - datetime: '2020-01-01'
+        source: Electricity Maps, 2020 average
+        value: 390.18
+      - datetime: '2021-01-01'
+        source: Electricity Maps, 2021 average
+        value: 390.18
     gas:
       datetime: '2021-01-01'
       source: eGrid 2020
       value: 390.1784429
     hydro discharge:
-    - datetime: '2018-01-01'
-      source: Electricity Maps, 2018 average
-      value: 390.18
-    - datetime: '2019-01-01'
-      source: Electricity Maps, 2019 average
-      value: 390.17999999999995
-    - datetime: '2020-01-01'
-      source: Electricity Maps, 2020 average
-      value: 390.18
-    - datetime: '2021-01-01'
-      source: Electricity Maps, 2021 average
-      value: 390.18
+      - datetime: '2018-01-01'
+        source: Electricity Maps, 2018 average
+        value: 390.18
+      - datetime: '2019-01-01'
+        source: Electricity Maps, 2019 average
+        value: 390.17999999999995
+      - datetime: '2020-01-01'
+        source: Electricity Maps, 2020 average
+        value: 390.18
+      - datetime: '2021-01-01'
+        source: Electricity Maps, 2021 average
+        value: 390.18
   lifecycle:
     battery discharge:
-    - datetime: '2018-01-01'
-      source: Electricity Maps, 2018 average
-      value: 510.18
-    - datetime: '2019-01-01'
-      source: Electricity Maps, 2019 average
-      value: 510.17999999999995
-    - datetime: '2020-01-01'
-      source: Electricity Maps, 2020 average
-      value: 510.18
-    - datetime: '2021-01-01'
-      source: Electricity Maps, 2021 average
-      value: 510.18
+      - datetime: '2018-01-01'
+        source: Electricity Maps, 2018 average
+        value: 510.18
+      - datetime: '2019-01-01'
+        source: Electricity Maps, 2019 average
+        value: 510.17999999999995
+      - datetime: '2020-01-01'
+        source: Electricity Maps, 2020 average
+        value: 510.18
+      - datetime: '2021-01-01'
+        source: Electricity Maps, 2021 average
+        value: 510.18
     coal:
       datetime: '2014-01-01'
       source: IPCC 2014
@@ -80,84 +80,84 @@ emissionFactors:
       source: eGrid 2020; IPCC 2014
       value: 510.1784429
     hydro discharge:
-    - datetime: '2018-01-01'
-      source: Electricity Maps, 2018 average
-      value: 510.18
-    - datetime: '2019-01-01'
-      source: Electricity Maps, 2019 average
-      value: 510.17999999999995
-    - datetime: '2020-01-01'
-      source: Electricity Maps, 2020 average
-      value: 510.18
-    - datetime: '2021-01-01'
-      source: Electricity Maps, 2021 average
-      value: 510.18
+      - datetime: '2018-01-01'
+        source: Electricity Maps, 2018 average
+        value: 510.18
+      - datetime: '2019-01-01'
+        source: Electricity Maps, 2019 average
+        value: 510.17999999999995
+      - datetime: '2020-01-01'
+        source: Electricity Maps, 2020 average
+        value: 510.18
+      - datetime: '2021-01-01'
+        source: Electricity Maps, 2021 average
+        value: 510.18
     oil:
       datetime: '2014-01-01'
       source: IPCC 2014; EIA 2020/BEIS 2021
       value: 650.0
 fallbackZoneMixes:
   powerOriginRatios:
-  - _source: Electricity Maps, 2018 average
-    datetime: '2018-01-01'
-    value:
-      battery discharge: 0.0
-      biomass: 0.0
-      coal: 0.0
-      gas: 1.0
-      geothermal: 0.0
-      hydro: 0.0
-      hydro discharge: 0.0
-      nuclear: 0.0
-      oil: 0.0
-      solar: 0.0
-      unknown: 0.0
-      wind: 0.0
-  - _source: Electricity Maps, 2019 average
-    datetime: '2019-01-01'
-    value:
-      battery discharge: 0.0
-      biomass: 0.0
-      coal: 0.0
-      gas: 1.0
-      geothermal: 0.0
-      hydro: 0.0
-      hydro discharge: 0.0
-      nuclear: 0.0
-      oil: 0.0
-      solar: 0.0
-      unknown: 0.0
-      wind: 0.0
-  - _source: Electricity Maps, 2020 average
-    datetime: '2020-01-01'
-    value:
-      battery discharge: 0.0
-      biomass: 0.0
-      coal: 0.0
-      gas: 1.0
-      geothermal: 0.0
-      hydro: 0.0
-      hydro discharge: 0.0
-      nuclear: 0.0
-      oil: 0.0
-      solar: 0.0
-      unknown: 0.0
-      wind: 0.0
-  - _source: Electricity Maps, 2021 average
-    datetime: '2021-01-01'
-    value:
-      battery discharge: 0.0
-      biomass: 0.0
-      coal: 0.0
-      gas: 1.0
-      geothermal: 0.0
-      hydro: 0.0
-      hydro discharge: 0.0
-      nuclear: 0.0
-      oil: 0.0
-      solar: 0.0
-      unknown: 0.0
-      wind: 0.0
+    - _source: Electricity Maps, 2018 average
+      datetime: '2018-01-01'
+      value:
+        battery discharge: 0.0
+        biomass: 0.0
+        coal: 0.0
+        gas: 1.0
+        geothermal: 0.0
+        hydro: 0.0
+        hydro discharge: 0.0
+        nuclear: 0.0
+        oil: 0.0
+        solar: 0.0
+        unknown: 0.0
+        wind: 0.0
+    - _source: Electricity Maps, 2019 average
+      datetime: '2019-01-01'
+      value:
+        battery discharge: 0.0
+        biomass: 0.0
+        coal: 0.0
+        gas: 1.0
+        geothermal: 0.0
+        hydro: 0.0
+        hydro discharge: 0.0
+        nuclear: 0.0
+        oil: 0.0
+        solar: 0.0
+        unknown: 0.0
+        wind: 0.0
+    - _source: Electricity Maps, 2020 average
+      datetime: '2020-01-01'
+      value:
+        battery discharge: 0.0
+        biomass: 0.0
+        coal: 0.0
+        gas: 1.0
+        geothermal: 0.0
+        hydro: 0.0
+        hydro discharge: 0.0
+        nuclear: 0.0
+        oil: 0.0
+        solar: 0.0
+        unknown: 0.0
+        wind: 0.0
+    - _source: Electricity Maps, 2021 average
+      datetime: '2021-01-01'
+      value:
+        battery discharge: 0.0
+        biomass: 0.0
+        coal: 0.0
+        gas: 1.0
+        geothermal: 0.0
+        hydro: 0.0
+        hydro discharge: 0.0
+        nuclear: 0.0
+        oil: 0.0
+        solar: 0.0
+        unknown: 0.0
+        wind: 0.0
 parsers:
   production: EIA.fetch_production_mix
 sources:

--- a/config/zones/US-SW-GRMA.yaml
+++ b/config/zones/US-SW-GRMA.yaml
@@ -1,8 +1,8 @@
 bounding_box:
-  - - -113.26607132
-    - 31.246901321
-  - - -111.760446548
-    - 33.5380344390001
+- - -113.26607132
+  - 31.246901321
+- - -111.760446548
+  - 33.5380344390001
 capacity:
   battery storage: 0
   biomass: 0
@@ -18,11 +18,13 @@ capacity:
   wind: 0
 comment: Gila River Power, Llc
 contributors:
-  - systemcatch
-  - robertahunt
-  - KabelWlan
+- systemcatch
+- robertahunt
+- KabelWlan
 delays:
   production: 30
+disclaimer: Data for real-time consumption and generation mix is estimated. Real-time
+  exchanges are not available.
 emissionFactors:
   lifecycle:
     coal:

--- a/config/zones/US-SW-GRMA.yaml
+++ b/config/zones/US-SW-GRMA.yaml
@@ -1,8 +1,8 @@
 bounding_box:
-- - -113.26607132
-  - 31.246901321
-- - -111.760446548
-  - 33.5380344390001
+  - - -113.26607132
+    - 31.246901321
+  - - -111.760446548
+    - 33.5380344390001
 capacity:
   battery storage: 0
   biomass: 0
@@ -18,9 +18,9 @@ capacity:
   wind: 0
 comment: Gila River Power, Llc
 contributors:
-- systemcatch
-- robertahunt
-- KabelWlan
+  - systemcatch
+  - robertahunt
+  - KabelWlan
 delays:
   production: 30
 disclaimer: Data for real-time consumption and generation mix is estimated. Real-time

--- a/config/zones/US-SW-HGMA.yaml
+++ b/config/zones/US-SW-HGMA.yaml
@@ -1,8 +1,8 @@
 bounding_box:
-  - - -114.158504486
-    - 32.855298996
-  - - -112.449426651
-    - 34.847730637
+- - -114.158504486
+  - 32.855298996
+- - -112.449426651
+  - 34.847730637
 capacity:
   battery storage: 0
   biomass: 0
@@ -18,26 +18,28 @@ capacity:
   wind: 0
 comment: New Harquahala Generating Company, Llc - Hgba
 contributors:
-  - systemcatch
-  - robertahunt
-  - KabelWlan
+- systemcatch
+- robertahunt
+- KabelWlan
 delays:
   production: 30
+disclaimer: Data for real-time consumption and generation mix is estimated. Real-time
+  exchanges are not available.
 emissionFactors:
   direct:
     battery discharge:
-      - datetime: '2021-01-01'
-        source: Electricity Maps, 2021 average
-        value: 370.0
+    - datetime: '2021-01-01'
+      source: Electricity Maps, 2021 average
+      value: 370.0
     hydro discharge:
-      - datetime: '2021-01-01'
-        source: Electricity Maps, 2021 average
-        value: 370.0
+    - datetime: '2021-01-01'
+      source: Electricity Maps, 2021 average
+      value: 370.0
   lifecycle:
     battery discharge:
-      - datetime: '2021-01-01'
-        source: Electricity Maps, 2021 average
-        value: 490.0
+    - datetime: '2021-01-01'
+      source: Electricity Maps, 2021 average
+      value: 490.0
     coal:
       datetime: '2014-01-01'
       source: IPCC 2014
@@ -47,30 +49,30 @@ emissionFactors:
       source: IPCC 2014
       value: 490.0
     hydro discharge:
-      - datetime: '2021-01-01'
-        source: Electricity Maps, 2021 average
-        value: 490.0
+    - datetime: '2021-01-01'
+      source: Electricity Maps, 2021 average
+      value: 490.0
     oil:
       datetime: '2014-01-01'
       source: IPCC 2014; EIA 2020/BEIS 2021
       value: 650.0
 fallbackZoneMixes:
   powerOriginRatios:
-    - _source: Electricity Maps, 2021 average
-      datetime: '2021-01-01'
-      value:
-        battery discharge: 0.0
-        biomass: 0.0
-        coal: 0.0
-        gas: 1.0
-        geothermal: 0.0
-        hydro: 0.0
-        hydro discharge: 0.0
-        nuclear: 0.0
-        oil: 0.0
-        solar: 0.0
-        unknown: 0.0
-        wind: 0.0
+  - _source: Electricity Maps, 2021 average
+    datetime: '2021-01-01'
+    value:
+      battery discharge: 0.0
+      biomass: 0.0
+      coal: 0.0
+      gas: 1.0
+      geothermal: 0.0
+      hydro: 0.0
+      hydro discharge: 0.0
+      nuclear: 0.0
+      oil: 0.0
+      solar: 0.0
+      unknown: 0.0
+      wind: 0.0
 parsers:
   production: EIA.fetch_production_mix
 sources:

--- a/config/zones/US-SW-HGMA.yaml
+++ b/config/zones/US-SW-HGMA.yaml
@@ -1,8 +1,8 @@
 bounding_box:
-- - -114.158504486
-  - 32.855298996
-- - -112.449426651
-  - 34.847730637
+  - - -114.158504486
+    - 32.855298996
+  - - -112.449426651
+    - 34.847730637
 capacity:
   battery storage: 0
   biomass: 0
@@ -18,9 +18,9 @@ capacity:
   wind: 0
 comment: New Harquahala Generating Company, Llc - Hgba
 contributors:
-- systemcatch
-- robertahunt
-- KabelWlan
+  - systemcatch
+  - robertahunt
+  - KabelWlan
 delays:
   production: 30
 disclaimer: Data for real-time consumption and generation mix is estimated. Real-time
@@ -28,18 +28,18 @@ disclaimer: Data for real-time consumption and generation mix is estimated. Real
 emissionFactors:
   direct:
     battery discharge:
-    - datetime: '2021-01-01'
-      source: Electricity Maps, 2021 average
-      value: 370.0
+      - datetime: '2021-01-01'
+        source: Electricity Maps, 2021 average
+        value: 370.0
     hydro discharge:
-    - datetime: '2021-01-01'
-      source: Electricity Maps, 2021 average
-      value: 370.0
+      - datetime: '2021-01-01'
+        source: Electricity Maps, 2021 average
+        value: 370.0
   lifecycle:
     battery discharge:
-    - datetime: '2021-01-01'
-      source: Electricity Maps, 2021 average
-      value: 490.0
+      - datetime: '2021-01-01'
+        source: Electricity Maps, 2021 average
+        value: 490.0
     coal:
       datetime: '2014-01-01'
       source: IPCC 2014
@@ -49,30 +49,30 @@ emissionFactors:
       source: IPCC 2014
       value: 490.0
     hydro discharge:
-    - datetime: '2021-01-01'
-      source: Electricity Maps, 2021 average
-      value: 490.0
+      - datetime: '2021-01-01'
+        source: Electricity Maps, 2021 average
+        value: 490.0
     oil:
       datetime: '2014-01-01'
       source: IPCC 2014; EIA 2020/BEIS 2021
       value: 650.0
 fallbackZoneMixes:
   powerOriginRatios:
-  - _source: Electricity Maps, 2021 average
-    datetime: '2021-01-01'
-    value:
-      battery discharge: 0.0
-      biomass: 0.0
-      coal: 0.0
-      gas: 1.0
-      geothermal: 0.0
-      hydro: 0.0
-      hydro discharge: 0.0
-      nuclear: 0.0
-      oil: 0.0
-      solar: 0.0
-      unknown: 0.0
-      wind: 0.0
+    - _source: Electricity Maps, 2021 average
+      datetime: '2021-01-01'
+      value:
+        battery discharge: 0.0
+        biomass: 0.0
+        coal: 0.0
+        gas: 1.0
+        geothermal: 0.0
+        hydro: 0.0
+        hydro discharge: 0.0
+        nuclear: 0.0
+        oil: 0.0
+        solar: 0.0
+        unknown: 0.0
+        wind: 0.0
 parsers:
   production: EIA.fetch_production_mix
 sources:

--- a/config/zones/US-SW-PNM.yaml
+++ b/config/zones/US-SW-PNM.yaml
@@ -1,8 +1,8 @@
 bounding_box:
-  - - -111.30730807308066
-    - 30.832316356872
-  - - -101.53402034020334
-    - 38.30081076184365
+- - -111.30730807308066
+  - 30.832316356872
+- - -101.53402034020334
+  - 38.30081076184365
 capacity:
   battery storage: 13.8
   biomass: 14.6
@@ -18,38 +18,40 @@ capacity:
   wind: 2569
 comment: Public Service Company Of New Mexico
 contributors:
-  - systemcatch
-  - robertahunt
-  - KabelWlan
-  - brandongalbraith
+- systemcatch
+- robertahunt
+- KabelWlan
+- brandongalbraith
 delays:
   consumption: 30
   consumptionForecast: 30
   production: 30
+disclaimer: Data for real-time consumption and generation mix is estimated. Real-time
+  exchanges are not available.
 emissionFactors:
   direct:
     battery discharge:
-      - datetime: '2015-01-01'
-        source: Electricity Maps, 2015 average
-        value: 431.26093766802705
-      - datetime: '2016-01-01'
-        source: Electricity Maps, 2016 average
-        value: 614.2774212632262
-      - datetime: '2017-01-01'
-        source: Electricity Maps, 2017 average
-        value: 614.0029455876082
-      - datetime: '2018-01-01'
-        source: Electricity Maps, 2018 average
-        value: 660.2357353192027
-      - datetime: '2019-01-01'
-        source: Electricity Maps, 2019 average
-        value: 613.9423941805912
-      - datetime: '2020-01-01'
-        source: Electricity Maps, 2020 average
-        value: 616.5295429066152
-      - datetime: '2021-01-01'
-        source: Electricity Maps, 2021 average
-        value: 620.554254535142
+    - datetime: '2015-01-01'
+      source: Electricity Maps, 2015 average
+      value: 431.26093766802705
+    - datetime: '2016-01-01'
+      source: Electricity Maps, 2016 average
+      value: 614.2774212632262
+    - datetime: '2017-01-01'
+      source: Electricity Maps, 2017 average
+      value: 614.0029455876082
+    - datetime: '2018-01-01'
+      source: Electricity Maps, 2018 average
+      value: 660.2357353192027
+    - datetime: '2019-01-01'
+      source: Electricity Maps, 2019 average
+      value: 613.9423941805912
+    - datetime: '2020-01-01'
+      source: Electricity Maps, 2020 average
+      value: 616.5295429066152
+    - datetime: '2021-01-01'
+      source: Electricity Maps, 2021 average
+      value: 620.554254535142
     coal:
       datetime: '2020-01-01'
       source: eGrid 2020
@@ -59,82 +61,81 @@ emissionFactors:
       source: eGrid 2020
       value: 412.1499722
     hydro discharge:
-      - datetime: '2015-01-01'
-        source: Electricity Maps, 2015 average
-        value: 431.26093766802705
-      - datetime: '2016-01-01'
-        source: Electricity Maps, 2016 average
-        value: 614.2774212632262
-      - datetime: '2017-01-01'
-        source: Electricity Maps, 2017 average
-        value: 614.0029455876082
-      - datetime: '2018-01-01'
-        source: Electricity Maps, 2018 average
-        value: 660.2357353192027
-      - datetime: '2019-01-01'
-        source: Electricity Maps, 2019 average
-        value: 613.9423941805912
-      - datetime: '2020-01-01'
-        source: Electricity Maps, 2020 average
-        value: 616.5295429066152
-      - datetime: '2021-01-01'
-        source: Electricity Maps, 2021 average
-        value: 620.554254535142
+    - datetime: '2015-01-01'
+      source: Electricity Maps, 2015 average
+      value: 431.26093766802705
+    - datetime: '2016-01-01'
+      source: Electricity Maps, 2016 average
+      value: 614.2774212632262
+    - datetime: '2017-01-01'
+      source: Electricity Maps, 2017 average
+      value: 614.0029455876082
+    - datetime: '2018-01-01'
+      source: Electricity Maps, 2018 average
+      value: 660.2357353192027
+    - datetime: '2019-01-01'
+      source: Electricity Maps, 2019 average
+      value: 613.9423941805912
+    - datetime: '2020-01-01'
+      source: Electricity Maps, 2020 average
+      value: 616.5295429066152
+    - datetime: '2021-01-01'
+      source: Electricity Maps, 2021 average
+      value: 620.554254535142
   lifecycle:
     battery discharge:
-      - datetime: '2015-01-01'
-        source: Electricity Maps, 2015 average
-        value: 497.3976329313718
-      - datetime: '2016-01-01'
-        source: Electricity Maps, 2016 average
-        value: 673.1078913394612
-      - datetime: '2017-01-01'
-        source: Electricity Maps, 2017 average
-        value: 672.7746055231751
-      - datetime: '2018-01-01'
-        source: Electricity Maps, 2018 average
-        value: 720.3321301062109
-      - datetime: '2019-01-01'
-        source: Electricity Maps, 2019 average
-        value: 671.19743499245
-      - datetime: '2020-01-01'
-        source: Electricity Maps, 2020 average
-        value: 678.4258291107535
-      - datetime: '2021-01-01'
-        source: Electricity Maps, 2021 average
-        value: 677.0004108933182
+    - datetime: '2015-01-01'
+      source: Electricity Maps, 2015 average
+      value: 497.3976329313718
+    - datetime: '2016-01-01'
+      source: Electricity Maps, 2016 average
+      value: 673.1078913394612
+    - datetime: '2017-01-01'
+      source: Electricity Maps, 2017 average
+      value: 672.7746055231751
+    - datetime: '2018-01-01'
+      source: Electricity Maps, 2018 average
+      value: 720.3321301062109
+    - datetime: '2019-01-01'
+      source: Electricity Maps, 2019 average
+      value: 671.19743499245
+    - datetime: '2020-01-01'
+      source: Electricity Maps, 2020 average
+      value: 678.4258291107535
+    - datetime: '2021-01-01'
+      source: Electricity Maps, 2021 average
+      value: 677.0004108933182
     coal:
       datetime: '2020-01-01'
-      source: >-
-        eGrid 2020; Oberschelp, Christopher, et al. "Global emission hotspots of
-        coal power generation."
+      source: eGrid 2020; Oberschelp, Christopher, et al. "Global emission hotspots
+        of coal power generation."
       value: 1246.197747
     gas:
       datetime: '2021-01-01'
       source: eGrid 2020; IPCC 2014
       value: 532.1499722
     hydro discharge:
-      - datetime: '2015-01-01'
-        source: Electricity Maps, 2015 average
-        value: 497.3976329313718
-      - datetime: '2016-01-01'
-        source: Electricity Maps, 2016 average
-        value: 673.1078913394612
-      - datetime: '2017-01-01'
-        source: Electricity Maps, 2017 average
-        value: 672.7746055231751
-      - datetime: '2018-01-01'
-        source: Electricity Maps, 2018 average
-        value: 720.3321301062109
-      - datetime: '2019-01-01'
-        source: Electricity Maps, 2019 average
-        value: 671.19743499245
-      - datetime: '2020-01-01'
-        source: Electricity Maps, 2020 average
-        value: 678.4258291107535
-      - datetime: '2021-01-01'
-        source: Electricity Maps, 2021 average
-        value: 677.0004108933182
+    - datetime: '2015-01-01'
+      source: Electricity Maps, 2015 average
+      value: 497.3976329313718
+    - datetime: '2016-01-01'
+      source: Electricity Maps, 2016 average
+      value: 673.1078913394612
+    - datetime: '2017-01-01'
+      source: Electricity Maps, 2017 average
+      value: 672.7746055231751
+    - datetime: '2018-01-01'
+      source: Electricity Maps, 2018 average
+      value: 720.3321301062109
+    - datetime: '2019-01-01'
+      source: Electricity Maps, 2019 average
+      value: 671.19743499245
+    - datetime: '2020-01-01'
+      source: Electricity Maps, 2020 average
+      value: 678.4258291107535
+    - datetime: '2021-01-01'
+      source: Electricity Maps, 2021 average
+      value: 677.0004108933182
     oil:
       datetime: '2014-01-01'
       source: IPCC 2014; EIA 2020/BEIS 2021
@@ -145,123 +146,120 @@ emissionFactors:
       value: 25.6
 fallbackZoneMixes:
   powerOriginRatios:
-    - _source: Electricity Maps, 2015 average
-      datetime: '2015-01-01'
-      value:
-        battery discharge: 0
-        biomass: 0
-        coal: 0.38771715539485374
-        gas: 0.2724026841992751
-        geothermal: 0
-        hydro: 0.004573210109852285
-        hydro discharge: 0.07387535451744988
-        nuclear: 0
-        oil: 0
-        solar: 0.05226940404200543
-        unknown: 0.002975512255600611
-        wind: 0.20618827946450805
-    - _source: Electricity Maps, 2016 average
-      datetime: '2016-01-01'
-      value:
-        battery discharge: 0
-        biomass: 0
-        coal: 0.38771562214248273
-        gas: 0.2724042767725692
-        geothermal: 0
-        hydro: 0.004573214239360576
-        hydro discharge: 0.07387505809857528
-        nuclear: 0.00000398869848528616
-        oil: 0
-        solar: 0.052266634712780737
-        unknown: 0.002975499125725628
-        wind: 0.20618730118981254
-    - _source: Electricity Maps, 2017 average
-      datetime: '2017-01-01'
-      value:
-        battery discharge: 0
-        biomass: 0.0000014319959293045346
-        coal: 0.38787000997374177
-        gas: 0.27213168558226253
-        geothermal: 0
-        hydro: 0.0046887194203005765
-        hydro discharge: 0.07363171707581435
-        nuclear: 0.0002264681786714291
-        oil: 0.000005845381016113336
-        solar: 0.05201950779238791
-        unknown: 0.0029732699100892324
-        wind: 0.20645236108672213
-    - _source: Electricity Maps, 2018 average
-      datetime: '2018-01-01'
-      value:
-        battery discharge: 1.4572269917253567e-9
-        biomass: 0.0000016648818380462202
-        coal: 0.43657685098134624
-        gas: 0.30083363278497965
-        geothermal: 5.501031893763222e-7
-        hydro: 0.00858580365355281
-        hydro discharge: 0.041254977758074844
-        nuclear: 0.054739911525366676
-        oil: 0.000017191635434879894
-        solar: 0.0318863641509966
-        unknown: 0.001387849871876304
-        wind: 0.12471581614590807
-    - _source: Electricity Maps, 2019 average
-      datetime: '2019-01-01'
-      value:
-        battery discharge: 0
-        biomass: 0.000001393573696687838
-        coal: 0.413688934823115
-        gas: 0.2983789494035916
-        geothermal: 4.438132791999483e-7
-        hydro: 0.015942838140732222
-        hydro discharge: 0.0002987742926241703
-        nuclear: 0.06073270344662972
-        oil: 0.000005639656378778979
-        solar: 0.04052693869946087
-        unknown: 0.004152664021485728
-        wind: 0.16627112924415613
-    - _source: Electricity Maps, 2020 average
-      datetime: '2020-01-01'
-      value:
-        battery discharge: 2.2255674041083404e-8
-        biomass: 0.000004470822519868409
-        coal: 0.39922543098281843
-        gas: 0.33976560233365255
-        geothermal: 0.0000027323119822745472
-        hydro: 0.013521996291436028
-        hydro discharge: 0.0022492868167113566
-        nuclear: 0.014729002813492978
-        oil: 0.000007247645850225123
-        solar: 0.06238068043006682
-        unknown: 0.0046709592366452396
-        wind: 0.1634444537995314
-    - _source: Electricity Maps, 2021 average
-      datetime: '2021-01-01'
-      value:
-        battery discharge: 7.971373353265002e-8
-        biomass: 0.000003874596260751892
-        coal: 0.4220726207071528
-        gas: 0.2842637412047576
-        geothermal: 0.000004490257649525338
-        hydro: 0.009299115827648724
-        hydro discharge: 0.0002427512151048489
-        nuclear: 0.01826379014220589
-        oil: 0.00000413239386707025
-        solar: 0.060853018969143045
-        unknown: 0.0034331645009460067
-        wind: 0.2015590525638787
+  - _source: Electricity Maps, 2015 average
+    datetime: '2015-01-01'
+    value:
+      battery discharge: 0
+      biomass: 0
+      coal: 0.38771715539485374
+      gas: 0.2724026841992751
+      geothermal: 0
+      hydro: 0.004573210109852285
+      hydro discharge: 0.07387535451744988
+      nuclear: 0
+      oil: 0
+      solar: 0.05226940404200543
+      unknown: 0.002975512255600611
+      wind: 0.20618827946450805
+  - _source: Electricity Maps, 2016 average
+    datetime: '2016-01-01'
+    value:
+      battery discharge: 0
+      biomass: 0
+      coal: 0.38771562214248273
+      gas: 0.2724042767725692
+      geothermal: 0
+      hydro: 0.004573214239360576
+      hydro discharge: 0.07387505809857528
+      nuclear: 3.98869848528616e-06
+      oil: 0
+      solar: 0.052266634712780737
+      unknown: 0.002975499125725628
+      wind: 0.20618730118981254
+  - _source: Electricity Maps, 2017 average
+    datetime: '2017-01-01'
+    value:
+      battery discharge: 0
+      biomass: 1.4319959293045346e-06
+      coal: 0.38787000997374177
+      gas: 0.27213168558226253
+      geothermal: 0
+      hydro: 0.0046887194203005765
+      hydro discharge: 0.07363171707581435
+      nuclear: 0.0002264681786714291
+      oil: 5.845381016113336e-06
+      solar: 0.05201950779238791
+      unknown: 0.0029732699100892324
+      wind: 0.20645236108672213
+  - _source: Electricity Maps, 2018 average
+    datetime: '2018-01-01'
+    value:
+      battery discharge: 1.4572269917253567e-09
+      biomass: 1.6648818380462202e-06
+      coal: 0.43657685098134624
+      gas: 0.30083363278497965
+      geothermal: 5.501031893763222e-07
+      hydro: 0.00858580365355281
+      hydro discharge: 0.041254977758074844
+      nuclear: 0.054739911525366676
+      oil: 1.7191635434879894e-05
+      solar: 0.0318863641509966
+      unknown: 0.001387849871876304
+      wind: 0.12471581614590807
+  - _source: Electricity Maps, 2019 average
+    datetime: '2019-01-01'
+    value:
+      battery discharge: 0
+      biomass: 1.393573696687838e-06
+      coal: 0.413688934823115
+      gas: 0.2983789494035916
+      geothermal: 4.438132791999483e-07
+      hydro: 0.015942838140732222
+      hydro discharge: 0.0002987742926241703
+      nuclear: 0.06073270344662972
+      oil: 5.639656378778979e-06
+      solar: 0.04052693869946087
+      unknown: 0.004152664021485728
+      wind: 0.16627112924415613
+  - _source: Electricity Maps, 2020 average
+    datetime: '2020-01-01'
+    value:
+      battery discharge: 2.2255674041083404e-08
+      biomass: 4.470822519868409e-06
+      coal: 0.39922543098281843
+      gas: 0.33976560233365255
+      geothermal: 2.7323119822745472e-06
+      hydro: 0.013521996291436028
+      hydro discharge: 0.0022492868167113566
+      nuclear: 0.014729002813492978
+      oil: 7.247645850225123e-06
+      solar: 0.06238068043006682
+      unknown: 0.0046709592366452396
+      wind: 0.1634444537995314
+  - _source: Electricity Maps, 2021 average
+    datetime: '2021-01-01'
+    value:
+      battery discharge: 7.971373353265002e-08
+      biomass: 3.874596260751892e-06
+      coal: 0.4220726207071528
+      gas: 0.2842637412047576
+      geothermal: 4.490257649525338e-06
+      hydro: 0.009299115827648724
+      hydro discharge: 0.0002427512151048489
+      nuclear: 0.01826379014220589
+      oil: 4.13239386707025e-06
+      solar: 0.060853018969143045
+      unknown: 0.0034331645009460067
+      wind: 0.2015590525638787
 parsers:
   consumption: EIA.fetch_consumption
   consumptionForecast: EIA.fetch_consumption_forecast
   production: EIA.fetch_production_mix
 sources:
   INCER ACV:
-    link: >-
-      https://docs.google.com/spreadsheets/d/1w5DJ7sPen6axIHU8TCVcuzNCjlct4I6JAbhUlw-ZXu8/edit?usp=sharing
+    link: https://docs.google.com/spreadsheets/d/1w5DJ7sPen6axIHU8TCVcuzNCjlct4I6JAbhUlw-ZXu8/edit?usp=sharing
   IPCC 2014:
-    link: >-
-      https://www.ipcc.ch/site/assets/uploads/2018/02/ipcc_wg3_ar5_annex-iii.pdf#page=7
+    link: https://www.ipcc.ch/site/assets/uploads/2018/02/ipcc_wg3_ar5_annex-iii.pdf#page=7
   eGrid 2020:
-    link: >-
-      https://drive.google.com/file/d/1_FAAuTtIdMuORZKsqHnd9vMNHlQgYarh/view?usp=sharing
+    link: https://drive.google.com/file/d/1_FAAuTtIdMuORZKsqHnd9vMNHlQgYarh/view?usp=sharing
 timezone: US/Mountain

--- a/config/zones/US-SW-PNM.yaml
+++ b/config/zones/US-SW-PNM.yaml
@@ -1,8 +1,8 @@
 bounding_box:
-- - -111.30730807308066
-  - 30.832316356872
-- - -101.53402034020334
-  - 38.30081076184365
+  - - -111.30730807308066
+    - 30.832316356872
+  - - -101.53402034020334
+    - 38.30081076184365
 capacity:
   battery storage: 13.8
   biomass: 14.6
@@ -18,10 +18,10 @@ capacity:
   wind: 2569
 comment: Public Service Company Of New Mexico
 contributors:
-- systemcatch
-- robertahunt
-- KabelWlan
-- brandongalbraith
+  - systemcatch
+  - robertahunt
+  - KabelWlan
+  - brandongalbraith
 delays:
   consumption: 30
   consumptionForecast: 30
@@ -31,27 +31,27 @@ disclaimer: Data for real-time consumption and generation mix is estimated. Real
 emissionFactors:
   direct:
     battery discharge:
-    - datetime: '2015-01-01'
-      source: Electricity Maps, 2015 average
-      value: 431.26093766802705
-    - datetime: '2016-01-01'
-      source: Electricity Maps, 2016 average
-      value: 614.2774212632262
-    - datetime: '2017-01-01'
-      source: Electricity Maps, 2017 average
-      value: 614.0029455876082
-    - datetime: '2018-01-01'
-      source: Electricity Maps, 2018 average
-      value: 660.2357353192027
-    - datetime: '2019-01-01'
-      source: Electricity Maps, 2019 average
-      value: 613.9423941805912
-    - datetime: '2020-01-01'
-      source: Electricity Maps, 2020 average
-      value: 616.5295429066152
-    - datetime: '2021-01-01'
-      source: Electricity Maps, 2021 average
-      value: 620.554254535142
+      - datetime: '2015-01-01'
+        source: Electricity Maps, 2015 average
+        value: 431.26093766802705
+      - datetime: '2016-01-01'
+        source: Electricity Maps, 2016 average
+        value: 614.2774212632262
+      - datetime: '2017-01-01'
+        source: Electricity Maps, 2017 average
+        value: 614.0029455876082
+      - datetime: '2018-01-01'
+        source: Electricity Maps, 2018 average
+        value: 660.2357353192027
+      - datetime: '2019-01-01'
+        source: Electricity Maps, 2019 average
+        value: 613.9423941805912
+      - datetime: '2020-01-01'
+        source: Electricity Maps, 2020 average
+        value: 616.5295429066152
+      - datetime: '2021-01-01'
+        source: Electricity Maps, 2021 average
+        value: 620.554254535142
     coal:
       datetime: '2020-01-01'
       source: eGrid 2020
@@ -61,50 +61,50 @@ emissionFactors:
       source: eGrid 2020
       value: 412.1499722
     hydro discharge:
-    - datetime: '2015-01-01'
-      source: Electricity Maps, 2015 average
-      value: 431.26093766802705
-    - datetime: '2016-01-01'
-      source: Electricity Maps, 2016 average
-      value: 614.2774212632262
-    - datetime: '2017-01-01'
-      source: Electricity Maps, 2017 average
-      value: 614.0029455876082
-    - datetime: '2018-01-01'
-      source: Electricity Maps, 2018 average
-      value: 660.2357353192027
-    - datetime: '2019-01-01'
-      source: Electricity Maps, 2019 average
-      value: 613.9423941805912
-    - datetime: '2020-01-01'
-      source: Electricity Maps, 2020 average
-      value: 616.5295429066152
-    - datetime: '2021-01-01'
-      source: Electricity Maps, 2021 average
-      value: 620.554254535142
+      - datetime: '2015-01-01'
+        source: Electricity Maps, 2015 average
+        value: 431.26093766802705
+      - datetime: '2016-01-01'
+        source: Electricity Maps, 2016 average
+        value: 614.2774212632262
+      - datetime: '2017-01-01'
+        source: Electricity Maps, 2017 average
+        value: 614.0029455876082
+      - datetime: '2018-01-01'
+        source: Electricity Maps, 2018 average
+        value: 660.2357353192027
+      - datetime: '2019-01-01'
+        source: Electricity Maps, 2019 average
+        value: 613.9423941805912
+      - datetime: '2020-01-01'
+        source: Electricity Maps, 2020 average
+        value: 616.5295429066152
+      - datetime: '2021-01-01'
+        source: Electricity Maps, 2021 average
+        value: 620.554254535142
   lifecycle:
     battery discharge:
-    - datetime: '2015-01-01'
-      source: Electricity Maps, 2015 average
-      value: 497.3976329313718
-    - datetime: '2016-01-01'
-      source: Electricity Maps, 2016 average
-      value: 673.1078913394612
-    - datetime: '2017-01-01'
-      source: Electricity Maps, 2017 average
-      value: 672.7746055231751
-    - datetime: '2018-01-01'
-      source: Electricity Maps, 2018 average
-      value: 720.3321301062109
-    - datetime: '2019-01-01'
-      source: Electricity Maps, 2019 average
-      value: 671.19743499245
-    - datetime: '2020-01-01'
-      source: Electricity Maps, 2020 average
-      value: 678.4258291107535
-    - datetime: '2021-01-01'
-      source: Electricity Maps, 2021 average
-      value: 677.0004108933182
+      - datetime: '2015-01-01'
+        source: Electricity Maps, 2015 average
+        value: 497.3976329313718
+      - datetime: '2016-01-01'
+        source: Electricity Maps, 2016 average
+        value: 673.1078913394612
+      - datetime: '2017-01-01'
+        source: Electricity Maps, 2017 average
+        value: 672.7746055231751
+      - datetime: '2018-01-01'
+        source: Electricity Maps, 2018 average
+        value: 720.3321301062109
+      - datetime: '2019-01-01'
+        source: Electricity Maps, 2019 average
+        value: 671.19743499245
+      - datetime: '2020-01-01'
+        source: Electricity Maps, 2020 average
+        value: 678.4258291107535
+      - datetime: '2021-01-01'
+        source: Electricity Maps, 2021 average
+        value: 677.0004108933182
     coal:
       datetime: '2020-01-01'
       source: eGrid 2020; Oberschelp, Christopher, et al. "Global emission hotspots
@@ -115,27 +115,27 @@ emissionFactors:
       source: eGrid 2020; IPCC 2014
       value: 532.1499722
     hydro discharge:
-    - datetime: '2015-01-01'
-      source: Electricity Maps, 2015 average
-      value: 497.3976329313718
-    - datetime: '2016-01-01'
-      source: Electricity Maps, 2016 average
-      value: 673.1078913394612
-    - datetime: '2017-01-01'
-      source: Electricity Maps, 2017 average
-      value: 672.7746055231751
-    - datetime: '2018-01-01'
-      source: Electricity Maps, 2018 average
-      value: 720.3321301062109
-    - datetime: '2019-01-01'
-      source: Electricity Maps, 2019 average
-      value: 671.19743499245
-    - datetime: '2020-01-01'
-      source: Electricity Maps, 2020 average
-      value: 678.4258291107535
-    - datetime: '2021-01-01'
-      source: Electricity Maps, 2021 average
-      value: 677.0004108933182
+      - datetime: '2015-01-01'
+        source: Electricity Maps, 2015 average
+        value: 497.3976329313718
+      - datetime: '2016-01-01'
+        source: Electricity Maps, 2016 average
+        value: 673.1078913394612
+      - datetime: '2017-01-01'
+        source: Electricity Maps, 2017 average
+        value: 672.7746055231751
+      - datetime: '2018-01-01'
+        source: Electricity Maps, 2018 average
+        value: 720.3321301062109
+      - datetime: '2019-01-01'
+        source: Electricity Maps, 2019 average
+        value: 671.19743499245
+      - datetime: '2020-01-01'
+        source: Electricity Maps, 2020 average
+        value: 678.4258291107535
+      - datetime: '2021-01-01'
+        source: Electricity Maps, 2021 average
+        value: 677.0004108933182
     oil:
       datetime: '2014-01-01'
       source: IPCC 2014; EIA 2020/BEIS 2021
@@ -146,111 +146,111 @@ emissionFactors:
       value: 25.6
 fallbackZoneMixes:
   powerOriginRatios:
-  - _source: Electricity Maps, 2015 average
-    datetime: '2015-01-01'
-    value:
-      battery discharge: 0
-      biomass: 0
-      coal: 0.38771715539485374
-      gas: 0.2724026841992751
-      geothermal: 0
-      hydro: 0.004573210109852285
-      hydro discharge: 0.07387535451744988
-      nuclear: 0
-      oil: 0
-      solar: 0.05226940404200543
-      unknown: 0.002975512255600611
-      wind: 0.20618827946450805
-  - _source: Electricity Maps, 2016 average
-    datetime: '2016-01-01'
-    value:
-      battery discharge: 0
-      biomass: 0
-      coal: 0.38771562214248273
-      gas: 0.2724042767725692
-      geothermal: 0
-      hydro: 0.004573214239360576
-      hydro discharge: 0.07387505809857528
-      nuclear: 3.98869848528616e-06
-      oil: 0
-      solar: 0.052266634712780737
-      unknown: 0.002975499125725628
-      wind: 0.20618730118981254
-  - _source: Electricity Maps, 2017 average
-    datetime: '2017-01-01'
-    value:
-      battery discharge: 0
-      biomass: 1.4319959293045346e-06
-      coal: 0.38787000997374177
-      gas: 0.27213168558226253
-      geothermal: 0
-      hydro: 0.0046887194203005765
-      hydro discharge: 0.07363171707581435
-      nuclear: 0.0002264681786714291
-      oil: 5.845381016113336e-06
-      solar: 0.05201950779238791
-      unknown: 0.0029732699100892324
-      wind: 0.20645236108672213
-  - _source: Electricity Maps, 2018 average
-    datetime: '2018-01-01'
-    value:
-      battery discharge: 1.4572269917253567e-09
-      biomass: 1.6648818380462202e-06
-      coal: 0.43657685098134624
-      gas: 0.30083363278497965
-      geothermal: 5.501031893763222e-07
-      hydro: 0.00858580365355281
-      hydro discharge: 0.041254977758074844
-      nuclear: 0.054739911525366676
-      oil: 1.7191635434879894e-05
-      solar: 0.0318863641509966
-      unknown: 0.001387849871876304
-      wind: 0.12471581614590807
-  - _source: Electricity Maps, 2019 average
-    datetime: '2019-01-01'
-    value:
-      battery discharge: 0
-      biomass: 1.393573696687838e-06
-      coal: 0.413688934823115
-      gas: 0.2983789494035916
-      geothermal: 4.438132791999483e-07
-      hydro: 0.015942838140732222
-      hydro discharge: 0.0002987742926241703
-      nuclear: 0.06073270344662972
-      oil: 5.639656378778979e-06
-      solar: 0.04052693869946087
-      unknown: 0.004152664021485728
-      wind: 0.16627112924415613
-  - _source: Electricity Maps, 2020 average
-    datetime: '2020-01-01'
-    value:
-      battery discharge: 2.2255674041083404e-08
-      biomass: 4.470822519868409e-06
-      coal: 0.39922543098281843
-      gas: 0.33976560233365255
-      geothermal: 2.7323119822745472e-06
-      hydro: 0.013521996291436028
-      hydro discharge: 0.0022492868167113566
-      nuclear: 0.014729002813492978
-      oil: 7.247645850225123e-06
-      solar: 0.06238068043006682
-      unknown: 0.0046709592366452396
-      wind: 0.1634444537995314
-  - _source: Electricity Maps, 2021 average
-    datetime: '2021-01-01'
-    value:
-      battery discharge: 7.971373353265002e-08
-      biomass: 3.874596260751892e-06
-      coal: 0.4220726207071528
-      gas: 0.2842637412047576
-      geothermal: 4.490257649525338e-06
-      hydro: 0.009299115827648724
-      hydro discharge: 0.0002427512151048489
-      nuclear: 0.01826379014220589
-      oil: 4.13239386707025e-06
-      solar: 0.060853018969143045
-      unknown: 0.0034331645009460067
-      wind: 0.2015590525638787
+    - _source: Electricity Maps, 2015 average
+      datetime: '2015-01-01'
+      value:
+        battery discharge: 0
+        biomass: 0
+        coal: 0.38771715539485374
+        gas: 0.2724026841992751
+        geothermal: 0
+        hydro: 0.004573210109852285
+        hydro discharge: 0.07387535451744988
+        nuclear: 0
+        oil: 0
+        solar: 0.05226940404200543
+        unknown: 0.002975512255600611
+        wind: 0.20618827946450805
+    - _source: Electricity Maps, 2016 average
+      datetime: '2016-01-01'
+      value:
+        battery discharge: 0
+        biomass: 0
+        coal: 0.38771562214248273
+        gas: 0.2724042767725692
+        geothermal: 0
+        hydro: 0.004573214239360576
+        hydro discharge: 0.07387505809857528
+        nuclear: 3.98869848528616e-06
+        oil: 0
+        solar: 0.052266634712780737
+        unknown: 0.002975499125725628
+        wind: 0.20618730118981254
+    - _source: Electricity Maps, 2017 average
+      datetime: '2017-01-01'
+      value:
+        battery discharge: 0
+        biomass: 1.4319959293045346e-06
+        coal: 0.38787000997374177
+        gas: 0.27213168558226253
+        geothermal: 0
+        hydro: 0.0046887194203005765
+        hydro discharge: 0.07363171707581435
+        nuclear: 0.0002264681786714291
+        oil: 5.845381016113336e-06
+        solar: 0.05201950779238791
+        unknown: 0.0029732699100892324
+        wind: 0.20645236108672213
+    - _source: Electricity Maps, 2018 average
+      datetime: '2018-01-01'
+      value:
+        battery discharge: 1.4572269917253567e-09
+        biomass: 1.6648818380462202e-06
+        coal: 0.43657685098134624
+        gas: 0.30083363278497965
+        geothermal: 5.501031893763222e-07
+        hydro: 0.00858580365355281
+        hydro discharge: 0.041254977758074844
+        nuclear: 0.054739911525366676
+        oil: 1.7191635434879894e-05
+        solar: 0.0318863641509966
+        unknown: 0.001387849871876304
+        wind: 0.12471581614590807
+    - _source: Electricity Maps, 2019 average
+      datetime: '2019-01-01'
+      value:
+        battery discharge: 0
+        biomass: 1.393573696687838e-06
+        coal: 0.413688934823115
+        gas: 0.2983789494035916
+        geothermal: 4.438132791999483e-07
+        hydro: 0.015942838140732222
+        hydro discharge: 0.0002987742926241703
+        nuclear: 0.06073270344662972
+        oil: 5.639656378778979e-06
+        solar: 0.04052693869946087
+        unknown: 0.004152664021485728
+        wind: 0.16627112924415613
+    - _source: Electricity Maps, 2020 average
+      datetime: '2020-01-01'
+      value:
+        battery discharge: 2.2255674041083404e-08
+        biomass: 4.470822519868409e-06
+        coal: 0.39922543098281843
+        gas: 0.33976560233365255
+        geothermal: 2.7323119822745472e-06
+        hydro: 0.013521996291436028
+        hydro discharge: 0.0022492868167113566
+        nuclear: 0.014729002813492978
+        oil: 7.247645850225123e-06
+        solar: 0.06238068043006682
+        unknown: 0.0046709592366452396
+        wind: 0.1634444537995314
+    - _source: Electricity Maps, 2021 average
+      datetime: '2021-01-01'
+      value:
+        battery discharge: 7.971373353265002e-08
+        biomass: 3.874596260751892e-06
+        coal: 0.4220726207071528
+        gas: 0.2842637412047576
+        geothermal: 4.490257649525338e-06
+        hydro: 0.009299115827648724
+        hydro discharge: 0.0002427512151048489
+        nuclear: 0.01826379014220589
+        oil: 4.13239386707025e-06
+        solar: 0.060853018969143045
+        unknown: 0.0034331645009460067
+        wind: 0.2015590525638787
 parsers:
   consumption: EIA.fetch_consumption
   consumptionForecast: EIA.fetch_consumption_forecast

--- a/config/zones/US-SW-PNM.yaml
+++ b/config/zones/US-SW-PNM.yaml
@@ -107,8 +107,9 @@ emissionFactors:
         value: 677.0004108933182
     coal:
       datetime: '2020-01-01'
-      source: eGrid 2020; Oberschelp, Christopher, et al. "Global emission hotspots
-        of coal power generation."
+      source: >-
+        eGrid 2020; Oberschelp, Christopher, et al. "Global emission hotspots of
+        coal power generation."
       value: 1246.197747
     gas:
       datetime: '2021-01-01'
@@ -171,7 +172,7 @@ fallbackZoneMixes:
         geothermal: 0
         hydro: 0.004573214239360576
         hydro discharge: 0.07387505809857528
-        nuclear: 3.98869848528616e-06
+        nuclear: 0.00000398869848528616
         oil: 0
         solar: 0.052266634712780737
         unknown: 0.002975499125725628
@@ -180,29 +181,29 @@ fallbackZoneMixes:
       datetime: '2017-01-01'
       value:
         battery discharge: 0
-        biomass: 1.4319959293045346e-06
+        biomass: 0.0000014319959293045346
         coal: 0.38787000997374177
         gas: 0.27213168558226253
         geothermal: 0
         hydro: 0.0046887194203005765
         hydro discharge: 0.07363171707581435
         nuclear: 0.0002264681786714291
-        oil: 5.845381016113336e-06
+        oil: 0.000005845381016113336
         solar: 0.05201950779238791
         unknown: 0.0029732699100892324
         wind: 0.20645236108672213
     - _source: Electricity Maps, 2018 average
       datetime: '2018-01-01'
       value:
-        battery discharge: 1.4572269917253567e-09
-        biomass: 1.6648818380462202e-06
+        battery discharge: 1.4572269917253567e-9
+        biomass: 0.0000016648818380462202
         coal: 0.43657685098134624
         gas: 0.30083363278497965
-        geothermal: 5.501031893763222e-07
+        geothermal: 5.501031893763222e-7
         hydro: 0.00858580365355281
         hydro discharge: 0.041254977758074844
         nuclear: 0.054739911525366676
-        oil: 1.7191635434879894e-05
+        oil: 0.000017191635434879894
         solar: 0.0318863641509966
         unknown: 0.001387849871876304
         wind: 0.12471581614590807
@@ -210,44 +211,44 @@ fallbackZoneMixes:
       datetime: '2019-01-01'
       value:
         battery discharge: 0
-        biomass: 1.393573696687838e-06
+        biomass: 0.000001393573696687838
         coal: 0.413688934823115
         gas: 0.2983789494035916
-        geothermal: 4.438132791999483e-07
+        geothermal: 4.438132791999483e-7
         hydro: 0.015942838140732222
         hydro discharge: 0.0002987742926241703
         nuclear: 0.06073270344662972
-        oil: 5.639656378778979e-06
+        oil: 0.000005639656378778979
         solar: 0.04052693869946087
         unknown: 0.004152664021485728
         wind: 0.16627112924415613
     - _source: Electricity Maps, 2020 average
       datetime: '2020-01-01'
       value:
-        battery discharge: 2.2255674041083404e-08
-        biomass: 4.470822519868409e-06
+        battery discharge: 2.2255674041083404e-8
+        biomass: 0.000004470822519868409
         coal: 0.39922543098281843
         gas: 0.33976560233365255
-        geothermal: 2.7323119822745472e-06
+        geothermal: 0.0000027323119822745472
         hydro: 0.013521996291436028
         hydro discharge: 0.0022492868167113566
         nuclear: 0.014729002813492978
-        oil: 7.247645850225123e-06
+        oil: 0.000007247645850225123
         solar: 0.06238068043006682
         unknown: 0.0046709592366452396
         wind: 0.1634444537995314
     - _source: Electricity Maps, 2021 average
       datetime: '2021-01-01'
       value:
-        battery discharge: 7.971373353265002e-08
-        biomass: 3.874596260751892e-06
+        battery discharge: 7.971373353265002e-8
+        biomass: 0.000003874596260751892
         coal: 0.4220726207071528
         gas: 0.2842637412047576
-        geothermal: 4.490257649525338e-06
+        geothermal: 0.000004490257649525338
         hydro: 0.009299115827648724
         hydro discharge: 0.0002427512151048489
         nuclear: 0.01826379014220589
-        oil: 4.13239386707025e-06
+        oil: 0.00000413239386707025
         solar: 0.060853018969143045
         unknown: 0.0034331645009460067
         wind: 0.2015590525638787
@@ -257,9 +258,12 @@ parsers:
   production: EIA.fetch_production_mix
 sources:
   INCER ACV:
-    link: https://docs.google.com/spreadsheets/d/1w5DJ7sPen6axIHU8TCVcuzNCjlct4I6JAbhUlw-ZXu8/edit?usp=sharing
+    link: >-
+      https://docs.google.com/spreadsheets/d/1w5DJ7sPen6axIHU8TCVcuzNCjlct4I6JAbhUlw-ZXu8/edit?usp=sharing
   IPCC 2014:
-    link: https://www.ipcc.ch/site/assets/uploads/2018/02/ipcc_wg3_ar5_annex-iii.pdf#page=7
+    link: >-
+      https://www.ipcc.ch/site/assets/uploads/2018/02/ipcc_wg3_ar5_annex-iii.pdf#page=7
   eGrid 2020:
-    link: https://drive.google.com/file/d/1_FAAuTtIdMuORZKsqHnd9vMNHlQgYarh/view?usp=sharing
+    link: >-
+      https://drive.google.com/file/d/1_FAAuTtIdMuORZKsqHnd9vMNHlQgYarh/view?usp=sharing
 timezone: US/Mountain

--- a/config/zones/US-SW-SRP.yaml
+++ b/config/zones/US-SW-SRP.yaml
@@ -1,8 +1,8 @@
 bounding_box:
-- - -113.83417
-  - 32.00496
-- - -110.438901961
-  - 34.54817
+  - - -113.83417
+    - 32.00496
+  - - -110.438901961
+    - 34.54817
 capacity:
   battery storage: 305
   biomass: 0
@@ -18,9 +18,9 @@ capacity:
   wind: 113.4
 comment: Salt River Project
 contributors:
-- systemcatch
-- robertahunt
-- KabelWlan
+  - systemcatch
+  - robertahunt
+  - KabelWlan
 delays:
   consumption: 30
   consumptionForecast: 30
@@ -30,27 +30,27 @@ disclaimer: Data for real-time consumption and generation mix is estimated. Real
 emissionFactors:
   direct:
     battery discharge:
-    - datetime: '2015-01-01'
-      source: Electricity Maps, 2015 average
-      value: 187.39370352085754
-    - datetime: '2016-01-01'
-      source: Electricity Maps, 2016 average
-      value: 211.15834447270018
-    - datetime: '2017-01-01'
-      source: Electricity Maps, 2017 average
-      value: 210.77922223932822
-    - datetime: '2018-01-01'
-      source: Electricity Maps, 2018 average
-      value: 250.09802307967547
-    - datetime: '2019-01-01'
-      source: Electricity Maps, 2019 average
-      value: 348.4782315083393
-    - datetime: '2020-01-01'
-      source: Electricity Maps, 2020 average
-      value: 245.0086310006108
-    - datetime: '2021-01-01'
-      source: Electricity Maps, 2021 average
-      value: 240.19057250496743
+      - datetime: '2015-01-01'
+        source: Electricity Maps, 2015 average
+        value: 187.39370352085754
+      - datetime: '2016-01-01'
+        source: Electricity Maps, 2016 average
+        value: 211.15834447270018
+      - datetime: '2017-01-01'
+        source: Electricity Maps, 2017 average
+        value: 210.77922223932822
+      - datetime: '2018-01-01'
+        source: Electricity Maps, 2018 average
+        value: 250.09802307967547
+      - datetime: '2019-01-01'
+        source: Electricity Maps, 2019 average
+        value: 348.4782315083393
+      - datetime: '2020-01-01'
+        source: Electricity Maps, 2020 average
+        value: 245.0086310006108
+      - datetime: '2021-01-01'
+        source: Electricity Maps, 2021 average
+        value: 240.19057250496743
     coal:
       datetime: '2020-01-01'
       source: eGrid 2020
@@ -60,50 +60,50 @@ emissionFactors:
       source: eGrid 2020
       value: 376.0036772
     hydro discharge:
-    - datetime: '2015-01-01'
-      source: Electricity Maps, 2015 average
-      value: 187.39370352085754
-    - datetime: '2016-01-01'
-      source: Electricity Maps, 2016 average
-      value: 211.15834447270018
-    - datetime: '2017-01-01'
-      source: Electricity Maps, 2017 average
-      value: 210.77922223932822
-    - datetime: '2018-01-01'
-      source: Electricity Maps, 2018 average
-      value: 250.09802307967547
-    - datetime: '2019-01-01'
-      source: Electricity Maps, 2019 average
-      value: 348.4782315083393
-    - datetime: '2020-01-01'
-      source: Electricity Maps, 2020 average
-      value: 245.0086310006108
-    - datetime: '2021-01-01'
-      source: Electricity Maps, 2021 average
-      value: 240.19057250496743
+      - datetime: '2015-01-01'
+        source: Electricity Maps, 2015 average
+        value: 187.39370352085754
+      - datetime: '2016-01-01'
+        source: Electricity Maps, 2016 average
+        value: 211.15834447270018
+      - datetime: '2017-01-01'
+        source: Electricity Maps, 2017 average
+        value: 210.77922223932822
+      - datetime: '2018-01-01'
+        source: Electricity Maps, 2018 average
+        value: 250.09802307967547
+      - datetime: '2019-01-01'
+        source: Electricity Maps, 2019 average
+        value: 348.4782315083393
+      - datetime: '2020-01-01'
+        source: Electricity Maps, 2020 average
+        value: 245.0086310006108
+      - datetime: '2021-01-01'
+        source: Electricity Maps, 2021 average
+        value: 240.19057250496743
   lifecycle:
     battery discharge:
-    - datetime: '2015-01-01'
-      source: Electricity Maps, 2015 average
-      value: 246.7038563137638
-    - datetime: '2016-01-01'
-      source: Electricity Maps, 2016 average
-      value: 269.9713981359454
-    - datetime: '2017-01-01'
-      source: Electricity Maps, 2017 average
-      value: 269.5316591405361
-    - datetime: '2018-01-01'
-      source: Electricity Maps, 2018 average
-      value: 299.98934813544923
-    - datetime: '2019-01-01'
-      source: Electricity Maps, 2019 average
-      value: 348.4782315083393
-    - datetime: '2020-01-01'
-      source: Electricity Maps, 2020 average
-      value: 312.7684058220017
-    - datetime: '2021-01-01'
-      source: Electricity Maps, 2021 average
-      value: 301.1148243883558
+      - datetime: '2015-01-01'
+        source: Electricity Maps, 2015 average
+        value: 246.7038563137638
+      - datetime: '2016-01-01'
+        source: Electricity Maps, 2016 average
+        value: 269.9713981359454
+      - datetime: '2017-01-01'
+        source: Electricity Maps, 2017 average
+        value: 269.5316591405361
+      - datetime: '2018-01-01'
+        source: Electricity Maps, 2018 average
+        value: 299.98934813544923
+      - datetime: '2019-01-01'
+        source: Electricity Maps, 2019 average
+        value: 348.4782315083393
+      - datetime: '2020-01-01'
+        source: Electricity Maps, 2020 average
+        value: 312.7684058220017
+      - datetime: '2021-01-01'
+        source: Electricity Maps, 2021 average
+        value: 301.1148243883558
     coal:
       datetime: '2020-01-01'
       source: eGrid 2020; IPCC 2014
@@ -113,27 +113,27 @@ emissionFactors:
       source: eGrid 2020; IPCC 2014
       value: 496.0036772
     hydro discharge:
-    - datetime: '2015-01-01'
-      source: Electricity Maps, 2015 average
-      value: 246.7038563137638
-    - datetime: '2016-01-01'
-      source: Electricity Maps, 2016 average
-      value: 269.9713981359454
-    - datetime: '2017-01-01'
-      source: Electricity Maps, 2017 average
-      value: 269.5316591405361
-    - datetime: '2018-01-01'
-      source: Electricity Maps, 2018 average
-      value: 299.98934813544923
-    - datetime: '2019-01-01'
-      source: Electricity Maps, 2019 average
-      value: 348.4782315083393
-    - datetime: '2020-01-01'
-      source: Electricity Maps, 2020 average
-      value: 312.7684058220017
-    - datetime: '2021-01-01'
-      source: Electricity Maps, 2021 average
-      value: 301.1148243883558
+      - datetime: '2015-01-01'
+        source: Electricity Maps, 2015 average
+        value: 246.7038563137638
+      - datetime: '2016-01-01'
+        source: Electricity Maps, 2016 average
+        value: 269.9713981359454
+      - datetime: '2017-01-01'
+        source: Electricity Maps, 2017 average
+        value: 269.5316591405361
+      - datetime: '2018-01-01'
+        source: Electricity Maps, 2018 average
+        value: 299.98934813544923
+      - datetime: '2019-01-01'
+        source: Electricity Maps, 2019 average
+        value: 348.4782315083393
+      - datetime: '2020-01-01'
+        source: Electricity Maps, 2020 average
+        value: 312.7684058220017
+      - datetime: '2021-01-01'
+        source: Electricity Maps, 2021 average
+        value: 301.1148243883558
     oil:
       datetime: '2014-01-01'
       source: IPCC 2014; EIA 2020/BEIS 2021
@@ -144,111 +144,111 @@ emissionFactors:
       value: 25.6
 fallbackZoneMixes:
   powerOriginRatios:
-  - _source: Electricity Maps, 2015 average
-    datetime: '2015-01-01'
-    value:
-      battery discharge: 0.0
-      biomass: 0.0
-      coal: 0.04642444710729002
-      gas: 0.40648624369054626
-      geothermal: 0.0
-      hydro: 0.004434165011901996
-      hydro discharge: 0.006351855404964932
-      nuclear: 0.5092886647963919
-      oil: 9.768364475275976e-05
-      solar: 0.023775823227590955
-      unknown: 0.00031281181649993073
-      wind: 0.002827811742634391
-  - _source: Electricity Maps, 2016 average
-    datetime: '2016-01-01'
-    value:
-      battery discharge: 0.0
-      biomass: 0.0
-      coal: 0.04642450732594513
-      gas: 0.4064867937164666
-      geothermal: 0.0
-      hydro: 0.004434173074998432
-      hydro discharge: 0.006351859127897313
-      nuclear: 0.5092892646032979
-      oil: 9.7683957300656e-05
-      solar: 0.02377459640498656
-      unknown: 0.0003128124950321635
-      wind: 0.002827816116576366
-  - _source: Electricity Maps, 2017 average
-    datetime: '2017-01-01'
-    value:
-      battery discharge: 9.917524142751436e-07
-      biomass: 1.1678220057998583e-05
-      coal: 0.04635268318209338
-      gas: 0.40575306970353037
-      geothermal: 2.337374377505823e-05
-      hydro: 0.004603266367314713
-      hydro discharge: 0.006241786589779481
-      nuclear: 0.5082929736114199
-      oil: 9.994185185086015e-05
-      solar: 0.025428790484784924
-      unknown: 0.00031876606299156694
-      wind: 0.002872731701926678
-  - _source: Electricity Maps, 2018 average
-    datetime: '2018-01-01'
-    value:
-      battery discharge: 2.2819207343442711e-07
-      biomass: 1.733972585114749e-05
-      coal: 0.10962992308769597
-      gas: 0.320236130948567
-      geothermal: 5.246186575785931e-05
-      hydro: 0.008500023740369926
-      hydro discharge: 0.005306354618196026
-      nuclear: 0.5205127262498452
-      oil: 6.787112643016511e-05
-      solar: 0.03223859927549613
-      unknown: 0.0005493013967047005
-      wind: 0.0028897996769162524
-  - _source: Electricity Maps, 2019 average
-    datetime: '2019-01-01'
-    value:
-      battery discharge: 8.694496371284462e-09
-      biomass: 2.6357554760339526e-06
-      coal: 0.05951216682362443
-      gas: 0.4196327993015271
-      geothermal: 4.896324532567913e-06
-      hydro: 0.015927661673760266
-      hydro discharge: 0.0009936660166770805
-      nuclear: 0.4707883548938263
-      oil: 3.44887989753973e-06
-      solar: 0.02984410980076394
-      unknown: 0.0009564337260749617
-      wind: 0.0023352976858127777
-  - _source: Electricity Maps, 2020 average
-    datetime: '2020-01-01'
-    value:
-      battery discharge: 7.544984390328269e-08
-      biomass: 7.179115873523524e-06
-      coal: 0.04940484820654241
-      gas: 0.49077260053207755
-      geothermal: 1.0161702998996308e-05
-      hydro: 0.013962260007047417
-      hydro discharge: 0.0013247430904099894
-      nuclear: 0.4049444915024207
-      oil: 3.2428680115637174e-06
-      solar: 0.03439053559771423
-      unknown: 0.0023484476262584987
-      wind: 0.002832832462811265
-  - _source: Electricity Maps, 2021 average
-    datetime: '2021-01-01'
-    value:
-      battery discharge: 5.298218098349407e-07
-      biomass: 2.476086382233557e-05
-      coal: 0.06695769303648147
-      gas: 0.4204770937946904
-      geothermal: 4.3226815052572826e-05
-      hydro: 0.01759550645428339
-      hydro discharge: 0.001347392380042143
-      nuclear: 0.4664796846521921
-      oil: 1.4181039200532568e-06
-      solar: 0.017749440673082414
-      unknown: 0.0006973867001293964
-      wind: 0.008626087900728219
+    - _source: Electricity Maps, 2015 average
+      datetime: '2015-01-01'
+      value:
+        battery discharge: 0.0
+        biomass: 0.0
+        coal: 0.04642444710729002
+        gas: 0.40648624369054626
+        geothermal: 0.0
+        hydro: 0.004434165011901996
+        hydro discharge: 0.006351855404964932
+        nuclear: 0.5092886647963919
+        oil: 9.768364475275976e-05
+        solar: 0.023775823227590955
+        unknown: 0.00031281181649993073
+        wind: 0.002827811742634391
+    - _source: Electricity Maps, 2016 average
+      datetime: '2016-01-01'
+      value:
+        battery discharge: 0.0
+        biomass: 0.0
+        coal: 0.04642450732594513
+        gas: 0.4064867937164666
+        geothermal: 0.0
+        hydro: 0.004434173074998432
+        hydro discharge: 0.006351859127897313
+        nuclear: 0.5092892646032979
+        oil: 9.7683957300656e-05
+        solar: 0.02377459640498656
+        unknown: 0.0003128124950321635
+        wind: 0.002827816116576366
+    - _source: Electricity Maps, 2017 average
+      datetime: '2017-01-01'
+      value:
+        battery discharge: 9.917524142751436e-07
+        biomass: 1.1678220057998583e-05
+        coal: 0.04635268318209338
+        gas: 0.40575306970353037
+        geothermal: 2.337374377505823e-05
+        hydro: 0.004603266367314713
+        hydro discharge: 0.006241786589779481
+        nuclear: 0.5082929736114199
+        oil: 9.994185185086015e-05
+        solar: 0.025428790484784924
+        unknown: 0.00031876606299156694
+        wind: 0.002872731701926678
+    - _source: Electricity Maps, 2018 average
+      datetime: '2018-01-01'
+      value:
+        battery discharge: 2.2819207343442711e-07
+        biomass: 1.733972585114749e-05
+        coal: 0.10962992308769597
+        gas: 0.320236130948567
+        geothermal: 5.246186575785931e-05
+        hydro: 0.008500023740369926
+        hydro discharge: 0.005306354618196026
+        nuclear: 0.5205127262498452
+        oil: 6.787112643016511e-05
+        solar: 0.03223859927549613
+        unknown: 0.0005493013967047005
+        wind: 0.0028897996769162524
+    - _source: Electricity Maps, 2019 average
+      datetime: '2019-01-01'
+      value:
+        battery discharge: 8.694496371284462e-09
+        biomass: 2.6357554760339526e-06
+        coal: 0.05951216682362443
+        gas: 0.4196327993015271
+        geothermal: 4.896324532567913e-06
+        hydro: 0.015927661673760266
+        hydro discharge: 0.0009936660166770805
+        nuclear: 0.4707883548938263
+        oil: 3.44887989753973e-06
+        solar: 0.02984410980076394
+        unknown: 0.0009564337260749617
+        wind: 0.0023352976858127777
+    - _source: Electricity Maps, 2020 average
+      datetime: '2020-01-01'
+      value:
+        battery discharge: 7.544984390328269e-08
+        biomass: 7.179115873523524e-06
+        coal: 0.04940484820654241
+        gas: 0.49077260053207755
+        geothermal: 1.0161702998996308e-05
+        hydro: 0.013962260007047417
+        hydro discharge: 0.0013247430904099894
+        nuclear: 0.4049444915024207
+        oil: 3.2428680115637174e-06
+        solar: 0.03439053559771423
+        unknown: 0.0023484476262584987
+        wind: 0.002832832462811265
+    - _source: Electricity Maps, 2021 average
+      datetime: '2021-01-01'
+      value:
+        battery discharge: 5.298218098349407e-07
+        biomass: 2.476086382233557e-05
+        coal: 0.06695769303648147
+        gas: 0.4204770937946904
+        geothermal: 4.3226815052572826e-05
+        hydro: 0.01759550645428339
+        hydro discharge: 0.001347392380042143
+        nuclear: 0.4664796846521921
+        oil: 1.4181039200532568e-06
+        solar: 0.017749440673082414
+        unknown: 0.0006973867001293964
+        wind: 0.008626087900728219
 parsers:
   consumption: EIA.fetch_consumption
   consumptionForecast: EIA.fetch_consumption_forecast

--- a/config/zones/US-SW-SRP.yaml
+++ b/config/zones/US-SW-SRP.yaml
@@ -1,8 +1,8 @@
 bounding_box:
-  - - -113.83417
-    - 32.00496
-  - - -110.438901961
-    - 34.54817
+- - -113.83417
+  - 32.00496
+- - -110.438901961
+  - 34.54817
 capacity:
   battery storage: 305
   biomass: 0
@@ -18,37 +18,39 @@ capacity:
   wind: 113.4
 comment: Salt River Project
 contributors:
-  - systemcatch
-  - robertahunt
-  - KabelWlan
+- systemcatch
+- robertahunt
+- KabelWlan
 delays:
   consumption: 30
   consumptionForecast: 30
   production: 30
+disclaimer: Data for real-time consumption and generation mix is estimated. Real-time
+  exchanges are not available.
 emissionFactors:
   direct:
     battery discharge:
-      - datetime: '2015-01-01'
-        source: Electricity Maps, 2015 average
-        value: 187.39370352085754
-      - datetime: '2016-01-01'
-        source: Electricity Maps, 2016 average
-        value: 211.15834447270018
-      - datetime: '2017-01-01'
-        source: Electricity Maps, 2017 average
-        value: 210.77922223932822
-      - datetime: '2018-01-01'
-        source: Electricity Maps, 2018 average
-        value: 250.09802307967547
-      - datetime: '2019-01-01'
-        source: Electricity Maps, 2019 average
-        value: 348.4782315083393
-      - datetime: '2020-01-01'
-        source: Electricity Maps, 2020 average
-        value: 245.0086310006108
-      - datetime: '2021-01-01'
-        source: Electricity Maps, 2021 average
-        value: 240.19057250496743
+    - datetime: '2015-01-01'
+      source: Electricity Maps, 2015 average
+      value: 187.39370352085754
+    - datetime: '2016-01-01'
+      source: Electricity Maps, 2016 average
+      value: 211.15834447270018
+    - datetime: '2017-01-01'
+      source: Electricity Maps, 2017 average
+      value: 210.77922223932822
+    - datetime: '2018-01-01'
+      source: Electricity Maps, 2018 average
+      value: 250.09802307967547
+    - datetime: '2019-01-01'
+      source: Electricity Maps, 2019 average
+      value: 348.4782315083393
+    - datetime: '2020-01-01'
+      source: Electricity Maps, 2020 average
+      value: 245.0086310006108
+    - datetime: '2021-01-01'
+      source: Electricity Maps, 2021 average
+      value: 240.19057250496743
     coal:
       datetime: '2020-01-01'
       source: eGrid 2020
@@ -58,50 +60,50 @@ emissionFactors:
       source: eGrid 2020
       value: 376.0036772
     hydro discharge:
-      - datetime: '2015-01-01'
-        source: Electricity Maps, 2015 average
-        value: 187.39370352085754
-      - datetime: '2016-01-01'
-        source: Electricity Maps, 2016 average
-        value: 211.15834447270018
-      - datetime: '2017-01-01'
-        source: Electricity Maps, 2017 average
-        value: 210.77922223932822
-      - datetime: '2018-01-01'
-        source: Electricity Maps, 2018 average
-        value: 250.09802307967547
-      - datetime: '2019-01-01'
-        source: Electricity Maps, 2019 average
-        value: 348.4782315083393
-      - datetime: '2020-01-01'
-        source: Electricity Maps, 2020 average
-        value: 245.0086310006108
-      - datetime: '2021-01-01'
-        source: Electricity Maps, 2021 average
-        value: 240.19057250496743
+    - datetime: '2015-01-01'
+      source: Electricity Maps, 2015 average
+      value: 187.39370352085754
+    - datetime: '2016-01-01'
+      source: Electricity Maps, 2016 average
+      value: 211.15834447270018
+    - datetime: '2017-01-01'
+      source: Electricity Maps, 2017 average
+      value: 210.77922223932822
+    - datetime: '2018-01-01'
+      source: Electricity Maps, 2018 average
+      value: 250.09802307967547
+    - datetime: '2019-01-01'
+      source: Electricity Maps, 2019 average
+      value: 348.4782315083393
+    - datetime: '2020-01-01'
+      source: Electricity Maps, 2020 average
+      value: 245.0086310006108
+    - datetime: '2021-01-01'
+      source: Electricity Maps, 2021 average
+      value: 240.19057250496743
   lifecycle:
     battery discharge:
-      - datetime: '2015-01-01'
-        source: Electricity Maps, 2015 average
-        value: 246.7038563137638
-      - datetime: '2016-01-01'
-        source: Electricity Maps, 2016 average
-        value: 269.9713981359454
-      - datetime: '2017-01-01'
-        source: Electricity Maps, 2017 average
-        value: 269.5316591405361
-      - datetime: '2018-01-01'
-        source: Electricity Maps, 2018 average
-        value: 299.98934813544923
-      - datetime: '2019-01-01'
-        source: Electricity Maps, 2019 average
-        value: 348.4782315083393
-      - datetime: '2020-01-01'
-        source: Electricity Maps, 2020 average
-        value: 312.7684058220017
-      - datetime: '2021-01-01'
-        source: Electricity Maps, 2021 average
-        value: 301.1148243883558
+    - datetime: '2015-01-01'
+      source: Electricity Maps, 2015 average
+      value: 246.7038563137638
+    - datetime: '2016-01-01'
+      source: Electricity Maps, 2016 average
+      value: 269.9713981359454
+    - datetime: '2017-01-01'
+      source: Electricity Maps, 2017 average
+      value: 269.5316591405361
+    - datetime: '2018-01-01'
+      source: Electricity Maps, 2018 average
+      value: 299.98934813544923
+    - datetime: '2019-01-01'
+      source: Electricity Maps, 2019 average
+      value: 348.4782315083393
+    - datetime: '2020-01-01'
+      source: Electricity Maps, 2020 average
+      value: 312.7684058220017
+    - datetime: '2021-01-01'
+      source: Electricity Maps, 2021 average
+      value: 301.1148243883558
     coal:
       datetime: '2020-01-01'
       source: eGrid 2020; IPCC 2014
@@ -111,27 +113,27 @@ emissionFactors:
       source: eGrid 2020; IPCC 2014
       value: 496.0036772
     hydro discharge:
-      - datetime: '2015-01-01'
-        source: Electricity Maps, 2015 average
-        value: 246.7038563137638
-      - datetime: '2016-01-01'
-        source: Electricity Maps, 2016 average
-        value: 269.9713981359454
-      - datetime: '2017-01-01'
-        source: Electricity Maps, 2017 average
-        value: 269.5316591405361
-      - datetime: '2018-01-01'
-        source: Electricity Maps, 2018 average
-        value: 299.98934813544923
-      - datetime: '2019-01-01'
-        source: Electricity Maps, 2019 average
-        value: 348.4782315083393
-      - datetime: '2020-01-01'
-        source: Electricity Maps, 2020 average
-        value: 312.7684058220017
-      - datetime: '2021-01-01'
-        source: Electricity Maps, 2021 average
-        value: 301.1148243883558
+    - datetime: '2015-01-01'
+      source: Electricity Maps, 2015 average
+      value: 246.7038563137638
+    - datetime: '2016-01-01'
+      source: Electricity Maps, 2016 average
+      value: 269.9713981359454
+    - datetime: '2017-01-01'
+      source: Electricity Maps, 2017 average
+      value: 269.5316591405361
+    - datetime: '2018-01-01'
+      source: Electricity Maps, 2018 average
+      value: 299.98934813544923
+    - datetime: '2019-01-01'
+      source: Electricity Maps, 2019 average
+      value: 348.4782315083393
+    - datetime: '2020-01-01'
+      source: Electricity Maps, 2020 average
+      value: 312.7684058220017
+    - datetime: '2021-01-01'
+      source: Electricity Maps, 2021 average
+      value: 301.1148243883558
     oil:
       datetime: '2014-01-01'
       source: IPCC 2014; EIA 2020/BEIS 2021
@@ -142,111 +144,111 @@ emissionFactors:
       value: 25.6
 fallbackZoneMixes:
   powerOriginRatios:
-    - _source: Electricity Maps, 2015 average
-      datetime: '2015-01-01'
-      value:
-        battery discharge: 0.0
-        biomass: 0.0
-        coal: 0.04642444710729002
-        gas: 0.40648624369054626
-        geothermal: 0.0
-        hydro: 0.004434165011901996
-        hydro discharge: 0.006351855404964932
-        nuclear: 0.5092886647963919
-        oil: 9.768364475275976e-05
-        solar: 0.023775823227590955
-        unknown: 0.00031281181649993073
-        wind: 0.002827811742634391
-    - _source: Electricity Maps, 2016 average
-      datetime: '2016-01-01'
-      value:
-        battery discharge: 0.0
-        biomass: 0.0
-        coal: 0.04642450732594513
-        gas: 0.4064867937164666
-        geothermal: 0.0
-        hydro: 0.004434173074998432
-        hydro discharge: 0.006351859127897313
-        nuclear: 0.5092892646032979
-        oil: 9.7683957300656e-05
-        solar: 0.02377459640498656
-        unknown: 0.0003128124950321635
-        wind: 0.002827816116576366
-    - _source: Electricity Maps, 2017 average
-      datetime: '2017-01-01'
-      value:
-        battery discharge: 9.917524142751436e-07
-        biomass: 1.1678220057998583e-05
-        coal: 0.04635268318209338
-        gas: 0.40575306970353037
-        geothermal: 2.337374377505823e-05
-        hydro: 0.004603266367314713
-        hydro discharge: 0.006241786589779481
-        nuclear: 0.5082929736114199
-        oil: 9.994185185086015e-05
-        solar: 0.025428790484784924
-        unknown: 0.00031876606299156694
-        wind: 0.002872731701926678
-    - _source: Electricity Maps, 2018 average
-      datetime: '2018-01-01'
-      value:
-        battery discharge: 2.2819207343442711e-07
-        biomass: 1.733972585114749e-05
-        coal: 0.10962992308769597
-        gas: 0.320236130948567
-        geothermal: 5.246186575785931e-05
-        hydro: 0.008500023740369926
-        hydro discharge: 0.005306354618196026
-        nuclear: 0.5205127262498452
-        oil: 6.787112643016511e-05
-        solar: 0.03223859927549613
-        unknown: 0.0005493013967047005
-        wind: 0.0028897996769162524
-    - _source: Electricity Maps, 2019 average
-      datetime: '2019-01-01'
-      value:
-        battery discharge: 8.694496371284462e-09
-        biomass: 2.6357554760339526e-06
-        coal: 0.05951216682362443
-        gas: 0.4196327993015271
-        geothermal: 4.896324532567913e-06
-        hydro: 0.015927661673760266
-        hydro discharge: 0.0009936660166770805
-        nuclear: 0.4707883548938263
-        oil: 3.44887989753973e-06
-        solar: 0.02984410980076394
-        unknown: 0.0009564337260749617
-        wind: 0.0023352976858127777
-    - _source: Electricity Maps, 2020 average
-      datetime: '2020-01-01'
-      value:
-        battery discharge: 7.544984390328269e-08
-        biomass: 7.179115873523524e-06
-        coal: 0.04940484820654241
-        gas: 0.49077260053207755
-        geothermal: 1.0161702998996308e-05
-        hydro: 0.013962260007047417
-        hydro discharge: 0.0013247430904099894
-        nuclear: 0.4049444915024207
-        oil: 3.2428680115637174e-06
-        solar: 0.03439053559771423
-        unknown: 0.0023484476262584987
-        wind: 0.002832832462811265
-    - _source: Electricity Maps, 2021 average
-      datetime: '2021-01-01'
-      value:
-        battery discharge: 5.298218098349407e-07
-        biomass: 2.476086382233557e-05
-        coal: 0.06695769303648147
-        gas: 0.4204770937946904
-        geothermal: 4.3226815052572826e-05
-        hydro: 0.01759550645428339
-        hydro discharge: 0.001347392380042143
-        nuclear: 0.4664796846521921
-        oil: 1.4181039200532568e-06
-        solar: 0.017749440673082414
-        unknown: 0.0006973867001293964
-        wind: 0.008626087900728219
+  - _source: Electricity Maps, 2015 average
+    datetime: '2015-01-01'
+    value:
+      battery discharge: 0.0
+      biomass: 0.0
+      coal: 0.04642444710729002
+      gas: 0.40648624369054626
+      geothermal: 0.0
+      hydro: 0.004434165011901996
+      hydro discharge: 0.006351855404964932
+      nuclear: 0.5092886647963919
+      oil: 9.768364475275976e-05
+      solar: 0.023775823227590955
+      unknown: 0.00031281181649993073
+      wind: 0.002827811742634391
+  - _source: Electricity Maps, 2016 average
+    datetime: '2016-01-01'
+    value:
+      battery discharge: 0.0
+      biomass: 0.0
+      coal: 0.04642450732594513
+      gas: 0.4064867937164666
+      geothermal: 0.0
+      hydro: 0.004434173074998432
+      hydro discharge: 0.006351859127897313
+      nuclear: 0.5092892646032979
+      oil: 9.7683957300656e-05
+      solar: 0.02377459640498656
+      unknown: 0.0003128124950321635
+      wind: 0.002827816116576366
+  - _source: Electricity Maps, 2017 average
+    datetime: '2017-01-01'
+    value:
+      battery discharge: 9.917524142751436e-07
+      biomass: 1.1678220057998583e-05
+      coal: 0.04635268318209338
+      gas: 0.40575306970353037
+      geothermal: 2.337374377505823e-05
+      hydro: 0.004603266367314713
+      hydro discharge: 0.006241786589779481
+      nuclear: 0.5082929736114199
+      oil: 9.994185185086015e-05
+      solar: 0.025428790484784924
+      unknown: 0.00031876606299156694
+      wind: 0.002872731701926678
+  - _source: Electricity Maps, 2018 average
+    datetime: '2018-01-01'
+    value:
+      battery discharge: 2.2819207343442711e-07
+      biomass: 1.733972585114749e-05
+      coal: 0.10962992308769597
+      gas: 0.320236130948567
+      geothermal: 5.246186575785931e-05
+      hydro: 0.008500023740369926
+      hydro discharge: 0.005306354618196026
+      nuclear: 0.5205127262498452
+      oil: 6.787112643016511e-05
+      solar: 0.03223859927549613
+      unknown: 0.0005493013967047005
+      wind: 0.0028897996769162524
+  - _source: Electricity Maps, 2019 average
+    datetime: '2019-01-01'
+    value:
+      battery discharge: 8.694496371284462e-09
+      biomass: 2.6357554760339526e-06
+      coal: 0.05951216682362443
+      gas: 0.4196327993015271
+      geothermal: 4.896324532567913e-06
+      hydro: 0.015927661673760266
+      hydro discharge: 0.0009936660166770805
+      nuclear: 0.4707883548938263
+      oil: 3.44887989753973e-06
+      solar: 0.02984410980076394
+      unknown: 0.0009564337260749617
+      wind: 0.0023352976858127777
+  - _source: Electricity Maps, 2020 average
+    datetime: '2020-01-01'
+    value:
+      battery discharge: 7.544984390328269e-08
+      biomass: 7.179115873523524e-06
+      coal: 0.04940484820654241
+      gas: 0.49077260053207755
+      geothermal: 1.0161702998996308e-05
+      hydro: 0.013962260007047417
+      hydro discharge: 0.0013247430904099894
+      nuclear: 0.4049444915024207
+      oil: 3.2428680115637174e-06
+      solar: 0.03439053559771423
+      unknown: 0.0023484476262584987
+      wind: 0.002832832462811265
+  - _source: Electricity Maps, 2021 average
+    datetime: '2021-01-01'
+    value:
+      battery discharge: 5.298218098349407e-07
+      biomass: 2.476086382233557e-05
+      coal: 0.06695769303648147
+      gas: 0.4204770937946904
+      geothermal: 4.3226815052572826e-05
+      hydro: 0.01759550645428339
+      hydro discharge: 0.001347392380042143
+      nuclear: 0.4664796846521921
+      oil: 1.4181039200532568e-06
+      solar: 0.017749440673082414
+      unknown: 0.0006973867001293964
+      wind: 0.008626087900728219
 parsers:
   consumption: EIA.fetch_consumption
   consumptionForecast: EIA.fetch_consumption_forecast

--- a/config/zones/US-SW-TEPC.yaml
+++ b/config/zones/US-SW-TEPC.yaml
@@ -1,8 +1,8 @@
 bounding_box:
-  - - -115.25595
-    - 31.1808879800001
-  - - -110.070620884
-    - 36.710648233
+- - -115.25595
+  - 31.1808879800001
+- - -110.070620884
+  - 36.710648233
 capacity:
   battery storage: 50
   biomass: 0
@@ -18,37 +18,39 @@ capacity:
   wind: 379.8
 comment: Tucson Electric Power Company
 contributors:
-  - systemcatch
-  - robertahunt
-  - KabelWlan
+- systemcatch
+- robertahunt
+- KabelWlan
 delays:
   consumption: 30
   consumptionForecast: 30
   production: 30
+disclaimer: Data for real-time consumption and generation mix is estimated. Real-time
+  exchanges are not available.
 emissionFactors:
   direct:
     battery discharge:
-      - datetime: '2015-01-01'
-        source: Electricity Maps, 2015 average
-        value: 511.1656850757696
-      - datetime: '2016-01-01'
-        source: Electricity Maps, 2016 average
-        value: 709.2497223636744
-      - datetime: '2017-01-01'
-        source: Electricity Maps, 2017 average
-        value: 709.2472388309751
-      - datetime: '2018-01-01'
-        source: Electricity Maps, 2018 average
-        value: 653.2406936161116
-      - datetime: '2019-01-01'
-        source: Electricity Maps, 2019 average
-        value: 604.6993398365285
-      - datetime: '2020-01-01'
-        source: Electricity Maps, 2020 average
-        value: 599.1552585045458
-      - datetime: '2021-01-01'
-        source: Electricity Maps, 2021 average
-        value: 567.4448670565235
+    - datetime: '2015-01-01'
+      source: Electricity Maps, 2015 average
+      value: 511.1656850757696
+    - datetime: '2016-01-01'
+      source: Electricity Maps, 2016 average
+      value: 709.2497223636744
+    - datetime: '2017-01-01'
+      source: Electricity Maps, 2017 average
+      value: 709.2472388309751
+    - datetime: '2018-01-01'
+      source: Electricity Maps, 2018 average
+      value: 653.2406936161116
+    - datetime: '2019-01-01'
+      source: Electricity Maps, 2019 average
+      value: 604.6993398365285
+    - datetime: '2020-01-01'
+      source: Electricity Maps, 2020 average
+      value: 599.1552585045458
+    - datetime: '2021-01-01'
+      source: Electricity Maps, 2021 average
+      value: 567.4448670565235
     coal:
       datetime: '2020-01-01'
       source: eGrid 2020
@@ -58,50 +60,50 @@ emissionFactors:
       source: eGrid 2020
       value: 505.3167692
     hydro discharge:
-      - datetime: '2015-01-01'
-        source: Electricity Maps, 2015 average
-        value: 511.1656850757696
-      - datetime: '2016-01-01'
-        source: Electricity Maps, 2016 average
-        value: 709.2497223636744
-      - datetime: '2017-01-01'
-        source: Electricity Maps, 2017 average
-        value: 709.2472388309751
-      - datetime: '2018-01-01'
-        source: Electricity Maps, 2018 average
-        value: 653.2406936161116
-      - datetime: '2019-01-01'
-        source: Electricity Maps, 2019 average
-        value: 604.6993398365285
-      - datetime: '2020-01-01'
-        source: Electricity Maps, 2020 average
-        value: 599.1552585045458
-      - datetime: '2021-01-01'
-        source: Electricity Maps, 2021 average
-        value: 567.4448670565235
+    - datetime: '2015-01-01'
+      source: Electricity Maps, 2015 average
+      value: 511.1656850757696
+    - datetime: '2016-01-01'
+      source: Electricity Maps, 2016 average
+      value: 709.2497223636744
+    - datetime: '2017-01-01'
+      source: Electricity Maps, 2017 average
+      value: 709.2472388309751
+    - datetime: '2018-01-01'
+      source: Electricity Maps, 2018 average
+      value: 653.2406936161116
+    - datetime: '2019-01-01'
+      source: Electricity Maps, 2019 average
+      value: 604.6993398365285
+    - datetime: '2020-01-01'
+      source: Electricity Maps, 2020 average
+      value: 599.1552585045458
+    - datetime: '2021-01-01'
+      source: Electricity Maps, 2021 average
+      value: 567.4448670565235
   lifecycle:
     battery discharge:
-      - datetime: '2015-01-01'
-        source: Electricity Maps, 2015 average
-        value: 591.6140150263569
-      - datetime: '2016-01-01'
-        source: Electricity Maps, 2016 average
-        value: 788.3906851324865
-      - datetime: '2017-01-01'
-        source: Electricity Maps, 2017 average
-        value: 788.3880137100847
-      - datetime: '2018-01-01'
-        source: Electricity Maps, 2018 average
-        value: 722.3562498570468
-      - datetime: '2019-01-01'
-        source: Electricity Maps, 2019 average
-        value: 675.4721349799405
-      - datetime: '2020-01-01'
-        source: Electricity Maps, 2020 average
-        value: 678.4432302558616
-      - datetime: '2021-01-01'
-        source: Electricity Maps, 2021 average
-        value: 639.620389531979
+    - datetime: '2015-01-01'
+      source: Electricity Maps, 2015 average
+      value: 591.6140150263569
+    - datetime: '2016-01-01'
+      source: Electricity Maps, 2016 average
+      value: 788.3906851324865
+    - datetime: '2017-01-01'
+      source: Electricity Maps, 2017 average
+      value: 788.3880137100847
+    - datetime: '2018-01-01'
+      source: Electricity Maps, 2018 average
+      value: 722.3562498570468
+    - datetime: '2019-01-01'
+      source: Electricity Maps, 2019 average
+      value: 675.4721349799405
+    - datetime: '2020-01-01'
+      source: Electricity Maps, 2020 average
+      value: 678.4432302558616
+    - datetime: '2021-01-01'
+      source: Electricity Maps, 2021 average
+      value: 639.620389531979
     coal:
       datetime: '2020-01-01'
       source: eGrid 2020; IPCC 2014
@@ -111,27 +113,27 @@ emissionFactors:
       source: eGrid 2020; IPCC 2014
       value: 625.3167692
     hydro discharge:
-      - datetime: '2015-01-01'
-        source: Electricity Maps, 2015 average
-        value: 591.6140150263569
-      - datetime: '2016-01-01'
-        source: Electricity Maps, 2016 average
-        value: 788.3906851324865
-      - datetime: '2017-01-01'
-        source: Electricity Maps, 2017 average
-        value: 788.3880137100847
-      - datetime: '2018-01-01'
-        source: Electricity Maps, 2018 average
-        value: 722.3562498570468
-      - datetime: '2019-01-01'
-        source: Electricity Maps, 2019 average
-        value: 675.4721349799405
-      - datetime: '2020-01-01'
-        source: Electricity Maps, 2020 average
-        value: 678.4432302558616
-      - datetime: '2021-01-01'
-        source: Electricity Maps, 2021 average
-        value: 639.620389531979
+    - datetime: '2015-01-01'
+      source: Electricity Maps, 2015 average
+      value: 591.6140150263569
+    - datetime: '2016-01-01'
+      source: Electricity Maps, 2016 average
+      value: 788.3906851324865
+    - datetime: '2017-01-01'
+      source: Electricity Maps, 2017 average
+      value: 788.3880137100847
+    - datetime: '2018-01-01'
+      source: Electricity Maps, 2018 average
+      value: 722.3562498570468
+    - datetime: '2019-01-01'
+      source: Electricity Maps, 2019 average
+      value: 675.4721349799405
+    - datetime: '2020-01-01'
+      source: Electricity Maps, 2020 average
+      value: 678.4432302558616
+    - datetime: '2021-01-01'
+      source: Electricity Maps, 2021 average
+      value: 639.620389531979
     oil:
       datetime: '2014-01-01'
       source: IPCC 2014; EIA 2020/BEIS 2021
@@ -142,111 +144,111 @@ emissionFactors:
       value: 25.6
 fallbackZoneMixes:
   powerOriginRatios:
-    - _source: Electricity Maps, 2015 average
-      datetime: '2015-01-01'
-      value:
-        battery discharge: 0.0
-        biomass: 0.0
-        coal: 0.4762657415345327
-        gas: 0.39949798046059326
-        geothermal: 0.0
-        hydro: 0.0
-        hydro discharge: 0.0
-        nuclear: 0.0
-        oil: 0.0
-        solar: 0.06738931955133136
-        unknown: 0.002414375037718254
-        wind: 0.05443041396922187
-    - _source: Electricity Maps, 2016 average
-      datetime: '2016-01-01'
-      value:
-        battery discharge: 0.0
-        biomass: 0.0
-        coal: 0.47626740937820994
-        gas: 0.3994993794698493
-        geothermal: 0.0
-        hydro: 0.0
-        hydro discharge: 0.0
-        nuclear: 0.0
-        oil: 0.0
-        solar: 0.0673860543516837
-        unknown: 0.0024143834926621853
-        wind: 0.05443060458008019
-    - _source: Electricity Maps, 2017 average
-      datetime: '2017-01-01'
-      value:
-        battery discharge: 0.0
-        biomass: 0.0
-        coal: 0.4762657415345327
-        gas: 0.39949798046059326
-        geothermal: 0.0
-        hydro: 0.0
-        hydro discharge: 0.0
-        nuclear: 0.0
-        oil: 0.0
-        solar: 0.06738931955133136
-        unknown: 0.002414375037718254
-        wind: 0.05443041396922187
-    - _source: Electricity Maps, 2018 average
-      datetime: '2018-01-01'
-      value:
-        battery discharge: 3.040531285409837e-09
-        biomass: 2.7689104905798915e-06
-        coal: 0.4310684375247898
-        gas: 0.3634409629719336
-        geothermal: 3.0526934105514765e-06
-        hydro: 0.006572718506691301
-        hydro discharge: 0.03466292117806763
-        nuclear: 0.10731988650264276
-        oil: 1.9933723107146898e-05
-        solar: 0.0395587866808554
-        unknown: 0.0025990876966958958
-        wind: 0.014788371877286953
-    - _source: Electricity Maps, 2019 average
-      datetime: '2019-01-01'
-      value:
-        battery discharge: 1.0964131206574023e-08
-        biomass: 5.308326293398224e-06
-        coal: 0.3893105857275801
-        gas: 0.38545853979948547
-        geothermal: 8.934923538649631e-06
-        hydro: 0.02594516754824874
-        hydro discharge: 0.0008797095975435915
-        nuclear: 0.11982899976623715
-        oil: 5.897859194428627e-06
-        solar: 0.04576000342809588
-        unknown: 0.002620680376783651
-        wind: 0.03018811764625125
-    - _source: Electricity Maps, 2020 average
-      datetime: '2020-01-01'
-      value:
-        battery discharge: 1.4699349933008692e-07
-        biomass: 1.8905463920982467e-05
-        coal: 0.34710756684554234
-        gas: 0.4744045147398592
-        geothermal: 2.2734294594009017e-05
-        hydro: 0.02745058102001485
-        hydro discharge: 0.0013035355521830332
-        nuclear: 0.0569600474874679
-        oil: 9.742869129407049e-06
-        solar: 0.054094385419080356
-        unknown: 0.003966639178555639
-        wind: 0.034667361263682
-    - _source: Electricity Maps, 2021 average
-      datetime: '2021-01-01'
-      value:
-        battery discharge: 9.053605769979949e-07
-        biomass: 4.1403344373899375e-05
-        coal: 0.34129084751672967
-        gas: 0.41579894830508174
-        geothermal: 7.056741893456693e-05
-        hydro: 0.025875004670929378
-        hydro discharge: 0.00023265709191173473
-        nuclear: 0.08626205250520647
-        oil: 4.260779728436993e-06
-        solar: 0.0477595069358678
-        unknown: 0.0026178016069302204
-        wind: 0.08004739221640626
+  - _source: Electricity Maps, 2015 average
+    datetime: '2015-01-01'
+    value:
+      battery discharge: 0.0
+      biomass: 0.0
+      coal: 0.4762657415345327
+      gas: 0.39949798046059326
+      geothermal: 0.0
+      hydro: 0.0
+      hydro discharge: 0.0
+      nuclear: 0.0
+      oil: 0.0
+      solar: 0.06738931955133136
+      unknown: 0.002414375037718254
+      wind: 0.05443041396922187
+  - _source: Electricity Maps, 2016 average
+    datetime: '2016-01-01'
+    value:
+      battery discharge: 0.0
+      biomass: 0.0
+      coal: 0.47626740937820994
+      gas: 0.3994993794698493
+      geothermal: 0.0
+      hydro: 0.0
+      hydro discharge: 0.0
+      nuclear: 0.0
+      oil: 0.0
+      solar: 0.0673860543516837
+      unknown: 0.0024143834926621853
+      wind: 0.05443060458008019
+  - _source: Electricity Maps, 2017 average
+    datetime: '2017-01-01'
+    value:
+      battery discharge: 0.0
+      biomass: 0.0
+      coal: 0.4762657415345327
+      gas: 0.39949798046059326
+      geothermal: 0.0
+      hydro: 0.0
+      hydro discharge: 0.0
+      nuclear: 0.0
+      oil: 0.0
+      solar: 0.06738931955133136
+      unknown: 0.002414375037718254
+      wind: 0.05443041396922187
+  - _source: Electricity Maps, 2018 average
+    datetime: '2018-01-01'
+    value:
+      battery discharge: 3.040531285409837e-09
+      biomass: 2.7689104905798915e-06
+      coal: 0.4310684375247898
+      gas: 0.3634409629719336
+      geothermal: 3.0526934105514765e-06
+      hydro: 0.006572718506691301
+      hydro discharge: 0.03466292117806763
+      nuclear: 0.10731988650264276
+      oil: 1.9933723107146898e-05
+      solar: 0.0395587866808554
+      unknown: 0.0025990876966958958
+      wind: 0.014788371877286953
+  - _source: Electricity Maps, 2019 average
+    datetime: '2019-01-01'
+    value:
+      battery discharge: 1.0964131206574023e-08
+      biomass: 5.308326293398224e-06
+      coal: 0.3893105857275801
+      gas: 0.38545853979948547
+      geothermal: 8.934923538649631e-06
+      hydro: 0.02594516754824874
+      hydro discharge: 0.0008797095975435915
+      nuclear: 0.11982899976623715
+      oil: 5.897859194428627e-06
+      solar: 0.04576000342809588
+      unknown: 0.002620680376783651
+      wind: 0.03018811764625125
+  - _source: Electricity Maps, 2020 average
+    datetime: '2020-01-01'
+    value:
+      battery discharge: 1.4699349933008692e-07
+      biomass: 1.8905463920982467e-05
+      coal: 0.34710756684554234
+      gas: 0.4744045147398592
+      geothermal: 2.2734294594009017e-05
+      hydro: 0.02745058102001485
+      hydro discharge: 0.0013035355521830332
+      nuclear: 0.0569600474874679
+      oil: 9.742869129407049e-06
+      solar: 0.054094385419080356
+      unknown: 0.003966639178555639
+      wind: 0.034667361263682
+  - _source: Electricity Maps, 2021 average
+    datetime: '2021-01-01'
+    value:
+      battery discharge: 9.053605769979949e-07
+      biomass: 4.1403344373899375e-05
+      coal: 0.34129084751672967
+      gas: 0.41579894830508174
+      geothermal: 7.056741893456693e-05
+      hydro: 0.025875004670929378
+      hydro discharge: 0.00023265709191173473
+      nuclear: 0.08626205250520647
+      oil: 4.260779728436993e-06
+      solar: 0.0477595069358678
+      unknown: 0.0026178016069302204
+      wind: 0.08004739221640626
 parsers:
   consumption: EIA.fetch_consumption
   consumptionForecast: EIA.fetch_consumption_forecast

--- a/config/zones/US-SW-TEPC.yaml
+++ b/config/zones/US-SW-TEPC.yaml
@@ -1,8 +1,8 @@
 bounding_box:
-- - -115.25595
-  - 31.1808879800001
-- - -110.070620884
-  - 36.710648233
+  - - -115.25595
+    - 31.1808879800001
+  - - -110.070620884
+    - 36.710648233
 capacity:
   battery storage: 50
   biomass: 0
@@ -18,9 +18,9 @@ capacity:
   wind: 379.8
 comment: Tucson Electric Power Company
 contributors:
-- systemcatch
-- robertahunt
-- KabelWlan
+  - systemcatch
+  - robertahunt
+  - KabelWlan
 delays:
   consumption: 30
   consumptionForecast: 30
@@ -30,27 +30,27 @@ disclaimer: Data for real-time consumption and generation mix is estimated. Real
 emissionFactors:
   direct:
     battery discharge:
-    - datetime: '2015-01-01'
-      source: Electricity Maps, 2015 average
-      value: 511.1656850757696
-    - datetime: '2016-01-01'
-      source: Electricity Maps, 2016 average
-      value: 709.2497223636744
-    - datetime: '2017-01-01'
-      source: Electricity Maps, 2017 average
-      value: 709.2472388309751
-    - datetime: '2018-01-01'
-      source: Electricity Maps, 2018 average
-      value: 653.2406936161116
-    - datetime: '2019-01-01'
-      source: Electricity Maps, 2019 average
-      value: 604.6993398365285
-    - datetime: '2020-01-01'
-      source: Electricity Maps, 2020 average
-      value: 599.1552585045458
-    - datetime: '2021-01-01'
-      source: Electricity Maps, 2021 average
-      value: 567.4448670565235
+      - datetime: '2015-01-01'
+        source: Electricity Maps, 2015 average
+        value: 511.1656850757696
+      - datetime: '2016-01-01'
+        source: Electricity Maps, 2016 average
+        value: 709.2497223636744
+      - datetime: '2017-01-01'
+        source: Electricity Maps, 2017 average
+        value: 709.2472388309751
+      - datetime: '2018-01-01'
+        source: Electricity Maps, 2018 average
+        value: 653.2406936161116
+      - datetime: '2019-01-01'
+        source: Electricity Maps, 2019 average
+        value: 604.6993398365285
+      - datetime: '2020-01-01'
+        source: Electricity Maps, 2020 average
+        value: 599.1552585045458
+      - datetime: '2021-01-01'
+        source: Electricity Maps, 2021 average
+        value: 567.4448670565235
     coal:
       datetime: '2020-01-01'
       source: eGrid 2020
@@ -60,50 +60,50 @@ emissionFactors:
       source: eGrid 2020
       value: 505.3167692
     hydro discharge:
-    - datetime: '2015-01-01'
-      source: Electricity Maps, 2015 average
-      value: 511.1656850757696
-    - datetime: '2016-01-01'
-      source: Electricity Maps, 2016 average
-      value: 709.2497223636744
-    - datetime: '2017-01-01'
-      source: Electricity Maps, 2017 average
-      value: 709.2472388309751
-    - datetime: '2018-01-01'
-      source: Electricity Maps, 2018 average
-      value: 653.2406936161116
-    - datetime: '2019-01-01'
-      source: Electricity Maps, 2019 average
-      value: 604.6993398365285
-    - datetime: '2020-01-01'
-      source: Electricity Maps, 2020 average
-      value: 599.1552585045458
-    - datetime: '2021-01-01'
-      source: Electricity Maps, 2021 average
-      value: 567.4448670565235
+      - datetime: '2015-01-01'
+        source: Electricity Maps, 2015 average
+        value: 511.1656850757696
+      - datetime: '2016-01-01'
+        source: Electricity Maps, 2016 average
+        value: 709.2497223636744
+      - datetime: '2017-01-01'
+        source: Electricity Maps, 2017 average
+        value: 709.2472388309751
+      - datetime: '2018-01-01'
+        source: Electricity Maps, 2018 average
+        value: 653.2406936161116
+      - datetime: '2019-01-01'
+        source: Electricity Maps, 2019 average
+        value: 604.6993398365285
+      - datetime: '2020-01-01'
+        source: Electricity Maps, 2020 average
+        value: 599.1552585045458
+      - datetime: '2021-01-01'
+        source: Electricity Maps, 2021 average
+        value: 567.4448670565235
   lifecycle:
     battery discharge:
-    - datetime: '2015-01-01'
-      source: Electricity Maps, 2015 average
-      value: 591.6140150263569
-    - datetime: '2016-01-01'
-      source: Electricity Maps, 2016 average
-      value: 788.3906851324865
-    - datetime: '2017-01-01'
-      source: Electricity Maps, 2017 average
-      value: 788.3880137100847
-    - datetime: '2018-01-01'
-      source: Electricity Maps, 2018 average
-      value: 722.3562498570468
-    - datetime: '2019-01-01'
-      source: Electricity Maps, 2019 average
-      value: 675.4721349799405
-    - datetime: '2020-01-01'
-      source: Electricity Maps, 2020 average
-      value: 678.4432302558616
-    - datetime: '2021-01-01'
-      source: Electricity Maps, 2021 average
-      value: 639.620389531979
+      - datetime: '2015-01-01'
+        source: Electricity Maps, 2015 average
+        value: 591.6140150263569
+      - datetime: '2016-01-01'
+        source: Electricity Maps, 2016 average
+        value: 788.3906851324865
+      - datetime: '2017-01-01'
+        source: Electricity Maps, 2017 average
+        value: 788.3880137100847
+      - datetime: '2018-01-01'
+        source: Electricity Maps, 2018 average
+        value: 722.3562498570468
+      - datetime: '2019-01-01'
+        source: Electricity Maps, 2019 average
+        value: 675.4721349799405
+      - datetime: '2020-01-01'
+        source: Electricity Maps, 2020 average
+        value: 678.4432302558616
+      - datetime: '2021-01-01'
+        source: Electricity Maps, 2021 average
+        value: 639.620389531979
     coal:
       datetime: '2020-01-01'
       source: eGrid 2020; IPCC 2014
@@ -113,27 +113,27 @@ emissionFactors:
       source: eGrid 2020; IPCC 2014
       value: 625.3167692
     hydro discharge:
-    - datetime: '2015-01-01'
-      source: Electricity Maps, 2015 average
-      value: 591.6140150263569
-    - datetime: '2016-01-01'
-      source: Electricity Maps, 2016 average
-      value: 788.3906851324865
-    - datetime: '2017-01-01'
-      source: Electricity Maps, 2017 average
-      value: 788.3880137100847
-    - datetime: '2018-01-01'
-      source: Electricity Maps, 2018 average
-      value: 722.3562498570468
-    - datetime: '2019-01-01'
-      source: Electricity Maps, 2019 average
-      value: 675.4721349799405
-    - datetime: '2020-01-01'
-      source: Electricity Maps, 2020 average
-      value: 678.4432302558616
-    - datetime: '2021-01-01'
-      source: Electricity Maps, 2021 average
-      value: 639.620389531979
+      - datetime: '2015-01-01'
+        source: Electricity Maps, 2015 average
+        value: 591.6140150263569
+      - datetime: '2016-01-01'
+        source: Electricity Maps, 2016 average
+        value: 788.3906851324865
+      - datetime: '2017-01-01'
+        source: Electricity Maps, 2017 average
+        value: 788.3880137100847
+      - datetime: '2018-01-01'
+        source: Electricity Maps, 2018 average
+        value: 722.3562498570468
+      - datetime: '2019-01-01'
+        source: Electricity Maps, 2019 average
+        value: 675.4721349799405
+      - datetime: '2020-01-01'
+        source: Electricity Maps, 2020 average
+        value: 678.4432302558616
+      - datetime: '2021-01-01'
+        source: Electricity Maps, 2021 average
+        value: 639.620389531979
     oil:
       datetime: '2014-01-01'
       source: IPCC 2014; EIA 2020/BEIS 2021
@@ -144,111 +144,111 @@ emissionFactors:
       value: 25.6
 fallbackZoneMixes:
   powerOriginRatios:
-  - _source: Electricity Maps, 2015 average
-    datetime: '2015-01-01'
-    value:
-      battery discharge: 0.0
-      biomass: 0.0
-      coal: 0.4762657415345327
-      gas: 0.39949798046059326
-      geothermal: 0.0
-      hydro: 0.0
-      hydro discharge: 0.0
-      nuclear: 0.0
-      oil: 0.0
-      solar: 0.06738931955133136
-      unknown: 0.002414375037718254
-      wind: 0.05443041396922187
-  - _source: Electricity Maps, 2016 average
-    datetime: '2016-01-01'
-    value:
-      battery discharge: 0.0
-      biomass: 0.0
-      coal: 0.47626740937820994
-      gas: 0.3994993794698493
-      geothermal: 0.0
-      hydro: 0.0
-      hydro discharge: 0.0
-      nuclear: 0.0
-      oil: 0.0
-      solar: 0.0673860543516837
-      unknown: 0.0024143834926621853
-      wind: 0.05443060458008019
-  - _source: Electricity Maps, 2017 average
-    datetime: '2017-01-01'
-    value:
-      battery discharge: 0.0
-      biomass: 0.0
-      coal: 0.4762657415345327
-      gas: 0.39949798046059326
-      geothermal: 0.0
-      hydro: 0.0
-      hydro discharge: 0.0
-      nuclear: 0.0
-      oil: 0.0
-      solar: 0.06738931955133136
-      unknown: 0.002414375037718254
-      wind: 0.05443041396922187
-  - _source: Electricity Maps, 2018 average
-    datetime: '2018-01-01'
-    value:
-      battery discharge: 3.040531285409837e-09
-      biomass: 2.7689104905798915e-06
-      coal: 0.4310684375247898
-      gas: 0.3634409629719336
-      geothermal: 3.0526934105514765e-06
-      hydro: 0.006572718506691301
-      hydro discharge: 0.03466292117806763
-      nuclear: 0.10731988650264276
-      oil: 1.9933723107146898e-05
-      solar: 0.0395587866808554
-      unknown: 0.0025990876966958958
-      wind: 0.014788371877286953
-  - _source: Electricity Maps, 2019 average
-    datetime: '2019-01-01'
-    value:
-      battery discharge: 1.0964131206574023e-08
-      biomass: 5.308326293398224e-06
-      coal: 0.3893105857275801
-      gas: 0.38545853979948547
-      geothermal: 8.934923538649631e-06
-      hydro: 0.02594516754824874
-      hydro discharge: 0.0008797095975435915
-      nuclear: 0.11982899976623715
-      oil: 5.897859194428627e-06
-      solar: 0.04576000342809588
-      unknown: 0.002620680376783651
-      wind: 0.03018811764625125
-  - _source: Electricity Maps, 2020 average
-    datetime: '2020-01-01'
-    value:
-      battery discharge: 1.4699349933008692e-07
-      biomass: 1.8905463920982467e-05
-      coal: 0.34710756684554234
-      gas: 0.4744045147398592
-      geothermal: 2.2734294594009017e-05
-      hydro: 0.02745058102001485
-      hydro discharge: 0.0013035355521830332
-      nuclear: 0.0569600474874679
-      oil: 9.742869129407049e-06
-      solar: 0.054094385419080356
-      unknown: 0.003966639178555639
-      wind: 0.034667361263682
-  - _source: Electricity Maps, 2021 average
-    datetime: '2021-01-01'
-    value:
-      battery discharge: 9.053605769979949e-07
-      biomass: 4.1403344373899375e-05
-      coal: 0.34129084751672967
-      gas: 0.41579894830508174
-      geothermal: 7.056741893456693e-05
-      hydro: 0.025875004670929378
-      hydro discharge: 0.00023265709191173473
-      nuclear: 0.08626205250520647
-      oil: 4.260779728436993e-06
-      solar: 0.0477595069358678
-      unknown: 0.0026178016069302204
-      wind: 0.08004739221640626
+    - _source: Electricity Maps, 2015 average
+      datetime: '2015-01-01'
+      value:
+        battery discharge: 0.0
+        biomass: 0.0
+        coal: 0.4762657415345327
+        gas: 0.39949798046059326
+        geothermal: 0.0
+        hydro: 0.0
+        hydro discharge: 0.0
+        nuclear: 0.0
+        oil: 0.0
+        solar: 0.06738931955133136
+        unknown: 0.002414375037718254
+        wind: 0.05443041396922187
+    - _source: Electricity Maps, 2016 average
+      datetime: '2016-01-01'
+      value:
+        battery discharge: 0.0
+        biomass: 0.0
+        coal: 0.47626740937820994
+        gas: 0.3994993794698493
+        geothermal: 0.0
+        hydro: 0.0
+        hydro discharge: 0.0
+        nuclear: 0.0
+        oil: 0.0
+        solar: 0.0673860543516837
+        unknown: 0.0024143834926621853
+        wind: 0.05443060458008019
+    - _source: Electricity Maps, 2017 average
+      datetime: '2017-01-01'
+      value:
+        battery discharge: 0.0
+        biomass: 0.0
+        coal: 0.4762657415345327
+        gas: 0.39949798046059326
+        geothermal: 0.0
+        hydro: 0.0
+        hydro discharge: 0.0
+        nuclear: 0.0
+        oil: 0.0
+        solar: 0.06738931955133136
+        unknown: 0.002414375037718254
+        wind: 0.05443041396922187
+    - _source: Electricity Maps, 2018 average
+      datetime: '2018-01-01'
+      value:
+        battery discharge: 3.040531285409837e-09
+        biomass: 2.7689104905798915e-06
+        coal: 0.4310684375247898
+        gas: 0.3634409629719336
+        geothermal: 3.0526934105514765e-06
+        hydro: 0.006572718506691301
+        hydro discharge: 0.03466292117806763
+        nuclear: 0.10731988650264276
+        oil: 1.9933723107146898e-05
+        solar: 0.0395587866808554
+        unknown: 0.0025990876966958958
+        wind: 0.014788371877286953
+    - _source: Electricity Maps, 2019 average
+      datetime: '2019-01-01'
+      value:
+        battery discharge: 1.0964131206574023e-08
+        biomass: 5.308326293398224e-06
+        coal: 0.3893105857275801
+        gas: 0.38545853979948547
+        geothermal: 8.934923538649631e-06
+        hydro: 0.02594516754824874
+        hydro discharge: 0.0008797095975435915
+        nuclear: 0.11982899976623715
+        oil: 5.897859194428627e-06
+        solar: 0.04576000342809588
+        unknown: 0.002620680376783651
+        wind: 0.03018811764625125
+    - _source: Electricity Maps, 2020 average
+      datetime: '2020-01-01'
+      value:
+        battery discharge: 1.4699349933008692e-07
+        biomass: 1.8905463920982467e-05
+        coal: 0.34710756684554234
+        gas: 0.4744045147398592
+        geothermal: 2.2734294594009017e-05
+        hydro: 0.02745058102001485
+        hydro discharge: 0.0013035355521830332
+        nuclear: 0.0569600474874679
+        oil: 9.742869129407049e-06
+        solar: 0.054094385419080356
+        unknown: 0.003966639178555639
+        wind: 0.034667361263682
+    - _source: Electricity Maps, 2021 average
+      datetime: '2021-01-01'
+      value:
+        battery discharge: 9.053605769979949e-07
+        biomass: 4.1403344373899375e-05
+        coal: 0.34129084751672967
+        gas: 0.41579894830508174
+        geothermal: 7.056741893456693e-05
+        hydro: 0.025875004670929378
+        hydro discharge: 0.00023265709191173473
+        nuclear: 0.08626205250520647
+        oil: 4.260779728436993e-06
+        solar: 0.0477595069358678
+        unknown: 0.0026178016069302204
+        wind: 0.08004739221640626
 parsers:
   consumption: EIA.fetch_consumption
   consumptionForecast: EIA.fetch_consumption_forecast

--- a/config/zones/US-SW-WALC.yaml
+++ b/config/zones/US-SW-WALC.yaml
@@ -1,8 +1,8 @@
 bounding_box:
-  - - -124.21924
-    - 30.83201
-  - - -105.02991
-    - 44.1167400000001
+- - -124.21924
+  - 30.83201
+- - -105.02991
+  - 44.1167400000001
 capacity:
   battery storage: 90
   biomass: 0
@@ -18,86 +18,88 @@ capacity:
   wind: 350
 comment: Western Area Power Administration - Desert Southwest Region
 contributors:
-  - systemcatch
-  - robertahunt
-  - KabelWlan
+- systemcatch
+- robertahunt
+- KabelWlan
 delays:
   consumption: 30
   consumptionForecast: 30
   production: 30
+disclaimer: Data for real-time consumption and generation mix is estimated. Real-time
+  exchanges are not available.
 emissionFactors:
   direct:
     battery discharge:
-      - datetime: '2015-01-01'
-        source: Electricity Maps, 2015 average
-        value: 477.234329337245
-      - datetime: '2016-01-01'
-        source: Electricity Maps, 2016 average
-        value: 505.5613808004696
-      - datetime: '2017-01-01'
-        source: Electricity Maps, 2017 average
-        value: 504.59618347488276
-      - datetime: '2018-01-01'
-        source: Electricity Maps, 2018 average
-        value: 512.7942370508209
-      - datetime: '2019-01-01'
-        source: Electricity Maps, 2019 average
-        value: 299.4411029372588
-      - datetime: '2020-01-01'
-        source: Electricity Maps, 2020 average
-        value: 370.1343671836711
-      - datetime: '2021-01-01'
-        source: Electricity Maps, 2021 average
-        value: 331.91605662559556
+    - datetime: '2015-01-01'
+      source: Electricity Maps, 2015 average
+      value: 477.234329337245
+    - datetime: '2016-01-01'
+      source: Electricity Maps, 2016 average
+      value: 505.5613808004696
+    - datetime: '2017-01-01'
+      source: Electricity Maps, 2017 average
+      value: 504.59618347488276
+    - datetime: '2018-01-01'
+      source: Electricity Maps, 2018 average
+      value: 512.7942370508209
+    - datetime: '2019-01-01'
+      source: Electricity Maps, 2019 average
+      value: 299.4411029372588
+    - datetime: '2020-01-01'
+      source: Electricity Maps, 2020 average
+      value: 370.1343671836711
+    - datetime: '2021-01-01'
+      source: Electricity Maps, 2021 average
+      value: 331.91605662559556
     gas:
       datetime: '2021-01-01'
       source: eGrid 2020
       value: 517.3221021
     hydro discharge:
-      - datetime: '2015-01-01'
-        source: Electricity Maps, 2015 average
-        value: 477.234329337245
-      - datetime: '2016-01-01'
-        source: Electricity Maps, 2016 average
-        value: 505.5613808004696
-      - datetime: '2017-01-01'
-        source: Electricity Maps, 2017 average
-        value: 504.59618347488276
-      - datetime: '2018-01-01'
-        source: Electricity Maps, 2018 average
-        value: 512.7942370508209
-      - datetime: '2019-01-01'
-        source: Electricity Maps, 2019 average
-        value: 299.4411029372588
-      - datetime: '2020-01-01'
-        source: Electricity Maps, 2020 average
-        value: 370.1343671836711
-      - datetime: '2021-01-01'
-        source: Electricity Maps, 2021 average
-        value: 331.91605662559556
+    - datetime: '2015-01-01'
+      source: Electricity Maps, 2015 average
+      value: 477.234329337245
+    - datetime: '2016-01-01'
+      source: Electricity Maps, 2016 average
+      value: 505.5613808004696
+    - datetime: '2017-01-01'
+      source: Electricity Maps, 2017 average
+      value: 504.59618347488276
+    - datetime: '2018-01-01'
+      source: Electricity Maps, 2018 average
+      value: 512.7942370508209
+    - datetime: '2019-01-01'
+      source: Electricity Maps, 2019 average
+      value: 299.4411029372588
+    - datetime: '2020-01-01'
+      source: Electricity Maps, 2020 average
+      value: 370.1343671836711
+    - datetime: '2021-01-01'
+      source: Electricity Maps, 2021 average
+      value: 331.91605662559556
   lifecycle:
     battery discharge:
-      - datetime: '2015-01-01'
-        source: Electricity Maps, 2015 average
-        value: 540.0541346641934
-      - datetime: '2016-01-01'
-        source: Electricity Maps, 2016 average
-        value: 542.1413552404729
-      - datetime: '2017-01-01'
-        source: Electricity Maps, 2017 average
-        value: 542.063823119259
-      - datetime: '2018-01-01'
-        source: Electricity Maps, 2018 average
-        value: 541.31538864667
-      - datetime: '2019-01-01'
-        source: Electricity Maps, 2019 average
-        value: 341.33954903840356
-      - datetime: '2020-01-01'
-        source: Electricity Maps, 2020 average
-        value: 434.59988761055
-      - datetime: '2021-01-01'
-        source: Electricity Maps, 2021 average
-        value: 387.9264386600192
+    - datetime: '2015-01-01'
+      source: Electricity Maps, 2015 average
+      value: 540.0541346641934
+    - datetime: '2016-01-01'
+      source: Electricity Maps, 2016 average
+      value: 542.1413552404729
+    - datetime: '2017-01-01'
+      source: Electricity Maps, 2017 average
+      value: 542.063823119259
+    - datetime: '2018-01-01'
+      source: Electricity Maps, 2018 average
+      value: 541.31538864667
+    - datetime: '2019-01-01'
+      source: Electricity Maps, 2019 average
+      value: 341.33954903840356
+    - datetime: '2020-01-01'
+      source: Electricity Maps, 2020 average
+      value: 434.59988761055
+    - datetime: '2021-01-01'
+      source: Electricity Maps, 2021 average
+      value: 387.9264386600192
     coal:
       datetime: '2012-01-01'
       source: IPCC 2014; Oberschelp, Christopher, et al. "Global emission hotspots
@@ -108,138 +110,138 @@ emissionFactors:
       source: eGrid 2020; IPCC 2014
       value: 637.3221021
     hydro discharge:
-      - datetime: '2015-01-01'
-        source: Electricity Maps, 2015 average
-        value: 540.0541346641934
-      - datetime: '2016-01-01'
-        source: Electricity Maps, 2016 average
-        value: 542.1413552404729
-      - datetime: '2017-01-01'
-        source: Electricity Maps, 2017 average
-        value: 542.063823119259
-      - datetime: '2018-01-01'
-        source: Electricity Maps, 2018 average
-        value: 541.31538864667
-      - datetime: '2019-01-01'
-        source: Electricity Maps, 2019 average
-        value: 341.33954903840356
-      - datetime: '2020-01-01'
-        source: Electricity Maps, 2020 average
-        value: 434.59988761055
-      - datetime: '2021-01-01'
-        source: Electricity Maps, 2021 average
-        value: 387.9264386600192
+    - datetime: '2015-01-01'
+      source: Electricity Maps, 2015 average
+      value: 540.0541346641934
+    - datetime: '2016-01-01'
+      source: Electricity Maps, 2016 average
+      value: 542.1413552404729
+    - datetime: '2017-01-01'
+      source: Electricity Maps, 2017 average
+      value: 542.063823119259
+    - datetime: '2018-01-01'
+      source: Electricity Maps, 2018 average
+      value: 541.31538864667
+    - datetime: '2019-01-01'
+      source: Electricity Maps, 2019 average
+      value: 341.33954903840356
+    - datetime: '2020-01-01'
+      source: Electricity Maps, 2020 average
+      value: 434.59988761055
+    - datetime: '2021-01-01'
+      source: Electricity Maps, 2021 average
+      value: 387.9264386600192
     oil:
       datetime: '2014-01-01'
       source: IPCC 2014; EIA 2020/BEIS 2021
       value: 650.0
 fallbackZoneMixes:
   powerOriginRatios:
-    - _source: Electricity Maps, 2015 average
-      datetime: '2015-01-01'
-      value:
-        battery discharge: 0.0
-        biomass: 0.0
-        coal: 0.11275865522480874
-        gas: 0.016523394940958537
-        geothermal: 0.0
-        hydro: 0.02287174921988805
-        hydro discharge: 0.841183524983747
-        nuclear: 0.0
-        oil: 0.0
-        solar: 0.00120460026817122
-        unknown: 0.0
-        wind: 0.005457995643173142
-    - _source: Electricity Maps, 2016 average
-      datetime: '2016-01-01'
-      value:
-        battery discharge: 0.0
-        biomass: 0.0
-        coal: 0.11275867108483262
-        gas: 0.01652339726505009
-        geothermal: 0.0
-        hydro: 0.022871752436904855
-        hydro discharge: 0.8411836433000818
-        nuclear: 0.0
-        oil: 0.0
-        solar: 0.0012044598252164062
-        unknown: 0.0
-        wind: 0.005457996410865351
-    - _source: Electricity Maps, 2017 average
-      datetime: '2017-01-01'
-      value:
-        battery discharge: 1.2147918481686193e-06
-        biomass: 1.1017361957971994e-05
-        coal: 0.11313692395394728
-        gas: 0.02500676302292352
-        geothermal: 2.224191493891692e-05
-        hydro: 0.02325914698894506
-        hydro discharge: 0.8288764387739788
-        nuclear: 0.00011119872950544851
-        oil: 4.224005171103256e-06
-        solar: 0.0023728878786073615
-        unknown: 0.0013680473064892223
-        wind: 0.005829905158666821
-    - _source: Electricity Maps, 2018 average
-      datetime: '2018-01-01'
-      value:
-        battery discharge: 9.860216963240338e-07
-        biomass: 1.3584660857517051e-05
-        coal: 0.159849138650821
-        gas: 0.04925707850338489
-        geothermal: 3.6995451050113526e-05
-        hydro: 0.042812018972967825
-        hydro discharge: 0.7147709826796229
-        nuclear: 0.010636945735800617
-        oil: 6.452121079004758e-06
-        solar: 0.0026650639177689945
-        unknown: 0.004607682499270869
-        wind: 0.015345635064560019
-    - _source: Electricity Maps, 2019 average
-      datetime: '2019-01-01'
-      value:
-        battery discharge: 1.8738637475817087e-07
-        biomass: 4.336461414403634e-05
-        coal: 0.1585829152758928
-        gas: 0.1719960694583576
-        geothermal: 0.00010792944132321299
-        hydro: 0.2790206424200134
-        hydro discharge: 0.17742245350046715
-        nuclear: 0.17239837437686342
-        oil: 2.5385743242238745e-05
-        solar: 0.016491464295954647
-        unknown: 0.012064117082768302
-        wind: 0.01204576343911699
-    - _source: Electricity Maps, 2020 average
-      datetime: '2020-01-01'
-      value:
-        battery discharge: 1.954309601687892e-06
-        biomass: 0.0001597225871996771
-        coal: 0.14646973219499887
-        gas: 0.3949636060277778
-        geothermal: 0.0002430295578364423
-        hydro: 0.25416213771878315
-        hydro discharge: 0.07926390367893188
-        nuclear: 0.050270356038671686
-        oil: 3.0347593158926574e-05
-        solar: 0.04129613166475726
-        unknown: 0.01414966144247691
-        wind: 0.01910947754218467
-    - _source: Electricity Maps, 2021 average
-      datetime: '2021-01-01'
-      value:
-        battery discharge: 9.270180135786066e-06
-        biomass: 0.0004522981381489003
-        coal: 0.1516476167462289
-        gas: 0.34840775909172506
-        geothermal: 0.0007962904891875693
-        hydro: 0.27939103091269907
-        hydro discharge: 0.0003697690106543309
-        nuclear: 0.1030788442717644
-        oil: 3.333340963111223e-05
-        solar: 0.03844026358048691
-        unknown: 0.007971362500666244
-        wind: 0.06941333983826398
+  - _source: Electricity Maps, 2015 average
+    datetime: '2015-01-01'
+    value:
+      battery discharge: 0.0
+      biomass: 0.0
+      coal: 0.11275865522480874
+      gas: 0.016523394940958537
+      geothermal: 0.0
+      hydro: 0.02287174921988805
+      hydro discharge: 0.841183524983747
+      nuclear: 0.0
+      oil: 0.0
+      solar: 0.00120460026817122
+      unknown: 0.0
+      wind: 0.005457995643173142
+  - _source: Electricity Maps, 2016 average
+    datetime: '2016-01-01'
+    value:
+      battery discharge: 0.0
+      biomass: 0.0
+      coal: 0.11275867108483262
+      gas: 0.01652339726505009
+      geothermal: 0.0
+      hydro: 0.022871752436904855
+      hydro discharge: 0.8411836433000818
+      nuclear: 0.0
+      oil: 0.0
+      solar: 0.0012044598252164062
+      unknown: 0.0
+      wind: 0.005457996410865351
+  - _source: Electricity Maps, 2017 average
+    datetime: '2017-01-01'
+    value:
+      battery discharge: 1.2147918481686193e-06
+      biomass: 1.1017361957971994e-05
+      coal: 0.11313692395394728
+      gas: 0.02500676302292352
+      geothermal: 2.224191493891692e-05
+      hydro: 0.02325914698894506
+      hydro discharge: 0.8288764387739788
+      nuclear: 0.00011119872950544851
+      oil: 4.224005171103256e-06
+      solar: 0.0023728878786073615
+      unknown: 0.0013680473064892223
+      wind: 0.005829905158666821
+  - _source: Electricity Maps, 2018 average
+    datetime: '2018-01-01'
+    value:
+      battery discharge: 9.860216963240338e-07
+      biomass: 1.3584660857517051e-05
+      coal: 0.159849138650821
+      gas: 0.04925707850338489
+      geothermal: 3.6995451050113526e-05
+      hydro: 0.042812018972967825
+      hydro discharge: 0.7147709826796229
+      nuclear: 0.010636945735800617
+      oil: 6.452121079004758e-06
+      solar: 0.0026650639177689945
+      unknown: 0.004607682499270869
+      wind: 0.015345635064560019
+  - _source: Electricity Maps, 2019 average
+    datetime: '2019-01-01'
+    value:
+      battery discharge: 1.8738637475817087e-07
+      biomass: 4.336461414403634e-05
+      coal: 0.1585829152758928
+      gas: 0.1719960694583576
+      geothermal: 0.00010792944132321299
+      hydro: 0.2790206424200134
+      hydro discharge: 0.17742245350046715
+      nuclear: 0.17239837437686342
+      oil: 2.5385743242238745e-05
+      solar: 0.016491464295954647
+      unknown: 0.012064117082768302
+      wind: 0.01204576343911699
+  - _source: Electricity Maps, 2020 average
+    datetime: '2020-01-01'
+    value:
+      battery discharge: 1.954309601687892e-06
+      biomass: 0.0001597225871996771
+      coal: 0.14646973219499887
+      gas: 0.3949636060277778
+      geothermal: 0.0002430295578364423
+      hydro: 0.25416213771878315
+      hydro discharge: 0.07926390367893188
+      nuclear: 0.050270356038671686
+      oil: 3.0347593158926574e-05
+      solar: 0.04129613166475726
+      unknown: 0.01414966144247691
+      wind: 0.01910947754218467
+  - _source: Electricity Maps, 2021 average
+    datetime: '2021-01-01'
+    value:
+      battery discharge: 9.270180135786066e-06
+      biomass: 0.0004522981381489003
+      coal: 0.1516476167462289
+      gas: 0.34840775909172506
+      geothermal: 0.0007962904891875693
+      hydro: 0.27939103091269907
+      hydro discharge: 0.0003697690106543309
+      nuclear: 0.1030788442717644
+      oil: 3.333340963111223e-05
+      solar: 0.03844026358048691
+      unknown: 0.007971362500666244
+      wind: 0.06941333983826398
 parsers:
   consumption: EIA.fetch_consumption
   consumptionForecast: EIA.fetch_consumption_forecast

--- a/config/zones/US-SW-WALC.yaml
+++ b/config/zones/US-SW-WALC.yaml
@@ -1,8 +1,8 @@
 bounding_box:
-- - -124.21924
-  - 30.83201
-- - -105.02991
-  - 44.1167400000001
+  - - -124.21924
+    - 30.83201
+  - - -105.02991
+    - 44.1167400000001
 capacity:
   battery storage: 90
   biomass: 0
@@ -18,9 +18,9 @@ capacity:
   wind: 350
 comment: Western Area Power Administration - Desert Southwest Region
 contributors:
-- systemcatch
-- robertahunt
-- KabelWlan
+  - systemcatch
+  - robertahunt
+  - KabelWlan
 delays:
   consumption: 30
   consumptionForecast: 30
@@ -30,76 +30,76 @@ disclaimer: Data for real-time consumption and generation mix is estimated. Real
 emissionFactors:
   direct:
     battery discharge:
-    - datetime: '2015-01-01'
-      source: Electricity Maps, 2015 average
-      value: 477.234329337245
-    - datetime: '2016-01-01'
-      source: Electricity Maps, 2016 average
-      value: 505.5613808004696
-    - datetime: '2017-01-01'
-      source: Electricity Maps, 2017 average
-      value: 504.59618347488276
-    - datetime: '2018-01-01'
-      source: Electricity Maps, 2018 average
-      value: 512.7942370508209
-    - datetime: '2019-01-01'
-      source: Electricity Maps, 2019 average
-      value: 299.4411029372588
-    - datetime: '2020-01-01'
-      source: Electricity Maps, 2020 average
-      value: 370.1343671836711
-    - datetime: '2021-01-01'
-      source: Electricity Maps, 2021 average
-      value: 331.91605662559556
+      - datetime: '2015-01-01'
+        source: Electricity Maps, 2015 average
+        value: 477.234329337245
+      - datetime: '2016-01-01'
+        source: Electricity Maps, 2016 average
+        value: 505.5613808004696
+      - datetime: '2017-01-01'
+        source: Electricity Maps, 2017 average
+        value: 504.59618347488276
+      - datetime: '2018-01-01'
+        source: Electricity Maps, 2018 average
+        value: 512.7942370508209
+      - datetime: '2019-01-01'
+        source: Electricity Maps, 2019 average
+        value: 299.4411029372588
+      - datetime: '2020-01-01'
+        source: Electricity Maps, 2020 average
+        value: 370.1343671836711
+      - datetime: '2021-01-01'
+        source: Electricity Maps, 2021 average
+        value: 331.91605662559556
     gas:
       datetime: '2021-01-01'
       source: eGrid 2020
       value: 517.3221021
     hydro discharge:
-    - datetime: '2015-01-01'
-      source: Electricity Maps, 2015 average
-      value: 477.234329337245
-    - datetime: '2016-01-01'
-      source: Electricity Maps, 2016 average
-      value: 505.5613808004696
-    - datetime: '2017-01-01'
-      source: Electricity Maps, 2017 average
-      value: 504.59618347488276
-    - datetime: '2018-01-01'
-      source: Electricity Maps, 2018 average
-      value: 512.7942370508209
-    - datetime: '2019-01-01'
-      source: Electricity Maps, 2019 average
-      value: 299.4411029372588
-    - datetime: '2020-01-01'
-      source: Electricity Maps, 2020 average
-      value: 370.1343671836711
-    - datetime: '2021-01-01'
-      source: Electricity Maps, 2021 average
-      value: 331.91605662559556
+      - datetime: '2015-01-01'
+        source: Electricity Maps, 2015 average
+        value: 477.234329337245
+      - datetime: '2016-01-01'
+        source: Electricity Maps, 2016 average
+        value: 505.5613808004696
+      - datetime: '2017-01-01'
+        source: Electricity Maps, 2017 average
+        value: 504.59618347488276
+      - datetime: '2018-01-01'
+        source: Electricity Maps, 2018 average
+        value: 512.7942370508209
+      - datetime: '2019-01-01'
+        source: Electricity Maps, 2019 average
+        value: 299.4411029372588
+      - datetime: '2020-01-01'
+        source: Electricity Maps, 2020 average
+        value: 370.1343671836711
+      - datetime: '2021-01-01'
+        source: Electricity Maps, 2021 average
+        value: 331.91605662559556
   lifecycle:
     battery discharge:
-    - datetime: '2015-01-01'
-      source: Electricity Maps, 2015 average
-      value: 540.0541346641934
-    - datetime: '2016-01-01'
-      source: Electricity Maps, 2016 average
-      value: 542.1413552404729
-    - datetime: '2017-01-01'
-      source: Electricity Maps, 2017 average
-      value: 542.063823119259
-    - datetime: '2018-01-01'
-      source: Electricity Maps, 2018 average
-      value: 541.31538864667
-    - datetime: '2019-01-01'
-      source: Electricity Maps, 2019 average
-      value: 341.33954903840356
-    - datetime: '2020-01-01'
-      source: Electricity Maps, 2020 average
-      value: 434.59988761055
-    - datetime: '2021-01-01'
-      source: Electricity Maps, 2021 average
-      value: 387.9264386600192
+      - datetime: '2015-01-01'
+        source: Electricity Maps, 2015 average
+        value: 540.0541346641934
+      - datetime: '2016-01-01'
+        source: Electricity Maps, 2016 average
+        value: 542.1413552404729
+      - datetime: '2017-01-01'
+        source: Electricity Maps, 2017 average
+        value: 542.063823119259
+      - datetime: '2018-01-01'
+        source: Electricity Maps, 2018 average
+        value: 541.31538864667
+      - datetime: '2019-01-01'
+        source: Electricity Maps, 2019 average
+        value: 341.33954903840356
+      - datetime: '2020-01-01'
+        source: Electricity Maps, 2020 average
+        value: 434.59988761055
+      - datetime: '2021-01-01'
+        source: Electricity Maps, 2021 average
+        value: 387.9264386600192
     coal:
       datetime: '2012-01-01'
       source: IPCC 2014; Oberschelp, Christopher, et al. "Global emission hotspots
@@ -110,138 +110,138 @@ emissionFactors:
       source: eGrid 2020; IPCC 2014
       value: 637.3221021
     hydro discharge:
-    - datetime: '2015-01-01'
-      source: Electricity Maps, 2015 average
-      value: 540.0541346641934
-    - datetime: '2016-01-01'
-      source: Electricity Maps, 2016 average
-      value: 542.1413552404729
-    - datetime: '2017-01-01'
-      source: Electricity Maps, 2017 average
-      value: 542.063823119259
-    - datetime: '2018-01-01'
-      source: Electricity Maps, 2018 average
-      value: 541.31538864667
-    - datetime: '2019-01-01'
-      source: Electricity Maps, 2019 average
-      value: 341.33954903840356
-    - datetime: '2020-01-01'
-      source: Electricity Maps, 2020 average
-      value: 434.59988761055
-    - datetime: '2021-01-01'
-      source: Electricity Maps, 2021 average
-      value: 387.9264386600192
+      - datetime: '2015-01-01'
+        source: Electricity Maps, 2015 average
+        value: 540.0541346641934
+      - datetime: '2016-01-01'
+        source: Electricity Maps, 2016 average
+        value: 542.1413552404729
+      - datetime: '2017-01-01'
+        source: Electricity Maps, 2017 average
+        value: 542.063823119259
+      - datetime: '2018-01-01'
+        source: Electricity Maps, 2018 average
+        value: 541.31538864667
+      - datetime: '2019-01-01'
+        source: Electricity Maps, 2019 average
+        value: 341.33954903840356
+      - datetime: '2020-01-01'
+        source: Electricity Maps, 2020 average
+        value: 434.59988761055
+      - datetime: '2021-01-01'
+        source: Electricity Maps, 2021 average
+        value: 387.9264386600192
     oil:
       datetime: '2014-01-01'
       source: IPCC 2014; EIA 2020/BEIS 2021
       value: 650.0
 fallbackZoneMixes:
   powerOriginRatios:
-  - _source: Electricity Maps, 2015 average
-    datetime: '2015-01-01'
-    value:
-      battery discharge: 0.0
-      biomass: 0.0
-      coal: 0.11275865522480874
-      gas: 0.016523394940958537
-      geothermal: 0.0
-      hydro: 0.02287174921988805
-      hydro discharge: 0.841183524983747
-      nuclear: 0.0
-      oil: 0.0
-      solar: 0.00120460026817122
-      unknown: 0.0
-      wind: 0.005457995643173142
-  - _source: Electricity Maps, 2016 average
-    datetime: '2016-01-01'
-    value:
-      battery discharge: 0.0
-      biomass: 0.0
-      coal: 0.11275867108483262
-      gas: 0.01652339726505009
-      geothermal: 0.0
-      hydro: 0.022871752436904855
-      hydro discharge: 0.8411836433000818
-      nuclear: 0.0
-      oil: 0.0
-      solar: 0.0012044598252164062
-      unknown: 0.0
-      wind: 0.005457996410865351
-  - _source: Electricity Maps, 2017 average
-    datetime: '2017-01-01'
-    value:
-      battery discharge: 1.2147918481686193e-06
-      biomass: 1.1017361957971994e-05
-      coal: 0.11313692395394728
-      gas: 0.02500676302292352
-      geothermal: 2.224191493891692e-05
-      hydro: 0.02325914698894506
-      hydro discharge: 0.8288764387739788
-      nuclear: 0.00011119872950544851
-      oil: 4.224005171103256e-06
-      solar: 0.0023728878786073615
-      unknown: 0.0013680473064892223
-      wind: 0.005829905158666821
-  - _source: Electricity Maps, 2018 average
-    datetime: '2018-01-01'
-    value:
-      battery discharge: 9.860216963240338e-07
-      biomass: 1.3584660857517051e-05
-      coal: 0.159849138650821
-      gas: 0.04925707850338489
-      geothermal: 3.6995451050113526e-05
-      hydro: 0.042812018972967825
-      hydro discharge: 0.7147709826796229
-      nuclear: 0.010636945735800617
-      oil: 6.452121079004758e-06
-      solar: 0.0026650639177689945
-      unknown: 0.004607682499270869
-      wind: 0.015345635064560019
-  - _source: Electricity Maps, 2019 average
-    datetime: '2019-01-01'
-    value:
-      battery discharge: 1.8738637475817087e-07
-      biomass: 4.336461414403634e-05
-      coal: 0.1585829152758928
-      gas: 0.1719960694583576
-      geothermal: 0.00010792944132321299
-      hydro: 0.2790206424200134
-      hydro discharge: 0.17742245350046715
-      nuclear: 0.17239837437686342
-      oil: 2.5385743242238745e-05
-      solar: 0.016491464295954647
-      unknown: 0.012064117082768302
-      wind: 0.01204576343911699
-  - _source: Electricity Maps, 2020 average
-    datetime: '2020-01-01'
-    value:
-      battery discharge: 1.954309601687892e-06
-      biomass: 0.0001597225871996771
-      coal: 0.14646973219499887
-      gas: 0.3949636060277778
-      geothermal: 0.0002430295578364423
-      hydro: 0.25416213771878315
-      hydro discharge: 0.07926390367893188
-      nuclear: 0.050270356038671686
-      oil: 3.0347593158926574e-05
-      solar: 0.04129613166475726
-      unknown: 0.01414966144247691
-      wind: 0.01910947754218467
-  - _source: Electricity Maps, 2021 average
-    datetime: '2021-01-01'
-    value:
-      battery discharge: 9.270180135786066e-06
-      biomass: 0.0004522981381489003
-      coal: 0.1516476167462289
-      gas: 0.34840775909172506
-      geothermal: 0.0007962904891875693
-      hydro: 0.27939103091269907
-      hydro discharge: 0.0003697690106543309
-      nuclear: 0.1030788442717644
-      oil: 3.333340963111223e-05
-      solar: 0.03844026358048691
-      unknown: 0.007971362500666244
-      wind: 0.06941333983826398
+    - _source: Electricity Maps, 2015 average
+      datetime: '2015-01-01'
+      value:
+        battery discharge: 0.0
+        biomass: 0.0
+        coal: 0.11275865522480874
+        gas: 0.016523394940958537
+        geothermal: 0.0
+        hydro: 0.02287174921988805
+        hydro discharge: 0.841183524983747
+        nuclear: 0.0
+        oil: 0.0
+        solar: 0.00120460026817122
+        unknown: 0.0
+        wind: 0.005457995643173142
+    - _source: Electricity Maps, 2016 average
+      datetime: '2016-01-01'
+      value:
+        battery discharge: 0.0
+        biomass: 0.0
+        coal: 0.11275867108483262
+        gas: 0.01652339726505009
+        geothermal: 0.0
+        hydro: 0.022871752436904855
+        hydro discharge: 0.8411836433000818
+        nuclear: 0.0
+        oil: 0.0
+        solar: 0.0012044598252164062
+        unknown: 0.0
+        wind: 0.005457996410865351
+    - _source: Electricity Maps, 2017 average
+      datetime: '2017-01-01'
+      value:
+        battery discharge: 1.2147918481686193e-06
+        biomass: 1.1017361957971994e-05
+        coal: 0.11313692395394728
+        gas: 0.02500676302292352
+        geothermal: 2.224191493891692e-05
+        hydro: 0.02325914698894506
+        hydro discharge: 0.8288764387739788
+        nuclear: 0.00011119872950544851
+        oil: 4.224005171103256e-06
+        solar: 0.0023728878786073615
+        unknown: 0.0013680473064892223
+        wind: 0.005829905158666821
+    - _source: Electricity Maps, 2018 average
+      datetime: '2018-01-01'
+      value:
+        battery discharge: 9.860216963240338e-07
+        biomass: 1.3584660857517051e-05
+        coal: 0.159849138650821
+        gas: 0.04925707850338489
+        geothermal: 3.6995451050113526e-05
+        hydro: 0.042812018972967825
+        hydro discharge: 0.7147709826796229
+        nuclear: 0.010636945735800617
+        oil: 6.452121079004758e-06
+        solar: 0.0026650639177689945
+        unknown: 0.004607682499270869
+        wind: 0.015345635064560019
+    - _source: Electricity Maps, 2019 average
+      datetime: '2019-01-01'
+      value:
+        battery discharge: 1.8738637475817087e-07
+        biomass: 4.336461414403634e-05
+        coal: 0.1585829152758928
+        gas: 0.1719960694583576
+        geothermal: 0.00010792944132321299
+        hydro: 0.2790206424200134
+        hydro discharge: 0.17742245350046715
+        nuclear: 0.17239837437686342
+        oil: 2.5385743242238745e-05
+        solar: 0.016491464295954647
+        unknown: 0.012064117082768302
+        wind: 0.01204576343911699
+    - _source: Electricity Maps, 2020 average
+      datetime: '2020-01-01'
+      value:
+        battery discharge: 1.954309601687892e-06
+        biomass: 0.0001597225871996771
+        coal: 0.14646973219499887
+        gas: 0.3949636060277778
+        geothermal: 0.0002430295578364423
+        hydro: 0.25416213771878315
+        hydro discharge: 0.07926390367893188
+        nuclear: 0.050270356038671686
+        oil: 3.0347593158926574e-05
+        solar: 0.04129613166475726
+        unknown: 0.01414966144247691
+        wind: 0.01910947754218467
+    - _source: Electricity Maps, 2021 average
+      datetime: '2021-01-01'
+      value:
+        battery discharge: 9.270180135786066e-06
+        biomass: 0.0004522981381489003
+        coal: 0.1516476167462289
+        gas: 0.34840775909172506
+        geothermal: 0.0007962904891875693
+        hydro: 0.27939103091269907
+        hydro discharge: 0.0003697690106543309
+        nuclear: 0.1030788442717644
+        oil: 3.333340963111223e-05
+        solar: 0.03844026358048691
+        unknown: 0.007971362500666244
+        wind: 0.06941333983826398
 parsers:
   consumption: EIA.fetch_consumption
   consumptionForecast: EIA.fetch_consumption_forecast

--- a/config/zones/US-TEN-TVA.yaml
+++ b/config/zones/US-TEN-TVA.yaml
@@ -1,8 +1,8 @@
 bounding_box:
-- - -90.849224442
-  - 31.824126136000103
-- - -81.14647784
-  - 38.101846827
+  - - -90.849224442
+    - 31.824126136000103
+  - - -81.14647784
+    - 38.101846827
 capacity:
   battery storage: 1
   biomass: 288.9
@@ -18,9 +18,9 @@ capacity:
   wind: 28.8
 comment: Tennessee Valley Authority
 contributors:
-- systemcatch
-- robertahunt
-- KabelWlan
+  - systemcatch
+  - robertahunt
+  - KabelWlan
 delays:
   consumption: 30
   consumptionForecast: 30
@@ -30,27 +30,27 @@ disclaimer: Data for real-time consumption and generation mix is estimated. Real
 emissionFactors:
   direct:
     battery discharge:
-    - datetime: '2015-01-01'
-      source: Electricity Maps, 2015 average
-      value: 231.92380002652985
-    - datetime: '2016-01-01'
-      source: Electricity Maps, 2016 average
-      value: 288.1028190493361
-    - datetime: '2017-01-01'
-      source: Electricity Maps, 2017 average
-      value: 306.1350607682899
-    - datetime: '2018-01-01'
-      source: Electricity Maps, 2018 average
-      value: 355.7146475745379
-    - datetime: '2019-01-01'
-      source: Electricity Maps, 2019 average
-      value: 542.5236493219804
-    - datetime: '2020-01-01'
-      source: Electricity Maps, 2020 average
-      value: 269.7802346441538
-    - datetime: '2021-01-01'
-      source: Electricity Maps, 2021 average
-      value: 309.10263292981676
+      - datetime: '2015-01-01'
+        source: Electricity Maps, 2015 average
+        value: 231.92380002652985
+      - datetime: '2016-01-01'
+        source: Electricity Maps, 2016 average
+        value: 288.1028190493361
+      - datetime: '2017-01-01'
+        source: Electricity Maps, 2017 average
+        value: 306.1350607682899
+      - datetime: '2018-01-01'
+        source: Electricity Maps, 2018 average
+        value: 355.7146475745379
+      - datetime: '2019-01-01'
+        source: Electricity Maps, 2019 average
+        value: 542.5236493219804
+      - datetime: '2020-01-01'
+        source: Electricity Maps, 2020 average
+        value: 269.7802346441538
+      - datetime: '2021-01-01'
+        source: Electricity Maps, 2021 average
+        value: 309.10263292981676
     biomass:
       datetime: '2020-01-01'
       source: eGrid 2020
@@ -64,54 +64,54 @@ emissionFactors:
       source: eGrid 2020
       value: 391.2963051
     hydro discharge:
-    - datetime: '2015-01-01'
-      source: Electricity Maps, 2015 average
-      value: 231.92380002652985
-    - datetime: '2016-01-01'
-      source: Electricity Maps, 2016 average
-      value: 288.1028190493361
-    - datetime: '2017-01-01'
-      source: Electricity Maps, 2017 average
-      value: 306.1350607682899
-    - datetime: '2018-01-01'
-      source: Electricity Maps, 2018 average
-      value: 355.7146475745379
-    - datetime: '2019-01-01'
-      source: Electricity Maps, 2019 average
-      value: 542.5236493219804
-    - datetime: '2020-01-01'
-      source: Electricity Maps, 2020 average
-      value: 269.7802346441538
-    - datetime: '2021-01-01'
-      source: Electricity Maps, 2021 average
-      value: 309.10263292981676
+      - datetime: '2015-01-01'
+        source: Electricity Maps, 2015 average
+        value: 231.92380002652985
+      - datetime: '2016-01-01'
+        source: Electricity Maps, 2016 average
+        value: 288.1028190493361
+      - datetime: '2017-01-01'
+        source: Electricity Maps, 2017 average
+        value: 306.1350607682899
+      - datetime: '2018-01-01'
+        source: Electricity Maps, 2018 average
+        value: 355.7146475745379
+      - datetime: '2019-01-01'
+        source: Electricity Maps, 2019 average
+        value: 542.5236493219804
+      - datetime: '2020-01-01'
+        source: Electricity Maps, 2020 average
+        value: 269.7802346441538
+      - datetime: '2021-01-01'
+        source: Electricity Maps, 2021 average
+        value: 309.10263292981676
     oil:
       datetime: '2021-01-01'
       source: eGrid 2020
       value: 472.7975672
   lifecycle:
     battery discharge:
-    - datetime: '2015-01-01'
-      source: Electricity Maps, 2015 average
-      value: 284.52334828672963
-    - datetime: '2016-01-01'
-      source: Electricity Maps, 2016 average
-      value: 344.0990347035266
-    - datetime: '2017-01-01'
-      source: Electricity Maps, 2017 average
-      value: 363.22722494694557
-    - datetime: '2018-01-01'
-      source: Electricity Maps, 2018 average
-      value: 416.767758004206
-    - datetime: '2019-01-01'
-      source: Electricity Maps, 2019 average
-      value: 542.5236493219804
-    - datetime: '2020-01-01'
-      source: Electricity Maps, 2020 average
-      value: 324.32032114117305
-    - datetime: '2021-01-01'
-      source: Electricity Maps, 2021 average
-      value: 364.57502733192445
+      - datetime: '2015-01-01'
+        source: Electricity Maps, 2015 average
+        value: 284.52334828672963
+      - datetime: '2016-01-01'
+        source: Electricity Maps, 2016 average
+        value: 344.0990347035266
+      - datetime: '2017-01-01'
+        source: Electricity Maps, 2017 average
+        value: 363.22722494694557
+      - datetime: '2018-01-01'
+        source: Electricity Maps, 2018 average
+        value: 416.767758004206
+      - datetime: '2019-01-01'
+        source: Electricity Maps, 2019 average
+        value: 542.5236493219804
+      - datetime: '2020-01-01'
+        source: Electricity Maps, 2020 average
+        value: 324.32032114117305
+      - datetime: '2021-01-01'
+        source: Electricity Maps, 2021 average
+        value: 364.57502733192445
     biomass:
       datetime: '2020-01-01'
       source: eGrid 2020
@@ -126,27 +126,27 @@ emissionFactors:
       source: eGrid 2020; IPCC 2014
       value: 511.2963051
     hydro discharge:
-    - datetime: '2015-01-01'
-      source: Electricity Maps, 2015 average
-      value: 284.52334828672963
-    - datetime: '2016-01-01'
-      source: Electricity Maps, 2016 average
-      value: 344.0990347035266
-    - datetime: '2017-01-01'
-      source: Electricity Maps, 2017 average
-      value: 363.22722494694557
-    - datetime: '2018-01-01'
-      source: Electricity Maps, 2018 average
-      value: 416.767758004206
-    - datetime: '2019-01-01'
-      source: Electricity Maps, 2019 average
-      value: 542.5236493219804
-    - datetime: '2020-01-01'
-      source: Electricity Maps, 2020 average
-      value: 324.32032114117305
-    - datetime: '2021-01-01'
-      source: Electricity Maps, 2021 average
-      value: 364.57502733192445
+      - datetime: '2015-01-01'
+        source: Electricity Maps, 2015 average
+        value: 284.52334828672963
+      - datetime: '2016-01-01'
+        source: Electricity Maps, 2016 average
+        value: 344.0990347035266
+      - datetime: '2017-01-01'
+        source: Electricity Maps, 2017 average
+        value: 363.22722494694557
+      - datetime: '2018-01-01'
+        source: Electricity Maps, 2018 average
+        value: 416.767758004206
+      - datetime: '2019-01-01'
+        source: Electricity Maps, 2019 average
+        value: 542.5236493219804
+      - datetime: '2020-01-01'
+        source: Electricity Maps, 2020 average
+        value: 324.32032114117305
+      - datetime: '2021-01-01'
+        source: Electricity Maps, 2021 average
+        value: 364.57502733192445
     oil:
       datetime: '2021-01-01'
       source: eGrid 2020; IPCC 2014
@@ -157,111 +157,111 @@ emissionFactors:
       value: 26.06666667
 fallbackZoneMixes:
   powerOriginRatios:
-  - _source: Electricity Maps, 2015 average
-    datetime: '2015-01-01'
-    value:
-      battery discharge: 0.0
-      biomass: 0.0
-      coal: 0.1616582386585121
-      gas: 0.27899319691073954
-      geothermal: 0.0
-      hydro: 0.1345716777095002
-      hydro discharge: 0.018622098280262404
-      nuclear: 0.4009373330980699
-      oil: 3.7470785134482255e-05
-      solar: 0.004214653914558283
-      unknown: 0.0009275432672667829
-      wind: 3.744817150434678e-05
-  - _source: Electricity Maps, 2016 average
-    datetime: '2016-01-01'
-    value:
-      battery discharge: 0.0
-      biomass: 0.0
-      coal: 0.1616582789479754
-      gas: 0.2789932664431449
-      geothermal: 0.0
-      hydro: 0.1345717112482838
-      hydro discharge: 0.018622102921376598
-      nuclear: 0.400937433022145
-      oil: 3.7470794473182444e-05
-      solar: 0.004214405738792297
-      unknown: 0.0009275434984348369
-      wind: 3.744818083741106e-05
-  - _source: Electricity Maps, 2017 average
-    datetime: '2017-01-01'
-    value:
-      battery discharge: 0.0
-      biomass: 6.320190052090084e-07
-      coal: 0.17799067647540687
-      gas: 0.28119297939831983
-      geothermal: 0.0
-      hydro: 0.12633551124399225
-      hydro discharge: 0.017190390044270892
-      nuclear: 0.3823808536046388
-      oil: 0.0020837486077513344
-      solar: 0.004139838324907468
-      unknown: 0.0016228140095694
-      wind: 0.007490758389288306
-  - _source: Electricity Maps, 2018 average
-    datetime: '2018-01-01'
-    value:
-      battery discharge: 0.0
-      biomass: 1.7018039816903957e-06
-      coal: 0.22223622407399413
-      gas: 0.29706029831455505
-      geothermal: 0.0
-      hydro: 0.12026339990923705
-      hydro discharge: 0.007711219070678953
-      nuclear: 0.34247384024953603
-      oil: 0.001174600402059147
-      solar: 0.001285344537200879
-      unknown: 0.0023441154403520716
-      wind: 0.005732879216588767
-  - _source: Electricity Maps, 2019 average
-    datetime: '2019-01-01'
-    value:
-      battery discharge: 0.0
-      biomass: 2.972190149374324e-06
-      coal: 0.19671422009631043
-      gas: 0.2839093420601456
-      geothermal: 0.0
-      hydro: 0.11887751395561791
-      hydro discharge: 0.0014349204917260122
-      nuclear: 0.387814604848726
-      oil: 5.5487015285483246e-05
-      solar: 0.0030761841716749013
-      unknown: 0.0018904891890024853
-      wind: 0.006604216102733178
-  - _source: Electricity Maps, 2020 average
-    datetime: '2020-01-01'
-    value:
-      battery discharge: 0.0
-      biomass: 2.7595273636622703e-06
-      coal: 0.14817408868996257
-      gas: 0.2845618676876532
-      geothermal: 1.29805134938721e-10
-      hydro: 0.14505026944574126
-      hydro discharge: 0.0017788413265741642
-      nuclear: 0.40694696993549356
-      oil: 2.46832901419749e-05
-      solar: 0.0029908003288492114
-      unknown: 0.0021327208233315304
-      wind: 0.008947741061329952
-  - _source: Electricity Maps, 2021 average
-    datetime: '2021-01-01'
-    value:
-      battery discharge: 0.0
-      biomass: 3.3512877399276507e-06
-      coal: 0.19066058888018092
-      gas: 0.2700887255399683
-      geothermal: 6.245760553008274e-11
-      hydro: 0.1193625037070939
-      hydro discharge: 0.0012007719496972082
-      nuclear: 0.40035491494369607
-      oil: 5.272633584286267e-05
-      solar: 0.004549205501967344
-      unknown: 0.002267402950506192
-      wind: 0.011748960510310807
+    - _source: Electricity Maps, 2015 average
+      datetime: '2015-01-01'
+      value:
+        battery discharge: 0.0
+        biomass: 0.0
+        coal: 0.1616582386585121
+        gas: 0.27899319691073954
+        geothermal: 0.0
+        hydro: 0.1345716777095002
+        hydro discharge: 0.018622098280262404
+        nuclear: 0.4009373330980699
+        oil: 3.7470785134482255e-05
+        solar: 0.004214653914558283
+        unknown: 0.0009275432672667829
+        wind: 3.744817150434678e-05
+    - _source: Electricity Maps, 2016 average
+      datetime: '2016-01-01'
+      value:
+        battery discharge: 0.0
+        biomass: 0.0
+        coal: 0.1616582789479754
+        gas: 0.2789932664431449
+        geothermal: 0.0
+        hydro: 0.1345717112482838
+        hydro discharge: 0.018622102921376598
+        nuclear: 0.400937433022145
+        oil: 3.7470794473182444e-05
+        solar: 0.004214405738792297
+        unknown: 0.0009275434984348369
+        wind: 3.744818083741106e-05
+    - _source: Electricity Maps, 2017 average
+      datetime: '2017-01-01'
+      value:
+        battery discharge: 0.0
+        biomass: 6.320190052090084e-07
+        coal: 0.17799067647540687
+        gas: 0.28119297939831983
+        geothermal: 0.0
+        hydro: 0.12633551124399225
+        hydro discharge: 0.017190390044270892
+        nuclear: 0.3823808536046388
+        oil: 0.0020837486077513344
+        solar: 0.004139838324907468
+        unknown: 0.0016228140095694
+        wind: 0.007490758389288306
+    - _source: Electricity Maps, 2018 average
+      datetime: '2018-01-01'
+      value:
+        battery discharge: 0.0
+        biomass: 1.7018039816903957e-06
+        coal: 0.22223622407399413
+        gas: 0.29706029831455505
+        geothermal: 0.0
+        hydro: 0.12026339990923705
+        hydro discharge: 0.007711219070678953
+        nuclear: 0.34247384024953603
+        oil: 0.001174600402059147
+        solar: 0.001285344537200879
+        unknown: 0.0023441154403520716
+        wind: 0.005732879216588767
+    - _source: Electricity Maps, 2019 average
+      datetime: '2019-01-01'
+      value:
+        battery discharge: 0.0
+        biomass: 2.972190149374324e-06
+        coal: 0.19671422009631043
+        gas: 0.2839093420601456
+        geothermal: 0.0
+        hydro: 0.11887751395561791
+        hydro discharge: 0.0014349204917260122
+        nuclear: 0.387814604848726
+        oil: 5.5487015285483246e-05
+        solar: 0.0030761841716749013
+        unknown: 0.0018904891890024853
+        wind: 0.006604216102733178
+    - _source: Electricity Maps, 2020 average
+      datetime: '2020-01-01'
+      value:
+        battery discharge: 0.0
+        biomass: 2.7595273636622703e-06
+        coal: 0.14817408868996257
+        gas: 0.2845618676876532
+        geothermal: 1.29805134938721e-10
+        hydro: 0.14505026944574126
+        hydro discharge: 0.0017788413265741642
+        nuclear: 0.40694696993549356
+        oil: 2.46832901419749e-05
+        solar: 0.0029908003288492114
+        unknown: 0.0021327208233315304
+        wind: 0.008947741061329952
+    - _source: Electricity Maps, 2021 average
+      datetime: '2021-01-01'
+      value:
+        battery discharge: 0.0
+        biomass: 3.3512877399276507e-06
+        coal: 0.19066058888018092
+        gas: 0.2700887255399683
+        geothermal: 6.245760553008274e-11
+        hydro: 0.1193625037070939
+        hydro discharge: 0.0012007719496972082
+        nuclear: 0.40035491494369607
+        oil: 5.272633584286267e-05
+        solar: 0.004549205501967344
+        unknown: 0.002267402950506192
+        wind: 0.011748960510310807
 parsers:
   consumption: EIA.fetch_consumption
   consumptionForecast: EIA.fetch_consumption_forecast

--- a/config/zones/US-TEN-TVA.yaml
+++ b/config/zones/US-TEN-TVA.yaml
@@ -1,8 +1,8 @@
 bounding_box:
-  - - -90.849224442
-    - 31.824126136000103
-  - - -81.14647784
-    - 38.101846827
+- - -90.849224442
+  - 31.824126136000103
+- - -81.14647784
+  - 38.101846827
 capacity:
   battery storage: 1
   biomass: 288.9
@@ -18,37 +18,39 @@ capacity:
   wind: 28.8
 comment: Tennessee Valley Authority
 contributors:
-  - systemcatch
-  - robertahunt
-  - KabelWlan
+- systemcatch
+- robertahunt
+- KabelWlan
 delays:
   consumption: 30
   consumptionForecast: 30
   production: 30
+disclaimer: Data for real-time consumption and generation mix is estimated. Real-time
+  exchanges are not available.
 emissionFactors:
   direct:
     battery discharge:
-      - datetime: '2015-01-01'
-        source: Electricity Maps, 2015 average
-        value: 231.92380002652985
-      - datetime: '2016-01-01'
-        source: Electricity Maps, 2016 average
-        value: 288.1028190493361
-      - datetime: '2017-01-01'
-        source: Electricity Maps, 2017 average
-        value: 306.1350607682899
-      - datetime: '2018-01-01'
-        source: Electricity Maps, 2018 average
-        value: 355.7146475745379
-      - datetime: '2019-01-01'
-        source: Electricity Maps, 2019 average
-        value: 542.5236493219804
-      - datetime: '2020-01-01'
-        source: Electricity Maps, 2020 average
-        value: 269.7802346441538
-      - datetime: '2021-01-01'
-        source: Electricity Maps, 2021 average
-        value: 309.10263292981676
+    - datetime: '2015-01-01'
+      source: Electricity Maps, 2015 average
+      value: 231.92380002652985
+    - datetime: '2016-01-01'
+      source: Electricity Maps, 2016 average
+      value: 288.1028190493361
+    - datetime: '2017-01-01'
+      source: Electricity Maps, 2017 average
+      value: 306.1350607682899
+    - datetime: '2018-01-01'
+      source: Electricity Maps, 2018 average
+      value: 355.7146475745379
+    - datetime: '2019-01-01'
+      source: Electricity Maps, 2019 average
+      value: 542.5236493219804
+    - datetime: '2020-01-01'
+      source: Electricity Maps, 2020 average
+      value: 269.7802346441538
+    - datetime: '2021-01-01'
+      source: Electricity Maps, 2021 average
+      value: 309.10263292981676
     biomass:
       datetime: '2020-01-01'
       source: eGrid 2020
@@ -62,54 +64,54 @@ emissionFactors:
       source: eGrid 2020
       value: 391.2963051
     hydro discharge:
-      - datetime: '2015-01-01'
-        source: Electricity Maps, 2015 average
-        value: 231.92380002652985
-      - datetime: '2016-01-01'
-        source: Electricity Maps, 2016 average
-        value: 288.1028190493361
-      - datetime: '2017-01-01'
-        source: Electricity Maps, 2017 average
-        value: 306.1350607682899
-      - datetime: '2018-01-01'
-        source: Electricity Maps, 2018 average
-        value: 355.7146475745379
-      - datetime: '2019-01-01'
-        source: Electricity Maps, 2019 average
-        value: 542.5236493219804
-      - datetime: '2020-01-01'
-        source: Electricity Maps, 2020 average
-        value: 269.7802346441538
-      - datetime: '2021-01-01'
-        source: Electricity Maps, 2021 average
-        value: 309.10263292981676
+    - datetime: '2015-01-01'
+      source: Electricity Maps, 2015 average
+      value: 231.92380002652985
+    - datetime: '2016-01-01'
+      source: Electricity Maps, 2016 average
+      value: 288.1028190493361
+    - datetime: '2017-01-01'
+      source: Electricity Maps, 2017 average
+      value: 306.1350607682899
+    - datetime: '2018-01-01'
+      source: Electricity Maps, 2018 average
+      value: 355.7146475745379
+    - datetime: '2019-01-01'
+      source: Electricity Maps, 2019 average
+      value: 542.5236493219804
+    - datetime: '2020-01-01'
+      source: Electricity Maps, 2020 average
+      value: 269.7802346441538
+    - datetime: '2021-01-01'
+      source: Electricity Maps, 2021 average
+      value: 309.10263292981676
     oil:
       datetime: '2021-01-01'
       source: eGrid 2020
       value: 472.7975672
   lifecycle:
     battery discharge:
-      - datetime: '2015-01-01'
-        source: Electricity Maps, 2015 average
-        value: 284.52334828672963
-      - datetime: '2016-01-01'
-        source: Electricity Maps, 2016 average
-        value: 344.0990347035266
-      - datetime: '2017-01-01'
-        source: Electricity Maps, 2017 average
-        value: 363.22722494694557
-      - datetime: '2018-01-01'
-        source: Electricity Maps, 2018 average
-        value: 416.767758004206
-      - datetime: '2019-01-01'
-        source: Electricity Maps, 2019 average
-        value: 542.5236493219804
-      - datetime: '2020-01-01'
-        source: Electricity Maps, 2020 average
-        value: 324.32032114117305
-      - datetime: '2021-01-01'
-        source: Electricity Maps, 2021 average
-        value: 364.57502733192445
+    - datetime: '2015-01-01'
+      source: Electricity Maps, 2015 average
+      value: 284.52334828672963
+    - datetime: '2016-01-01'
+      source: Electricity Maps, 2016 average
+      value: 344.0990347035266
+    - datetime: '2017-01-01'
+      source: Electricity Maps, 2017 average
+      value: 363.22722494694557
+    - datetime: '2018-01-01'
+      source: Electricity Maps, 2018 average
+      value: 416.767758004206
+    - datetime: '2019-01-01'
+      source: Electricity Maps, 2019 average
+      value: 542.5236493219804
+    - datetime: '2020-01-01'
+      source: Electricity Maps, 2020 average
+      value: 324.32032114117305
+    - datetime: '2021-01-01'
+      source: Electricity Maps, 2021 average
+      value: 364.57502733192445
     biomass:
       datetime: '2020-01-01'
       source: eGrid 2020
@@ -124,27 +126,27 @@ emissionFactors:
       source: eGrid 2020; IPCC 2014
       value: 511.2963051
     hydro discharge:
-      - datetime: '2015-01-01'
-        source: Electricity Maps, 2015 average
-        value: 284.52334828672963
-      - datetime: '2016-01-01'
-        source: Electricity Maps, 2016 average
-        value: 344.0990347035266
-      - datetime: '2017-01-01'
-        source: Electricity Maps, 2017 average
-        value: 363.22722494694557
-      - datetime: '2018-01-01'
-        source: Electricity Maps, 2018 average
-        value: 416.767758004206
-      - datetime: '2019-01-01'
-        source: Electricity Maps, 2019 average
-        value: 542.5236493219804
-      - datetime: '2020-01-01'
-        source: Electricity Maps, 2020 average
-        value: 324.32032114117305
-      - datetime: '2021-01-01'
-        source: Electricity Maps, 2021 average
-        value: 364.57502733192445
+    - datetime: '2015-01-01'
+      source: Electricity Maps, 2015 average
+      value: 284.52334828672963
+    - datetime: '2016-01-01'
+      source: Electricity Maps, 2016 average
+      value: 344.0990347035266
+    - datetime: '2017-01-01'
+      source: Electricity Maps, 2017 average
+      value: 363.22722494694557
+    - datetime: '2018-01-01'
+      source: Electricity Maps, 2018 average
+      value: 416.767758004206
+    - datetime: '2019-01-01'
+      source: Electricity Maps, 2019 average
+      value: 542.5236493219804
+    - datetime: '2020-01-01'
+      source: Electricity Maps, 2020 average
+      value: 324.32032114117305
+    - datetime: '2021-01-01'
+      source: Electricity Maps, 2021 average
+      value: 364.57502733192445
     oil:
       datetime: '2021-01-01'
       source: eGrid 2020; IPCC 2014
@@ -155,111 +157,111 @@ emissionFactors:
       value: 26.06666667
 fallbackZoneMixes:
   powerOriginRatios:
-    - _source: Electricity Maps, 2015 average
-      datetime: '2015-01-01'
-      value:
-        battery discharge: 0.0
-        biomass: 0.0
-        coal: 0.1616582386585121
-        gas: 0.27899319691073954
-        geothermal: 0.0
-        hydro: 0.1345716777095002
-        hydro discharge: 0.018622098280262404
-        nuclear: 0.4009373330980699
-        oil: 3.7470785134482255e-05
-        solar: 0.004214653914558283
-        unknown: 0.0009275432672667829
-        wind: 3.744817150434678e-05
-    - _source: Electricity Maps, 2016 average
-      datetime: '2016-01-01'
-      value:
-        battery discharge: 0.0
-        biomass: 0.0
-        coal: 0.1616582789479754
-        gas: 0.2789932664431449
-        geothermal: 0.0
-        hydro: 0.1345717112482838
-        hydro discharge: 0.018622102921376598
-        nuclear: 0.400937433022145
-        oil: 3.7470794473182444e-05
-        solar: 0.004214405738792297
-        unknown: 0.0009275434984348369
-        wind: 3.744818083741106e-05
-    - _source: Electricity Maps, 2017 average
-      datetime: '2017-01-01'
-      value:
-        battery discharge: 0.0
-        biomass: 6.320190052090084e-07
-        coal: 0.17799067647540687
-        gas: 0.28119297939831983
-        geothermal: 0.0
-        hydro: 0.12633551124399225
-        hydro discharge: 0.017190390044270892
-        nuclear: 0.3823808536046388
-        oil: 0.0020837486077513344
-        solar: 0.004139838324907468
-        unknown: 0.0016228140095694
-        wind: 0.007490758389288306
-    - _source: Electricity Maps, 2018 average
-      datetime: '2018-01-01'
-      value:
-        battery discharge: 0.0
-        biomass: 1.7018039816903957e-06
-        coal: 0.22223622407399413
-        gas: 0.29706029831455505
-        geothermal: 0.0
-        hydro: 0.12026339990923705
-        hydro discharge: 0.007711219070678953
-        nuclear: 0.34247384024953603
-        oil: 0.001174600402059147
-        solar: 0.001285344537200879
-        unknown: 0.0023441154403520716
-        wind: 0.005732879216588767
-    - _source: Electricity Maps, 2019 average
-      datetime: '2019-01-01'
-      value:
-        battery discharge: 0.0
-        biomass: 2.972190149374324e-06
-        coal: 0.19671422009631043
-        gas: 0.2839093420601456
-        geothermal: 0.0
-        hydro: 0.11887751395561791
-        hydro discharge: 0.0014349204917260122
-        nuclear: 0.387814604848726
-        oil: 5.5487015285483246e-05
-        solar: 0.0030761841716749013
-        unknown: 0.0018904891890024853
-        wind: 0.006604216102733178
-    - _source: Electricity Maps, 2020 average
-      datetime: '2020-01-01'
-      value:
-        battery discharge: 0.0
-        biomass: 2.7595273636622703e-06
-        coal: 0.14817408868996257
-        gas: 0.2845618676876532
-        geothermal: 1.29805134938721e-10
-        hydro: 0.14505026944574126
-        hydro discharge: 0.0017788413265741642
-        nuclear: 0.40694696993549356
-        oil: 2.46832901419749e-05
-        solar: 0.0029908003288492114
-        unknown: 0.0021327208233315304
-        wind: 0.008947741061329952
-    - _source: Electricity Maps, 2021 average
-      datetime: '2021-01-01'
-      value:
-        battery discharge: 0.0
-        biomass: 3.3512877399276507e-06
-        coal: 0.19066058888018092
-        gas: 0.2700887255399683
-        geothermal: 6.245760553008274e-11
-        hydro: 0.1193625037070939
-        hydro discharge: 0.0012007719496972082
-        nuclear: 0.40035491494369607
-        oil: 5.272633584286267e-05
-        solar: 0.004549205501967344
-        unknown: 0.002267402950506192
-        wind: 0.011748960510310807
+  - _source: Electricity Maps, 2015 average
+    datetime: '2015-01-01'
+    value:
+      battery discharge: 0.0
+      biomass: 0.0
+      coal: 0.1616582386585121
+      gas: 0.27899319691073954
+      geothermal: 0.0
+      hydro: 0.1345716777095002
+      hydro discharge: 0.018622098280262404
+      nuclear: 0.4009373330980699
+      oil: 3.7470785134482255e-05
+      solar: 0.004214653914558283
+      unknown: 0.0009275432672667829
+      wind: 3.744817150434678e-05
+  - _source: Electricity Maps, 2016 average
+    datetime: '2016-01-01'
+    value:
+      battery discharge: 0.0
+      biomass: 0.0
+      coal: 0.1616582789479754
+      gas: 0.2789932664431449
+      geothermal: 0.0
+      hydro: 0.1345717112482838
+      hydro discharge: 0.018622102921376598
+      nuclear: 0.400937433022145
+      oil: 3.7470794473182444e-05
+      solar: 0.004214405738792297
+      unknown: 0.0009275434984348369
+      wind: 3.744818083741106e-05
+  - _source: Electricity Maps, 2017 average
+    datetime: '2017-01-01'
+    value:
+      battery discharge: 0.0
+      biomass: 6.320190052090084e-07
+      coal: 0.17799067647540687
+      gas: 0.28119297939831983
+      geothermal: 0.0
+      hydro: 0.12633551124399225
+      hydro discharge: 0.017190390044270892
+      nuclear: 0.3823808536046388
+      oil: 0.0020837486077513344
+      solar: 0.004139838324907468
+      unknown: 0.0016228140095694
+      wind: 0.007490758389288306
+  - _source: Electricity Maps, 2018 average
+    datetime: '2018-01-01'
+    value:
+      battery discharge: 0.0
+      biomass: 1.7018039816903957e-06
+      coal: 0.22223622407399413
+      gas: 0.29706029831455505
+      geothermal: 0.0
+      hydro: 0.12026339990923705
+      hydro discharge: 0.007711219070678953
+      nuclear: 0.34247384024953603
+      oil: 0.001174600402059147
+      solar: 0.001285344537200879
+      unknown: 0.0023441154403520716
+      wind: 0.005732879216588767
+  - _source: Electricity Maps, 2019 average
+    datetime: '2019-01-01'
+    value:
+      battery discharge: 0.0
+      biomass: 2.972190149374324e-06
+      coal: 0.19671422009631043
+      gas: 0.2839093420601456
+      geothermal: 0.0
+      hydro: 0.11887751395561791
+      hydro discharge: 0.0014349204917260122
+      nuclear: 0.387814604848726
+      oil: 5.5487015285483246e-05
+      solar: 0.0030761841716749013
+      unknown: 0.0018904891890024853
+      wind: 0.006604216102733178
+  - _source: Electricity Maps, 2020 average
+    datetime: '2020-01-01'
+    value:
+      battery discharge: 0.0
+      biomass: 2.7595273636622703e-06
+      coal: 0.14817408868996257
+      gas: 0.2845618676876532
+      geothermal: 1.29805134938721e-10
+      hydro: 0.14505026944574126
+      hydro discharge: 0.0017788413265741642
+      nuclear: 0.40694696993549356
+      oil: 2.46832901419749e-05
+      solar: 0.0029908003288492114
+      unknown: 0.0021327208233315304
+      wind: 0.008947741061329952
+  - _source: Electricity Maps, 2021 average
+    datetime: '2021-01-01'
+    value:
+      battery discharge: 0.0
+      biomass: 3.3512877399276507e-06
+      coal: 0.19066058888018092
+      gas: 0.2700887255399683
+      geothermal: 6.245760553008274e-11
+      hydro: 0.1193625037070939
+      hydro discharge: 0.0012007719496972082
+      nuclear: 0.40035491494369607
+      oil: 5.272633584286267e-05
+      solar: 0.004549205501967344
+      unknown: 0.002267402950506192
+      wind: 0.011748960510310807
 parsers:
   consumption: EIA.fetch_consumption
   consumptionForecast: EIA.fetch_consumption_forecast

--- a/config/zones/US-TEX-ERCO.yaml
+++ b/config/zones/US-TEX-ERCO.yaml
@@ -1,8 +1,8 @@
 bounding_box:
-- - -105.47656406478228
-  - 25.368442100637097
-- - -93.3295382953829
-  - 36.5577518713004
+  - - -105.47656406478228
+    - 25.368442100637097
+  - - -93.3295382953829
+    - 36.5577518713004
 capacity:
   battery storage: 2822.9
   biomass: 170.1
@@ -18,9 +18,9 @@ capacity:
   wind: 36855.4
 comment: Electric Reliability Council Of Texas, Inc.
 contributors:
-- systemcatch
-- robertahunt
-- KabelWlan
+  - systemcatch
+  - robertahunt
+  - KabelWlan
 delays:
   consumption: 30
   consumptionForecast: 30
@@ -30,27 +30,27 @@ disclaimer: Data for real-time consumption and generation mix is estimated. Real
 emissionFactors:
   direct:
     battery discharge:
-    - datetime: '2015-01-01'
-      source: Electricity Maps, 2015 average
-      value: 314.52344820264335
-    - datetime: '2016-01-01'
-      source: Electricity Maps, 2016 average
-      value: 380.0670884406045
-    - datetime: '2017-01-01'
-      source: Electricity Maps, 2017 average
-      value: 380.44227224267195
-    - datetime: '2018-01-01'
-      source: Electricity Maps, 2018 average
-      value: 458.58100785291015
-    - datetime: '2019-01-01'
-      source: Electricity Maps, 2019 average
-      value: 400.22966429364493
-    - datetime: '2020-01-01'
-      source: Electricity Maps, 2020 average
-      value: 369.393819397942
-    - datetime: '2021-01-01'
-      source: Electricity Maps, 2021 average
-      value: 366.1763011584388
+      - datetime: '2015-01-01'
+        source: Electricity Maps, 2015 average
+        value: 314.52344820264335
+      - datetime: '2016-01-01'
+        source: Electricity Maps, 2016 average
+        value: 380.0670884406045
+      - datetime: '2017-01-01'
+        source: Electricity Maps, 2017 average
+        value: 380.44227224267195
+      - datetime: '2018-01-01'
+        source: Electricity Maps, 2018 average
+        value: 458.58100785291015
+      - datetime: '2019-01-01'
+        source: Electricity Maps, 2019 average
+        value: 400.22966429364493
+      - datetime: '2020-01-01'
+        source: Electricity Maps, 2020 average
+        value: 369.393819397942
+      - datetime: '2021-01-01'
+        source: Electricity Maps, 2021 average
+        value: 366.1763011584388
     biomass:
       datetime: '2020-01-01'
       source: eGrid 2020
@@ -64,54 +64,54 @@ emissionFactors:
       source: eGrid 2020
       value: 393.100066
     hydro discharge:
-    - datetime: '2015-01-01'
-      source: Electricity Maps, 2015 average
-      value: 314.52344820264335
-    - datetime: '2016-01-01'
-      source: Electricity Maps, 2016 average
-      value: 380.0670884406045
-    - datetime: '2017-01-01'
-      source: Electricity Maps, 2017 average
-      value: 380.44227224267195
-    - datetime: '2018-01-01'
-      source: Electricity Maps, 2018 average
-      value: 458.58100785291015
-    - datetime: '2019-01-01'
-      source: Electricity Maps, 2019 average
-      value: 400.22966429364493
-    - datetime: '2020-01-01'
-      source: Electricity Maps, 2020 average
-      value: 369.393819397942
-    - datetime: '2021-01-01'
-      source: Electricity Maps, 2021 average
-      value: 366.1763011584388
+      - datetime: '2015-01-01'
+        source: Electricity Maps, 2015 average
+        value: 314.52344820264335
+      - datetime: '2016-01-01'
+        source: Electricity Maps, 2016 average
+        value: 380.0670884406045
+      - datetime: '2017-01-01'
+        source: Electricity Maps, 2017 average
+        value: 380.44227224267195
+      - datetime: '2018-01-01'
+        source: Electricity Maps, 2018 average
+        value: 458.58100785291015
+      - datetime: '2019-01-01'
+        source: Electricity Maps, 2019 average
+        value: 400.22966429364493
+      - datetime: '2020-01-01'
+        source: Electricity Maps, 2020 average
+        value: 369.393819397942
+      - datetime: '2021-01-01'
+        source: Electricity Maps, 2021 average
+        value: 366.1763011584388
     oil:
       datetime: '2021-01-01'
       source: eGrid 2020
       value: 1070.811109
   lifecycle:
     battery discharge:
-    - datetime: '2015-01-01'
-      source: Electricity Maps, 2015 average
-      value: 385.07543798821433
-    - datetime: '2016-01-01'
-      source: Electricity Maps, 2016 average
-      value: 445.7752079446886
-    - datetime: '2017-01-01'
-      source: Electricity Maps, 2017 average
-      value: 446.0986441158186
-    - datetime: '2018-01-01'
-      source: Electricity Maps, 2018 average
-      value: 527.8943617466861
-    - datetime: '2019-01-01'
-      source: Electricity Maps, 2019 average
-      value: 468.71234691802545
-    - datetime: '2020-01-01'
-      source: Electricity Maps, 2020 average
-      value: 435.4722763218861
-    - datetime: '2021-01-01'
-      source: Electricity Maps, 2021 average
-      value: 428.8286615039803
+      - datetime: '2015-01-01'
+        source: Electricity Maps, 2015 average
+        value: 385.07543798821433
+      - datetime: '2016-01-01'
+        source: Electricity Maps, 2016 average
+        value: 445.7752079446886
+      - datetime: '2017-01-01'
+        source: Electricity Maps, 2017 average
+        value: 446.0986441158186
+      - datetime: '2018-01-01'
+        source: Electricity Maps, 2018 average
+        value: 527.8943617466861
+      - datetime: '2019-01-01'
+        source: Electricity Maps, 2019 average
+        value: 468.71234691802545
+      - datetime: '2020-01-01'
+        source: Electricity Maps, 2020 average
+        value: 435.4722763218861
+      - datetime: '2021-01-01'
+        source: Electricity Maps, 2021 average
+        value: 428.8286615039803
     biomass:
       datetime: '2020-01-01'
       source: eGrid 2020
@@ -126,27 +126,27 @@ emissionFactors:
       source: eGrid 2020; IPCC 2014
       value: 513.100066
     hydro discharge:
-    - datetime: '2015-01-01'
-      source: Electricity Maps, 2015 average
-      value: 385.07543798821433
-    - datetime: '2016-01-01'
-      source: Electricity Maps, 2016 average
-      value: 445.7752079446886
-    - datetime: '2017-01-01'
-      source: Electricity Maps, 2017 average
-      value: 446.0986441158186
-    - datetime: '2018-01-01'
-      source: Electricity Maps, 2018 average
-      value: 527.8943617466861
-    - datetime: '2019-01-01'
-      source: Electricity Maps, 2019 average
-      value: 468.71234691802545
-    - datetime: '2020-01-01'
-      source: Electricity Maps, 2020 average
-      value: 435.4722763218861
-    - datetime: '2021-01-01'
-      source: Electricity Maps, 2021 average
-      value: 428.8286615039803
+      - datetime: '2015-01-01'
+        source: Electricity Maps, 2015 average
+        value: 385.07543798821433
+      - datetime: '2016-01-01'
+        source: Electricity Maps, 2016 average
+        value: 445.7752079446886
+      - datetime: '2017-01-01'
+        source: Electricity Maps, 2017 average
+        value: 446.0986441158186
+      - datetime: '2018-01-01'
+        source: Electricity Maps, 2018 average
+        value: 527.8943617466861
+      - datetime: '2019-01-01'
+        source: Electricity Maps, 2019 average
+        value: 468.71234691802545
+      - datetime: '2020-01-01'
+        source: Electricity Maps, 2020 average
+        value: 435.4722763218861
+      - datetime: '2021-01-01'
+        source: Electricity Maps, 2021 average
+        value: 428.8286615039803
     oil:
       datetime: '2021-01-01'
       source: eGrid 2020; IPCC 2014
@@ -157,111 +157,111 @@ emissionFactors:
       value: 25.6
 fallbackZoneMixes:
   powerOriginRatios:
-  - _source: Electricity Maps, 2015 average
-    datetime: '2015-01-01'
-    value:
-      battery discharge: 0
-      biomass: 0
-      coal: 0.1949175601554299
-      gas: 0.4459707369749529
-      geothermal: 0
-      hydro: 0.0015546525109556703
-      hydro discharge: 0
-      nuclear: 0.10425041841030042
-      oil: 0
-      solar: 0.029187962214659528
-      unknown: 0.002396495130441387
-      wind: 0.22172211912519735
-  - _source: Electricity Maps, 2016 average
-    datetime: '2016-01-01'
-    value:
-      battery discharge: 0
-      biomass: 0
-      coal: 0.19491786578971063
-      gas: 0.44597143626518254
-      geothermal: 0
-      hydro: 0.0015546549486790931
-      hydro discharge: 0
-      nuclear: 0.10425058187685324
-      oil: 0
-      solar: 0.029186439963721104
-      unknown: 0.002396498888189354
-      wind: 0.2217224667895142
-  - _source: Electricity Maps, 2017 average
-    datetime: '2017-01-01'
-    value:
-      battery discharge: 0
-      biomass: 9.087756717966885e-07
-      coal: 0.19548395546406835
-      gas: 0.4454141302867643
-      geothermal: 2.707928287678456e-09
-      hydro: 0.001654314009867084
-      hydro discharge: 1.968436095473181e-06
-      nuclear: 0.10417343585205613
-      oil: 4.180307351686353e-06
-      solar: 0.02911846509193006
-      unknown: 0.0023963729637807045
-      wind: 0.22175227678435283
-  - _source: Electricity Maps, 2018 average
-    datetime: '2018-01-01'
-    value:
-      battery discharge: 0
-      biomass: 2.3779565300735064e-06
-      coal: 0.263239747531722
-      gas: 0.4666873121121762
-      geothermal: 1.1762862823480964e-07
-      hydro: 0.002695217674846879
-      hydro discharge: 2.9757245317293465e-06
-      nuclear: 0.10357679169172854
-      oil: 8.941264390933385e-06
-      solar: 0.007688363243831027
-      unknown: 0.0007511075829053287
-      wind: 0.15534710284824138
-  - _source: Electricity Maps, 2019 average
-    datetime: '2019-01-01'
-    value:
-      battery discharge: 0
-      biomass: 4.287256435594376e-06
-      coal: 0.20469795913244668
-      gas: 0.4718020706914468
-      geothermal: 5.718985968836614e-07
-      hydro: 0.00248893228269732
-      hydro discharge: 9.158518455432301e-09
-      nuclear: 0.10807780597175065
-      oil: 6.7217002301580036e-06
-      solar: 0.01043756463148209
-      unknown: 0.0020304453419618578
-      wind: 0.20045369207798072
-  - _source: Electricity Maps, 2020 average
-    datetime: '2020-01-01'
-    value:
-      battery discharge: 0
-      biomass: 3.3786221909597205e-06
-      coal: 0.18147673657899296
-      gas: 0.4516422654145757
-      geothermal: 4.3172830964448203e-07
-      hydro: 0.001671563961287584
-      hydro discharge: 5.988489456358945e-08
-      nuclear: 0.109539433650337
-      oil: 4.8483115449904875e-06
-      solar: 0.021795940325638547
-      unknown: 0.0043298325423662964
-      wind: 0.2295355824236003
-  - _source: Electricity Maps, 2021 average
-    datetime: '2021-01-01'
-    value:
-      battery discharge: 0
-      biomass: 2.699271923729837e-06
-      coal: 0.19252396325419224
-      gas: 0.418260460555364
-      geothermal: 2.785496967056957e-07
-      hydro: 0.0013928784580988127
-      hydro discharge: 1.7836149624404227e-10
-      nuclear: 0.10324877356075696
-      oil: 7.002090139334862e-06
-      solar: 0.03879396735206749
-      unknown: 0.0015180241712047652
-      wind: 0.24425208187027933
+    - _source: Electricity Maps, 2015 average
+      datetime: '2015-01-01'
+      value:
+        battery discharge: 0
+        biomass: 0
+        coal: 0.1949175601554299
+        gas: 0.4459707369749529
+        geothermal: 0
+        hydro: 0.0015546525109556703
+        hydro discharge: 0
+        nuclear: 0.10425041841030042
+        oil: 0
+        solar: 0.029187962214659528
+        unknown: 0.002396495130441387
+        wind: 0.22172211912519735
+    - _source: Electricity Maps, 2016 average
+      datetime: '2016-01-01'
+      value:
+        battery discharge: 0
+        biomass: 0
+        coal: 0.19491786578971063
+        gas: 0.44597143626518254
+        geothermal: 0
+        hydro: 0.0015546549486790931
+        hydro discharge: 0
+        nuclear: 0.10425058187685324
+        oil: 0
+        solar: 0.029186439963721104
+        unknown: 0.002396498888189354
+        wind: 0.2217224667895142
+    - _source: Electricity Maps, 2017 average
+      datetime: '2017-01-01'
+      value:
+        battery discharge: 0
+        biomass: 9.087756717966885e-07
+        coal: 0.19548395546406835
+        gas: 0.4454141302867643
+        geothermal: 2.707928287678456e-09
+        hydro: 0.001654314009867084
+        hydro discharge: 1.968436095473181e-06
+        nuclear: 0.10417343585205613
+        oil: 4.180307351686353e-06
+        solar: 0.02911846509193006
+        unknown: 0.0023963729637807045
+        wind: 0.22175227678435283
+    - _source: Electricity Maps, 2018 average
+      datetime: '2018-01-01'
+      value:
+        battery discharge: 0
+        biomass: 2.3779565300735064e-06
+        coal: 0.263239747531722
+        gas: 0.4666873121121762
+        geothermal: 1.1762862823480964e-07
+        hydro: 0.002695217674846879
+        hydro discharge: 2.9757245317293465e-06
+        nuclear: 0.10357679169172854
+        oil: 8.941264390933385e-06
+        solar: 0.007688363243831027
+        unknown: 0.0007511075829053287
+        wind: 0.15534710284824138
+    - _source: Electricity Maps, 2019 average
+      datetime: '2019-01-01'
+      value:
+        battery discharge: 0
+        biomass: 4.287256435594376e-06
+        coal: 0.20469795913244668
+        gas: 0.4718020706914468
+        geothermal: 5.718985968836614e-07
+        hydro: 0.00248893228269732
+        hydro discharge: 9.158518455432301e-09
+        nuclear: 0.10807780597175065
+        oil: 6.7217002301580036e-06
+        solar: 0.01043756463148209
+        unknown: 0.0020304453419618578
+        wind: 0.20045369207798072
+    - _source: Electricity Maps, 2020 average
+      datetime: '2020-01-01'
+      value:
+        battery discharge: 0
+        biomass: 3.3786221909597205e-06
+        coal: 0.18147673657899296
+        gas: 0.4516422654145757
+        geothermal: 4.3172830964448203e-07
+        hydro: 0.001671563961287584
+        hydro discharge: 5.988489456358945e-08
+        nuclear: 0.109539433650337
+        oil: 4.8483115449904875e-06
+        solar: 0.021795940325638547
+        unknown: 0.0043298325423662964
+        wind: 0.2295355824236003
+    - _source: Electricity Maps, 2021 average
+      datetime: '2021-01-01'
+      value:
+        battery discharge: 0
+        biomass: 2.699271923729837e-06
+        coal: 0.19252396325419224
+        gas: 0.418260460555364
+        geothermal: 2.785496967056957e-07
+        hydro: 0.0013928784580988127
+        hydro discharge: 1.7836149624404227e-10
+        nuclear: 0.10324877356075696
+        oil: 7.002090139334862e-06
+        solar: 0.03879396735206749
+        unknown: 0.0015180241712047652
+        wind: 0.24425208187027933
 parsers:
   consumption: EIA.fetch_consumption
   consumptionForecast: EIA.fetch_consumption_forecast

--- a/config/zones/US-TEX-ERCO.yaml
+++ b/config/zones/US-TEX-ERCO.yaml
@@ -1,8 +1,8 @@
 bounding_box:
-  - - -105.47656406478228
-    - 25.368442100637097
-  - - -93.3295382953829
-    - 36.5577518713004
+- - -105.47656406478228
+  - 25.368442100637097
+- - -93.3295382953829
+  - 36.5577518713004
 capacity:
   battery storage: 2822.9
   biomass: 170.1
@@ -18,37 +18,39 @@ capacity:
   wind: 36855.4
 comment: Electric Reliability Council Of Texas, Inc.
 contributors:
-  - systemcatch
-  - robertahunt
-  - KabelWlan
+- systemcatch
+- robertahunt
+- KabelWlan
 delays:
   consumption: 30
   consumptionForecast: 30
   production: 30
+disclaimer: Data for real-time consumption and generation mix is estimated. Real-time
+  exchanges are not available.
 emissionFactors:
   direct:
     battery discharge:
-      - datetime: '2015-01-01'
-        source: Electricity Maps, 2015 average
-        value: 314.52344820264335
-      - datetime: '2016-01-01'
-        source: Electricity Maps, 2016 average
-        value: 380.0670884406045
-      - datetime: '2017-01-01'
-        source: Electricity Maps, 2017 average
-        value: 380.44227224267195
-      - datetime: '2018-01-01'
-        source: Electricity Maps, 2018 average
-        value: 458.58100785291015
-      - datetime: '2019-01-01'
-        source: Electricity Maps, 2019 average
-        value: 400.22966429364493
-      - datetime: '2020-01-01'
-        source: Electricity Maps, 2020 average
-        value: 369.393819397942
-      - datetime: '2021-01-01'
-        source: Electricity Maps, 2021 average
-        value: 366.1763011584388
+    - datetime: '2015-01-01'
+      source: Electricity Maps, 2015 average
+      value: 314.52344820264335
+    - datetime: '2016-01-01'
+      source: Electricity Maps, 2016 average
+      value: 380.0670884406045
+    - datetime: '2017-01-01'
+      source: Electricity Maps, 2017 average
+      value: 380.44227224267195
+    - datetime: '2018-01-01'
+      source: Electricity Maps, 2018 average
+      value: 458.58100785291015
+    - datetime: '2019-01-01'
+      source: Electricity Maps, 2019 average
+      value: 400.22966429364493
+    - datetime: '2020-01-01'
+      source: Electricity Maps, 2020 average
+      value: 369.393819397942
+    - datetime: '2021-01-01'
+      source: Electricity Maps, 2021 average
+      value: 366.1763011584388
     biomass:
       datetime: '2020-01-01'
       source: eGrid 2020
@@ -62,90 +64,89 @@ emissionFactors:
       source: eGrid 2020
       value: 393.100066
     hydro discharge:
-      - datetime: '2015-01-01'
-        source: Electricity Maps, 2015 average
-        value: 314.52344820264335
-      - datetime: '2016-01-01'
-        source: Electricity Maps, 2016 average
-        value: 380.0670884406045
-      - datetime: '2017-01-01'
-        source: Electricity Maps, 2017 average
-        value: 380.44227224267195
-      - datetime: '2018-01-01'
-        source: Electricity Maps, 2018 average
-        value: 458.58100785291015
-      - datetime: '2019-01-01'
-        source: Electricity Maps, 2019 average
-        value: 400.22966429364493
-      - datetime: '2020-01-01'
-        source: Electricity Maps, 2020 average
-        value: 369.393819397942
-      - datetime: '2021-01-01'
-        source: Electricity Maps, 2021 average
-        value: 366.1763011584388
+    - datetime: '2015-01-01'
+      source: Electricity Maps, 2015 average
+      value: 314.52344820264335
+    - datetime: '2016-01-01'
+      source: Electricity Maps, 2016 average
+      value: 380.0670884406045
+    - datetime: '2017-01-01'
+      source: Electricity Maps, 2017 average
+      value: 380.44227224267195
+    - datetime: '2018-01-01'
+      source: Electricity Maps, 2018 average
+      value: 458.58100785291015
+    - datetime: '2019-01-01'
+      source: Electricity Maps, 2019 average
+      value: 400.22966429364493
+    - datetime: '2020-01-01'
+      source: Electricity Maps, 2020 average
+      value: 369.393819397942
+    - datetime: '2021-01-01'
+      source: Electricity Maps, 2021 average
+      value: 366.1763011584388
     oil:
       datetime: '2021-01-01'
       source: eGrid 2020
       value: 1070.811109
   lifecycle:
     battery discharge:
-      - datetime: '2015-01-01'
-        source: Electricity Maps, 2015 average
-        value: 385.07543798821433
-      - datetime: '2016-01-01'
-        source: Electricity Maps, 2016 average
-        value: 445.7752079446886
-      - datetime: '2017-01-01'
-        source: Electricity Maps, 2017 average
-        value: 446.0986441158186
-      - datetime: '2018-01-01'
-        source: Electricity Maps, 2018 average
-        value: 527.8943617466861
-      - datetime: '2019-01-01'
-        source: Electricity Maps, 2019 average
-        value: 468.71234691802545
-      - datetime: '2020-01-01'
-        source: Electricity Maps, 2020 average
-        value: 435.4722763218861
-      - datetime: '2021-01-01'
-        source: Electricity Maps, 2021 average
-        value: 428.8286615039803
+    - datetime: '2015-01-01'
+      source: Electricity Maps, 2015 average
+      value: 385.07543798821433
+    - datetime: '2016-01-01'
+      source: Electricity Maps, 2016 average
+      value: 445.7752079446886
+    - datetime: '2017-01-01'
+      source: Electricity Maps, 2017 average
+      value: 446.0986441158186
+    - datetime: '2018-01-01'
+      source: Electricity Maps, 2018 average
+      value: 527.8943617466861
+    - datetime: '2019-01-01'
+      source: Electricity Maps, 2019 average
+      value: 468.71234691802545
+    - datetime: '2020-01-01'
+      source: Electricity Maps, 2020 average
+      value: 435.4722763218861
+    - datetime: '2021-01-01'
+      source: Electricity Maps, 2021 average
+      value: 428.8286615039803
     biomass:
       datetime: '2020-01-01'
       source: eGrid 2020
       value: 0.4539605655
     coal:
       datetime: '2020-01-01'
-      source: >-
-        eGrid 2020; Oberschelp, Christopher, et al. "Global emission hotspots of
-        coal power generation."
+      source: eGrid 2020; Oberschelp, Christopher, et al. "Global emission hotspots
+        of coal power generation."
       value: 1081.455715
     gas:
       datetime: '2021-01-01'
       source: eGrid 2020; IPCC 2014
       value: 513.100066
     hydro discharge:
-      - datetime: '2015-01-01'
-        source: Electricity Maps, 2015 average
-        value: 385.07543798821433
-      - datetime: '2016-01-01'
-        source: Electricity Maps, 2016 average
-        value: 445.7752079446886
-      - datetime: '2017-01-01'
-        source: Electricity Maps, 2017 average
-        value: 446.0986441158186
-      - datetime: '2018-01-01'
-        source: Electricity Maps, 2018 average
-        value: 527.8943617466861
-      - datetime: '2019-01-01'
-        source: Electricity Maps, 2019 average
-        value: 468.71234691802545
-      - datetime: '2020-01-01'
-        source: Electricity Maps, 2020 average
-        value: 435.4722763218861
-      - datetime: '2021-01-01'
-        source: Electricity Maps, 2021 average
-        value: 428.8286615039803
+    - datetime: '2015-01-01'
+      source: Electricity Maps, 2015 average
+      value: 385.07543798821433
+    - datetime: '2016-01-01'
+      source: Electricity Maps, 2016 average
+      value: 445.7752079446886
+    - datetime: '2017-01-01'
+      source: Electricity Maps, 2017 average
+      value: 446.0986441158186
+    - datetime: '2018-01-01'
+      source: Electricity Maps, 2018 average
+      value: 527.8943617466861
+    - datetime: '2019-01-01'
+      source: Electricity Maps, 2019 average
+      value: 468.71234691802545
+    - datetime: '2020-01-01'
+      source: Electricity Maps, 2020 average
+      value: 435.4722763218861
+    - datetime: '2021-01-01'
+      source: Electricity Maps, 2021 average
+      value: 428.8286615039803
     oil:
       datetime: '2021-01-01'
       source: eGrid 2020; IPCC 2014
@@ -156,123 +157,120 @@ emissionFactors:
       value: 25.6
 fallbackZoneMixes:
   powerOriginRatios:
-    - _source: Electricity Maps, 2015 average
-      datetime: '2015-01-01'
-      value:
-        battery discharge: 0
-        biomass: 0
-        coal: 0.1949175601554299
-        gas: 0.4459707369749529
-        geothermal: 0
-        hydro: 0.0015546525109556703
-        hydro discharge: 0
-        nuclear: 0.10425041841030042
-        oil: 0
-        solar: 0.029187962214659528
-        unknown: 0.002396495130441387
-        wind: 0.22172211912519735
-    - _source: Electricity Maps, 2016 average
-      datetime: '2016-01-01'
-      value:
-        battery discharge: 0
-        biomass: 0
-        coal: 0.19491786578971063
-        gas: 0.44597143626518254
-        geothermal: 0
-        hydro: 0.0015546549486790931
-        hydro discharge: 0
-        nuclear: 0.10425058187685324
-        oil: 0
-        solar: 0.029186439963721104
-        unknown: 0.002396498888189354
-        wind: 0.2217224667895142
-    - _source: Electricity Maps, 2017 average
-      datetime: '2017-01-01'
-      value:
-        battery discharge: 0
-        biomass: 9.087756717966885e-7
-        coal: 0.19548395546406835
-        gas: 0.4454141302867643
-        geothermal: 2.707928287678456e-9
-        hydro: 0.001654314009867084
-        hydro discharge: 0.000001968436095473181
-        nuclear: 0.10417343585205613
-        oil: 0.000004180307351686353
-        solar: 0.02911846509193006
-        unknown: 0.0023963729637807045
-        wind: 0.22175227678435283
-    - _source: Electricity Maps, 2018 average
-      datetime: '2018-01-01'
-      value:
-        battery discharge: 0
-        biomass: 0.0000023779565300735064
-        coal: 0.263239747531722
-        gas: 0.4666873121121762
-        geothermal: 1.1762862823480964e-7
-        hydro: 0.002695217674846879
-        hydro discharge: 0.0000029757245317293465
-        nuclear: 0.10357679169172854
-        oil: 0.000008941264390933385
-        solar: 0.007688363243831027
-        unknown: 0.0007511075829053287
-        wind: 0.15534710284824138
-    - _source: Electricity Maps, 2019 average
-      datetime: '2019-01-01'
-      value:
-        battery discharge: 0
-        biomass: 0.000004287256435594376
-        coal: 0.20469795913244668
-        gas: 0.4718020706914468
-        geothermal: 5.718985968836614e-7
-        hydro: 0.00248893228269732
-        hydro discharge: 9.158518455432301e-9
-        nuclear: 0.10807780597175065
-        oil: 0.0000067217002301580036
-        solar: 0.01043756463148209
-        unknown: 0.0020304453419618578
-        wind: 0.20045369207798072
-    - _source: Electricity Maps, 2020 average
-      datetime: '2020-01-01'
-      value:
-        battery discharge: 0
-        biomass: 0.0000033786221909597205
-        coal: 0.18147673657899296
-        gas: 0.4516422654145757
-        geothermal: 4.3172830964448203e-7
-        hydro: 0.001671563961287584
-        hydro discharge: 5.988489456358945e-8
-        nuclear: 0.109539433650337
-        oil: 0.0000048483115449904875
-        solar: 0.021795940325638547
-        unknown: 0.0043298325423662964
-        wind: 0.2295355824236003
-    - _source: Electricity Maps, 2021 average
-      datetime: '2021-01-01'
-      value:
-        battery discharge: 0
-        biomass: 0.000002699271923729837
-        coal: 0.19252396325419224
-        gas: 0.418260460555364
-        geothermal: 2.785496967056957e-7
-        hydro: 0.0013928784580988127
-        hydro discharge: 1.7836149624404227e-10
-        nuclear: 0.10324877356075696
-        oil: 0.000007002090139334862
-        solar: 0.03879396735206749
-        unknown: 0.0015180241712047652
-        wind: 0.24425208187027933
+  - _source: Electricity Maps, 2015 average
+    datetime: '2015-01-01'
+    value:
+      battery discharge: 0
+      biomass: 0
+      coal: 0.1949175601554299
+      gas: 0.4459707369749529
+      geothermal: 0
+      hydro: 0.0015546525109556703
+      hydro discharge: 0
+      nuclear: 0.10425041841030042
+      oil: 0
+      solar: 0.029187962214659528
+      unknown: 0.002396495130441387
+      wind: 0.22172211912519735
+  - _source: Electricity Maps, 2016 average
+    datetime: '2016-01-01'
+    value:
+      battery discharge: 0
+      biomass: 0
+      coal: 0.19491786578971063
+      gas: 0.44597143626518254
+      geothermal: 0
+      hydro: 0.0015546549486790931
+      hydro discharge: 0
+      nuclear: 0.10425058187685324
+      oil: 0
+      solar: 0.029186439963721104
+      unknown: 0.002396498888189354
+      wind: 0.2217224667895142
+  - _source: Electricity Maps, 2017 average
+    datetime: '2017-01-01'
+    value:
+      battery discharge: 0
+      biomass: 9.087756717966885e-07
+      coal: 0.19548395546406835
+      gas: 0.4454141302867643
+      geothermal: 2.707928287678456e-09
+      hydro: 0.001654314009867084
+      hydro discharge: 1.968436095473181e-06
+      nuclear: 0.10417343585205613
+      oil: 4.180307351686353e-06
+      solar: 0.02911846509193006
+      unknown: 0.0023963729637807045
+      wind: 0.22175227678435283
+  - _source: Electricity Maps, 2018 average
+    datetime: '2018-01-01'
+    value:
+      battery discharge: 0
+      biomass: 2.3779565300735064e-06
+      coal: 0.263239747531722
+      gas: 0.4666873121121762
+      geothermal: 1.1762862823480964e-07
+      hydro: 0.002695217674846879
+      hydro discharge: 2.9757245317293465e-06
+      nuclear: 0.10357679169172854
+      oil: 8.941264390933385e-06
+      solar: 0.007688363243831027
+      unknown: 0.0007511075829053287
+      wind: 0.15534710284824138
+  - _source: Electricity Maps, 2019 average
+    datetime: '2019-01-01'
+    value:
+      battery discharge: 0
+      biomass: 4.287256435594376e-06
+      coal: 0.20469795913244668
+      gas: 0.4718020706914468
+      geothermal: 5.718985968836614e-07
+      hydro: 0.00248893228269732
+      hydro discharge: 9.158518455432301e-09
+      nuclear: 0.10807780597175065
+      oil: 6.7217002301580036e-06
+      solar: 0.01043756463148209
+      unknown: 0.0020304453419618578
+      wind: 0.20045369207798072
+  - _source: Electricity Maps, 2020 average
+    datetime: '2020-01-01'
+    value:
+      battery discharge: 0
+      biomass: 3.3786221909597205e-06
+      coal: 0.18147673657899296
+      gas: 0.4516422654145757
+      geothermal: 4.3172830964448203e-07
+      hydro: 0.001671563961287584
+      hydro discharge: 5.988489456358945e-08
+      nuclear: 0.109539433650337
+      oil: 4.8483115449904875e-06
+      solar: 0.021795940325638547
+      unknown: 0.0043298325423662964
+      wind: 0.2295355824236003
+  - _source: Electricity Maps, 2021 average
+    datetime: '2021-01-01'
+    value:
+      battery discharge: 0
+      biomass: 2.699271923729837e-06
+      coal: 0.19252396325419224
+      gas: 0.418260460555364
+      geothermal: 2.785496967056957e-07
+      hydro: 0.0013928784580988127
+      hydro discharge: 1.7836149624404227e-10
+      nuclear: 0.10324877356075696
+      oil: 7.002090139334862e-06
+      solar: 0.03879396735206749
+      unknown: 0.0015180241712047652
+      wind: 0.24425208187027933
 parsers:
   consumption: EIA.fetch_consumption
   consumptionForecast: EIA.fetch_consumption_forecast
   production: EIA.fetch_production_mix
 sources:
   INCER ACV:
-    link: >-
-      https://docs.google.com/spreadsheets/d/1w5DJ7sPen6axIHU8TCVcuzNCjlct4I6JAbhUlw-ZXu8/edit?usp=sharing
+    link: https://docs.google.com/spreadsheets/d/1w5DJ7sPen6axIHU8TCVcuzNCjlct4I6JAbhUlw-ZXu8/edit?usp=sharing
   IPCC 2014:
-    link: >-
-      https://www.ipcc.ch/site/assets/uploads/2018/02/ipcc_wg3_ar5_annex-iii.pdf#page=7
+    link: https://www.ipcc.ch/site/assets/uploads/2018/02/ipcc_wg3_ar5_annex-iii.pdf#page=7
   eGrid 2020:
-    link: >-
-      https://drive.google.com/file/d/1_FAAuTtIdMuORZKsqHnd9vMNHlQgYarh/view?usp=sharing
+    link: https://drive.google.com/file/d/1_FAAuTtIdMuORZKsqHnd9vMNHlQgYarh/view?usp=sharing
 timezone: US/Central

--- a/config/zones/US-TEX-ERCO.yaml
+++ b/config/zones/US-TEX-ERCO.yaml
@@ -118,8 +118,9 @@ emissionFactors:
       value: 0.4539605655
     coal:
       datetime: '2020-01-01'
-      source: eGrid 2020; Oberschelp, Christopher, et al. "Global emission hotspots
-        of coal power generation."
+      source: >-
+        eGrid 2020; Oberschelp, Christopher, et al. "Global emission hotspots of
+        coal power generation."
       value: 1081.455715
     gas:
       datetime: '2021-01-01'
@@ -191,14 +192,14 @@ fallbackZoneMixes:
       datetime: '2017-01-01'
       value:
         battery discharge: 0
-        biomass: 9.087756717966885e-07
+        biomass: 9.087756717966885e-7
         coal: 0.19548395546406835
         gas: 0.4454141302867643
-        geothermal: 2.707928287678456e-09
+        geothermal: 2.707928287678456e-9
         hydro: 0.001654314009867084
-        hydro discharge: 1.968436095473181e-06
+        hydro discharge: 0.000001968436095473181
         nuclear: 0.10417343585205613
-        oil: 4.180307351686353e-06
+        oil: 0.000004180307351686353
         solar: 0.02911846509193006
         unknown: 0.0023963729637807045
         wind: 0.22175227678435283
@@ -206,14 +207,14 @@ fallbackZoneMixes:
       datetime: '2018-01-01'
       value:
         battery discharge: 0
-        biomass: 2.3779565300735064e-06
+        biomass: 0.0000023779565300735064
         coal: 0.263239747531722
         gas: 0.4666873121121762
-        geothermal: 1.1762862823480964e-07
+        geothermal: 1.1762862823480964e-7
         hydro: 0.002695217674846879
-        hydro discharge: 2.9757245317293465e-06
+        hydro discharge: 0.0000029757245317293465
         nuclear: 0.10357679169172854
-        oil: 8.941264390933385e-06
+        oil: 0.000008941264390933385
         solar: 0.007688363243831027
         unknown: 0.0007511075829053287
         wind: 0.15534710284824138
@@ -221,14 +222,14 @@ fallbackZoneMixes:
       datetime: '2019-01-01'
       value:
         battery discharge: 0
-        biomass: 4.287256435594376e-06
+        biomass: 0.000004287256435594376
         coal: 0.20469795913244668
         gas: 0.4718020706914468
-        geothermal: 5.718985968836614e-07
+        geothermal: 5.718985968836614e-7
         hydro: 0.00248893228269732
-        hydro discharge: 9.158518455432301e-09
+        hydro discharge: 9.158518455432301e-9
         nuclear: 0.10807780597175065
-        oil: 6.7217002301580036e-06
+        oil: 0.0000067217002301580036
         solar: 0.01043756463148209
         unknown: 0.0020304453419618578
         wind: 0.20045369207798072
@@ -236,14 +237,14 @@ fallbackZoneMixes:
       datetime: '2020-01-01'
       value:
         battery discharge: 0
-        biomass: 3.3786221909597205e-06
+        biomass: 0.0000033786221909597205
         coal: 0.18147673657899296
         gas: 0.4516422654145757
-        geothermal: 4.3172830964448203e-07
+        geothermal: 4.3172830964448203e-7
         hydro: 0.001671563961287584
-        hydro discharge: 5.988489456358945e-08
+        hydro discharge: 5.988489456358945e-8
         nuclear: 0.109539433650337
-        oil: 4.8483115449904875e-06
+        oil: 0.0000048483115449904875
         solar: 0.021795940325638547
         unknown: 0.0043298325423662964
         wind: 0.2295355824236003
@@ -251,14 +252,14 @@ fallbackZoneMixes:
       datetime: '2021-01-01'
       value:
         battery discharge: 0
-        biomass: 2.699271923729837e-06
+        biomass: 0.000002699271923729837
         coal: 0.19252396325419224
         gas: 0.418260460555364
-        geothermal: 2.785496967056957e-07
+        geothermal: 2.785496967056957e-7
         hydro: 0.0013928784580988127
         hydro discharge: 1.7836149624404227e-10
         nuclear: 0.10324877356075696
-        oil: 7.002090139334862e-06
+        oil: 0.000007002090139334862
         solar: 0.03879396735206749
         unknown: 0.0015180241712047652
         wind: 0.24425208187027933
@@ -268,9 +269,12 @@ parsers:
   production: EIA.fetch_production_mix
 sources:
   INCER ACV:
-    link: https://docs.google.com/spreadsheets/d/1w5DJ7sPen6axIHU8TCVcuzNCjlct4I6JAbhUlw-ZXu8/edit?usp=sharing
+    link: >-
+      https://docs.google.com/spreadsheets/d/1w5DJ7sPen6axIHU8TCVcuzNCjlct4I6JAbhUlw-ZXu8/edit?usp=sharing
   IPCC 2014:
-    link: https://www.ipcc.ch/site/assets/uploads/2018/02/ipcc_wg3_ar5_annex-iii.pdf#page=7
+    link: >-
+      https://www.ipcc.ch/site/assets/uploads/2018/02/ipcc_wg3_ar5_annex-iii.pdf#page=7
   eGrid 2020:
-    link: https://drive.google.com/file/d/1_FAAuTtIdMuORZKsqHnd9vMNHlQgYarh/view?usp=sharing
+    link: >-
+      https://drive.google.com/file/d/1_FAAuTtIdMuORZKsqHnd9vMNHlQgYarh/view?usp=sharing
 timezone: US/Central


### PR DESCRIPTION
## Issue

<!-- If you want to close an issue automatically when your PR is merged, write "Closes X" where X is the PR number. For example: Closes #000 -->

Some zones are missing disclaimers

## Description

Used the following script to automate the US zones (+ `pnpx prettier --write .`)

```python
from ruamel.yaml import YAML

from electricitymap.contrib.config import ZONES_CONFIG

yaml = YAML(typ="safe")
yaml.default_flow_style = False

EXCLUDED_ZONES = [
    "US-CAL-CISO",
    "US-MIDA-PJM",
    "US-CENT-SWPP",
    "US-NY-NYIS",
    "US-NE-ISNE",
    "US-HI-NI",
    "US-HI-KA",
    "US-HI-MO",
    "US-HI-MA",
    "US-HI-HA",
    "US-HI-KH",
    "US-HI-LA",
    "US-FLA-HST",
    "US-AK",
]

US_ZONES = [
    z_k
    for z_k in ZONES_CONFIG.keys()
    if z_k.startswith("US-") and z_k not in EXCLUDED_ZONES
]

# Read config/zones/${zone_key}.json and add disclaimer "Data for real-time consumption and generation mix is estimated. Real-time exchanges are not available."
for zone_key in US_ZONES:
    zone_config = yaml.load(
        open(f"config/zones/{zone_key}.yaml", "r", encoding="utf-8"),
    )
    zone_config[
        "disclaimer"
    ] = "Data for real-time consumption and generation mix is estimated. Real-time exchanges are not available."
    with open(f"config/zones/{zone_key}.yaml", "w", encoding="utf-8") as f:
        yaml.dump(zone_config, f)

```

### Preview

<!-- Please add screenshots and/or gif that shows visual changes (if applicable) -->

### Double check

- [x] I have tested my parser changes locally with `poetry run test_parser "zone_key"`
- [x] I have run `pnpx prettier --write .` and `poetry run format` to format my changes.
