### PR TITLE
Update US-NW-WACM hydro capacity

### DIFF
--- a/config/zones/US-NW-WACM.yaml
+++ b/config/zones/US-NW-WACM.yaml
@@ -9,7 +9,7 @@ capacity:
   coal: 4372.3
   gas: 1792
   geothermal: 0
-  hydro: 704.3
+  hydro: 1550
   hydro storage: 208.5
   nuclear: 0
   oil: 158.8


### PR DESCRIPTION
## Issue

<!-- If you want to close an issue automatically when your PR is merged, write "Closes X" where X is the PR number. For example: Closes #000 -->

The hydro production in WACM exceeds capacity every day. 

## Description

The reported capacity in the EIA table is indeed in the 700MW range, but everyday the reported generation peaks at around 1400-1500MW.
My hunch is that a lot of smaller hydro plants are not included in the capacity reports, underestimating the actual hydro capacity. 
I'm proposing to set as the capacity a value slightly above the max we've parsed since the beginning of 2023 (1545MW)

### Preview

<!-- Please add screenshots and/or gif that shows visual changes (if applicable) -->

### Double check

- [x] I have tested my parser changes locally with `poetry run test_parser "zone_key"`
- [x] I have run `pnpx prettier --write .` and `poetry run format` to format my changes.
