### PR TITLE
simplify_CI_setup_job

### DIFF
--- a/.github/filter-groups.yml
+++ b/.github/filter-groups.yml
@@ -1,0 +1,22 @@
+workflows:
+  - '.github/workflows/**/*.yml'
+
+frontend:
+  - 'web'
+  - '!web/public/locales/*.json'
+  - '!web/**/*.md'
+
+config:
+  - 'config/**/*.yaml'
+
+markdown:
+  - '**.md'
+
+json:
+  - '**.json'
+
+python:
+  - '**.py'
+  - 'pyproject.toml'
+  - 'poetry.lock'
+  - '.poetry-version'

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -18,66 +18,30 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 1
     outputs:
-      frontend: ${{ steps.check-frontend.outputs.any_changed }}
-      config: ${{ steps.check-config.outputs.any_changed }}
-      markdown: ${{ steps.check-markdown.outputs.any_changed }}
-      json: ${{ steps.check-json.outputs.any_changed }}
-      python: ${{ steps.check-python.outputs.any_changed }}
-      workflows: ${{ steps.check-workflows.outputs.any_changed }}
+      frontend: ${{ steps.check-changed-files.outputs.frontend_any_changed }}
+      config: ${{ steps.check-changed-files.outputs.config_any_changed }}
+      markdown: ${{ steps.check-changed-files.outputs.markdown_any_changed }}
+      json: ${{ steps.check-changed-files.json_any_changed }}
+      python: ${{ steps.check-changed-files.outputs.python_any_changed }}
+      workflows: ${{ steps.check-changed-files.outputs.workflows_any_changed }}
     steps:
       - name: Checkout
         uses: actions/checkout@v3
         with:
           fetch-depth: 2
-      - name: Check frontend files
-        id: check-frontend
+      - name: Check which files have changed
+        id: check-changed-files
         uses: tj-actions/changed-files@v37.0.5
         with:
-          files: |
-            web
-            !web/public/locales/*.json
-            !web/**/*.md
-      - name: Check config files
-        id: check-config
-        uses: tj-actions/changed-files@v37.0.5
-        with:
-          files: |
-            config/**/*.yaml
-      - name: Check markdown files
-        id: check-markdown
-        uses: tj-actions/changed-files@v37.0.5
-        with:
-          files: |
-            **.md
-      - name: Check json files
-        id: check-json
-        uses: tj-actions/changed-files@v37.0.5
-        with:
-          files: |
-            **.json
-      - name: Check python files
-        id: check-python
-        uses: tj-actions/changed-files@v37.0.5
-        with:
-          files: |
-            **.py
-            pyproject.toml
-            poetry.lock
-            .python-version
-      - name: Check if workflows have changed
-        id: check-workflows
-        uses: tj-actions/changed-files@v37.0.5
-        with:
-          files: |
-            .github/workflows/**/*.yml
+          files_yaml_from_source_file: .github/filter-groups.yml
       - name: Log outputs
         run: |
-          echo "frontend changed: ${{ steps.check-frontend.outputs.any_changed }}"
-          echo "config changed: ${{ steps.check-config.outputs.any_changed }}"
-          echo "markdown changed: ${{ steps.check-markdown.outputs.any_changed }}"
-          echo "json changed: ${{ steps.check-json.outputs.any_changed }}"
-          echo "python changed: ${{ steps.check-python.outputs.any_changed }}"
-          echo "workflows changed: ${{ steps.check-workflows.outputs.any_changed }}"
+          echo "frontend changed: ${{ steps.check-changed-files.outputs.frontend_any_changed }}
+          echo "config changed: ${{ steps.check-changed-files.outputs.config_any_changed }}
+          echo "markdown changed: ${{ steps.check-changed-files.outputs.markdown_any_changed }}
+          echo "json changed: ${{ steps.check-changed-files.json_any_changed }}
+          echo "python changed: ${{ steps.check-changed-files.outputs.python_any_changed }}
+          echo "workflows changed: ${{ steps.check-changed-files.outputs.workflows_any_changed }}
 
   # Repository wide checks
   prettier:


### PR DESCRIPTION
## Description

Simplifies the CI setup job by checking multiple categories in one go and uses a separate config file for it to allow for easier maintenance in the future. This also saves about 4 seconds on the total (and blocking) CI time.

### Double check

- [x] I have run `pnpx prettier --write .` and `poetry run format` to format my changes.
