### PR TITLE
optimize python codeql scanning

### DIFF
--- a/.github/codeql-config.yml
+++ b/.github/codeql-config.yml
@@ -2,3 +2,6 @@ name: 'CodeQL config'
 paths-ignore:
   - mockserver
   - 'web/**/*.test.ts'
+
+# This is the new recommended setting for analyzing Python projects.
+setup-python-dependencies: false

--- a/.github/codeql-config.yml
+++ b/.github/codeql-config.yml
@@ -2,6 +2,3 @@ name: 'CodeQL config'
 paths-ignore:
   - mockserver
   - 'web/**/*.test.ts'
-
-# This is the new recommended setting for analyzing Python projects.
-setup-python-dependencies: false

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -28,6 +28,8 @@ jobs:
         uses: github/codeql-action/init@v2
         with:
           languages: ${{ matrix.language }}
+          # This is the new recommended setting for analyzing Python projects.
+          setup-python-dependencies: false
           config-file: ./.github/codeql-config.yml
           # If you wish to specify custom queries, you can do so here or in a config file.
           # By default, queries listed here will override any specified in a config file.
@@ -38,3 +40,4 @@ jobs:
         uses: github/codeql-action/analyze@v2
         with:
           category: '/language:${{matrix.language}}'
+

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -40,4 +40,3 @@ jobs:
         uses: github/codeql-action/analyze@v2
         with:
           category: '/language:${{matrix.language}}'
-


### PR DESCRIPTION
## Issue

The Python CodeQL job takes a long time to run.

## Description

Skips python dependency installation for CodeQL, this is the new recommended setup from GitHub and they use it on new projects.


### Double check

- [x] I have run `pnpx prettier --write .` and `poetry run format` to format my changes.
