### PR TITLE
Disabled CA verification on get requests for CA-SK

### DIFF
--- a/parsers/CA_SK.py
+++ b/parsers/CA_SK.py
@@ -64,7 +64,7 @@ def fetch_production(
 
     # Set the headers to mimic a user browser as the API will return a 403 if not.
     headers = {"user-agent": USER_AGENT}
-    response: Response = session.get(PRODUCTION_URL, headers=headers)
+    response: Response = session.get(PRODUCTION_URL, headers=headers, verify=False)
 
     if not response.ok:
         raise ParserException(
@@ -115,7 +115,7 @@ def fetch_consumption(
     # Set the headers to mimic a user browser as the API will return a 403 if not.
     headers = {"user-agent": USER_AGENT}
 
-    response: Response = session.get(CONSUMPTION_URL)  # , headers=headers)
+    response: Response = session.get(CONSUMPTION_URL, verify=False)  # , headers=headers)
 
     if not response.ok:
         raise ParserException(


### PR DESCRIPTION
## Issue

<!-- If you want to close an issue automatically when your PR is merged, write "Closes X" where X is the PR number. For example: Closes #000 -->
Closes #5562



## Description

<!-- Explains the goal of this PR -->
Disables CA verification for the GET requests on the Saskatchewan data sites.

### Preview

<!-- Please add screenshots and/or gif that shows visual changes (if applicable) -->

### Double check

- [ ] I have tested my parser changes locally with `poetry run test_parser "zone_key"`
- [ ] I have run `pnpx prettier --write .` and `poetry run format` to format my changes.
