### PR TITLE
fix flex of zone disclaimer tooltip

### DIFF
--- a/web/src/features/panels/zone/ZoneHeaderTitle.tsx
+++ b/web/src/features/panels/zone/ZoneHeaderTitle.tsx
@@ -60,14 +60,14 @@ export default function ZoneHeaderTitle({
                   )}
                 </div>
               </TooltipWrapper>
+              {disclaimer && (
+                <TooltipWrapper side="bottom" tooltipContent={disclaimer}>
+                  <div className="ml-1 mr-1 h-6 w-6 shrink-0 select-none rounded-full bg-white text-center drop-shadow dark:border dark:border-gray-500 dark:bg-gray-900">
+                    <p>i</p>
+                  </div>
+                </TooltipWrapper>
+              )}
             </div>
-            {disclaimer && (
-              <TooltipWrapper side="bottom" tooltipContent={disclaimer}>
-                <div className="mr-1 h-6 w-6 select-none rounded-full bg-white text-center drop-shadow dark:border dark:border-gray-500 dark:bg-gray-900 sm:mr-0">
-                  <p>i</p>
-                </div>
-              </TooltipWrapper>
-            )}
           </div>
         </div>
         <div className="flex h-auto flex-wrap items-center gap-1 text-center">


### PR DESCRIPTION
## Issue
Long zone names caused our zone disclaimer tooltip icon to get squished

## Description
This PR moves the zone tooltip up so it flexes with the rest of the ZoneTitleHeader and ```flex-shrink:0``` to the tooltip icon. 

### Preview
Then:
<img width="510" alt="image" src="https://github.com/electricitymaps/electricitymaps-contrib/assets/18622768/419a3d22-1f64-4885-9f0d-94daf173859b">

Now:
<img width="508" alt="image" src="https://github.com/electricitymaps/electricitymaps-contrib/assets/18622768/6213663e-0c30-4830-b87d-1551eec94c78">


### Double check

- [x] I have tested my parser changes locally with `poetry run test_parser "zone_key"`
- [x] I have run `pnpx prettier --write .` and `poetry run format` to format my changes.
