### PR TITLE
Added aria labels to icon only buttons

### DIFF
--- a/web/public/locales/en.json
+++ b/web/public/locales/en.json
@@ -148,6 +148,17 @@
     "dataIsDelayed": "Data is delayed",
     "price": "Price"
   },
+  "aria": {
+    "label": {
+      "selectLanguage": "Select language",
+      "colorBlindMode": "Color blind mode",
+      "windLayer": "Wind layer",
+      "solarLayer": "Solar layer",
+      "changeTheme": "Change theme",
+      "hideSidePanel": "Hide side panel",
+      "showSidePanel": "Show side panel"
+    }
+  },
   "aggregateButtons": {
     "country": "country",
     "zone": "zone"

--- a/web/src/features/map-controls/LanguageSelector.tsx
+++ b/web/src/features/map-controls/LanguageSelector.tsx
@@ -31,6 +31,7 @@ export function LanguageSelector({ isMobile }: { isMobile?: boolean }) {
           <MapButton
             icon={<HiLanguage size={20} style={{ strokeWidth: '0.5' }} />}
             tooltipText={__('tooltips.selectLanguage')}
+            ariaLabel={__('aria.label.selectLanguage')}
           />
         )
       }

--- a/web/src/features/map-controls/MapButton.tsx
+++ b/web/src/features/map-controls/MapButton.tsx
@@ -8,6 +8,7 @@ interface MapButtonProperties {
   className?: string;
   dataTestId?: string;
   asToggle?: boolean;
+  ariaLabel?: string;
 }
 
 export default function MapButton({
@@ -17,6 +18,7 @@ export default function MapButton({
   dataTestId,
   onClick,
   asToggle,
+  ariaLabel,
 }: MapButtonProperties) {
   const Component = asToggle ? Toggle.Root : 'div';
   return (
@@ -24,8 +26,9 @@ export default function MapButton({
       <Component
         onClick={onClick}
         className={`pointer-events-auto flex h-8 w-8 items-center justify-center rounded bg-white text-left shadow-lg transition hover:bg-gray-100 dark:bg-gray-900 dark:hover:bg-gray-800 ${className}`}
-        aria-label="Toggle functionality" // TODO: This should be more precise!
+        aria-label={ariaLabel}
         data-test-id={dataTestId}
+        role="button"
       >
         <div>{icon}</div>
       </Component>

--- a/web/src/features/map-controls/MapControls.tsx
+++ b/web/src/features/map-controls/MapControls.tsx
@@ -101,6 +101,9 @@ function WeatherButton({ type }: { type: 'wind' | 'solar' }) {
       dataTestId={`${type}-layer-button`}
       className={`${isLoadingLayer ? 'cursor-default' : 'cursor-pointer'}`}
       onClick={isLoadingLayer ? () => {} : onToggle}
+      ariaLabel={
+        type == 'wind' ? __('aria.label.windLayer') : __('aria.label.solarLayer')
+      }
       asToggle
     />
   );
@@ -140,6 +143,7 @@ function DesktopMapControls() {
           tooltipText={__('legends.colorblindmode')}
           onClick={handleColorblindModeToggle}
           asToggle
+          ariaLabel={__('aria.label.colorBlindMode')}
         />
         {areWeatherLayersAllowed && (
           <>

--- a/web/src/features/map-controls/ThemeSelector.tsx
+++ b/web/src/features/map-controls/ThemeSelector.tsx
@@ -39,6 +39,7 @@ export default function ThemeSelector({ isMobile }: { isMobile?: boolean }) {
           <MapButton
             icon={<BsMoonStars size={14} style={{ strokeWidth: '0.2' }} />}
             tooltipText={__('tooltips.changeTheme')}
+            ariaLabel={__('aria.label.changeTheme')}
           />
         )
       }

--- a/web/src/features/panels/LeftPanel.tsx
+++ b/web/src/features/panels/LeftPanel.tsx
@@ -14,6 +14,7 @@ import {
 import FAQPanel from './faq/FAQPanel';
 import { leftPanelOpenAtom } from './panelAtoms';
 import RankingPanel from './ranking-panel/RankingPanel';
+import { useTranslation } from 'translation/translation';
 
 import ZoneDetails from './zone/ZoneDetails';
 
@@ -62,6 +63,7 @@ type CollapseButtonProps = {
 };
 
 function CollapseButton({ isCollapsed, onCollapse }: CollapseButtonProps) {
+  const { __ } = useTranslation();
   return (
     <button
       data-test-id="left-panel-collapse-button"
@@ -69,6 +71,9 @@ function CollapseButton({ isCollapsed, onCollapse }: CollapseButtonProps) {
         'absolute left-full top-2 z-10 h-12 w-6 cursor-pointer rounded-r bg-zinc-50 pl-1 shadow-[6px_2px_10px_-3px_rgba(0,0,0,0.1)] hover:bg-zinc-100 dark:bg-gray-800 dark:hover:bg-gray-600'
       }
       onClick={onCollapse}
+      aria-label={
+        isCollapsed ? __('aria.label.showSidePanel') : __('aria.label.hideSidePanel')
+      }
     >
       {isCollapsed ? <HiChevronRight /> : <HiChevronLeft />}
     </button>


### PR DESCRIPTION
## Issue
Issue described here: https://github.com/electricitymaps/electricitymaps-contrib/issues/5695

## Description
- Added a new `ariaLabel` prop to the Map button component that can be passed strings from the localisation files
- Added an aria section in localisation file and a sub section with labels. The idea here is that the aria-section in the localisation file could contain multple aria types like [descriptions](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-description) or [placeholders](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-placeholder) etc.


## Preview

<img width="437" alt="Screenshot 2023-08-04 at 14 20 15" src="https://github.com/electricitymaps/electricitymaps-contrib/assets/28294647/16930666-7338-46b3-b658-ad83b30aa179">. 

Accessibility score: 78 -> 93. 

<img width="407" alt="Screenshot 2023-08-04 at 14 20 56" src="https://github.com/electricitymaps/electricitymaps-contrib/assets/28294647/bb8b4f41-3a16-49ea-be9e-2418164463d0">. 

Aria labels applied to 5 right side map buttons + side panel show/hide -button

