### PR TITLE
Fix negative scaling in graphs

### DIFF
--- a/web/src/features/charts/elements/AreaGraph.tsx
+++ b/web/src/features/charts/elements/AreaGraph.tsx
@@ -23,13 +23,24 @@ const Y_AXIS_WIDTH = 40;
 const Y_AXIS_PADDING = 4;
 
 const getTotalValues = (layers: any) => {
-  const values = layers
-    .flatMap((layer: any) => layer.datapoints.map((d: any) => d[1]))
-    .filter(() => Number.isFinite);
-
+  // Use a single loop to find the min and max values of the datapoints
+  let min = 0;
+  let max = 0;
+  for (const layer of layers) {
+    for (const [low, high] of layer.datapoints) {
+      // Check if the values are finite numbers
+      if (Number.isFinite(low)) {
+        min = Math.min(min, low);
+      }
+      if (Number.isFinite(high)) {
+        max = Math.max(max, high);
+      }
+    }
+  }
+  // Return the min and max values
   return {
-    min: Number.isFinite(Math.min(...values)) ? Math.min(...values) : 0,
-    max: Number.isFinite(Math.max(...values)) ? Math.max(...values) : 0,
+    min: min,
+    max: max,
   };
 };
 


### PR DESCRIPTION
## Issue

Our graphs currently don't take negative values into account at all when scaling.

## Description

This PR ensures that negative values are taken into account, it should also have a performance improvement in the affected function.

This fixes our price graphs and is needed for #5647.

### Preview
#### Before:
![image](https://github.com/electricitymaps/electricitymaps-contrib/assets/30777521/5d2b71f9-674b-4a43-a75e-505c8de21ed6)
#### After:
![image](https://github.com/electricitymaps/electricitymaps-contrib/assets/30777521/f0be7f38-2769-468e-8241-6df6b7bdd16e)

### Double check

- [x] I have run `pnpx prettier --write .` and `poetry run format` to format my changes.
