### PR TITLE
Fix tooltip position on negative values

### DIFF
--- a/web/src/features/charts/elements/GraphHoverline.tsx
+++ b/web/src/features/charts/elements/GraphHoverline.tsx
@@ -33,12 +33,11 @@ const GraphHoverLine = React.memo(
     if (interval) {
       x += 0.5 * interval;
     }
-    let y = datapoint && Number.isFinite(datapoint[1]) && valueScale(datapoint[1]);
 
-    if (datapoint && datapoint[0] < 0) {
-      // For negative values, we push the circle below the x-axis
-      y -= datapoint[0] + CIRCLE_RADIUS;
-    }
+    // For negative values we use the first value in the array
+    // For positive values we use the second value in the array
+    const yIndex = datapoint?.at(0) < 0 ? 0 : 1;
+    const y = Number.isFinite(datapoint?.at(yIndex)) && valueScale(datapoint?.at(yIndex));
 
     const showVerticalLine = Number.isFinite(x);
     const showMarker = Number.isFinite(x) && Number.isFinite(y);


### PR DESCRIPTION
## Issue

The position of the chart tooltip on negative values where wildly out of position.

## Description

This fixes the issue 🙂

This is needed for our price graphs as well as for #5647.
(The commit in this PR is also cherry picked to and included in #5647).

### Preview

#### Before:
![image](https://github.com/electricitymaps/electricitymaps-contrib/assets/30777521/e003be9c-fd5a-4a12-b045-ea48a8afd6cc)
#### After:
![image](https://github.com/electricitymaps/electricitymaps-contrib/assets/30777521/a2ebe6a1-e8de-41d5-b2a3-6676648ff67d)


### Double check

- [x] I have run `pnpx prettier --write .` and `poetry run format` to format my changes.
