### PR TITLE
Remove Unused Dependency: Deepdiff

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -147,23 +147,6 @@ pytz = "*"
 "zope.interface" = "*"
 
 [[package]]
-name = "deepdiff"
-version = "5.8.1"
-description = "Deep Difference and Search of any Python object/data."
-optional = false
-python-versions = ">=3.6"
-files = [
-    {file = "deepdiff-5.8.1-py3-none-any.whl", hash = "sha256:e9aea49733f34fab9a0897038d8f26f9d94a97db1790f1b814cced89e9e0d2b7"},
-    {file = "deepdiff-5.8.1.tar.gz", hash = "sha256:8d4eb2c4e6cbc80b811266419cb71dd95a157094a3947ccf937a94d44943c7b8"},
-]
-
-[package.dependencies]
-ordered-set = ">=4.1.0,<4.2.0"
-
-[package.extras]
-cli = ["clevercsv (==0.7.1)", "click (==8.0.3)", "pyyaml (==5.4.1)", "toml (==0.10.2)"]
-
-[[package]]
 name = "defusedxml"
 version = "0.7.1"
 description = "XML bomb protection for Python stdlib modules"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,6 @@ xlrd = {version="^2.0.1", optional=true}
 xmltodict = {version = "^0.13.0", optional=true}
 black = "22.12.0"
 isort = "5.12.0"
-deepdiff = "^5.8.1"
 PyYAML = "^6.0"
 openpyxl = {version="^3.1.2", optional=true}
 pydataxm = {version="^0.3.2", optional=true}


### PR DESCRIPTION
## Summary

This pull request removes the unused dependency `deepdiff` from the `pyproject.toml` and `poetry.lock` configuration files. The removal of this dependency is a finding from ongoing research aimed at identifying and eliminating code bloat within software projects.

## Rationale

The `deepdiff` library was previously used within the project but was deemed unnecessary and removed  in #5269.  Despite its removal from the source code, `deepdiff` remained listed as a requirement in the project's configuration files. Removing this unused dependency  reduces the overall footprint of the application, mitigating potential security risks, and simplifying the dependency management process.

## Changes

- Removed the `deepdiff` dependency from `pyproject.toml` and `poetry.lock` 

## Impact

- **Reduced Package Size**: The removal of this unused dependency will lead to a decrease in the overall size of the installed packages.
- **Simplified Dependency Tree**: Fewer dependencies make the project easier to maintain and can speed up installation.


### Double check

- [x] I have run `pnpx prettier --write .` and `poetry run format` to format my changes.
