### PR TITLE
Updated capacities for Hungary

### DIFF
--- a/DATA_SOURCES.md
+++ b/DATA_SOURCES.md
@@ -271,8 +271,9 @@ For many European countries, data is available from [ENTSO-E](https://transparen
 - Honduras: [ENEE](http://www.enee.hn/planificacion/2018/boletines/Boletin%20Estadistico%20Mes%20de%20Septiembre%202018%20PDF.pdf)
 - Hong Kong: [CLP](https://www.clp.com.hk/en/about-clp/power-generation)
 - Hungary:
-  - Solar: [MAVIR](https://www.mavir.hu/documents/10258/246425808/PV+STATISZTIKA_HU_20230701_ig_v1.pdf/06d76259-877f-6064-4a55-cf46ac1fbbac?t=1689240158131)
-  - Other: [ENTSO-E](https://transparency.entsoe.eu/generation/r2/installedGenerationCapacityAggregation/show)
+  - Biomass: [ENTSO-E](https://transparency.entsoe.eu/generation/r2/installedGenerationCapacityAggregation/show)
+  - Solar: [MAVIR](https://www.mavir.hu/documents/10258/246425808/PV+STATISZTIKA_HU_20230701_ig_v1.pdf)
+  - Other: [MAVIR](https://www.mavir.hu/web/mavir/energia-mix-eromuvi-beepitett-teljesitokepesseg-adatok)
 - Iceland
   - Oil: [Statistics Iceland](http://px.hagstofa.is/pxen/pxweb/en/Atvinnuvegir/Atvinnuvegir__orkumal/IDN02101.px)
   - Geothermal, Wind and Hydro: [IRENA](https://www.irena.org/publications/2022/Apr/Renewable-Capacity-Statistics-2022)

--- a/config/zones/HU.yaml
+++ b/config/zones/HU.yaml
@@ -4,17 +4,18 @@ bounding_box:
   - - 22.710531447
     - 48.6238540716
 capacity:
-  biomass: 262
-  coal: 1049
-  gas: 4035
-  geothermal: 3
-  hydro: 61
+  battery storage: 9.34
+  biomass: 213
+  coal: 828.9
+  gas: 3171.082
+  geothermal: 2.7
+  hydro: 61.188
   hydro storage: 0
-  nuclear: 1916
-  oil: 425
+  nuclear: 1915.6
+  oil: 424.8
   solar: 5038.843
-  unknown: 70
-  wind: 323
+  unknown: 120
+  wind: 323.275
 contributors:
   - corradio
   - nessie2013


### PR DESCRIPTION
## Description

Updated capacities for Hungary. The actual data is from this [pdf](https://www.mavir.hu/documents/10258/246425808/BT_2015-20230701_ig_BR+NT_HU_v1.pdf).
I have also updated DATA_SOURCES.md with a link to the subpage where the latest pdf can always be found.
Biomass capacity should still be obtained from ENTSO-E, because in the pdf provided by MAVIR biomass is combined with other sources.

### Double check

- [x] I have tested my parser changes locally with `poetry run test_parser "zone_key"`
- [x] I have run `pnpx prettier --write .` and `poetry run format` to format my changes.
