### PR TITLE
Fix zone switching from URL

### DIFF
--- a/web/src/features/map/Map.tsx
+++ b/web/src/features/map/Map.tsx
@@ -192,7 +192,7 @@ export default function MapPage(): ReactElement {
       const centerMinusLeftPanelWidth = [center[0] - 10, center[1]] as [number, number];
       map.flyTo({ center: isMobile ? center : centerMinusLeftPanelWidth, zoom: 3.5 });
     }
-  }, [location.pathname, isLoadingMap]);
+  }, [location.pathname, isLoadingMap, geometries]);
 
   const onClick = (event: mapboxgl.MapLayerMouseEvent) => {
     const map = mapReference.current?.getMap();

--- a/web/src/features/panels/zone/ZoneDetails.tsx
+++ b/web/src/features/panels/zone/ZoneDetails.tsx
@@ -31,7 +31,7 @@ export default function ZoneDetails(): JSX.Element {
   const hasSubZones = getHasSubZones(zoneId);
   const isSubZone = zoneId ? zoneId.includes('-') : true;
   const { data, isError, isLoading } = useGetZone();
-
+  console.log('isSubZone:', isSubZone);
   // TODO: App-backend should not return an empty array as "data" if the zone does not
   // exist.
   if (Array.isArray(data)) {
@@ -44,10 +44,10 @@ export default function ZoneDetails(): JSX.Element {
     }
     // When first hitting the map (or opening a zone from the ranking panel),
     // set the correct matching view mode (zone or country).
-    if (!isSubZone) {
+    if (hasSubZones && !isSubZone) {
       setViewMode(SpatialAggregate.COUNTRY);
     }
-    if (isSubZone) {
+    if (!hasSubZones && isSubZone) {
       setViewMode(SpatialAggregate.ZONE);
     }
   }, []);

--- a/web/src/features/panels/zone/ZoneDetails.tsx
+++ b/web/src/features/panels/zone/ZoneDetails.tsx
@@ -31,7 +31,6 @@ export default function ZoneDetails(): JSX.Element {
   const hasSubZones = getHasSubZones(zoneId);
   const isSubZone = zoneId ? zoneId.includes('-') : true;
   const { data, isError, isLoading } = useGetZone();
-  console.log('isSubZone:', isSubZone);
   // TODO: App-backend should not return an empty array as "data" if the zone does not
   // exist.
   if (Array.isArray(data)) {

--- a/web/src/features/panels/zone/ZoneDetails.tsx
+++ b/web/src/features/panels/zone/ZoneDetails.tsx
@@ -26,9 +26,8 @@ export default function ZoneDetails(): JSX.Element {
   }
   const [timeAverage] = useAtom(timeAverageAtom);
   const [displayByEmissions] = useAtom(displayByEmissionsAtom);
-  const [viewMode, setViewMode] = useAtom(spatialAggregateAtom);
+  const [setViewMode] = useAtom(spatialAggregateAtom);
   const [selectedDatetime] = useAtom(selectedDatetimeIndexAtom);
-  const isZoneView = viewMode === SpatialAggregate.ZONE;
   const hasSubZones = getHasSubZones(zoneId);
   const isSubZone = zoneId ? zoneId.includes('-') : true;
   const { data, isError, isLoading } = useGetZone();
@@ -45,10 +44,10 @@ export default function ZoneDetails(): JSX.Element {
     }
     // When first hitting the map (or opening a zone from the ranking panel),
     // set the correct matching view mode (zone or country).
-    if (hasSubZones && isZoneView) {
+    if (!isSubZone) {
       setViewMode(SpatialAggregate.COUNTRY);
     }
-    if (isSubZone && !isZoneView) {
+    if (isSubZone) {
       setViewMode(SpatialAggregate.ZONE);
     }
   }, []);

--- a/web/src/features/panels/zone/ZoneDetails.tsx
+++ b/web/src/features/panels/zone/ZoneDetails.tsx
@@ -26,7 +26,7 @@ export default function ZoneDetails(): JSX.Element {
   }
   const [timeAverage] = useAtom(timeAverageAtom);
   const [displayByEmissions] = useAtom(displayByEmissionsAtom);
-  const [setViewMode] = useAtom(spatialAggregateAtom);
+  const [_, setViewMode] = useAtom(spatialAggregateAtom);
   const [selectedDatetime] = useAtom(selectedDatetimeIndexAtom);
   const hasSubZones = getHasSubZones(zoneId);
   const isSubZone = zoneId ? zoneId.includes('-') : true;


### PR DESCRIPTION
## Issue
The zone / country switching was not working when going from a country URL to a zone URL

## Description
This PR updates the logic in our zone details useEffect to only use isSubZone which is taken from the params, the issue was that the spatialAggregateAtom was not updated on first render so the switch would not happen when navigating from a URL. If this atom was in the useEffect dependency array it would fix the URL issue but conflicts with the way we handle switching in the toggle and you would cause a double toggle every time it was clicked.

I've also added the geometries as a dependency to the map zone switching / fly to zone useEffect, this means the map now uses our ```getApproximateFeature``` function and will show an approximate zone when the selected zone is not present on the map.
 
### Things to test
URL zone switching:
- zone -> country
- country -> zone
Ranking panel zone switching:
- zone -> country
- country -> zone
Map zone switching; toggle the spatial aggregate toggle from various states

### Double check

- [x] I have tested my parser changes locally with `poetry run test_parser "zone_key"`
- [x] I have run `pnpx prettier --write .` and `poetry run format` to format my changes.
