### PR TITLE
updated capacities for JP-KY

### DIFF
--- a/DATA_SOURCES.md
+++ b/DATA_SOURCES.md
@@ -296,7 +296,7 @@ For many European countries, data is available from [ENTSO-E](https://transparen
   - (Tamil Nadu): [tnebsldc](https://tnebsldc.org/reports1/peakdet.pdf)
 - Japan:
   - Tokyo: [Power-Plants](http://agora.ex.nii.ac.jp/earthquake/201103-eastjapan/energy/electrical-japan/operator/3.html.ja)
-  - Kyūshū: [Electrical Japan](https://agora-ex-nii-ac-jp.translate.goog/earthquake/201103-eastjapan/energy/electrical-japan/operator/9.html.ja?_x_tr_sl=ja&_x_tr_tl=en&_x_tr_hl=en-US&_x_tr_pto=wapp&_x_tr_sch=http)
+  - Kyūshū: [TSO - Kyuden](https://www.kyuden.co.jp/library/pdf/en/ir/integratedreport/2022/en_integratedreport_2022.pdf)
   - Tohoku
     - Wind: [The Wind Power](https://www.thewindpower.net/country_zones_en_11_japan.php)
   - Hokkaidō

--- a/config/zones/JP-KY.yaml
+++ b/config/zones/JP-KY.yaml
@@ -4,12 +4,13 @@ bounding_box:
   - - 131.89
     - 35.11
 capacity:
-  geothermal: 210.2
+  geothermal: 553
   hydro: 1247
   hydro storage: 2350
   nuclear: 5258
   unknown: 9976.94
-  wind: 3.25
+  wind: 630
+  solar: 10910
 contributors:
   - tmslaine
   - lorrieq

--- a/config/zones/JP-KY.yaml
+++ b/config/zones/JP-KY.yaml
@@ -8,7 +8,6 @@ capacity:
   hydro: 1247
   hydro storage: 2350
   nuclear: 5258
-  unknown: 9976.94
   wind: 630
   solar: 10910
 contributors:


### PR DESCRIPTION
## Issue
When implementing the estimation method for JP-KY, we have found that the capacities are outdated according to the last integrated report and the data we fetch from the parser. 

## Description
We update solar and wind capacities to match the latest Integrated report from the TSO Kyuden (page 33) [Link](https://www.kyuden.co.jp/library/pdf/en/ir/integratedreport/2022/en_integratedreport_2022.pdf)

### Preview
N/A

