### PR TITLE
Fix area graph color for storage

### DIFF
--- a/web/src/features/charts/elements/AreaGraphLayers.tsx
+++ b/web/src/features/charts/elements/AreaGraphLayers.tsx
@@ -4,6 +4,8 @@ import { area, curveStepAfter } from 'd3-shape';
 import React from 'react';
 import { detectHoveredDatapointIndex, getNextDatetime, noop } from '../graphUtils';
 import { AreaGraphElement } from '../types';
+import { modeColor } from 'utils/constants';
+import { ElectricityModeType } from 'types';
 
 interface AreaGraphLayersProps {
   layers: any[];
@@ -66,7 +68,7 @@ function AreaGraphLayers({
   return (
     <g>
       {layers.map((layer, ind) => {
-        const isGradient = typeof layer.fill === 'function';
+        const isGradient = modeColor[layer.key as ElectricityModeType] ? false : true;
         const gradientId = `areagraph-gradient-${layer.key}`;
         // A datapoint valid until the next one
         // However, for the last point (or for missing points),
@@ -103,7 +105,7 @@ function AreaGraphLayers({
               className={layers.length > 1 ? 'sm:hover:opacity-75' : ''}
               style={{ cursor: 'pointer' }}
               stroke={layer.stroke}
-              fill={isGradient ? `url(#${gradientId})` : layer.fill}
+              fill={isGradient ? `url(#${gradientId})` : layer.fill(layer.key)}
               d={layerArea(datapoints) || undefined}
               /* Support only click events in mobile mode, otherwise react to mouse hovers */
               onClick={isMobile ? (event_) => handleLayerMouseMove(event_, ind) : noop}


### PR DESCRIPTION
## Issue

The color in the area graphs for hydro storage and battery storage turned black due to a space in the name.

## Description
So we did some checking further down the line that I was not aware of. This PR fixes that check to work with the new structure.

### Preview
#### Before:
![image](https://github.com/electricitymaps/electricitymaps-contrib/assets/30777521/0369fca0-c69f-45b6-8032-d8d80d24bc36)
#### After:
![image](https://github.com/electricitymaps/electricitymaps-contrib/assets/30777521/58b42b94-6201-4f6b-9235-c2cd7ba721dc)


### Double check

- [x] I have run `pnpx prettier --write .` and `poetry run format` to format my changes.
