### PR TITLE
remove disclaimer from yaml file

### DIFF
--- a/config/zones/JP-HKD.yaml
+++ b/config/zones/JP-HKD.yaml
@@ -21,7 +21,6 @@ contributors:
   - pierresegonne
   - wobniarin
   - PPsyrius
-disclaimer: The data provider (Hokkaido Electric Power Network HEPCO) provides live data only for solar and unknown. We are working on improving the data quality for this zone.
 emissionFactors:
   lifecycle:
     unknown:


### PR DESCRIPTION
## Issue

JP-HKD has an estimation method and data is complete, but we still show a disclaimer on the app

## Description
this PR removes the disclaimer 

### Preview
N/A

### Double check

- [X] I have tested my parser changes locally with `poetry run test_parser "zone_key"`
- [X] I have run `pnpx prettier --write .` and `poetry run format` to format my changes.
