### PR TITLE
[Hackday] - Download CSV button in App

### DIFF
--- a/web/src/components/Modal.tsx
+++ b/web/src/components/Modal.tsx
@@ -27,7 +27,7 @@ export default function Modal({ isOpen, setIsOpen, title, children }: ModalProps
           >
             <HiXMark size="18" />
           </Dialog.Close>
-          <div className="px-2 py-3 sm:p-[25px_55px]">{children}</div>
+          <div className="px-2 py-3 sm:p-[25px_32px]">{children}</div>
         </Dialog.Content>
       </Dialog.Portal>
     </Dialog.Root>

--- a/web/src/features/modals/modalAtoms.ts
+++ b/web/src/features/modals/modalAtoms.ts
@@ -3,3 +3,4 @@ import { atom } from 'jotai';
 export const isFAQModalOpenAtom = atom(false);
 export const isInfoModalOpenAtom = atom(false);
 export const isSettingsModalOpenAtom = atom(false);
+export const isDownloadModalOpenAtom = atom(false);

--- a/web/src/features/panels/zone/DownloadModal.tsx
+++ b/web/src/features/panels/zone/DownloadModal.tsx
@@ -1,0 +1,58 @@
+import Modal from 'components/Modal';
+import { isDownloadModalOpenAtom } from 'features/modals/modalAtoms';
+import { useAtom } from 'jotai';
+import { useState, type ReactElement } from 'react';
+import { useParams } from 'react-router-dom';
+import { HiArrowDownTray } from 'react-icons/hi2';
+
+interface DownloadModalProperties {
+  zoneName: string;
+}
+
+export default function DownloadModal({
+  zoneName,
+}: DownloadModalProperties): ReactElement {
+  const [isOpen, setIsOpen] = useAtom(isDownloadModalOpenAtom);
+  const { zoneId } = useParams();
+  const [selectedYear, setSelectedYear] = useState('2022');
+  const [selectedFrequency, setSelectedFrequency] = useState('hourly');
+
+  return (
+    <Modal isOpen={isOpen} setIsOpen={setIsOpen} title="Download Data">
+      <div className="mb-4">Download CSV for: {zoneName}</div>
+      <div className="mb-4">
+        <select
+          value={selectedYear}
+          onChange={(event) => setSelectedYear(event.target.value)}
+          className="w-full rounded border p-2"
+        >
+          <option value="2021">2021</option>
+          <option value="2022">2022</option>
+        </select>
+      </div>
+      <div className="mb-4">
+        <select
+          value={selectedFrequency}
+          onChange={(event) => setSelectedFrequency(event.target.value)}
+          className="w-full rounded border p-2"
+        >
+          <option value="hourly">Hourly</option>
+          <option value="daily">Daily</option>
+          <option value="monthly">Monthly</option>
+          <option value="yearly">Yearly</option>
+        </select>
+      </div>
+      <a
+        href={`https://data.electricitymaps.com/${zoneId}_${selectedYear}_${selectedFrequency}.csv`}
+        onClick={() => setIsOpen(false)}
+      >
+        <div>
+          <button className="flex w-full items-center justify-center rounded bg-brand-green p-2 text-white hover:bg-green-800">
+            <HiArrowDownTray className="mr-2" />
+            Download
+          </button>
+        </div>
+      </a>
+    </Modal>
+  );
+}

--- a/web/src/features/panels/zone/ZoneHeaderTitle.tsx
+++ b/web/src/features/panels/zone/ZoneHeaderTitle.tsx
@@ -2,11 +2,14 @@ import Badge from 'components/Badge';
 import { CountryFlag } from 'components/Flag';
 import { TimeDisplay } from 'components/TimeDisplay';
 import TooltipWrapper from 'components/tooltips/TooltipWrapper';
-import { HiArrowLeft } from 'react-icons/hi2';
+import { HiArrowLeft, HiArrowDownTray } from 'react-icons/hi2';
 import { Link } from 'react-router-dom';
 import { getCountryName, getZoneName, useTranslation } from 'translation/translation';
 import { createToWithState } from 'utils/helpers';
 import { getDisclaimer } from './util';
+import { isDownloadModalOpenAtom } from 'features/modals/modalAtoms';
+import { useAtom } from 'jotai';
+import DownloadModal from './DownloadModal';
 
 interface ZoneHeaderTitleProps {
   zoneId: string;
@@ -25,9 +28,12 @@ export default function ZoneHeaderTitle({
   const returnToMapLink = createToWithState('/map');
   const countryName = getCountryName(zoneId);
   const disclaimer = getDisclaimer(zoneId);
+  const [isOpen, setIsOpen] = useAtom(isDownloadModalOpenAtom);
+  const hasCSV = true;
 
   return (
     <div className="flex w-full grow flex-row overflow-hidden pb-2 pl-2">
+      <DownloadModal zoneName={title} />
       <Link
         className="text-3xl self-center py-4 pr-4"
         to={returnToMapLink}
@@ -49,7 +55,7 @@ export default function ZoneHeaderTitle({
                 tooltipContent={title.length > 20 ? title : undefined}
                 side="bottom"
               >
-                <div className="ml-2 flex w-full flex-row overflow-hidden">
+                <div className="ml-2 flex w-full flex-row  overflow-hidden">
                   <h2 className="truncate text-lg font-medium" data-test-id="zone-name">
                     {title}
                   </h2>
@@ -60,13 +66,28 @@ export default function ZoneHeaderTitle({
                   )}
                 </div>
               </TooltipWrapper>
+
+              {hasCSV && (
+                <TooltipWrapper
+                  side="bottom"
+                  tooltipContent="Download historical data in CSV format"
+                >
+                  <button
+                    onClick={() => setIsOpen(!isOpen)}
+                    className="flex cursor-pointer items-center pl-2"
+                  >
+                    <HiArrowDownTray size={22} />
+                  </button>
+                </TooltipWrapper>
+              )}
               {disclaimer && (
                 <TooltipWrapper side="bottom" tooltipContent={disclaimer}>
-                  <div className="ml-2 mr-4 h-6 w-6 shrink-0 select-none rounded-full bg-white text-center drop-shadow dark:border dark:border-gray-500 dark:bg-gray-900">
+                  <div className="ml-2 h-6 w-6 shrink-0 select-none rounded-full bg-white text-center drop-shadow dark:border dark:border-gray-500 dark:bg-gray-900">
                     <p>i</p>
                   </div>
                 </TooltipWrapper>
               )}
+              {hasCSV || disclaimer ? <div className="w-4" /> : null}
             </div>
           </div>
         </div>


### PR DESCRIPTION
## Issue
**Hackday Project**

Download annual CSV data in the app

## Description
This PR adds a download modal to the zone details panel. 

This allows users to select and download hourly, daily, monthly or yearly CSVs for 2021 and 2022. 

### Double check

- [x] I have tested my parser changes locally with `poetry run test_parser "zone_key"`
- [x] I have run `pnpx prettier --write .` and `poetry run format` to format my changes.
