### PR TITLE
String enums for units

### DIFF
--- a/web/src/components/CarbonIntensityDisplay.tsx
+++ b/web/src/components/CarbonIntensityDisplay.tsx
@@ -1,4 +1,5 @@
 import { useCo2ColorScale } from 'hooks/theme';
+import { CarbonUnits } from 'utils/units';
 
 function Square({ co2Intensity }: { co2Intensity: number }) {
   const co2ColorScale = useCo2ColorScale();
@@ -27,7 +28,7 @@ export function CarbonIntensityDisplay({
     <>
       {withSquare && <Square co2Intensity={intensityAsNumber} />}
       <p className={className}>
-        <b>{Math.round(intensityAsNumber) || '?'}</b>&nbsp;gCO₂eq/kWh
+        <b>{Math.round(intensityAsNumber) || '?'}</b>&nbsp;{CarbonUnits.GRAM}
       </p>
     </>
   );

--- a/web/src/components/CarbonIntensityDisplay.tsx
+++ b/web/src/components/CarbonIntensityDisplay.tsx
@@ -28,7 +28,8 @@ export function CarbonIntensityDisplay({
     <>
       {withSquare && <Square co2Intensity={intensityAsNumber} />}
       <p className={className}>
-        <b>{Math.round(intensityAsNumber) || '?'}</b>&nbsp;{CarbonUnits.GRAM}
+        <b>{Math.round(intensityAsNumber) || '?'}</b>&nbsp;
+        {CarbonUnits.GRAMS_CO2EQ_PER_WATT_HOUR}
       </p>
     </>
   );

--- a/web/src/components/CarbonIntensitySquare.tsx
+++ b/web/src/components/CarbonIntensitySquare.tsx
@@ -1,6 +1,7 @@
 import { animated, useSpring } from '@react-spring/web';
 import { useTranslation } from 'translation/translation';
 import { useCo2ColorScale } from '../hooks/theme';
+import { CarbonUnits } from 'utils/units';
 
 /**
  * This function finds the optimal text color based on a custom formula
@@ -55,7 +56,9 @@ function CarbonIntensitySquare({ intensity, withSubtext }: CarbonIntensitySquare
       </div>
       <div className="mt-2 flex flex-col items-center">
         <div className="text-sm">{__('country-panel.carbonintensity')}</div>
-        {withSubtext && <div className="text-sm">(gCO₂eq/kWh)</div>}
+        {withSubtext && (
+          <div className="text-sm">{CarbonUnits.GRAMS_CO2EQ_PER_WATT_HOUR}</div>
+        )}
       </div>
     </div>
   );

--- a/web/src/components/legend/Co2Legend.tsx
+++ b/web/src/components/legend/Co2Legend.tsx
@@ -2,6 +2,7 @@ import { useCo2ColorScale } from 'hooks/theme';
 import type { ReactElement } from 'react';
 import { useTranslation } from 'translation/translation';
 import HorizontalColorbar from './ColorBar';
+import { CarbonUnits } from 'utils/units';
 
 function LegendItem({
   label,
@@ -27,7 +28,10 @@ export default function Co2Legend(): ReactElement {
   const co2ColorScale = useCo2ColorScale();
   return (
     <div>
-      <LegendItem label={__('legends.carbonintensity')} unit="gCO₂eq/kWh">
+      <LegendItem
+        label={__('legends.carbonintensity')}
+        unit={CarbonUnits.GRAMS_CO2EQ_PER_WATT_HOUR}
+      >
         <HorizontalColorbar colorScale={co2ColorScale} ticksCount={6} id={'co2'} />
       </LegendItem>
     </div>

--- a/web/src/features/charts/BreakdownChart.stories.ts
+++ b/web/src/features/charts/BreakdownChart.stories.ts
@@ -5,6 +5,7 @@ import { TimeAverages } from '../../utils/constants';
 import AreaGraph from './elements/AreaGraph';
 import { getLayerFill } from './hooks/useBreakdownChartData';
 import { zoneDetailMock } from 'stories/mockData';
+import { EnergyUnits } from 'utils/units';
 
 const meta: Meta<typeof AreaGraph> = {
   title: 'charts/BreakdownChart',
@@ -503,7 +504,7 @@ export const IncludesStorage: Story = {
     layerKeys: Object.keys(includesStorageData[0].layerData),
     layerFill,
     selectedTimeAggregate: TimeAverages.HOURLY,
-    valueAxisLabel: '€ / MWh',
+    valueAxisLabel: `€ / ${EnergyUnits.MEGAWATT_HOURS}`,
     isMobile: false,
     height: '12em',
     datetimes: chartData.map((d) => d.datetime),

--- a/web/src/features/charts/PriceChart.stories.ts
+++ b/web/src/features/charts/PriceChart.stories.ts
@@ -3,6 +3,7 @@ import { TimeAverages } from '../../utils/constants';
 import AreaGraph from './elements/AreaGraph';
 import { getFills } from './hooks/usePriceChartData';
 import { zoneDetailMock } from 'stories/mockData';
+import { EnergyUnits } from 'utils/units';
 
 const meta: Meta<typeof AreaGraph> = {
   title: 'charts/PriceChart',
@@ -166,7 +167,7 @@ export const NegativePrices: Story = {
     layerFill: getFills(negativePrices).layerFill,
     markerFill: getFills(negativePrices).markerFill,
     selectedTimeAggregate: TimeAverages.HOURLY,
-    valueAxisLabel: '€ / MWh',
+    valueAxisLabel: `€ / ${EnergyUnits.MEGAWATT_HOURS}`,
     isMobile: false,
     height: '12em',
     datetimes: chartData.map((d) => d.datetime),
@@ -200,7 +201,7 @@ export const MissingEntries: Story = {
     layerFill: getFills(missingEntriesData).layerFill,
     markerFill: getFills(missingEntriesData).markerFill,
     selectedTimeAggregate: TimeAverages.HOURLY,
-    valueAxisLabel: '€ / MWh',
+    valueAxisLabel: `€ / ${EnergyUnits.MEGAWATT_HOURS}`,
     isMobile: false,
     height: '12em',
     datetimes: chartData.map((d) => d.datetime),

--- a/web/src/features/charts/bar-breakdown/BarElectricityBreakdownChart.tsx
+++ b/web/src/features/charts/bar-breakdown/BarElectricityBreakdownChart.tsx
@@ -17,6 +17,7 @@ import {
   getDataBlockPositions,
   getElectricityProductionValue,
 } from './utils';
+import { PowerUnits } from 'utils/units';
 
 interface BarElectricityBreakdownChartProps {
   height: number;
@@ -94,15 +95,16 @@ function BarElectricityBreakdownChart({
     .domain([minPower, maxPower])
     .range([0, width - LABEL_MAX_WIDTH - PADDING_X]);
 
+  // TODO: use unified formatting function in the future.
   const formatTick = (t: number) => {
     const [x1, x2] = powerScale.domain();
     if (x2 - x1 <= 1) {
-      return `${t * 1e3} kW`;
+      return `${t * 1e3} ${PowerUnits.KILOWATTS}`;
     }
     if (x2 - x1 <= 1e3) {
-      return `${t} MW`;
+      return `${t} ${PowerUnits.MEGAWATTS}`;
     }
-    return `${t * 1e-3} GW`;
+    return `${t * 1e-3} ${PowerUnits.GIGAWATTS}`;
   };
 
   return (

--- a/web/src/features/charts/bar-breakdown/EmptyBarBreakdownChart.tsx
+++ b/web/src/features/charts/bar-breakdown/EmptyBarBreakdownChart.tsx
@@ -7,6 +7,7 @@ import Axis from './elements/Axis';
 import HorizontalBar from './elements/HorizontalBar';
 import Row from './elements/Row';
 import { getDataBlockPositions } from './utils';
+import { PowerUnits } from 'utils/units';
 
 interface EmptyBarBreakdownChartProps {
   height: number;
@@ -50,7 +51,7 @@ function EmptyBarBreakdownChart({
   // eslint-disable-next-line unicorn/consistent-function-scoping
   const formatTick = (t: number) => {
     // TODO: format tick depending on displayByEmissions
-    return `${t} GW`;
+    return `${t} ${PowerUnits.GIGAWATTS}`;
   };
 
   return (

--- a/web/src/features/charts/hooks/usePriceChartData.ts
+++ b/web/src/features/charts/hooks/usePriceChartData.ts
@@ -3,6 +3,7 @@ import getSymbolFromCurrency from 'currency-symbol-map';
 import { max as d3Max, min as d3Min } from 'd3-array';
 import { scaleLinear } from 'd3-scale';
 import { AreaGraphElement } from '../types';
+import { EnergyUnits } from 'utils/units';
 
 export function getFills(data: AreaGraphElement[]) {
   const priceMaxValue =
@@ -49,7 +50,7 @@ export function usePriceChartData() {
   const currencySymbol: string = getSymbolFromCurrency(
     Object.values(zoneData.zoneStates)[0].price?.currency // Every price has the same currency
   );
-  const valueAxisLabel = `${currencySymbol || '?'} / MWh`;
+  const valueAxisLabel = `${currencySymbol || '?'} / ${EnergyUnits.MEGAWATT_HOURS}}`;
 
   const { layerFill, markerFill } = getFills(chartData);
 

--- a/web/src/features/charts/tooltips/ChartTooltips.cy.tsx
+++ b/web/src/features/charts/tooltips/ChartTooltips.cy.tsx
@@ -1,3 +1,4 @@
+import { CarbonUnits } from 'utils/units';
 import BreakdownChartTooltip from './BreakdownChartTooltip';
 import CarbonChartTooltip from './CarbonChartTooltip';
 import EmissionChartTooltip from './EmissionChartTooltip';
@@ -8,7 +9,7 @@ it('Carbon chart tooltip', () => {
     <CarbonChartTooltip zoneDetail={zoneDetailMock} selectedLayerKey="carbonIntensity" />
   );
   cy.contains('Carbon intensity');
-  cy.contains(`187 gCO₂eq/kWh`);
+  cy.contains(`187 ${CarbonUnits.GRAMS_CO2EQ_PER_WATT_HOUR}`);
   cy.contains('2022');
 });
 it('Breakdown chart tooltip', () => {
@@ -33,7 +34,7 @@ it('Carbon chart tooltip mobile', () => {
     <CarbonChartTooltip zoneDetail={zoneDetailMock} selectedLayerKey="carbonIntensity" />
   );
   cy.contains('Carbon intensity');
-  cy.contains(`187 gCO₂eq/kWh`);
+  cy.contains(`187 ${CarbonUnits.GRAMS_CO2EQ_PER_WATT_HOUR}}`);
   cy.contains('2022');
 });
 it('Breakdown chart tooltip mobile', () => {

--- a/web/src/features/charts/tooltips/ChartTooltips.cy.tsx
+++ b/web/src/features/charts/tooltips/ChartTooltips.cy.tsx
@@ -34,7 +34,7 @@ it('Carbon chart tooltip mobile', () => {
     <CarbonChartTooltip zoneDetail={zoneDetailMock} selectedLayerKey="carbonIntensity" />
   );
   cy.contains('Carbon intensity');
-  cy.contains(`187 ${CarbonUnits.GRAMS_CO2EQ_PER_WATT_HOUR}}`);
+  cy.contains(`187 ${CarbonUnits.GRAMS_CO2EQ_PER_WATT_HOUR}`);
   cy.contains('2022');
 });
 it('Breakdown chart tooltip mobile', () => {

--- a/web/src/features/charts/tooltips/PriceChartTooltip.tsx
+++ b/web/src/features/charts/tooltips/PriceChartTooltip.tsx
@@ -4,6 +4,7 @@ import { useTranslation } from 'translation/translation';
 import { timeAverageAtom } from 'utils/state/atoms';
 import { InnerAreaGraphTooltipProps } from '../types';
 import AreaGraphToolTipHeader from './AreaGraphTooltipHeader';
+import { EnergyUnits } from 'utils/units';
 
 export default function PriceChartTooltip({ zoneDetail }: InnerAreaGraphTooltipProps) {
   const [timeAverage] = useAtom(timeAverageAtom);
@@ -28,7 +29,7 @@ export default function PriceChartTooltip({ zoneDetail }: InnerAreaGraphTooltipP
       />
       <p className="flex justify-center text-base">
         <b className="mr-1">{value}</b>
-        {currency} / MWh
+        {currency} / {EnergyUnits.MEGAWATT_HOURS}
       </p>
     </div>
   );

--- a/web/src/utils/formatting.ts
+++ b/web/src/utils/formatting.ts
@@ -1,6 +1,7 @@
 import * as d3 from 'd3-format';
 import { translate } from '../translation/translation';
 import { TimeAverages } from './constants';
+import { PowerUnits } from './units';
 
 const DEFAULT_NUM_DIGITS = 3;
 
@@ -45,20 +46,20 @@ const scalePower = function (maxPower: number | undefined) {
 
   if (value < 1) {
     return {
-      unit: 'kW',
+      unit: PowerUnits.KILOWATTS,
       formattingFactor: 1e-3,
     };
   }
 
   if (value < 1e3) {
     return {
-      unit: 'MW',
+      unit: PowerUnits.MEGAWATTS,
       formattingFactor: 1,
     };
   }
 
   return {
-    unit: 'GW',
+    unit: PowerUnits.GIGAWATTS,
     formattingFactor: 1e3,
   };
 };

--- a/web/src/utils/units.ts
+++ b/web/src/utils/units.ts
@@ -18,6 +18,5 @@ export enum EnergyUnits {
 
 export enum CarbonUnits {
   GRAMS_CO2EQ_PER_WATT_HOUR = 'gCO₂eq/kWh',
-  CO2EQ_PER_MINUTE = 'CO₂eq/min',
   CO2EQ_PER_HOUR = 'CO₂eq/h',
 }

--- a/web/src/utils/units.ts
+++ b/web/src/utils/units.ts
@@ -1,0 +1,23 @@
+export enum PowerUnits {
+  WATTS = 'W',
+  KILOWATTS = 'kW',
+  MEGAWATTS = 'MW',
+  GIGAWATTS = 'GW',
+  TERAWATTS = 'TW',
+  PETAWATTS = 'PW',
+}
+
+export enum EnergyUnits {
+  WATT_HOURS = 'Wh',
+  KILOWATT_HOURS = 'kWh',
+  MEGAWATT_HOURS = 'MWh',
+  GIGAWATT_HOURS = 'GWh',
+  TERAWATT_HOURS = 'TWh',
+  PETAWATT_HOURS = 'PWh',
+}
+
+export enum CarbonUnits {
+  GRAMS_CO2EQ_PER_WATT_HOUR = 'gCO₂eq/kWh',
+  CO2EQ_PER_MINUTE = 'CO₂eq/min',
+  CO2EQ_PER_HOUR = 'CO₂eq/h',
+}


### PR DESCRIPTION
## Description

Uses string enums for units instead of hardcoded strings everywhere.

### Double check

- [x] I have run `pnpx prettier --write .` and `poetry run format` to format my changes.
