### PR TITLE
Update ranking panel to sort with zone / country toggle

### DIFF
--- a/web/src/features/panels/ranking-panel/RankingPanel.tsx
+++ b/web/src/features/panels/ranking-panel/RankingPanel.tsx
@@ -2,7 +2,11 @@ import useGetState from 'api/getState';
 import { useCo2ColorScale } from 'hooks/theme';
 import { useAtom } from 'jotai';
 import { ReactElement, useState } from 'react';
-import { productionConsumptionAtom, selectedDatetimeIndexAtom } from 'utils/state/atoms';
+import {
+  productionConsumptionAtom,
+  selectedDatetimeIndexAtom,
+  spatialAggregateAtom,
+} from 'utils/state/atoms';
 import { useTranslation } from '../../../translation/translation';
 import { getRankedState } from './getRankingPanelData';
 import InfoText from './InfoText';
@@ -16,9 +20,14 @@ export default function RankingPanel(): ReactElement {
   const [selectedDatetime] = useAtom(selectedDatetimeIndexAtom);
   const [searchTerm, setSearchTerm] = useState('');
   const [electricityMode] = useAtom(productionConsumptionAtom);
-  const inputHandler = (inputEvent: any) => {
-    const lowerCase = inputEvent.target.value.toLowerCase();
-    setSearchTerm(lowerCase);
+  const [spatialAggregation] = useAtom(spatialAggregateAtom);
+  const inputHandler = (inputEvent: React.ChangeEvent<HTMLInputElement>) => {
+    const { target } = inputEvent;
+
+    if (target && typeof target.value === 'string') {
+      const lowerCase = target.value.toLowerCase();
+      setSearchTerm(lowerCase);
+    }
   };
 
   const { data } = useGetState();
@@ -27,7 +36,8 @@ export default function RankingPanel(): ReactElement {
     getCo2colorScale,
     'asc',
     selectedDatetime.datetimeString,
-    electricityMode
+    electricityMode,
+    spatialAggregation
   );
   const filteredList = rankedList.filter((zone) => {
     if (zone.countryName && zone.countryName.toLowerCase().includes(searchTerm)) {


### PR DESCRIPTION
## Issue
The ranking panel currently includes all countries and subzones regardless of the position of the zone / country toggle

## Description

This PR updates the ranking panel to include filtering based on the zone / country toggle

### Double check

- [x] I have tested my parser changes locally with `poetry run test_parser "zone_key"`
- [x] I have run `pnpx prettier --write .` and `poetry run format` to format my changes.
