### PR TITLE
TotalConsumption events : add validation to filter 0 values

### DIFF
--- a/electricitymap/contrib/lib/models/events.py
+++ b/electricitymap/contrib/lib/models/events.py
@@ -542,8 +542,8 @@ class TotalConsumption(Event):
         # TODO in the future those checks should be performed in the data quality layer.
         if v > 500000:
             raise ValueError(f"Total consumption is implausibly high, above 500GW: {v}")
-        if v==0:
-             raise ValueError(f"Total consumption cannot be 0 MW: {v}")
+        if v == 0:
+            raise ValueError(f"Total consumption cannot be 0 MW: {v}")
         return v
 
     @staticmethod

--- a/electricitymap/contrib/lib/models/events.py
+++ b/electricitymap/contrib/lib/models/events.py
@@ -542,6 +542,8 @@ class TotalConsumption(Event):
         # TODO in the future those checks should be performed in the data quality layer.
         if v > 500000:
             raise ValueError(f"Total consumption is implausibly high, above 500GW: {v}")
+        if v==0:
+             raise ValueError(f"Total consumption cannot be 0 MW: {v}")
         return v
 
     @staticmethod

--- a/parsers/IN.py
+++ b/parsers/IN.py
@@ -279,8 +279,7 @@ def fetch_consumption_from_meritindia(
 
         for future in concurrent.futures.as_completed(futures):
             total_consumption += future.result()
-    if total_consumption == 0:
-        raise ParserException(parser="IN.py", message=f"{target_datetime}: No valid consumption data found", zone_key=zone_key)
+
     consumption_list = TotalConsumptionList(logger=logger)
     consumption_list.append(
         zoneKey=ZoneKey(zone_key),

--- a/parsers/IN.py
+++ b/parsers/IN.py
@@ -279,7 +279,8 @@ def fetch_consumption_from_meritindia(
 
         for future in concurrent.futures.as_completed(futures):
             total_consumption += future.result()
-
+    if total_consumption == 0:
+        raise ParserException(parser="IN.py", message=f"{target_datetime}: No valid consumption data found", zone_key=zone_key)
     consumption_list = TotalConsumptionList(logger=logger)
     consumption_list.append(
         zoneKey=ZoneKey(zone_key),

--- a/parsers/test/test_ES.py
+++ b/parsers/test/test_ES.py
@@ -32,7 +32,6 @@ class TestES(TestCase):
 
         self.assertEqual(len(data_list), 0)
 
-
     # Production
     @patch.object(ElHierro, "get_all")
     def test_fetch_production_el_hierro(self, mocked_get_all):

--- a/parsers/test/test_ES.py
+++ b/parsers/test/test_ES.py
@@ -29,16 +29,9 @@ class TestES(TestCase):
     def test_fetch_consumption(self, mocked_get_all):
         mocked_get_all.return_value = self.mocked_responses
         data_list = ES.fetch_consumption(ZoneKey("ES-CN-HI"), self.session)
-        self.assertEqual(len(data_list), 2)
-        for data in data_list:
-            self.assertEqual(data["zoneKey"], "ES-CN-HI")
-            self.assertEqual(data["source"], "demanda.ree.es")
-            self.assertTrue(isinstance(data["datetime"], datetime))
-            self.assertIsNotNone(data["consumption"])
-        self.assertEqual(
-            data_list[0]["datetime"],
-            datetime.fromtimestamp(1687192328).astimezone(timezone.utc),
-        )
+
+        self.assertEqual(len(data_list), 0)
+
 
     # Production
     @patch.object(ElHierro, "get_all")

--- a/parsers/test/test_MX.py
+++ b/parsers/test/test_MX.py
@@ -39,4 +39,3 @@ class TestFetchConsumption(TestCase):
 
         data = fetch_consumption(ZoneKey("MX-BCS"), self.session)
         assert len(data) == 0
-

--- a/parsers/test/test_MX.py
+++ b/parsers/test/test_MX.py
@@ -38,6 +38,5 @@ class TestFetchConsumption(TestCase):
     def test_fetch_consumption_BCS(self):
 
         data = fetch_consumption(ZoneKey("MX-BCS"), self.session)
-        assert data[0]["zoneKey"] == "MX-BCS"
-        assert data[0]["datetime"] == datetime.now(pytz.timezone("America/Tijuana"))
-        assert data[0]["consumption"] == 0.0
+        assert len(data) == 0
+


### PR DESCRIPTION
## Issue
Parsed consumption can be 0 MW 
<img width="407" alt="image" src="https://github.com/electricitymaps/electricitymaps-contrib/assets/107848894/17f18bac-5ba3-4a9a-8b30-2a4c3b408056">

## Description

add parser exception to avoid getting 0s 

### Preview

NA

### Double check

- [ ] I have tested my parser changes locally with `poetry run test_parser "zone_key"`
- [ ] I have run `pnpx prettier --write .` and `poetry run format` to format my changes.
