### PR TITLE
Prevent overflow on tooltip datetimes and electricity / emmissions toggle

### DIFF
--- a/web/src/components/ToggleButton.tsx
+++ b/web/src/components/ToggleButton.tsx
@@ -41,14 +41,12 @@ export default function ToggleButton({
   return (
     <div
       className={twMerge(
-        'z-10 flex h-9 rounded-full bg-gray-200/80 px-1 shadow dark:bg-gray-800/80',
+        'z-10 flex h-9 min-w-fit rounded-full bg-gray-200/80 px-1 shadow dark:bg-gray-800/80',
         transparentBackground ? 'backdrop-blur-sm' : 'bg-gray-200'
       )}
     >
       <ToggleGroupRoot
-        className={
-          'flex-start flex flex-grow flex-row items-center justify-between self-center rounded-full'
-        }
+        className={'flex flex-grow flex-row items-center justify-between rounded-full'}
         type="single"
         aria-label="Toggle between modes"
         value={selectedOption}

--- a/web/src/features/charts/tooltips/AreaGraphTooltipHeader.tsx
+++ b/web/src/features/charts/tooltips/AreaGraphTooltipHeader.tsx
@@ -23,11 +23,11 @@ export default function AreaGraphToolTipHeader(props: AreaGraphToolTipHeaderProp
               height: 16,
               width: 16,
             }}
-            className="rounded-sm font-bold"
+            className="rounded-sm  font-bold"
           ></div>
-          <p className="pr-2 text-base">{title}</p>
+          <p className="px-1 text-base">{title}</p>
         </div>
-        <div className="my-1 h-[32px] max-w-[160px] select-none rounded-full bg-brand-green/10 px-3 py-2 text-sm text-brand-green dark:bg-gray-700 dark:text-white">
+        <div className="my-1 h-[32px] max-w-[165px] select-none whitespace-nowrap rounded-full bg-brand-green/10 px-3 py-2 text-sm text-brand-green dark:bg-gray-700 dark:text-white">
           {formatDate(datetime, i18n.language, timeAverage)}
         </div>
       </div>


### PR DESCRIPTION
## Issue
We have some display edge cases



## Description
This PR fixes toggle and tooltip overflow issues

### Preview
Old:
![image](https://github.com/electricitymaps/electricitymaps-contrib/assets/18622768/a006ff38-d752-4dad-982d-efd59006e7d1)
<img width="326" alt="image" src="https://github.com/electricitymaps/electricitymaps-contrib/assets/18622768/10d5b0e5-4ae5-4260-aa50-9b9cb6f10ed6">

New:
<img width="384" alt="image" src="https://github.com/electricitymaps/electricitymaps-contrib/assets/18622768/8403e11f-5774-4155-87ff-7ed35bc8f827">

<img width="337" alt="image" src="https://github.com/electricitymaps/electricitymaps-contrib/assets/18622768/56f94da4-52a4-48b6-9de7-c2b5face7c00">


### Double check

- [x] I have tested my parser changes locally with `poetry run test_parser "zone_key"`
- [x] I have run `pnpx prettier --write .` and `poetry run format` to format my changes.
