### PR TITLE
Fixes bug where hydro storage shows high emissions despite being 0

### DIFF
--- a/web/src/features/charts/bar-breakdown/utils.ts
+++ b/web/src/features/charts/bar-breakdown/utils.ts
@@ -59,8 +59,8 @@ export const getProductionData = (data: ZoneDetail): ProductionDataType[] =>
 
     // Production CO₂ intensity
     const gCo2eqPerkWh = getProductionCo2Intensity(mode, data);
-    const value = isStorage && storage ? storage : production || 0;
-    const gCo2eqPerHour = gCo2eqPerkWh * 1e3 * value;
+    const value = isStorage ? storage : production || 0;
+    const gCo2eqPerHour = gCo2eqPerkWh * 1e3 * (value || 0);
     const tCo2eqPerMin = gCo2eqPerHour / 1e6 / 60;
 
     return {


### PR DESCRIPTION
## Issue

Closes #5510

## Description

Fixes bug where storage shows a long bar, despite being 0.

### Preview

**Before:**
<img width="485" alt="Screenshot 2023-08-27 at 22 31 15" src="https://github.com/electricitymaps/electricitymaps-contrib/assets/3296643/cc310e49-c42d-4ad9-8657-b57b18efb1ed">


**After:**
<img width="480" alt="Screenshot 2023-08-27 at 22 29 51" src="https://github.com/electricitymaps/electricitymaps-contrib/assets/3296643/1198817b-4e3b-4fe9-861c-60f04bedd40f">
