### PR TITLE
Add percentages to exchange tooltip

### DIFF
--- a/web/src/features/charts/tooltips/NetExchangeChartTooltip.tsx
+++ b/web/src/features/charts/tooltips/NetExchangeChartTooltip.tsx
@@ -29,7 +29,6 @@ export default function NetExchangeChartTooltip({
   const netExchange = getNetExchange(zoneDetail, displayByEmissions);
   const netProduction = getNetProduction(zoneDetail, displayByEmissions);
   const netConsumption = getNetConsumption(zoneDetail, displayByEmissions);
-  //const exchangesList = zoneDetail.exchange
   const { formattingFactor, unit } = displayByEmissions
     ? {
         formattingFactor: 1,

--- a/web/src/features/charts/tooltips/NetExchangeChartTooltip.tsx
+++ b/web/src/features/charts/tooltips/NetExchangeChartTooltip.tsx
@@ -1,10 +1,18 @@
 import { useAtom } from 'jotai';
-import { useTranslation } from 'translation/translation';
+import { getZoneName, useTranslation } from 'translation/translation';
 import { displayByEmissionsAtom, timeAverageAtom } from 'utils/state/atoms';
 import { InnerAreaGraphTooltipProps } from '../types';
 import AreaGraphToolTipHeader from './AreaGraphTooltipHeader';
-import { getNetExchange, round } from 'utils/helpers';
+import {
+  getNetConsumption,
+  getNetExchange,
+  getNetProduction,
+  getZoneKey,
+  round,
+} from 'utils/helpers';
 import { scalePower } from 'utils/formatting';
+import { getRatioPercent } from '../graphUtils';
+import { CountryFlag } from 'components/Flag';
 
 export default function NetExchangeChartTooltip({
   zoneDetail,
@@ -19,6 +27,9 @@ export default function NetExchangeChartTooltip({
   const { stateDatetime } = zoneDetail;
 
   const netExchange = getNetExchange(zoneDetail, displayByEmissions);
+  const netProduction = getNetProduction(zoneDetail, displayByEmissions);
+  const netConsumption = getNetConsumption(zoneDetail, displayByEmissions);
+  //const exchangesList = zoneDetail.exchange
   const { formattingFactor, unit } = displayByEmissions
     ? {
         formattingFactor: 1,
@@ -37,6 +48,19 @@ export default function NetExchangeChartTooltip({
       <p className="flex justify-center text-base">
         {netExchange >= 0 ? __('tooltips.importing') : __('tooltips.exporting')}{' '}
         <b className="mx-1">{Math.abs(round(netExchange / formattingFactor))}</b> {unit}
+      </p>
+      <p className="inline-flex flex-wrap items-center justify-center gap-x-1 text-sm">
+        {__('tooltips.representing')} {}
+        <b>
+          {getRatioPercent(
+            Math.abs(netExchange),
+            netExchange >= 0 ? netConsumption : netProduction
+          )}{' '}
+          %
+        </b>
+        of electricity {netExchange >= 0 ? 'available' : 'produced'} in{' '}
+        {<CountryFlag className="shadow-3xl" zoneId={getZoneKey(zoneDetail)} />}{' '}
+        <b> {getZoneName(getZoneKey(zoneDetail))} </b>
       </p>
     </div>
   );

--- a/web/src/utils/helpers.ts
+++ b/web/src/utils/helpers.ts
@@ -5,6 +5,11 @@ import {
   ZoneDetail,
 } from 'types';
 import { useParams, useMatch } from 'react-router-dom';
+import {
+  tonsPerHourToGramsPerMinute,
+  getTotalElectricity,
+} from 'features/charts/graphUtils';
+import { Mode } from './constants';
 
 export function getZoneFromPath() {
   const { zoneId } = useParams();
@@ -147,4 +152,45 @@ export function getNetExchange(
   return displayByEmissions
     ? round(zoneData.totalCo2NetExchange / 1e6 / 60) // in tCO₂eq/min
     : round(zoneData.totalImport - zoneData.totalExport);
+}
+
+/**
+ * Returns the net production of a zone
+ * @param zoneData - The zone data
+ * @returns The net production
+ */
+export function getNetProduction(
+  zoneData: ZoneDetail,
+  displayByEmissions: boolean
+): number {
+  return displayByEmissions
+    ? round(zoneData.totalCo2Production / 1e6 / 60) // in tCO₂eq/min
+    : round(zoneData.totalProduction);
+}
+
+/**
+ * Returns the net consumption of a zone
+ * @param zoneData - The zone data
+ * @returns The net consumption
+ */
+export function getNetConsumption(
+  zoneData: ZoneDetail,
+  displayByEmissions: boolean
+): number {
+  return displayByEmissions
+    ? round(
+        tonsPerHourToGramsPerMinute(
+          getTotalElectricity(zoneData, true, Mode.CONSUMPTION)
+        ) * 100
+      ) / 100 // in tCO₂eq/min
+    : round(zoneData.totalConsumption);
+}
+
+/**
+ * Returns the zoneKey of a zone
+ * @param zoneData - The zone data
+ * @returns The zoneKey
+ */
+export function getZoneKey(zoneData: ZoneDetail): string {
+  return zoneData.zoneKey;
 }


### PR DESCRIPTION
## Description

This PR adds the percentage of electricity that net exchanges represent to the net exchange tooltip.
I've decided to make it so that the percentage is calculated with the total electricity produced or total consumed based on whether the imports are positive or negative. I feel it is a more useful metric, and also avoids confusing users in some strange cases, e.g. country exports 50 % of electricity produced but it says 100 % of electricity available.
The PR is mostly done, but I'd need some help regarding translations.
Also, feel free to raise any issues about code style as this is my first time writing typescript.

### Preview
![Screenshot_20230829_210307](https://github.com/electricitymaps/electricitymaps-contrib/assets/84802276/63bf193b-998b-4343-9df5-d8f66aba3835)

It also works in the CO2 category:

![Screenshot_20230829_210517](https://github.com/electricitymaps/electricitymaps-contrib/assets/84802276/ddbb2fa9-c935-4a2c-a195-cf7e3a503f81)

I though about changing the text in the case of being in the CO2 category but "CO2 available" seems a bit wrong. It would be interesting if someone came with some better text.

### Check

- [x] I have run `pnpx prettier --write .` and `poetry run format` to format my changes.
