### PR TITLE
Update readme with link to data portal

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,4 +87,4 @@ The carbon intensity of each type of power plant takes into account emissions ar
 
 **How can I get access to historical data or the live API?**
 All this and more can be found **[here](https://electricitymaps.com/)**.
-You can also visit our **[data portal](https://www.electricitymaps.com/data-portal)** to download historical datasets data.
+You can also visit our **[data portal](https://www.electricitymaps.com/data-portal)** to download historical datasets.

--- a/README.md
+++ b/README.md
@@ -87,3 +87,4 @@ The carbon intensity of each type of power plant takes into account emissions ar
 
 **How can I get access to historical data or the live API?**
 All this and more can be found **[here](https://electricitymaps.com/)**.
+You can also visit our **[data portal](https://www.electricitymaps.com/data-portal)** to download historical datasets data.


### PR DESCRIPTION
## Issue

I noticed that the readme on contrib didn't included a link to the data portal. Would be a shame to miss out on the brand new data portal.

## Description

Add link to the data portal in the readme.

### Double check

- [ ] I have tested my parser changes locally with `poetry run test_parser "zone_key"`
- [ ] I have run `pnpx prettier --write .` and `poetry run format` to format my changes.
