### PR TITLE
Fix EIA parser reports 0 hydro production as 0 hydro storage

### DIFF
--- a/parsers/EIA.py
+++ b/parsers/EIA.py
@@ -447,7 +447,7 @@ def create_production_storage(
     production_value = production_point["value"]
     production_mix = ProductionMix()
     storage_mix = StorageMix()
-    if production_value > 0:
+    if production_value >= 0:
         production_mix.add_value(fuel_type, production_value)
         return production_mix, None
     if fuel_type == "hydro":

--- a/parsers/EIA.py
+++ b/parsers/EIA.py
@@ -447,15 +447,11 @@ def create_production_storage(
     production_value = production_point["value"]
     production_mix = ProductionMix()
     storage_mix = StorageMix()
-    if production_value >= 0:
-        production_mix.add_value(fuel_type, production_value)
-        return production_mix, None
-    if fuel_type == "hydro":
+    if production_value < 0 and fuel_type == "hydro":
         # Negative hydro is reported by some BAs, according to the EIA those are pumped storage.
         # https://www.eia.gov/electricity/gridmonitor/about
         storage_mix.add_value("hydro", abs(production_value))
         return None, storage_mix
-
     # production_value > negative_threshold, this is considered to be self consumption and should be reported as 0.
     # Lower values are set to None as they are most likely outliers.
     production_mix.add_value(


### PR DESCRIPTION
## Issue

We noticed that US-NW-NWMT went down on the map. The reason for this is that estimations are failing because of an outlier in the data. The EIA reported 0 hydro production at 2023-08-23 15:00:00.000000 +00:00 which got interpreted by our parser as a 0 hydro storage. In itself its not wrong but this extra transformation is causing troubles down the line so we should stick to the normal data as much as possible and therefore report it as 0 production.

## Description

- Update the `create_production_storage` so that 0 hydro production is reported as production instead of storage.
- simplify the function logic by inverting the if clause.

### Double check

- [ ] I have tested my parser changes locally with `poetry run test_parser "zone_key"`
- [ ] I have run `pnpx prettier --write .` and `poetry run format` to format my changes.
