### PR TITLE
Update dark-mode styling of map controls

### DIFF
--- a/web/src/features/charts/PriceChart.tsx
+++ b/web/src/features/charts/PriceChart.tsx
@@ -44,10 +44,10 @@ function PriceChart({ datetimes, timeAverage }: PriceChartProps) {
   return (
     <>
       <ChartTitle translationKey="country-history.electricityprices" />
-      <div className="relative  overflow-hidden">
+      <div className="relative overflow-hidden">
         {isPriceDisabled && (
           <div className="absolute top-0 -ml-3 h-full w-[115%]">
-            <div className=" h-full w-full rounded bg-white opacity-90 dark:bg-gray-900" />
+            <div className="h-full w-full rounded bg-white opacity-90 dark:bg-gray-900" />
             <div className="absolute left-[45%] top-[50%] z-10 w-60 -translate-x-1/2 -translate-y-1/2 rounded-sm bg-gray-200 p-2 text-center text-sm shadow-lg dark:border dark:border-gray-700 dark:bg-gray-800">
               {__(`country-panel.disabledPriceReasons.${priceDisabledReason}`)}
             </div>

--- a/web/src/features/charts/PriceChart.tsx
+++ b/web/src/features/charts/PriceChart.tsx
@@ -44,9 +44,9 @@ function PriceChart({ datetimes, timeAverage }: PriceChartProps) {
   return (
     <>
       <ChartTitle translationKey="country-history.electricityprices" />
-      <div className="relative">
+      <div className="relative  overflow-hidden">
         {isPriceDisabled && (
-          <div className="absolute top-0 -ml-2 h-full w-[110%]">
+          <div className="absolute top-0 -ml-3 h-full w-[115%]">
             <div className=" h-full w-full rounded bg-white opacity-90 dark:bg-gray-900" />
             <div className="absolute left-[45%] top-[50%] z-10 w-60 -translate-x-1/2 -translate-y-1/2 rounded-sm bg-gray-200 p-2 text-center text-sm shadow-lg dark:border dark:border-gray-700 dark:bg-gray-800">
               {__(`country-panel.disabledPriceReasons.${priceDisabledReason}`)}

--- a/web/src/features/charts/PriceChart.tsx
+++ b/web/src/features/charts/PriceChart.tsx
@@ -46,9 +46,9 @@ function PriceChart({ datetimes, timeAverage }: PriceChartProps) {
       <ChartTitle translationKey="country-history.electricityprices" />
       <div className="relative">
         {isPriceDisabled && (
-          <div className="absolute top-0 h-full w-full">
-            <div className=" h-full w-full rounded bg-white opacity-50 dark:bg-gray-700" />
-            <div className="absolute left-[50%] top-[50%] z-10 w-60 -translate-x-1/2 -translate-y-1/2 rounded-sm bg-gray-200 p-2 text-center text-sm shadow-lg dark:bg-gray-900">
+          <div className="absolute top-0 -ml-2 h-full w-[110%]">
+            <div className=" h-full w-full rounded bg-white opacity-90 dark:bg-gray-900" />
+            <div className="absolute left-[45%] top-[50%] z-10 w-60 -translate-x-1/2 -translate-y-1/2 rounded-sm bg-gray-200 p-2 text-center text-sm shadow-lg dark:border dark:border-gray-700 dark:bg-gray-800">
               {__(`country-panel.disabledPriceReasons.${priceDisabledReason}`)}
             </div>
           </div>

--- a/web/src/features/charts/tooltips/NetExchangeChartTooltip.tsx
+++ b/web/src/features/charts/tooltips/NetExchangeChartTooltip.tsx
@@ -1,10 +1,10 @@
 import { useAtom } from 'jotai';
 import { useTranslation } from 'translation/translation';
+import { scalePower } from 'utils/formatting';
+import { getNetExchange, round } from 'utils/helpers';
 import { displayByEmissionsAtom, timeAverageAtom } from 'utils/state/atoms';
 import { InnerAreaGraphTooltipProps } from '../types';
 import AreaGraphToolTipHeader from './AreaGraphTooltipHeader';
-import { getNetExchange, round } from 'utils/helpers';
-import { scalePower } from 'utils/formatting';
 
 export default function NetExchangeChartTooltip({
   zoneDetail,
@@ -27,7 +27,7 @@ export default function NetExchangeChartTooltip({
     : scalePower(netExchange);
 
   return (
-    <div className="w-full rounded-md bg-white p-3 shadow-xl dark:bg-gray-900 sm:w-max">
+    <div className="w-full rounded-md bg-white p-3 shadow-xl dark:border dark:border-gray-700 dark:bg-gray-800 sm:w-[350px]">
       <AreaGraphToolTipHeader
         datetime={new Date(stateDatetime)}
         timeAverage={timeAverage}

--- a/web/src/features/charts/tooltips/PriceChartTooltip.tsx
+++ b/web/src/features/charts/tooltips/PriceChartTooltip.tsx
@@ -2,9 +2,9 @@ import getSymbolFromCurrency from 'currency-symbol-map';
 import { useAtom } from 'jotai';
 import { useTranslation } from 'translation/translation';
 import { timeAverageAtom } from 'utils/state/atoms';
+import { EnergyUnits } from 'utils/units';
 import { InnerAreaGraphTooltipProps } from '../types';
 import AreaGraphToolTipHeader from './AreaGraphTooltipHeader';
-import { EnergyUnits } from 'utils/units';
 
 export default function PriceChartTooltip({ zoneDetail }: InnerAreaGraphTooltipProps) {
   const [timeAverage] = useAtom(timeAverageAtom);
@@ -20,7 +20,7 @@ export default function PriceChartTooltip({ zoneDetail }: InnerAreaGraphTooltipP
   const value = priceIsDefined ? price?.value : '';
 
   return (
-    <div className="w-full rounded-md bg-white p-3 shadow-xl dark:bg-gray-900 sm:w-64">
+    <div className="w-full rounded-md bg-white p-3 shadow-xl dark:border dark:border-gray-700 dark:bg-gray-800  sm:w-64">
       <AreaGraphToolTipHeader
         datetime={new Date(stateDatetime)}
         timeAverage={timeAverage}

--- a/web/src/features/exchanges/ExchangeArrow.tsx
+++ b/web/src/features/exchanges/ExchangeArrow.tsx
@@ -1,15 +1,15 @@
 /* eslint-disable unicorn/no-null */
+import MobileTooltipWrapper from 'components/tooltips/MobileTooltipWrapper';
+import TooltipWrapper from 'components/tooltips/TooltipWrapper';
+import { mapMovingAtom } from 'features/map/mapAtoms';
+import { useSetAtom } from 'jotai';
 import { useEffect, useMemo } from 'react';
 import { MapboxMap } from 'react-map-gl';
 import { resolvePath } from 'react-router-dom';
 import { ExchangeArrowData } from 'types';
-import { quantizedCo2IntensityScale, quantizedExchangeSpeedScale } from './scales';
-import { mapMovingAtom } from 'features/map/mapAtoms';
-import { useSetAtom } from 'jotai';
-import TooltipWrapper from 'components/tooltips/TooltipWrapper';
 import ExchangeTooltip from './ExchangeTooltip';
-import MobileTooltipWrapper from 'components/tooltips/MobileTooltipWrapper';
 import MobileExchangeTooltip from './MobileExchangeTooltip';
+import { quantizedCo2IntensityScale, quantizedExchangeSpeedScale } from './scales';
 
 interface ExchangeArrowProps {
   data: ExchangeArrowData;
@@ -119,7 +119,7 @@ function ExchangeArrow({
         </picture>
       </MobileTooltipWrapper>
       <TooltipWrapper
-        tooltipClassName="max-h-[256px] max-w-[512px] top-[-76px] hidden md:flex"
+        tooltipClassName="max-h-[256px] max-w-[512px] top-[-76px] hidden md:flex bg-red-500"
         tooltipContent={<ExchangeTooltip exchangeData={data} />}
         side="right"
         sideOffset={10}

--- a/web/src/features/map-controls/LanguageSelector.tsx
+++ b/web/src/features/map-controls/LanguageSelector.tsx
@@ -1,9 +1,9 @@
 import { useState } from 'react';
+import { HiLanguage } from 'react-icons/hi2';
 import { languageNames } from 'translation/locales';
 import { useTranslation } from 'translation/translation';
-import MapOptionSelector from './MapOptionSelector';
 import MapButton from './MapButton';
-import { HiLanguage } from 'react-icons/hi2';
+import MapOptionSelector from './MapOptionSelector';
 
 type LanguageNamesKey = keyof typeof languageNames;
 
@@ -23,7 +23,7 @@ export function LanguageSelector({ isMobile }: { isMobile?: boolean }) {
     <MapOptionSelector
       trigger={
         isMobile ? (
-          <div className="flex w-fit min-w-[232px] items-center justify-center gap-x-2 ">
+          <div className="flex w-fit min-w-[232px] items-center justify-center gap-x-2 dark:border dark:border-gray-700 dark:bg-gray-800 ">
             <HiLanguage size={21} />
             {__('tooltips.selectLanguage')}
           </div>
@@ -45,7 +45,7 @@ export function LanguageSelector({ isMobile }: { isMobile?: boolean }) {
           onClick={() => handleLanguageSelect(key)}
           className={`w-full cursor-pointer px-2 py-1 text-start text-sm transition hover:bg-gray-200 dark:hover:bg-gray-700 ${
             languageNames[key] === selectedLanguage &&
-            'bg-gray-100 font-bold dark:bg-gray-800'
+            'bg-gray-100 font-bold dark:bg-gray-700'
           }`}
         >
           {languageNames[key]}

--- a/web/src/features/map-controls/MapButton.tsx
+++ b/web/src/features/map-controls/MapButton.tsx
@@ -25,7 +25,7 @@ export default function MapButton({
     <TooltipWrapper tooltipContent={tooltipText}>
       <Component
         onClick={onClick}
-        className={`pointer-events-auto flex h-8 w-8 items-center justify-center rounded bg-white text-left shadow-lg transition hover:bg-gray-100 dark:bg-gray-900 dark:hover:bg-gray-800 ${className}`}
+        className={`pointer-events-auto flex h-8 w-8 items-center justify-center rounded bg-white/90 text-left shadow-lg backdrop-blur-sm transition hover:bg-gray-100 dark:bg-gray-800/80 dark:hover:bg-gray-900/90 ${className}`}
         aria-label={ariaLabel}
         data-test-id={dataTestId}
         role="button"

--- a/web/src/features/map-controls/MapControls.tsx
+++ b/web/src/features/map-controls/MapControls.tsx
@@ -128,7 +128,7 @@ function DesktopMapControls() {
   };
 
   return (
-    <div className="pointer-events-none absolute right-3 top-3 z-30 hidden flex-col items-end md:flex">
+    <div className="pointer-events-none absolute right-3 top-2 z-30 hidden flex-col items-end md:flex">
       <div className="pointer-events-auto mb-16 flex flex-col items-end space-y-2">
         <ConsumptionProductionToggle />
         <SpatialAggregatesToggle />

--- a/web/src/features/map-controls/MapControls.tsx
+++ b/web/src/features/map-controls/MapControls.tsx
@@ -7,12 +7,13 @@ import { HiCog6Tooth, HiOutlineInformationCircle } from 'react-icons/hi2';
 import { MoonLoader } from 'react-spinners';
 import { useTranslation } from 'translation/translation';
 import trackEvent from 'utils/analytics';
-import { TimeAverages, ToggleOptions } from 'utils/constants';
+import { ThemeOptions, TimeAverages, ToggleOptions } from 'utils/constants';
 import {
   colorblindModeAtom,
   selectedDatetimeIndexAtom,
   solarLayerEnabledAtom,
   solarLayerLoadingAtom,
+  themeAtom,
   timeAverageAtom,
   windLayerAtom,
   windLayerLoadingAtom,
@@ -65,6 +66,7 @@ export const weatherButtonMap = {
 };
 
 function WeatherButton({ type }: { type: 'wind' | 'solar' }) {
+  const [theme] = useAtom(themeAtom);
   const { __ } = useTranslation();
   const [enabled, setEnabled] = useAtom(weatherButtonMap[type].enabledAtom);
   const [isLoadingLayer, setIsLoadingLayer] = useAtom(weatherButtonMap[type].loadingAtom);
@@ -75,6 +77,7 @@ function WeatherButton({ type }: { type: 'wind' | 'solar' }) {
     solar: isEnabled ? __('tooltips.hideSolarLayer') : __('tooltips.showSolarLayer'),
   };
 
+  const spinnerColor = theme === ThemeOptions.DARK ? 'white' : 'black';
   const weatherId = `${type.charAt(0).toUpperCase() + type.slice(1)}`; // Capitalize first letter
 
   const onToggle = () => {
@@ -92,7 +95,7 @@ function WeatherButton({ type }: { type: 'wind' | 'solar' }) {
     <MapButton
       icon={
         isLoadingLayer ? (
-          <MoonLoader size={14} color="#135836" />
+          <MoonLoader size={14} color={spinnerColor} />
         ) : (
           <Icon size={weatherButtonMap[type].iconSize} color={isEnabled ? '' : 'gray'} />
         )

--- a/web/src/features/map-controls/MapOptionSelector.tsx
+++ b/web/src/features/map-controls/MapOptionSelector.tsx
@@ -1,7 +1,7 @@
-import { useTranslation } from 'translation/translation';
-import { Root, Trigger, Content, Arrow } from '@radix-ui/react-dropdown-menu';
+import { Arrow, Content, Root, Trigger } from '@radix-ui/react-dropdown-menu';
 import { useState } from 'react';
 import { twMerge } from 'tailwind-merge';
+import { useTranslation } from 'translation/translation';
 
 interface MapOptionSelectorProps {
   trigger: React.ReactNode;
@@ -26,7 +26,7 @@ export default function MapOptionSelector({
         className={twMerge(
           isOpen ? 'pointer-events-none' : 'pointer-events-auto',
           isMobile &&
-            'rounded-full bg-white py-3  text-md font-bold shadow-[0px_0px_13px_rgb(0_0_0/12%)] transition duration-200 hover:shadow-[0px_0px_23px_rgb(0_0_0/20%)] dark:bg-gray-600 dark:hover:shadow-[0px_0px_23px_rgb(0_0_0/50%)]'
+            'rounded-full bg-white py-3  text-md font-bold shadow-[0px_0px_13px_rgb(0_0_0/12%)] transition duration-200 hover:shadow-[0px_0px_23px_rgb(0_0_0/20%)] dark:border dark:border-gray-700 dark:bg-gray-800 '
         )}
         data-test-id={testId}
         onClick={toggleTooltip}
@@ -35,7 +35,7 @@ export default function MapOptionSelector({
         {trigger}
       </Trigger>
       <Content
-        className="pointer-events-auto z-50 max-h-[190px] w-[120px] overflow-auto rounded bg-white dark:bg-gray-900"
+        className="pointer-events-auto z-50 max-h-[190px] w-[120px] overflow-auto rounded bg-white dark:bg-gray-800"
         sideOffset={isMobile ? -10 : 5}
         side={isMobile ? 'bottom' : 'left'}
         onClick={toggleTooltip}

--- a/web/src/features/map/MapTooltip.tsx
+++ b/web/src/features/map/MapTooltip.tsx
@@ -10,13 +10,13 @@ import { useTranslation } from 'translation/translation';
 import { StateZoneData } from 'types';
 import { Mode } from 'utils/constants';
 import { formatDate } from 'utils/formatting';
+import { getCarbonIntensity, getFossilFuelRatio, getRenewableRatio } from 'utils/helpers';
 import {
   productionConsumptionAtom,
   selectedDatetimeIndexAtom,
   timeAverageAtom,
 } from 'utils/state/atoms';
 import { hoveredZoneAtom, mapMovingAtom, mousePositionAtom } from './mapAtoms';
-import { getCarbonIntensity, getFossilFuelRatio, getRenewableRatio } from 'utils/helpers';
 
 function TooltipInner({
   zoneData,
@@ -109,7 +109,7 @@ export default function MapTooltip() {
     return (
       <Portal.Root className="absolute left-0 top-0 hidden h-0 w-0 md:block">
         <div
-          className="pointer-events-none relative w-[300px] rounded border bg-zinc-50 p-3  text-sm shadow-lg dark:border-0 dark:bg-gray-900"
+          className="pointer-events-none relative w-[300px] rounded border bg-zinc-50 p-3  text-sm shadow-lg dark:border dark:border-gray-700 dark:bg-gray-800 "
           style={{ left: tooltipWithDataPositon.x, top: tooltipWithDataPositon.y }}
         >
           <div>
@@ -126,7 +126,7 @@ export default function MapTooltip() {
   return (
     <Portal.Root className="absolute left-0 top-0 hidden h-0 w-0 md:block">
       <div
-        className="pointer-events-none relative w-[176px] rounded border bg-zinc-50 p-3 text-center text-sm drop-shadow-sm dark:border-0 dark:bg-gray-900"
+        className="pointer-events-none relative w-[176px] rounded border bg-zinc-50 p-3 text-center text-sm drop-shadow-sm dark:border dark:border-gray-700 dark:bg-gray-800"
         style={{ left: emptyTooltipPosition.x, top: emptyTooltipPosition.y }}
       >
         <div>

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -73,18 +73,27 @@
 button.maplibregl-ctrl-zoom-in.mapboxgl-ctrl-zoom-in {
   width: 33px;
   height: 32px;
+  border-top-left-radius: 4px;
+  border-top-right-radius: 4px;
 }
 button.maplibregl-ctrl-zoom-out.mapboxgl-ctrl-zoom-out {
   width: 33px;
   height: 32px;
   border-color: lightgray;
+  border-bottom-left-radius: 4px;
+  border-bottom-right-radius: 4px;
 }
 
 .dark button.maplibregl-ctrl-zoom-out.mapboxgl-ctrl-zoom-out {
-  border-color: gray;
+  border-color: theme(colors.gray.600);
 }
 .dark .maplibregl-ctrl.maplibregl-ctrl-group.mapboxgl-ctrl.mapboxgl-ctrl-group {
-  background-color: theme(colors.gray.900) !important;
+  @apply backdrop-blur-sm;
+  background: transparent;
+}
+.dark .maplibregl-ctrl.maplibregl-ctrl-group.mapboxgl-ctrl.mapboxgl-ctrl-group button {
+  background-color: theme(colors.gray.800) !important;
+  opacity: 0.8 !important;
 }
 .dark button.maplibregl-ctrl-zoom-in.mapboxgl-ctrl-zoom-in > span {
   background-image: url("data:image/svg+xml;charset=utf-8,%3Csvg width='29' height='29' viewBox='0 0 29 29' xmlns='http://www.w3.org/2000/svg' fill='%23FFF'%3E%3Cpath d='M14.5 8.5c-.75 0-1.5.75-1.5 1.5v3h-3c-.75 0-1.5.75-1.5 1.5S9.25 16 10 16h3v3c0 .75.75 1.5 1.5 1.5S16 19.75 16 19v-3h3c.75 0 1.5-.75 1.5-1.5S19.75 13 19 13h-3v-3c0-.75-.75-1.5-1.5-1.5z'/%3E%3C/svg%3E") !important;


### PR DESCRIPTION
## Description

Make the map control buttons and selectors look nicer and more similar to the toggles.
Also updated styling on a bunch of tooltips that were missed earlier.

### Preview

<img width="403" alt="Screenshot 2023-09-04 at 00 18 59" src="https://github.com/electricitymaps/electricitymaps-contrib/assets/3296643/378f4dd9-ae59-48df-bfe3-36da45bccfeb">

