### PR TITLE
Select api version based on feature flag

### DIFF
--- a/web/src/api/getZone.ts
+++ b/web/src/api/getZone.ts
@@ -8,13 +8,16 @@ import { timeAverageAtom } from 'utils/state/atoms';
 
 import { getZoneFromPath } from 'utils/helpers';
 import { getBasePath, getHeaders, QUERY_KEYS } from './helpers';
+import { useFeatureFlag } from 'features/feature-flags/api';
 
 const getZone = async (
   timeAverage: TimeAverages,
-  zoneId?: string
+  zoneId?: string,
+  apiVersion?: string
 ): Promise<ZoneDetails> => {
   invariant(zoneId, 'Zone ID is required');
-  const path = `/v6/details/${timeAverage}/${zoneId}`;
+
+  const path = `/${apiVersion}/details/${timeAverage}/${zoneId}`;
   const requestOptions: RequestInit = {
     method: 'GET',
     headers: await getHeaders(path),
@@ -37,10 +40,12 @@ const getZone = async (
 // should we add a check for this?
 const useGetZone = (): UseQueryResult<ZoneDetails> => {
   const zoneId = getZoneFromPath();
+  const totalEnergy = useFeatureFlag('total-energy');
+  const apiVersion = totalEnergy ? 'v7' : 'v6';
   const [timeAverage] = useAtom(timeAverageAtom);
   return useQuery<ZoneDetails>(
-    [QUERY_KEYS.ZONE, { zone: zoneId, aggregate: timeAverage }],
-    async () => getZone(timeAverage, zoneId)
+    [QUERY_KEYS.ZONE, { zone: zoneId, aggregate: timeAverage, apiVersion }],
+    async () => getZone(timeAverage, zoneId, apiVersion)
   );
 };
 


### PR DESCRIPTION
## Issue
Draft PR for inspiration if we want to do something like this later

## Description
This PR adds allows the zone api to select between v6 and v7 based on the total-energy feature flag

### Double check

- [x] I have tested my parser changes locally with `poetry run test_parser "zone_key"`
- [x] I have run `pnpx prettier --write .` and `poetry run format` to format my changes.
