### PR TITLE
Update emission naming values

### DIFF
--- a/web/cypress/e2e/countrypanel.spec.ts
+++ b/web/cypress/e2e/countrypanel.spec.ts
@@ -21,7 +21,7 @@ describe('Country Panel', () => {
 
     cy.contains('Carbon emissions').should('have.attr', 'aria-checked', 'false');
     cy.contains('Carbon emissions').click().should('have.attr', 'aria-checked', 'true');
-    cy.contains('0 t/min');
+    cy.contains('0 t');
     cy.contains('Electricity consumption').click();
 
     // // test graph tooltip

--- a/web/public/locales/en.json
+++ b/web/public/locales/en.json
@@ -208,6 +208,7 @@
   "electricityImportedFrom": "<b>%1$s %%</b> of electricity available in %4$s <b>%2$s</b> is imported from %5$s <b>%3$s</b>",
   "emissionsImportedFrom": "<b>%1$s %%</b> of emissions from electricity available in %4$s <b>%2$s</b> are imported from %5$s <b>%3$s</b>",
   "ofCO2eqPerMinute": "of CO₂eq per minute",
+  "ofCO2eq": "of CO₂eq",
   "theMap": {
     "groupName": "The map",
     "mapColors-question": "What do the colors on the map mean?",

--- a/web/src/features/charts/EmissionChart.tsx
+++ b/web/src/features/charts/EmissionChart.tsx
@@ -32,7 +32,7 @@ function EmissionChart({ timeAverage, datetimes }: EmissionChartProps) {
         data={chartData}
         layerKeys={layerKeys}
         layerFill={layerFill}
-        valueAxisLabel="CO₂eq / min"
+        valueAxisLabel="tCO₂eq"
         markerUpdateHandler={noop}
         markerHideHandler={noop}
         datetimes={datetimes}

--- a/web/src/features/charts/hooks/useBreakdownChartData.ts
+++ b/web/src/features/charts/hooks/useBreakdownChartData.ts
@@ -161,7 +161,7 @@ function getGenerationValue(
 }
 
 interface ValuesInfo {
-  valueAxisLabel: string; // For example, GW or tCO₂eq/min
+  valueAxisLabel: string; // For example, GW or tCO₂eq
   valueFactor: number;
 }
 
@@ -174,7 +174,7 @@ function getValuesInfo(
   );
 
   const format = scalePower(maxTotalValue);
-  const valueAxisLabel = displayByEmissions ? 'CO₂eq / min' : format.unit;
+  const valueAxisLabel = displayByEmissions ? 'tCO₂eq' : format.unit;
   const valueFactor = format.formattingFactor;
   return { valueAxisLabel, valueFactor };
 }

--- a/web/src/features/charts/hooks/useNetExchangeChartData.ts
+++ b/web/src/features/charts/hooks/useNetExchangeChartData.ts
@@ -68,7 +68,7 @@ export function useNetExchangeChartData() {
 }
 
 interface ValuesInfo {
-  valueAxisLabel: string; // For example, GW or tCO₂eq/min
+  valueAxisLabel: string; // For example, GW or CO₂eq
   valueFactor: number;
 }
 
@@ -82,7 +82,7 @@ function getValuesInfo(
 
   const { unit, formattingFactor } = displayByEmissions
     ? {
-        unit: 'tCO₂eq/min',
+        unit: 'tCO₂eq',
         formattingFactor: 1,
       }
     : scalePower(maxTotalValue);

--- a/web/src/features/charts/tooltips/BreakdownChartTooltip.tsx
+++ b/web/src/features/charts/tooltips/BreakdownChartTooltip.tsx
@@ -166,7 +166,7 @@ export function BreakdownChartTooltipContent({
           value={emissions}
           total={totalEmissions}
           format={formatCo2}
-          label={__('ofCO2eqPerMinute')}
+          label={__('ofCO2eq')}
           useTotalUnit
         />
       )}
@@ -194,7 +194,7 @@ export function BreakdownChartTooltipContent({
             value={emissions}
             total={totalEmissions}
             format={formatCo2}
-            label={__('ofCO2eqPerMinute')}
+            label={__('ofCO2eq')}
             useTotalUnit
           />
         </>

--- a/web/src/features/charts/tooltips/EmissionChartTooltip.tsx
+++ b/web/src/features/charts/tooltips/EmissionChartTooltip.tsx
@@ -27,7 +27,7 @@ export default function EmissionChartTooltip({ zoneDetail }: InnerAreaGraphToolt
         title={__('country-panel.emissions')}
       />
       <p className="flex justify-center text-base">
-        <b className="mr-1">{formatCo2(totalEmissions)}</b> {__('ofCO2eqPerMinute')}
+        <b className="mr-1">{formatCo2(totalEmissions)}</b> {__('ofCO2eq')}
       </p>
     </div>
   );

--- a/web/src/features/charts/tooltips/NetExchangeChartTooltip.tsx
+++ b/web/src/features/charts/tooltips/NetExchangeChartTooltip.tsx
@@ -21,7 +21,7 @@ export default function NetExchangeChartTooltip({
   const netExchange = getNetExchange(zoneDetail, displayByEmissions);
   const { formattingFactor, unit: powerUnit } = scalePower(netExchange);
 
-  const unit = displayByEmissions ? __('ofCO2eqPerMinute') : powerUnit;
+  const unit = displayByEmissions ? __('ofCO2eq') : powerUnit;
   const value = displayByEmissions
     ? formatCo2(Math.abs(netExchange))
     : Math.abs(round(netExchange / formattingFactor));

--- a/web/src/utils/helpers.ts
+++ b/web/src/utils/helpers.ts
@@ -145,6 +145,6 @@ export function getNetExchange(
     return Number.NaN;
   }
   return displayByEmissions
-    ? round(zoneData.totalCo2NetExchange) // in tCO₂eq/min
+    ? round(zoneData.totalCo2NetExchange) // in tCO₂eq
     : round(zoneData.totalImport - zoneData.totalExport);
 }


### PR DESCRIPTION
## Issue
We previously considered emission to be grams of CO2 / minute, we're moving to total emissions for each datetime and granularity

## Description
This PR updates units in the app related to emissions to no longer per minutes

The charts made sense with tonne as the base unit in the axis labels. It would be worth checking this still makes sense when values are very low. 


### Double check

- [x] I have tested my parser changes locally with `poetry run test_parser "zone_key"`
- [x] I have run `pnpx prettier --write .` and `poetry run format` to format my changes.
