### PR TITLE
Simplify pnpm caching

### DIFF
--- a/.github/workflows/deploy-preview-branch.yml
+++ b/.github/workflows/deploy-preview-branch.yml
@@ -26,6 +26,7 @@ jobs:
         with:
           node-version: 18
           cache: 'pnpm'
+          cache-dependency-path: "**/pnpm-lock.yaml"
       - name: Install web dependencies
         run: pnpm install --frozen-lockfile
         working-directory: ./web

--- a/.github/workflows/deploy-preview-branch.yml
+++ b/.github/workflows/deploy-preview-branch.yml
@@ -25,14 +25,8 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: 18
-      - name: Restore node_modules for web
-        id: cache-web
-        uses: actions/cache@v3
-        with:
-          path: web/node_modules
-          key: ${{ runner.os }}-node_modules-${{ hashFiles('./web/pnpm-lock.yaml') }}
+          cache: 'pnpm'
       - name: Install web dependencies
-        if: steps.cache-web.outputs.cache-hit != 'true'
         run: pnpm install --frozen-lockfile
         working-directory: ./web
       - name: Build

--- a/.github/workflows/deploy-preview-branch.yml
+++ b/.github/workflows/deploy-preview-branch.yml
@@ -26,7 +26,7 @@ jobs:
         with:
           node-version: 18
           cache: 'pnpm'
-          cache-dependency-path: "**/pnpm-lock.yaml"
+          cache-dependency-path: '**/pnpm-lock.yaml'
       - name: Install web dependencies
         run: pnpm install --frozen-lockfile
         working-directory: ./web

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -22,7 +22,7 @@ jobs:
         with:
           node-version: 18
           cache: 'pnpm'
-          cache-dependency-path: "**/pnpm-lock.yaml"
+          cache-dependency-path: '**/pnpm-lock.yaml'
       - name: Install web dependencies
         run: pnpm install --frozen-lockfile
         working-directory: ./web

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -21,14 +21,8 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: 18
-      - name: Restore node_modules for web
-        id: cache-web
-        uses: actions/cache@v3
-        with:
-          path: web/node_modules
-          key: ${{ runner.os }}-node_modules-${{ hashFiles('./web/pnpm-lock.yaml') }}
+          cache: 'pnpm'
       - name: Install web dependencies
-        if: steps.cache-web.outputs.cache-hit != 'true'
         run: pnpm install --frozen-lockfile
         working-directory: ./web
       - name: Build

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -22,6 +22,7 @@ jobs:
         with:
           node-version: 18
           cache: 'pnpm'
+          cache-dependency-path: "**/pnpm-lock.yaml"
       - name: Install web dependencies
         run: pnpm install --frozen-lockfile
         working-directory: ./web

--- a/.github/workflows/eslint.yml
+++ b/.github/workflows/eslint.yml
@@ -26,7 +26,7 @@ jobs:
         with:
           node-version: 18
           cache: 'pnpm'
-          cache-dependency-path: "**/pnpm-lock.yaml"
+          cache-dependency-path: '**/pnpm-lock.yaml'
       - name: Install web dependencies
         run: pnpm install --frozen-lockfile
       - name: Generate config files

--- a/.github/workflows/eslint.yml
+++ b/.github/workflows/eslint.yml
@@ -26,6 +26,7 @@ jobs:
         with:
           node-version: 18
           cache: 'pnpm'
+          cache-dependency-path: "**/pnpm-lock.yaml"
       - name: Install web dependencies
         run: pnpm install --frozen-lockfile
       - name: Generate config files

--- a/.github/workflows/eslint.yml
+++ b/.github/workflows/eslint.yml
@@ -25,17 +25,10 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: 18
-      - name: Restore node_modules for web
-        id: cache-web
-        uses: actions/cache@v3
-        with:
-          path: ./web/node_modules
-          key: ${{ runner.os }}-node_modules-${{ hashFiles('./web/pnpm-lock.yaml') }}
+          cache: 'pnpm'
       - name: Install web dependencies
-        if: steps.cache.outputs.cache-hit != 'true'
         run: pnpm install --frozen-lockfile
       - name: Generate config files
-        if: steps.cache.outputs.cache-hit == 'true'
         run: pnpm create-generated-files
       - name: Restore ESLint cache
         uses: actions/cache@v3

--- a/.github/workflows/prettier.yml
+++ b/.github/workflows/prettier.yml
@@ -19,14 +19,8 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: 18
-      - name: Restore node_modules for web
-        id: cache-web
-        uses: actions/cache@v3
-        with:
-          path: web/node_modules
-          key: ${{ runner.os }}-node_modules-${{ hashFiles('./web/pnpm-lock.yaml') }}
+          cache: 'pnpm'
       - name: Install web dependencies
-        if: steps.cache-web.outputs.cache-hit != 'true'
         run: pnpm install --frozen-lockfile
         working-directory: ./web
       - name: Prettier Check

--- a/.github/workflows/prettier.yml
+++ b/.github/workflows/prettier.yml
@@ -20,7 +20,7 @@ jobs:
         with:
           node-version: 18
           cache: 'pnpm'
-          cache-dependency-path: "**/pnpm-lock.yaml"
+          cache-dependency-path: '**/pnpm-lock.yaml'
       - name: Install web dependencies
         run: pnpm install --frozen-lockfile
         working-directory: ./web

--- a/.github/workflows/prettier.yml
+++ b/.github/workflows/prettier.yml
@@ -20,6 +20,7 @@ jobs:
         with:
           node-version: 18
           cache: 'pnpm'
+          cache-dependency-path: "**/pnpm-lock.yaml"
       - name: Install web dependencies
         run: pnpm install --frozen-lockfile
         working-directory: ./web

--- a/.github/workflows/typecheck.yml
+++ b/.github/workflows/typecheck.yml
@@ -21,6 +21,7 @@ jobs:
         with:
           node-version: 18
           cache: 'pnpm'
+          cache-dependency-path: "**/pnpm-lock.yaml"
       - name: Install web dependencies
         run: pnpm install --frozen-lockfile
       - name: Generate config files

--- a/.github/workflows/typecheck.yml
+++ b/.github/workflows/typecheck.yml
@@ -20,14 +20,8 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: 18
-      - name: Restore node_modules for web
-        id: cache-web
-        uses: actions/cache@v3
-        with:
-          path: ./web/node_modules
-          key: ${{ runner.os }}-node_modules-${{ hashFiles('./web/pnpm-lock.yaml') }}
+          cache: 'pnpm'
       - name: Install web dependencies
-        if: steps.cache.outputs.cache-hit != 'true'
         run: pnpm install --frozen-lockfile
       - name: Generate config files
         run: pnpm create-generated-files

--- a/.github/workflows/typecheck.yml
+++ b/.github/workflows/typecheck.yml
@@ -21,7 +21,7 @@ jobs:
         with:
           node-version: 18
           cache: 'pnpm'
-          cache-dependency-path: "**/pnpm-lock.yaml"
+          cache-dependency-path: '**/pnpm-lock.yaml'
       - name: Install web dependencies
         run: pnpm install --frozen-lockfile
       - name: Generate config files

--- a/.github/workflows/unit_test.yml
+++ b/.github/workflows/unit_test.yml
@@ -21,6 +21,7 @@ jobs:
         with:
           node-version: 18
           cache: 'pnpm'
+          cache-dependency-path: "**/pnpm-lock.yaml"
       - name: Install web dependencies
         run: pnpm install --frozen-lockfile
       - name: Generate config files

--- a/.github/workflows/unit_test.yml
+++ b/.github/workflows/unit_test.yml
@@ -20,17 +20,10 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: 18
-      - name: Restore node_modules for web
-        id: cache-web
-        uses: actions/cache@v3
-        with:
-          path: ./web/node_modules
-          key: ${{ runner.os }}-node_modules-${{ hashFiles('./web/pnpm-lock.yaml') }}
+          cache: 'pnpm'
       - name: Install web dependencies
-        if: steps.cache.outputs.cache-hit != 'true'
         run: pnpm install --frozen-lockfile
       - name: Generate config files
-        if: steps.cache.outputs.cache-hit == 'true'
         run: pnpm create-generated-files
       - name: Run test
         run: pnpm run test:ci

--- a/.github/workflows/unit_test.yml
+++ b/.github/workflows/unit_test.yml
@@ -21,7 +21,7 @@ jobs:
         with:
           node-version: 18
           cache: 'pnpm'
-          cache-dependency-path: "**/pnpm-lock.yaml"
+          cache-dependency-path: '**/pnpm-lock.yaml'
       - name: Install web dependencies
         run: pnpm install --frozen-lockfile
       - name: Generate config files

--- a/.github/workflows/validate_generate_files.yml
+++ b/.github/workflows/validate_generate_files.yml
@@ -21,7 +21,7 @@ jobs:
         with:
           node-version: 18
           cache: 'pnpm'
-          cache-dependency-path: "**/pnpm-lock.yaml"
+          cache-dependency-path: '**/pnpm-lock.yaml'
       - name: Install web dependencies
         run: pnpm install --frozen-lockfile
       - name: Generate zone config

--- a/.github/workflows/validate_generate_files.yml
+++ b/.github/workflows/validate_generate_files.yml
@@ -21,6 +21,7 @@ jobs:
         with:
           node-version: 18
           cache: 'pnpm'
+          cache-dependency-path: "**/pnpm-lock.yaml"
       - name: Install web dependencies
         run: pnpm install --frozen-lockfile
       - name: Generate zone config

--- a/.github/workflows/validate_generate_files.yml
+++ b/.github/workflows/validate_generate_files.yml
@@ -20,14 +20,8 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: 18
-      - name: Restore node_modules for web
-        id: cache-web
-        uses: actions/cache@v3
-        with:
-          path: ./web/node_modules
-          key: ${{ runner.os }}-node_modules-${{ hashFiles('./web/pnpm-lock.yaml') }}
+          cache: 'pnpm'
       - name: Install web dependencies
-        if: steps.cache.outputs.cache-hit != 'true'
         run: pnpm install --frozen-lockfile
       - name: Generate zone config
         run: pnpm run generate-zones-config

--- a/.github/workflows/validate_generated_files.yml
+++ b/.github/workflows/validate_generated_files.yml
@@ -20,14 +20,8 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: 18
-      - name: Restore node_modules
-        id: cache
-        uses: actions/cache@v3
-        with:
-          path: ./web/node_modules
-          key: ${{ runner.os }}-node_modules-${{ hashFiles('./web/pnpm-lock.yaml') }}
+          cache: 'pnpm'
       - name: Install web dependencies
-        if: steps.cache.outputs.cache-hit != 'true'
         run: pnpm install --frozen-lockfile
       - name: zones + exchanges
         run: pnpm run generate-zones-config

--- a/.github/workflows/validate_generated_files.yml
+++ b/.github/workflows/validate_generated_files.yml
@@ -21,6 +21,7 @@ jobs:
         with:
           node-version: 18
           cache: 'pnpm'
+          cache-dependency-path: "**/pnpm-lock.yaml"
       - name: Install web dependencies
         run: pnpm install --frozen-lockfile
       - name: zones + exchanges

--- a/.github/workflows/validate_generated_files.yml
+++ b/.github/workflows/validate_generated_files.yml
@@ -21,7 +21,7 @@ jobs:
         with:
           node-version: 18
           cache: 'pnpm'
-          cache-dependency-path: "**/pnpm-lock.yaml"
+          cache-dependency-path: '**/pnpm-lock.yaml'
       - name: Install web dependencies
         run: pnpm install --frozen-lockfile
       - name: zones + exchanges


### PR DESCRIPTION
## Issue

The setup node action have added built in caching and this in combination to our switch to pnpm makes our current caching logic unnecissarily  complex.

## Description

This removes the custom caching logic and use the built in version in the setup node action in combination with the pnpm global store.

