### PR TITLE
PH-updated parser to handle battery storage

### DIFF
--- a/parsers/PH.py
+++ b/parsers/PH.py
@@ -9,11 +9,14 @@ from requests import Response, Session
 
 from electricitymap.contrib.config.constants import PRODUCTION_MODES
 from electricitymap.contrib.lib.models.event_lists import (
-    EventSourceType,
     ExchangeList,
     ProductionBreakdownList,
 )
-from electricitymap.contrib.lib.models.events import ProductionMix, StorageMix
+from electricitymap.contrib.lib.models.events import (
+    EventSourceType,
+    ProductionMix,
+    StorageMix,
+)
 from electricitymap.contrib.lib.types import ZoneKey
 from parsers.lib.config import refetch_frequency
 from parsers.lib.exceptions import ParserException


### PR DESCRIPTION
## Issue

Power plant mapping was updated with battery storage facilities but the current parser was not built to capture that

## Description

update the parser to collect battery storage
remove the pivot table part because it is not very efficient method

### Preview

<img width="802" alt="image" src="https://github.com/electricitymaps/electricitymaps-contrib/assets/107848894/863b5393-f5fa-4d15-8710-639e32e5ae46">


### Double check

- [ ] I have tested my parser changes locally with `poetry run test_parser "zone_key"`
- [ ] I have run `pnpx prettier --write .` and `poetry run format` to format my changes.
