### PR TITLE
Round values in add_value() method

### DIFF
--- a/electricitymap/contrib/lib/models/events.py
+++ b/electricitymap/contrib/lib/models/events.py
@@ -30,7 +30,9 @@ class Mix(BaseModel, ABC):
         existing_value: Optional[float] = getattr(self, mode)
         if existing_value is not None:
             value = 0 if value is None else value
-            self.__setattr__(mode, round(existing_value + value, 6)) # 6 decimal places gives us a precision of 1 W.
+            self.__setattr__(
+                mode, round(existing_value + value, 6)
+            )  # 6 decimal places gives us a precision of 1 W.
         else:
             self.__setattr__(mode, value if value is None else round(value, 6))
 

--- a/electricitymap/contrib/lib/models/events.py
+++ b/electricitymap/contrib/lib/models/events.py
@@ -30,9 +30,9 @@ class Mix(BaseModel, ABC):
         existing_value: Optional[float] = getattr(self, mode)
         if existing_value is not None:
             value = 0 if value is None else value
-            self.__setattr__(mode, existing_value + value)
+            self.__setattr__(mode, round(existing_value + value, 6)) # 6 decimal places gives us a precision of 1 W.
         else:
-            self.__setattr__(mode, value)
+            self.__setattr__(mode, value if value is None else round(value, 6))
 
     @classmethod
     def merge(cls, mixes: List["Mix"]) -> "Mix":

--- a/parsers/test/test_EIA.py
+++ b/parsers/test/test_EIA.py
@@ -149,13 +149,13 @@ class TestEIAProduction(TestEIA):
             {
                 "zoneKey": "US-CAR-SC",
                 "source": "eia.gov",
-                "production": {"nuclear": 330.6666336},
+                "production": {"nuclear": 330.666634},
                 "storage": {},
             },
             {
                 "zoneKey": "US-CAR-SC",
                 "source": "eia.gov",
-                "production": {"nuclear": 330.3333003},
+                "production": {"nuclear": 330.3333},
                 "storage": {},
             },
         ]
@@ -165,13 +165,13 @@ class TestEIAProduction(TestEIA):
             {
                 "zoneKey": "US-CAR-SCEG",
                 "source": "eia.gov",
-                "production": {"nuclear": 661.3333663999999},
+                "production": {"nuclear": 661.333366},
                 "storage": {},
             },
             {
                 "zoneKey": "US-CAR-SCEG",
                 "source": "eia.gov",
-                "production": {"nuclear": 660.6666997},
+                "production": {"nuclear": 660.6667},
                 "storage": {},
             },
         ]

--- a/parsers/test/test_FR_O.py
+++ b/parsers/test/test_FR_O.py
@@ -116,9 +116,9 @@ class TestFR_O(unittest.TestCase):
                 "production": {
                     "biomass": 0.38,
                     "hydro": 5.426,
-                    "oil": 110.23200000000001,
+                    "oil": 110.232,
                     "solar": 74.562,
-                    "wind": 2.3480000000000003,
+                    "wind": 2.348,
                 },
                 "source": "opendata-corse.edf.fr",
                 "sourceType": "estimated",


### PR DESCRIPTION
## Issue
Due to how python works we accidentally introduce floating point errors when adding values, this is a random behaviour.

## Description

This PR introduces rounding to the add value function to eliminate these floating point errors. 6 digits was chosen as the number of decimals as it gives us a precision of 1 watt, it is hard to imagine our source values would be more accurate than this considering the scales we are looking at but this can be increased if deemed necessary.

### Preview

<!-- Please add screenshots and/or gif that shows visual changes (if applicable) -->

### Double check

- [x] I have tested my parser changes locally with `poetry run test_parser "zone_key"`
- [x] I have run `pnpx prettier --write .` and `poetry run format` to format my changes.
