### PR TITLE
Update positioning of AR-UY exchange

### DIFF
--- a/config/exchanges/AR_UY.yaml
+++ b/config/exchanges/AR_UY.yaml
@@ -1,6 +1,6 @@
 lonlat:
-  - -56.117
-  - -32.499
+  - -58.150
+  - -32.199
 parsers:
   exchange: UY.fetch_exchange
-rotation: 180
+rotation: 90


### PR DESCRIPTION
## Issue
Argentina -> Uruguay exchange was the middle of Uruguay

## Description
This PR updates the position of the AR->UY exchange 

### Preview
Before:
<img width="661" alt="image" src="https://github.com/electricitymaps/electricitymaps-contrib/assets/18622768/79c7b29f-391e-4a2a-a5b5-d1ddd2764f4b">


After:
<img width="662" alt="image" src="https://github.com/electricitymaps/electricitymaps-contrib/assets/18622768/3e1a9a39-feff-4cce-af2d-78fdcdfb627b">


### Double check

- [x] I have tested my parser changes locally with `poetry run test_parser "zone_key"`
- [x] I have run `pnpx prettier --write .` and `poetry run format` to format my changes.
