### PR TITLE
[total-energy] Update "by source" label to make it more clear

### DIFF
--- a/web/public/locales/da.json
+++ b/web/public/locales/da.json
@@ -19,7 +19,14 @@
     "electricity": "Elektricitet",
     "electricityproduction": "Elproduktion",
     "electricityconsumption": "Elforbrug",
-    "bysource": "efter kilde",
+    "by-source": {
+      "emissions": "CO₂-udledning per kilde",
+      "electricity-production": "Elproduktion per kilde",
+      "electricity-consumption": "Elforbrug per kilde",
+      "total-emissions": "Samlede CO₂-udledninger per kilde",
+      "total-electricity-production": "Samlet elproduktion per kilde",
+      "total-electricity-consumption": "Samlet elforbrug per kilde"
+    },
     "emissions": "CO₂-udledning",
     "helpfrom": "med hjælp fra",
     "addeditsource": "<a href=\"%s\" target=\"_blank\">Tilføj eller rediger kilde</a>",

--- a/web/public/locales/de.json
+++ b/web/public/locales/de.json
@@ -35,8 +35,14 @@
     "renewable": "regenerativ",
     "electricityproduction": "Stromerzeugung",
     "electricityconsumption": "Stromverbrauch",
-    "bysource": "nach Quelle:",
-    "averagebysource": "Durchschnitt nach Quelle:",
+    "by-source": {
+      "emissions": "CO₂-Emissionen nach Quelle",
+      "electricity-production": "Stromerzeugung nach Quelle",
+      "electricity-consumption": "Stromverbrauch nach Quelle",
+      "total-emissions": "Gesamte CO₂-Emissionen nach Quelle",
+      "total-electricity-production": "Gesamte Stromerzeugung nach Quelle",
+      "total-electricity-consumption": "Gesamter Stromverbrauch nach Quelle"
+    },
     "emissions": "CO₂-Emissionen",
     "addeditsource": "<a href=\"%s\" target=\"_blank\">Quelle bearbeiten oder hinzufügen</a>",
     "helpfrom": "mit Unterstützung von",

--- a/web/public/locales/en.json
+++ b/web/public/locales/en.json
@@ -49,8 +49,6 @@
     "renewable": "Renewable",
     "electricityproduction": "Electricity production",
     "electricityconsumption": "Electricity consumption",
-    "bysource": "by source",
-    "averagebysource": "average by source",
     "emissions": "Carbon emissions",
     "addeditsource": "<a href=\"%s\" target=\"_blank\">add or edit source</a>",
     "helpfrom": "with help from",
@@ -68,7 +66,15 @@
     "aggregatedTooltip": "The data for this zone is aggregated based on historical hourly values",
     "helpUs": "Help us identify the problem by taking a look at the <a href=\"%s\" target=\"_blank\">runtime logs</a> or contact the data provider.",
     "noParserInfo": "We do not yet have any information about this area.<br/> Want to help fix this? You can contribute by <a href=\"%s\" target=\"_blank\">adding area data</a>.",
-    "now": "Now"
+    "now": "Now",
+    "by-source": {
+      "emissions": "Carbon emissions by source",
+      "electricity-production": "Electricity production by source",
+      "electricity-consumption": "Electricity consumption by source",
+      "total-emissions": "Total carbon emissions by source",
+      "total-electricity-production": "Total electricity production by source",
+      "total-electricity-consumption": "Total electricity consumption by source"
+    }
   },
   "time-controller": {
     "title": "Display data from the past"
@@ -80,11 +86,7 @@
   },
   "country-history": {
     "carbonintensity": {
-      "default": "Carbon intensity in the last %1$s",
-      "hourly": "Carbon intensity in the last 24 hours",
-      "daily": "Carbon intensity in the last month",
-      "monthly": "Carbon intensity in the last year",
-      "yearly": "Carbon intensity in the last 5 years"
+      "default": "Carbon intensity in the last %1$s"
     },
     "emissions": {
       "default": "Emissions in the last %1$s"

--- a/web/public/locales/es.json
+++ b/web/public/locales/es.json
@@ -49,7 +49,14 @@
     "renewable": "Renovables",
     "electricityproduction": "Producción de electricidad",
     "electricityconsumption": "Consumo de electricidad",
-    "bysource": "por fuente",
+    "by-source": {
+      "emissions": "Emisiones de CO₂ por fuente",
+      "electricity-production": "Producción de electricidad por fuente",
+      "electricity-consumption": "Consumo de electricidad por fuente",
+      "total-emissions": "Emisiones totales de CO₂ por fuente",
+      "total-electricity-production": "Producción total de electricidad por fuente",
+      "total-electricity-consumption": "Consumo total de electricidad por fuente"
+    },
     "emissions": "Emisiones de CO₂",
     "addeditsource": "<a href=\"%s\" target=\"_blank\">añadir o modificar fuente</a>",
     "helpfrom": "con la ayuda de",

--- a/web/public/locales/fr.json
+++ b/web/public/locales/fr.json
@@ -35,7 +35,14 @@
     "lowcarbon": "Bas carbone",
     "electricityproduction": "Production électrique",
     "electricityconsumption": "Consommation électrique",
-    "bysource": "par source",
+    "by-source": {
+      "emissions": "Émissions de carbone par source",
+      "electricity-production": "Production d'électricité par source",
+      "electricity-consumption": "Consommation d'électricité par source",
+      "total-emissions": "Émissions totales de carbone par source",
+      "total-electricity-production": "Production totale d'électricité par source",
+      "total-electricity-consumption": "Consommation totale d'électricité par source"
+    },
     "emissions": "Émissions",
     "addeditsource": "<a href=\"%s\" target=\"_blank\">ajouter ou modifier la source</a>",
     "helpfrom": "avec l’aide de",
@@ -47,7 +54,6 @@
     },
     "now": "Maintenant",
     "dataIsDelayed": "Les données relatives à cette région peuvent avoir jusqu'à %s heures de retard. Les données temps-réel ne peuvent pas être affichées.",
-    "averagebysource": "moyenne par source",
     "estimated": "estimé",
     "aggregated": "aggrégé",
     "dataIsEstimated": "Certaines données de cette région sont estimées. En savoir plus sur notre méthodologie d'estimation <a href=\"https://github.com/electricityMaps/electricitymaps-contrib/wiki/Estimation-methods\" target=\"_blank\">ici</a>.",

--- a/web/public/locales/hi.json
+++ b/web/public/locales/hi.json
@@ -49,8 +49,6 @@
     "renewable": "अक्षय",
     "electricityproduction": "बिजली उत्पादन",
     "electricityconsumption": "बिजली खर्च",
-    "bysource": "श्रोत से",
-    "averagebysource": "श्रोतों का औसत",
     "emissions": "कार्बन उत्सर्जन",
     "addeditsource": "<a href=\"%s\" target=\"_blank\">श्रोत जोड़ें या श्रोत में बदलाव करें</a>",
     "helpfrom": "की मदद से",

--- a/web/public/locales/it.json
+++ b/web/public/locales/it.json
@@ -49,8 +49,14 @@
     "renewable": "Rinnovabile",
     "electricityproduction": "Produzione elettrica",
     "electricityconsumption": "Consumo elettrico",
-    "bysource": "per fonte",
-    "averagebysource": "media per fonte",
+    "by-source": {
+      "emissions": "Emissioni di carbonio per fonte",
+      "electricity-production": "Produzione di elettricità per fonte",
+      "electricity-consumption": "Consumo di elettricità per fonte",
+      "total-emissions": "Emissioni totali di carbonio per fonte",
+      "total-electricity-production": "Produzione totale di elettricità per fonte",
+      "total-electricity-consumption": "Consumo totale di elettricità per fonte"
+    },
     "emissions": "Emissioni di carbonio",
     "addeditsource": "<a href=\"%s\" target=\"_blank\">Aggiungi o modifica fonte</a>",
     "helpfrom": "con l'aiuto di",

--- a/web/public/locales/pt-BR.json
+++ b/web/public/locales/pt-BR.json
@@ -35,7 +35,14 @@
     "renewable": "Renovável",
     "electricityproduction": "Produção de eletricidade",
     "electricityconsumption": "Consumo de eletricidade",
-    "bysource": "por fonte",
+    "by-source": {
+      "emissions": "Emissões de carbono por fonte",
+      "electricity-production": "Produção de eletricidade por fonte",
+      "electricity-consumption": "Consumo de eletricidade por fonte",
+      "total-emissions": "Emissões totais de carbono por fonte",
+      "total-electricity-production": "Produção total de eletricidade por fonte",
+      "total-electricity-consumption": "Consumo total de eletricidade por fonte"
+    },
     "emissions": "Emissões de carbono",
     "addeditsource": "<a href=\"%s\" target=\"_blank\">adicionar ou editar fonte de dados</a>",
     "helpfrom": "com ajuda de",
@@ -44,7 +51,6 @@
     "noParserInfo": "Nós não temos nenhuma informação sobre essa área.<br/> Gostaria de corrigir isso? Você pode contribuir <a href=\"%s\" target=\"_blank\">adicionando dados da área</a>.",
     "now": "Agora",
     "dataIsDelayed": "Dados para essa região podem estar até %s horas atrasados. Dados em tempo real estão indisponíveis.",
-    "averagebysource": "média por fonte",
     "estimated": "estimado",
     "aggregated": "agregado",
     "dataIsEstimated": "Parte dos dados dessa região são estimados. Leia mais sobre nossa metodologia de estimativas <a href=\"https://github.com/electricityMaps/electricitymaps-contrib/wiki/Estimation-methods\" target=\"_blank\">aqui</a>.",

--- a/web/public/locales/sl.json
+++ b/web/public/locales/sl.json
@@ -49,8 +49,14 @@
     "renewable": "obnovljiva",
     "electricityproduction": "Proizvodnja električne energije",
     "electricityconsumption": "Poraba električne energije",
-    "bysource": "po viru",
-    "averagebysource": "povprečje glede na vir",
+    "by-source": {
+      "emissions": "Izpusti ogljika po virih",
+      "electricity-production": "Proizvodnja električne energije po virih",
+      "electricity-consumption": "Poraba električne energije po virih",
+      "total-emissions": "Skupni izpusti ogljika po virih",
+      "total-electricity-production": "Skupna proizvodnja električne energije po virih",
+      "total-electricity-consumption": "Skupna poraba električne energije po virih"
+    },
     "emissions": "ogljične emisije",
     "addeditsource": "<a href=\"%s\" target=\"_blank\">dodaj ali uredi vir</a>",
     "helpfrom": "s pomočjo od",

--- a/web/public/locales/sv.json
+++ b/web/public/locales/sv.json
@@ -49,7 +49,14 @@
     "renewable": "Förnybart",
     "electricityproduction": "Elproduktion",
     "electricityconsumption": "Elkonsumtion",
-    "bysource": "per källa",
+    "by-source": {
+      "emissions": "Koldioxidutsläpp per källa",
+      "electricity-production": "Elproduktion per källa",
+      "electricity-consumption": "Elkonsumtion per källa",
+      "total-emissions": "Totala koldioxidutsläpp per källa",
+      "total-electricity-production": "Total elproduktion per källa",
+      "total-electricity-consumption": "Total ekonsumtion per källa"
+    },
     "emissions": "Koldioxidutsläpp",
     "addeditsource": "<a href=\"%s\" target=\"_blank\">lägg till eller redigera källa</a>",
     "helpfrom": "med hjälp från",
@@ -64,8 +71,7 @@
     "aggregatedTooltip": "Data för denna zon är aggregerad baserat på historiska timvärden",
     "helpUs": "Hjälp oss identifiera problem genom att kolla på <a href=\"%s\" target=\"_blank\">körningsloggarna</a> eller kontakta dataleverantören.",
     "noParserInfo": "Vi har ännu ingen information om denna region.<br/> Vill du hjälpa till med att fixa det? Du kan bidra genom att <a href=\"%s\" target=\"_blank\">lägga till data för regionen</a>.",
-    "now": "Nu",
-    "averagebysource": "genomsnitt per källa"
+    "now": "Nu"
   },
   "time-controller": {
     "title": "Visa historisk data"

--- a/web/public/locales/zh-CN.json
+++ b/web/public/locales/zh-CN.json
@@ -24,8 +24,6 @@
     "source": "来源",
     "carbonintensity": "碳强度",
     "electricityproduction": "电力生产",
-    "bysource": "按来源",
-    "averagebysource": "按来源平均",
     "helpfrom": "得力于",
     "emissions": "碳排放量",
     "addeditsource": "<a href=\"%s\" target=\"_blank\">新增或编辑来源</a>",

--- a/web/public/locales/zh-TW.json
+++ b/web/public/locales/zh-TW.json
@@ -49,8 +49,6 @@
     "renewable": "可再生能源",
     "electricityproduction": "電力生產",
     "electricityconsumption": "用電量",
-    "bysource": "按來源",
-    "averagebysource": "來源平均",
     "emissions": "碳排放量",
     "addeditsource": "<a href=\"%s\" target=\"_blank\">新增或編輯來源</a>",
     "helpfrom": "with help from",

--- a/web/src/features/charts/bar-breakdown/elements/BySource.tsx
+++ b/web/src/features/charts/bar-breakdown/elements/BySource.tsx
@@ -1,24 +1,43 @@
 import { useAtom } from 'jotai';
 import { useTranslation } from 'translation/translation';
 import { TimeAverages } from 'utils/constants';
-import { displayByEmissionsAtom, timeAverageAtom } from 'utils/state/atoms';
+import {
+  displayByEmissionsAtom,
+  productionConsumptionAtom,
+  timeAverageAtom,
+} from 'utils/state/atoms';
+
+const getText = (
+  timePeriod: TimeAverages,
+  dataType: 'emissions' | 'production' | 'consumption',
+  __: (text: string) => string
+) => {
+  const translations = {
+    hourly: {
+      emissions: __('country-panel.by-source.emissions'),
+      production: __('country-panel.by-source.electricity-production'),
+      consumption: __('country-panel.by-source.electricity-consumption'),
+    },
+    default: {
+      emissions: __('country-panel.by-source.total-emissions'),
+      production: __('country-panel.by-source.total-electricity-production'),
+      consumption: __('country-panel.by-source.total-electricity-consumption'),
+    },
+  };
+  const period = timePeriod === TimeAverages.HOURLY ? 'hourly' : 'default';
+  return translations[period][dataType];
+};
 
 export default function BySource({ className }: { className?: string }) {
   const { __ } = useTranslation();
   const [timeAverage] = useAtom(timeAverageAtom);
   const [displayByEmissions] = useAtom(displayByEmissionsAtom);
+  const [mixMode] = useAtom(productionConsumptionAtom);
+
+  const dataType = displayByEmissions ? 'emissions' : mixMode;
+  const text = getText(timeAverage, dataType, __);
+
   return (
-    <div className={`relative pb-2 pt-4 text-md font-bold ${className}`}>
-      {__(
-        displayByEmissions
-          ? 'country-panel.emissions'
-          : 'country-panel.electricityproduction'
-      )}{' '}
-      {__(
-        timeAverage === TimeAverages.HOURLY
-          ? 'country-panel.bysource'
-          : 'country-panel.averagebysource'
-      )}
-    </div>
+    <div className={`relative pb-2 pt-4 text-md font-bold ${className}`}>{text}</div>
   );
 }


### PR DESCRIPTION
## Description

Changes the label to include "total X by source" to make it more clear what data is displayed.
I used ChatGPT for translations and attempted to verify with existing translations - only did it for languages where we had the "averagebysource" key translated.

### Preview

![Screenshot 2023-09-08 at 10 05 34](https://github.com/electricitymaps/electricitymaps-contrib/assets/3296643/9e5fd663-8344-4444-bf10-60855281b1c5)

