### PR TITLE
Update capacity to use power and production to use energy

### DIFF
--- a/web/src/features/charts/tooltips/BreakdownChartTooltip.tsx
+++ b/web/src/features/charts/tooltips/BreakdownChartTooltip.tsx
@@ -7,7 +7,7 @@ import { renderToString } from 'react-dom/server';
 import { getZoneName, useTranslation } from 'translation/translation';
 import { ElectricityModeType, Maybe, ZoneDetail } from 'types';
 import { Mode, TimeAverages, modeColor } from 'utils/constants';
-import { formatCo2, formatEnergy } from 'utils/formatting';
+import { formatCo2, formatEnergy, formatPower } from 'utils/formatting';
 import {
   displayByEmissionsAtom,
   productionConsumptionAtom,
@@ -184,7 +184,7 @@ export function BreakdownChartTooltipContent({
               {__('tooltips.utilizing')} <b>{getRatioPercent(usage, capacity)} %</b>{' '}
               {__('tooltips.ofinstalled')}
               <br />
-              <MetricRatio value={usage} total={(capacity ??= 0)} format={formatEnergy} />
+              <MetricRatio value={usage} total={(capacity ??= 0)} format={formatPower} />
               <br />
             </>
           )}

--- a/web/src/utils/formatting.test.ts
+++ b/web/src/utils/formatting.test.ts
@@ -74,7 +74,7 @@ describe('formatCo2', () => {
     const expected = '1 kg';
     expect(actual).toBe(expected);
   });
-  it('handles tons', () => {
+  it('handles tonnes', () => {
     const actual = formatCo2(1_000_000);
     const expected = '1 t';
     expect(actual).toBe(expected);
@@ -82,12 +82,17 @@ describe('formatCo2', () => {
 
   it('uses same unit as another value would', () => {
     const actual = formatCo2(23_500, 2_350_000);
-    const expected = '0 t';
+    const expected = '0.02 t';
     expect(actual).toBe(expected);
   });
 
-  it('adds decimals if comparing with tons', () => {
+  it('adds decimals if comparing with tonnes', () => {
     const actual = formatCo2(200_500, 2_350_000);
+    const expected = '0.2 t';
+    expect(actual).toBe(expected);
+  });
+  it('adds decimals if comparing with large tonnes', () => {
+    const actual = formatCo2(200_500, 992_350_000);
     const expected = '0.2 t';
     expect(actual).toBe(expected);
   });

--- a/web/src/utils/formatting.test.ts
+++ b/web/src/utils/formatting.test.ts
@@ -91,6 +91,11 @@ describe('formatCo2', () => {
     const expected = '0.2 t';
     expect(actual).toBe(expected);
   });
+  it('handles real data value', () => {
+    const actual = formatCo2(740_703_650);
+    const expected = '740 t';
+    expect(actual).toBe(expected);
+  });
   it('handles kilotonnes', () => {
     const actual = formatCo2(99_000_000_000);
     const expected = '99 kt';
@@ -102,7 +107,7 @@ describe('formatCo2', () => {
     expect(actual).toBe(expected);
   });
   it('handles megatonnes close to 1Gt rounding down', () => {
-    const actual = formatCo2(994_000_000_000_000);
+    const actual = formatCo2(994_320_320_231_123);
     const expected = '990 Mt';
     expect(actual).toBe(expected);
   });

--- a/web/src/utils/formatting.test.ts
+++ b/web/src/utils/formatting.test.ts
@@ -1,5 +1,5 @@
 import { removeDuplicateSources } from 'features/panels/zone/Attribution';
-import { formatCo2, formatDataSources, formatEnergy } from './formatting';
+import { formatCo2, formatDataSources, formatEnergy, formatPower } from './formatting';
 
 describe('formatEnergy', () => {
   it('handles NaN input', () => {
@@ -38,9 +38,9 @@ describe('formatEnergy', () => {
     expect(actual).toBe(expected);
   });
 
-  it('handles PWh', () => {
+  it('Converts PWh to TWh', () => {
     const actual = formatEnergy(1_222_000_000.234_567);
-    const expected = '1.2 PWh';
+    const expected = '1200 TWh';
     expect(actual).toBe(expected);
   });
 
@@ -59,6 +59,62 @@ describe('formatEnergy', () => {
   it('handles 0 input for number of digits', () => {
     const actual = formatEnergy(12_313, 0);
     const expected = '10 GWh';
+    expect(actual).toBe(expected);
+  });
+});
+
+describe('formatPower', () => {
+  it('handles NaN input', () => {
+    const actual = formatPower(Number.NaN);
+    const expected = Number.NaN;
+    expect(actual).toBe(expected);
+  });
+
+  it('handles custom number of digits', () => {
+    const actual = formatPower(1.234_567, 4);
+    const expected = '1.235 MW';
+    expect(actual).toBe(expected);
+  });
+
+  it('handles default number kW', () => {
+    const actual = formatPower(0.002_234_567);
+    const expected = '2.2 kW';
+    expect(actual).toBe(expected);
+  });
+
+  it('handles MW', () => {
+    const actual = formatPower(1.234_567);
+    const expected = '1.2 MW';
+    expect(actual).toBe(expected);
+  });
+
+  it('handles GW', () => {
+    const actual = formatPower(1222.234_567);
+    const expected = '1.2 GW';
+    expect(actual).toBe(expected);
+  });
+
+  it('handles TW', () => {
+    const actual = formatPower(1_222_000.234_567);
+    const expected = '1.2 TW';
+    expect(actual).toBe(expected);
+  });
+
+  it('handles zero input', () => {
+    const actual = formatPower(0);
+    const expected = '0 W';
+    expect(actual).toBe(expected);
+  });
+
+  it('handles 1 input for number of digits', () => {
+    const actual = formatPower(12_313, 1);
+    const expected = '10 GW';
+    expect(actual).toBe(expected);
+  });
+
+  it('handles 0 input for number of digits', () => {
+    const actual = formatPower(12_313, 0);
+    const expected = '10 GW';
     expect(actual).toBe(expected);
   });
 });

--- a/web/src/utils/formatting.ts
+++ b/web/src/utils/formatting.ts
@@ -29,26 +29,24 @@ export const formatCo2 = function (grams: number, valueToMatch?: number): string
     return '?';
   }
 
-  // Assume gCO₂ input
-  const value = grams;
-
   // Ensure both numbers are at the same scale
-  const checkAgainst = valueToMatch ?? value;
+  const checkAgainst = valueToMatch ?? grams;
 
+  //Values less than 1Mt
   if (Math.round(checkAgainst) < 1e9) {
-    let decimals = value < 1 ? 2 : 1;
+    let decimals = grams < 1 ? 2 : 1;
     // Remove decimals for large values
-    if (value > 1_000_000) {
+    if (grams > 1_000_000) {
       decimals = 2;
     }
     if (checkAgainst < 1e6) {
-      return addSpaceBetweenNumberAndUnit(`${d3.format(`,.${decimals}~s`)(value)}g`);
+      return addSpaceBetweenNumberAndUnit(`${d3.format(`,.${decimals}~s`)(grams)}g`);
     }
 
-    return addSpaceBetweenNumberAndUnit(`${d3.format(`,.${decimals}~r`)(value / 1e6)}t`);
+    return addSpaceBetweenNumberAndUnit(`${d3.format(`,.${decimals}~r`)(grams / 1e6)}t`);
   }
-  // megato(ns or above as a default
-  return addSpaceBetweenNumberAndUnit(`${d3.format(',.2~s')(value / 1e6)}t`);
+  // tonnes or above with significant figures as a default
+  return addSpaceBetweenNumberAndUnit(`${d3.format(',.2~s')(grams / 1e6)}t`);
 };
 
 const scalePower = function (maxPower: number | undefined) {

--- a/web/src/utils/formatting.ts
+++ b/web/src/utils/formatting.ts
@@ -23,40 +23,32 @@ export const formatEnergy = function (
   return addSpaceBetweenNumberAndUnit(power);
 };
 
-export const formatCo2 = function (grams: number, valueToMatch?: number) {
-  if (grams == undefined || Number.isNaN(grams)) {
+export const formatCo2 = function (grams: number, valueToMatch?: number): string {
+  // Validate input
+  if (grams == null || Number.isNaN(grams)) {
     return '?';
   }
 
-  // Assume gCO₂ / h input
+  // Assume gCO₂ input
   const value = grams;
 
   // Ensure both numbers are at the same scale
   const checkAgainst = valueToMatch ?? value;
 
-  // grams and kilograms
-  if (checkAgainst < 1_000_000) {
-    return addSpaceBetweenNumberAndUnit(`${d3.format(`,.0~s`)(value)}g`);
-  }
-
-  // tons
-  if (Math.round(checkAgainst) < 1e8) {
+  if (Math.round(checkAgainst) < 1e9) {
     let decimals = value < 1 ? 2 : 1;
     // Remove decimals for large values
     if (value > 1_000_000) {
-      decimals = 0;
+      decimals = 2;
+    }
+    if (checkAgainst < 1e6) {
+      return addSpaceBetweenNumberAndUnit(`${d3.format(`,.${decimals}~s`)(value)}g`);
     }
 
-    return addSpaceBetweenNumberAndUnit(`${d3.format(`,.${decimals}~f`)(value / 1e6)}t`);
+    return addSpaceBetweenNumberAndUnit(`${d3.format(`,.${decimals}~r`)(value / 1e6)}t`);
   }
-
-  // Hundred thousands of tons
-  if (Math.round(checkAgainst) < 1e9) {
-    return addSpaceBetweenNumberAndUnit(`${d3.format(`,.2~s`)(value / 1e6)}t`);
-  }
-
-  // megatons or above
-  return addSpaceBetweenNumberAndUnit(`${d3.format(`,.2~s`)(value / 1e6)}t`);
+  // megato(ns or above as a default
+  return addSpaceBetweenNumberAndUnit(`${d3.format(',.2~s')(value / 1e6)}t`);
 };
 
 const scalePower = function (maxPower: number | undefined) {

--- a/web/src/utils/formatting.ts
+++ b/web/src/utils/formatting.ts
@@ -9,29 +9,32 @@ function addSpaceBetweenNumberAndUnit(inputString: string) {
   return inputString.replace(/([A-Za-z])/, ' $1');
 }
 
-export const formatEnergy = function (
+export const formatPower = function (
   d: number,
-  numberDigits: number = DEFAULT_NUM_DIGITS,
-  isCapacity = false
+  numberDigits: number = DEFAULT_NUM_DIGITS
 ) {
   // Assume MW input
   if (d == undefined || Number.isNaN(d)) {
     return d;
   }
   const significantFigures = d.toString().length > 1 ? numberDigits : 1;
-  const unit = isCapacity ? 'W' : 'Wh';
   const power =
     d < 1e9
-      ? d3.format(`.${significantFigures}s`)(d * 1e6) + unit
-      : d3.format(`.${significantFigures}r`)(d / 1e6) + 'TWh';
+      ? d3.format(`.${significantFigures}s`)(d * 1e6) + 'W'
+      : d3.format(`.${significantFigures}r`)(d / 1e6) + 'TW';
   return addSpaceBetweenNumberAndUnit(power);
 };
 
-export const formatPower = function (
+export const formatEnergy = function (
   d: number,
   numberDigits: number = DEFAULT_NUM_DIGITS
 ) {
-  return formatEnergy(d, numberDigits, true);
+  const power = formatPower(d, numberDigits);
+  // Assume MW input
+  if (power == undefined || Number.isNaN(power)) {
+    return power;
+  }
+  return power + 'h';
 };
 
 export const formatCo2 = function (grams: number, valueToMatch?: number): string {

--- a/web/src/utils/formatting.ts
+++ b/web/src/utils/formatting.ts
@@ -23,13 +23,13 @@ export const formatEnergy = function (
   return addSpaceBetweenNumberAndUnit(power);
 };
 
-export const formatCo2 = function (gramPerHour: number, valueToMatch?: number) {
-  if (gramPerHour == undefined || Number.isNaN(gramPerHour)) {
+export const formatCo2 = function (grams: number, valueToMatch?: number) {
+  if (grams == undefined || Number.isNaN(grams)) {
     return '?';
   }
 
   // Assume gCO₂ / h input
-  const value = gramPerHour;
+  const value = grams;
 
   // Ensure both numbers are at the same scale
   const checkAgainst = valueToMatch ?? value;
@@ -52,7 +52,7 @@ export const formatCo2 = function (gramPerHour: number, valueToMatch?: number) {
 
   // Hundred thousands of tons
   if (Math.round(checkAgainst) < 1e9) {
-    return addSpaceBetweenNumberAndUnit(`${d3.format(`,.1~f`)(value / 1e6)}Mt`);
+    return addSpaceBetweenNumberAndUnit(`${d3.format(`,.2~s`)(value / 1e6)}t`);
   }
 
   // megatons or above

--- a/web/src/utils/formatting.ts
+++ b/web/src/utils/formatting.ts
@@ -11,16 +11,27 @@ function addSpaceBetweenNumberAndUnit(inputString: string) {
 
 export const formatEnergy = function (
   d: number,
-  numberDigits: number = DEFAULT_NUM_DIGITS
+  numberDigits: number = DEFAULT_NUM_DIGITS,
+  isCapacity = false
 ) {
   // Assume MW input
   if (d == undefined || Number.isNaN(d)) {
     return d;
   }
   const significantFigures = d.toString().length > 1 ? numberDigits : 1;
-
-  const power = `${d3.format(`.${significantFigures}s`)(d * 1e6)}Wh`;
+  const unit = isCapacity ? 'W' : 'Wh';
+  const power =
+    d < 1e9
+      ? d3.format(`.${significantFigures}s`)(d * 1e6) + unit
+      : d3.format(`.${significantFigures}r`)(d / 1e6) + 'TWh';
   return addSpaceBetweenNumberAndUnit(power);
+};
+
+export const formatPower = function (
+  d: number,
+  numberDigits: number = DEFAULT_NUM_DIGITS
+) {
+  return formatEnergy(d, numberDigits, true);
 };
 
 export const formatCo2 = function (grams: number, valueToMatch?: number): string {


### PR DESCRIPTION
## Issue
PWh isn't a common measure and capacity is measured by power

## Description
This PR updates our formatting to show a maximum of TW / TWh and will use power values for capacity


### Preview
![image](https://github.com/electricitymaps/electricitymaps-contrib/assets/18622768/8e6b7f04-0ed6-4cc9-bcc2-606068b0f6c1)
### Double check

- [x] I have tested my parser changes locally with `poetry run test_parser "zone_key"`
- [x] I have run `pnpx prettier --write .` and `poetry run format` to format my changes.
