### PR TITLE
fix IL production parser and add total production

### DIFF
--- a/parsers/IL.py
+++ b/parsers/IL.py
@@ -19,7 +19,16 @@ from typing import Optional
 
 import arrow
 from bs4 import BeautifulSoup
-from requests import Session, get
+from requests import Response, Session
+
+from electricitymap.contrib.lib.models.event_lists import (
+    ProductionBreakdownList,
+    TotalProductionList,
+)
+from electricitymap.contrib.lib.models.events import ProductionMix
+from electricitymap.contrib.lib.types import ZoneKey
+
+URL = "https://www.noga-iso.co.il/Umbraco/Api/Documents/GetElectricalData"
 
 IEC_URL = "www.iec.co.il"
 IEC_PRODUCTION = (
@@ -99,25 +108,70 @@ def extract_price_date(soup):
     return date
 
 
+def fetch_noga_iso_data(session: Session, logger: Logger):
+    """Fetches data from Noga-ISO"""
+    response: Response = session.get(URL)
+    if not response.ok:
+        logger.warning(
+            f"IL.py",
+            "Failed to fetch data from www.noga-iso.co.il with error: {response.status_code}",
+        )
+
+    data = response.json()
+    return data
+
+
 def fetch_production(
-    zone_key: str = "IL",
+    zone_key: ZoneKey = ZoneKey("IL"),
     session: Optional[Session] = None,
     target_datetime: Optional[datetime] = None,
     logger: Logger = getLogger(__name__),
-) -> dict:
+):
     if target_datetime:
         raise NotImplementedError("This parser is not yet able to parse past dates")
 
-    data = fetch_all()
-    production = [float(item) for item in data]
+    session = session or Session()
 
-    # all mapped to unknown as there is no available breakdown
-    return {
-        "zoneKey": zone_key,
-        "datetime": arrow.now(TZ).datetime,
-        "production": {"unknown": production[0] + production[1]},
-        "source": IEC_URL,
-    }
+    data = fetch_noga_iso_data(session, logger)
+    eventList = ProductionBreakdownList(logger=logger)
+
+    productionMix = ProductionMix()
+
+    productionMix.add_value(
+        mode="unknown", value=float(data.get("Production").replace(",", ""))
+    )
+
+    eventList.append(
+        zoneKey=zone_key,
+        datetime=arrow.now(TZ).datetime,
+        production=productionMix,
+        source="noga-iso.co.il",
+    )
+
+    return eventList.to_list()
+
+
+def fetch_total_production(
+    zone_key: ZoneKey = ZoneKey("IL"),
+    session: Optional[Session] = None,
+    target_datetime: Optional[datetime] = None,
+    logger: Logger = getLogger(__name__),
+):
+    if target_datetime:
+        raise NotImplementedError("This parser is not yet able to parse past dates")
+
+    session = session or Session()
+
+    data = fetch_noga_iso_data(session, logger)
+
+    eventList = TotalProductionList(logger=logger)
+
+    eventList.append(
+        zoneKey=zone_key,
+        datetime=arrow.now(TZ).datetime,
+        value=float(data.get("Production").replace(",", "")),
+        source="noga-iso.co.il",
+    )
 
 
 def fetch_consumption(

--- a/parsers/IL.py
+++ b/parsers/IL.py
@@ -19,7 +19,7 @@ from typing import Optional
 
 import arrow
 from bs4 import BeautifulSoup
-from requests import Response, Session
+from requests import Response, Session, get
 
 from electricitymap.contrib.lib.models.event_lists import (
     ProductionBreakdownList,


### PR DESCRIPTION
## Issue

[ELE-2774](https://linear.app/electricitymaps/issue/ELE-2774/priority-zones-down-il-za-in)

## Description

Get the production parser for IL up and running again. Also adds a totalProduction function but that is so far unused (I and Robin have talked about switching to that from unknown when we only have the total production).

### Double check

- [x] I have tested my parser changes locally with `poetry run test_parser "zone_key"`
- [x] I have run `pnpx prettier --write .` and `poetry run format` to format my changes.
