### PR TITLE
Automatically sort imports 

### DIFF
--- a/web/.eslintrc.json
+++ b/web/.eslintrc.json
@@ -20,6 +20,25 @@
     "prettier"
   ],
   "rules": {
+    "import/order": [
+      "error",
+      {
+        "groups": ["external", "internal"],
+        "pathGroups": [
+          {
+            "pattern": "react",
+            "group": "external",
+            "position": "before"
+          }
+        ],
+        "pathGroupsExcludedImportTypes": ["react"],
+        "newlines-between": "always",
+        "alphabetize": {
+          "order": "asc",
+          "caseInsensitive": true
+        }
+      }
+    ],
     // TODO: TEMPORARILY DISABLED DURING INITIAL DEVELOPMENT
     "@typescript-eslint/no-empty-interface": "off",
     "@typescript-eslint/no-empty-function": "off",

--- a/web/geo/files.ts
+++ b/web/geo/files.ts
@@ -1,9 +1,9 @@
 import yaml from 'js-yaml';
+
+import { ZoneConfig } from './types';
 import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
-
-import { ZoneConfig } from './types';
 
 const sortObjectByKey = (object: ZoneConfig) =>
   Object.keys(object)

--- a/web/geo/generateAggregates.ts
+++ b/web/geo/generateAggregates.ts
@@ -1,4 +1,5 @@
 import { Feature, MultiPolygon, union } from '@turf/turf';
+
 import { ZonesConfig, WorldFeatureCollection, FeatureProperties } from './types';
 
 const emptyFeature: Feature<MultiPolygon, FeatureProperties> = {

--- a/web/geo/generateExchangesToExclude.ts
+++ b/web/geo/generateExchangesToExclude.ts
@@ -1,6 +1,6 @@
-import { mergeExchanges } from '../scripts/generateZonesConfig.js';
 import { ZonesConfig } from './types.js';
 import { fileExists, getJSON, writeJSON } from './utilities.js';
+import { mergeExchanges } from '../scripts/generateZonesConfig.js';
 
 const exchangeConfig = mergeExchanges();
 

--- a/web/geo/generateTopojson.ts
+++ b/web/geo/generateTopojson.ts
@@ -1,7 +1,8 @@
 import * as turf from '@turf/turf';
 import { topology } from 'topojson-server';
-import { fileExists, getJSON, round, writeJSON } from './utilities.js';
+
 import { WorldFeatureCollection } from './types.js';
+import { fileExists, getJSON, round, writeJSON } from './utilities.js';
 
 function getCenter(geojson: WorldFeatureCollection, zoneName: string) {
   switch (zoneName) {

--- a/web/geo/generateWorld.ts
+++ b/web/geo/generateWorld.ts
@@ -1,13 +1,14 @@
 import { coordEach } from '@turf/turf';
-import * as path from 'node:path';
-import { fileURLToPath } from 'node:url';
-import { mergeZones } from '../scripts/generateZonesConfig.js';
+
 import { generateAggregates } from './generateAggregates.js';
 import { generateExchangesToIgnore } from './generateExchangesToExclude.js';
 import { generateTopojson } from './generateTopojson.js';
+import { WorldFeatureCollection } from './types.js';
 import { getJSON, round } from './utilities.js';
 import { validateGeometry } from './validate.js';
-import { WorldFeatureCollection } from './types.js';
+import { mergeZones } from '../scripts/generateZonesConfig.js';
+import * as path from 'node:path';
+import { fileURLToPath } from 'node:url';
 
 export const config = {
   WORLD_PATH: path.resolve(fileURLToPath(new URL('world.geojson', import.meta.url))),

--- a/web/geo/generateZoneBoundingBoxes.ts
+++ b/web/geo/generateZoneBoundingBoxes.ts
@@ -1,11 +1,12 @@
+import { Position } from '@turf/turf';
+import yaml from 'js-yaml';
+
+import { saveZoneYaml } from './files.js';
+import { WorldFeatureCollection, ZoneConfig } from './types.js';
+import { getJSON } from './utilities.js';
 import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
-import yaml from 'js-yaml';
-import { saveZoneYaml } from './files.js';
-import { getJSON } from './utilities.js';
-import { WorldFeatureCollection, ZoneConfig } from './types.js';
-import { Position } from '@turf/turf';
 
 const inputArguments = process.argv.slice(2);
 

--- a/web/geo/types.ts
+++ b/web/geo/types.ts
@@ -1,4 +1,5 @@
 import { FeatureCollection, Feature, MultiPolygon, Polygon } from '@turf/turf';
+
 import { config } from './generateWorld';
 
 export type GeoConfig = typeof config;

--- a/web/geo/utilities.ts
+++ b/web/geo/utilities.ts
@@ -14,6 +14,7 @@ import {
   Properties,
   truncate,
 } from '@turf/turf';
+
 import * as fs from 'node:fs';
 
 /* Transform the feature collection of polygons and multi-polygons into a feature collection of polygons only */

--- a/web/geo/validate.ts
+++ b/web/geo/validate.ts
@@ -11,10 +11,10 @@ import {
   getGeom,
   intersect,
 } from '@turf/turf';
-import { getHoles, getPolygons, log, writeJSON } from './utilities.js';
 
-import { mergeZones } from '../scripts/generateZonesConfig.js';
 import { GeoConfig, WorldFeatureCollection } from './types.js';
+import { getHoles, getPolygons, log, writeJSON } from './utilities.js';
+import { mergeZones } from '../scripts/generateZonesConfig.js';
 
 // TODO: Improve this function so each check returns error messages,
 // so we can show all errors instead of taking them one at a time.

--- a/web/scripts/generateZonesConfig.ts
+++ b/web/scripts/generateZonesConfig.ts
@@ -1,9 +1,7 @@
 /* This script aggregates the per-zone config files into a single zones.json/exchanges.json
 file to enable easy importing within web/ */
 import * as yaml from 'js-yaml';
-import * as fs from 'node:fs';
-import * as path from 'node:path';
-import { fileURLToPath } from 'node:url';
+
 import {
   ExchangeConfig,
   ExchangesConfig,
@@ -11,6 +9,9 @@ import {
   ZonesConfig,
 } from '../geo/types.js';
 import { round } from '../geo/utilities.js';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { fileURLToPath } from 'node:url';
 
 const BASE_CONFIG_PATH = '../../config';
 

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1,13 +1,15 @@
+import { ReactElement, Suspense, lazy, useEffect, useLayoutEffect } from 'react';
+
 import { App as Cap } from '@capacitor/app';
 import { Capacitor } from '@capacitor/core';
 import { ToastProvider } from '@radix-ui/react-toast';
 import * as Sentry from '@sentry/react';
 import { useGetAppVersion } from 'api/getAppVersion';
 import useGetState from 'api/getState';
-import LoadingOverlay from 'components/LoadingOverlay';
-import Toast from 'components/Toast';
 import LegendContainer from 'components/legend/LegendContainer';
+import LoadingOverlay from 'components/LoadingOverlay';
 import { OnboardingModal } from 'components/modals/OnboardingModal';
+import Toast from 'components/Toast';
 import ErrorComponent from 'features/error-boundary/ErrorBoundary';
 import FeatureFlagsManager from 'features/feature-flags/FeatureFlagsManager';
 import Header from 'features/header/Header';
@@ -17,7 +19,6 @@ import SettingsModal from 'features/modals/SettingsModal';
 import TotalEnergyIntroModal from 'features/modals/TotalEnergyIntroModal';
 import TimeControllerWrapper from 'features/time/TimeControllerWrapper';
 import { useDarkMode } from 'hooks/theme';
-import { ReactElement, Suspense, lazy, useEffect, useLayoutEffect } from 'react';
 import trackEvent from 'utils/analytics';
 
 const MapWrapper = lazy(async () => import('features/map/MapWrapper'));

--- a/web/src/api/getAppVersion.ts
+++ b/web/src/api/getAppVersion.ts
@@ -1,5 +1,6 @@
 import { useQuery } from '@tanstack/react-query';
 import { resolvePath } from 'react-router-dom';
+
 import { ONE_HOUR } from './helpers';
 
 async function getVersion(): Promise<{ version: string }> {

--- a/web/src/api/getState.ts
+++ b/web/src/api/getState.ts
@@ -2,9 +2,10 @@ import type { UseQueryResult } from '@tanstack/react-query';
 import { useQuery } from '@tanstack/react-query';
 import { useAtom } from 'jotai';
 import type { GridState } from 'types';
-import { getBasePath, getHeaders, QUERY_KEYS } from './helpers';
-import { timeAverageAtom } from 'utils/state/atoms';
 import { TimeAverages } from 'utils/constants';
+import { timeAverageAtom } from 'utils/state/atoms';
+
+import { getBasePath, getHeaders, QUERY_KEYS } from './helpers';
 
 const getState = async (timeAverage: string): Promise<GridState> => {
   const path = `v6/state/${timeAverage}`;

--- a/web/src/api/getZone.ts
+++ b/web/src/api/getZone.ts
@@ -4,9 +4,9 @@ import { useAtom } from 'jotai';
 import invariant from 'tiny-invariant';
 import type { ZoneDetails } from 'types';
 import { TimeAverages } from 'utils/constants';
+import { getZoneFromPath } from 'utils/helpers';
 import { timeAverageAtom } from 'utils/state/atoms';
 
-import { getZoneFromPath } from 'utils/helpers';
 import { getBasePath, getHeaders, QUERY_KEYS } from './helpers';
 
 const getZone = async (

--- a/web/src/components/Button.stories.tsx
+++ b/web/src/components/Button.stories.tsx
@@ -1,6 +1,6 @@
 import type { Meta, StoryObj } from '@storybook/react';
-
 import { HiMagnifyingGlass } from 'react-icons/hi2';
+
 import { Button } from './Button';
 
 const meta: Meta<typeof Button> = {

--- a/web/src/components/Button.tsx
+++ b/web/src/components/Button.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+
 import { twMerge } from 'tailwind-merge';
 
 // This value is selected based on appropriate size given most labels in most languages.

--- a/web/src/components/CarbonIntensitySquare.stories.ts
+++ b/web/src/components/CarbonIntensitySquare.stories.ts
@@ -1,4 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react';
+
 import CarbonIntensitySquare from './CarbonIntensitySquare';
 
 const meta: Meta<typeof CarbonIntensitySquare> = {

--- a/web/src/components/CarbonIntensitySquare.tsx
+++ b/web/src/components/CarbonIntensitySquare.tsx
@@ -1,7 +1,8 @@
 import { animated, useSpring } from '@react-spring/web';
 import { useTranslation } from 'translation/translation';
-import { useCo2ColorScale } from '../hooks/theme';
 import { CarbonUnits } from 'utils/units';
+
+import { useCo2ColorScale } from '../hooks/theme';
 
 /**
  * This function finds the optimal text color based on a custom formula

--- a/web/src/components/CircularGauge.tsx
+++ b/web/src/components/CircularGauge.tsx
@@ -1,4 +1,5 @@
 import { Label, Pie, PieChart } from 'recharts';
+
 import TooltipWrapper from './tooltips/TooltipWrapper';
 
 const PIE_START_ANGLE = 90;

--- a/web/src/components/TimeSlider.stories.tsx
+++ b/web/src/components/TimeSlider.stories.tsx
@@ -1,6 +1,7 @@
+import { useEffect, useState } from 'react';
+
 import type { Meta, StoryObj } from '@storybook/react';
 
-import { useEffect, useState } from 'react';
 import {
   TimeSliderBasic,
   TimeSliderProps,

--- a/web/src/components/Toast.tsx
+++ b/web/src/components/Toast.tsx
@@ -1,5 +1,6 @@
-import * as ToastPrimitive from '@radix-ui/react-toast';
 import { useState } from 'react';
+
+import * as ToastPrimitive from '@radix-ui/react-toast';
 
 type Props = {
   title: string;

--- a/web/src/components/ToggleButton.tsx
+++ b/web/src/components/ToggleButton.tsx
@@ -1,3 +1,5 @@
+import { ReactElement, useState } from 'react';
+
 import {
   Item as ToggleGroupItem,
   Root as ToggleGroupRoot,
@@ -9,8 +11,8 @@ import {
   Root as TooltipRoot,
   Trigger as TooltipTrigger,
 } from '@radix-ui/react-tooltip';
-import { ReactElement, useState } from 'react';
 import { twMerge } from 'tailwind-merge';
+
 import { useTranslation } from '../translation/translation';
 
 interface ToggleButtonProperties {

--- a/web/src/components/ZoneName.tsx
+++ b/web/src/components/ZoneName.tsx
@@ -1,6 +1,7 @@
+import { twMerge } from 'tailwind-merge';
+
 import { CountryFlag } from './Flag';
 import { getShortenedZoneNameWithCountry } from '../translation/translation';
-import { twMerge } from 'tailwind-merge';
 
 export function ZoneName({ zone, textStyle }: { zone: string; textStyle?: string }) {
   return (

--- a/web/src/components/legend/Co2Legend.tsx
+++ b/web/src/components/legend/Co2Legend.tsx
@@ -1,8 +1,10 @@
-import { useCo2ColorScale } from 'hooks/theme';
 import type { ReactElement } from 'react';
+
+import { useCo2ColorScale } from 'hooks/theme';
 import { useTranslation } from 'translation/translation';
-import HorizontalColorbar from './ColorBar';
 import { CarbonUnits } from 'utils/units';
+
+import HorizontalColorbar from './ColorBar';
 
 function LegendItem({
   label,

--- a/web/src/components/legend/ColorBar.tsx
+++ b/web/src/components/legend/ColorBar.tsx
@@ -1,5 +1,5 @@
-import { ScaleLinear, scaleLinear } from 'd3-scale';
 import { extent } from 'd3-array';
+import { ScaleLinear, scaleLinear } from 'd3-scale';
 
 const spreadOverDomain = (scale: any, count: number) => {
   const [x1, x2] = (extent(scale.domain()) as unknown as [number, number]) ?? [0, 0];

--- a/web/src/components/legend/LegendContainer.tsx
+++ b/web/src/components/legend/LegendContainer.tsx
@@ -1,11 +1,13 @@
-import { useAtom } from 'jotai';
 import type { ReactElement } from 'react';
+
+import { useAtom } from 'jotai';
 import { ToggleOptions } from 'utils/constants';
 import {
   selectedDatetimeIndexAtom,
   solarLayerEnabledAtom,
   windLayerAtom,
 } from 'utils/state/atoms';
+
 import Co2Legend from './Co2Legend';
 import SolarLegend from './SolarLegend';
 import WindLegend from './WindLegend';

--- a/web/src/components/legend/SolarLegend.tsx
+++ b/web/src/components/legend/SolarLegend.tsx
@@ -1,5 +1,7 @@
 import type { ReactElement } from 'react';
+
 import { useTranslation } from 'translation/translation';
+
 import HorizontalColorbar from './ColorBar';
 import { solarColor } from '../../features/weather-layers/solar/utils';
 

--- a/web/src/components/legend/WindLegend.tsx
+++ b/web/src/components/legend/WindLegend.tsx
@@ -1,7 +1,9 @@
 import type { ReactElement } from 'react';
-import { useTranslation } from 'translation/translation';
-import HorizontalColorbar from './ColorBar';
+
 import { windColor } from 'features/weather-layers/wind-layer/scales';
+import { useTranslation } from 'translation/translation';
+
+import HorizontalColorbar from './ColorBar';
 
 function LegendItem({
   label,

--- a/web/src/components/modals/OnboardingModal.cy.tsx
+++ b/web/src/components/modals/OnboardingModal.cy.tsx
@@ -1,4 +1,5 @@
 import { BrowserRouter } from 'react-router-dom';
+
 import { OnboardingModal } from './OnboardingModal';
 
 it('mounts', () => {

--- a/web/src/components/modals/OnboardingModal.tsx
+++ b/web/src/components/modals/OnboardingModal.tsx
@@ -1,7 +1,7 @@
+import { useAtom } from 'jotai';
 import { resolvePath, useSearchParams } from 'react-router-dom';
 import { hasOnboardingBeenSeenAtom } from 'utils/state/atoms';
 
-import { useAtom } from 'jotai';
 import Modal from './OnboardingModalInner';
 
 const views = [

--- a/web/src/components/tooltips/MobileTooltipWrapper.tsx
+++ b/web/src/components/tooltips/MobileTooltipWrapper.tsx
@@ -1,5 +1,6 @@
-import * as Tooltip from '@radix-ui/react-tooltip';
 import { ReactElement, useState } from 'react';
+
+import * as Tooltip from '@radix-ui/react-tooltip';
 import { twMerge } from 'tailwind-merge';
 
 interface MobileTooltipWrapperProperties {

--- a/web/src/components/tooltips/TooltipWrapper.tsx
+++ b/web/src/components/tooltips/TooltipWrapper.tsx
@@ -1,5 +1,6 @@
-import * as Tooltip from '@radix-ui/react-tooltip';
 import { ReactElement } from 'react';
+
+import * as Tooltip from '@radix-ui/react-tooltip';
 import { twMerge } from 'tailwind-merge';
 
 interface TooltipWrapperProperties {

--- a/web/src/features/charts/BreakdownChart.stories.ts
+++ b/web/src/features/charts/BreakdownChart.stories.ts
@@ -1,11 +1,12 @@
 import type { Meta, StoryObj } from '@storybook/react';
+import { zoneDetailMock } from 'stories/mockData';
+import { EnergyUnits } from 'utils/units';
+
+import AreaGraph from './elements/AreaGraph';
+import { getLayerFill } from './hooks/useBreakdownChartData';
 import { colors } from '../../hooks/colors';
 import { getCo2ColorScale } from '../../hooks/theme';
 import { TimeAverages } from '../../utils/constants';
-import AreaGraph from './elements/AreaGraph';
-import { getLayerFill } from './hooks/useBreakdownChartData';
-import { zoneDetailMock } from 'stories/mockData';
-import { EnergyUnits } from 'utils/units';
 
 const meta: Meta<typeof AreaGraph> = {
   title: 'charts/BreakdownChart',

--- a/web/src/features/charts/BreakdownChart.tsx
+++ b/web/src/features/charts/BreakdownChart.tsx
@@ -1,12 +1,13 @@
+import { max, sum } from 'd3-array';
 import { useTranslation } from 'translation/translation';
 import { Mode, TimeAverages } from 'utils/constants';
+import { formatCo2 } from 'utils/formatting';
+
 import { ChartTitle } from './ChartTitle';
 import AreaGraph from './elements/AreaGraph';
 import { noop } from './graphUtils';
 import useBreakdownChartData from './hooks/useBreakdownChartData';
 import BreakdownChartTooltip from './tooltips/BreakdownChartTooltip';
-import { formatCo2 } from 'utils/formatting';
-import { max, sum } from 'd3-array';
 
 interface BreakdownChartProps {
   displayByEmissions: boolean;

--- a/web/src/features/charts/CarbonChart.tsx
+++ b/web/src/features/charts/CarbonChart.tsx
@@ -1,4 +1,5 @@
 import { TimeAverages } from 'utils/constants';
+
 import { ChartTitle } from './ChartTitle';
 import AreaGraph from './elements/AreaGraph';
 import { noop } from './graphUtils';

--- a/web/src/features/charts/EmissionChart.tsx
+++ b/web/src/features/charts/EmissionChart.tsx
@@ -1,8 +1,8 @@
 import { TimeAverages } from 'utils/constants';
+import { formatCo2 } from 'utils/formatting';
+
 import { ChartTitle } from './ChartTitle';
 import AreaGraph from './elements/AreaGraph';
-
-import { formatCo2 } from 'utils/formatting';
 import { noop } from './graphUtils';
 import { useEmissionChartData } from './hooks/useEmissionChartData';
 import EmissionChartTooltip from './tooltips/EmissionChartTooltip';

--- a/web/src/features/charts/NetExchangeChart.tsx
+++ b/web/src/features/charts/NetExchangeChart.tsx
@@ -1,12 +1,13 @@
+import { useAtom } from 'jotai';
 import { TimeAverages } from 'utils/constants';
+import { formatCo2 } from 'utils/formatting';
+import { displayByEmissionsAtom, productionConsumptionAtom } from 'utils/state/atoms';
+
 import { ChartTitle } from './ChartTitle';
 import AreaGraph from './elements/AreaGraph';
 import { noop } from './graphUtils';
 import { useNetExchangeChartData } from './hooks/useNetExchangeChartData';
 import NetExchangeChartTooltip from './tooltips/NetExchangeChartTooltip';
-import { useAtom } from 'jotai';
-import { displayByEmissionsAtom, productionConsumptionAtom } from 'utils/state/atoms';
-import { formatCo2 } from 'utils/formatting';
 
 interface NetExchangeChartProps {
   datetimes: Date[];

--- a/web/src/features/charts/PriceChart.stories.ts
+++ b/web/src/features/charts/PriceChart.stories.ts
@@ -1,9 +1,10 @@
 import type { Meta, StoryObj } from '@storybook/react';
-import { TimeAverages } from '../../utils/constants';
-import AreaGraph from './elements/AreaGraph';
-import { getFills } from './hooks/usePriceChartData';
 import { zoneDetailMock } from 'stories/mockData';
 import { EnergyUnits } from 'utils/units';
+
+import AreaGraph from './elements/AreaGraph';
+import { getFills } from './hooks/usePriceChartData';
+import { TimeAverages } from '../../utils/constants';
 
 const meta: Meta<typeof AreaGraph> = {
   title: 'charts/PriceChart',

--- a/web/src/features/charts/PriceChart.tsx
+++ b/web/src/features/charts/PriceChart.tsx
@@ -1,5 +1,6 @@
 import { useTranslation } from 'translation/translation';
 import { TimeAverages } from 'utils/constants';
+
 import { ChartTitle } from './ChartTitle';
 import AreaGraph from './elements/AreaGraph';
 import { noop } from './graphUtils';

--- a/web/src/features/charts/bar-breakdown/BarBreakdownChart.tsx
+++ b/web/src/features/charts/bar-breakdown/BarBreakdownChart.tsx
@@ -1,19 +1,21 @@
+import React, { useState } from 'react';
+
 import * as Portal from '@radix-ui/react-portal';
 import { getOffsetTooltipPosition } from 'components/tooltips/utilities';
 import { useAtom } from 'jotai';
-import React, { useState } from 'react';
 import { HiXMark } from 'react-icons/hi2';
 import { useTranslation } from 'translation/translation';
 import { ElectricityModeType, ZoneDetail, ZoneKey } from 'types';
 import { displayByEmissionsAtom } from 'utils/state/atoms';
 import { useBreakpoint } from 'utils/styling';
 import { useReferenceWidthHeightObserver } from 'utils/viewport';
-import useBarBreakdownChartData from '../hooks/useBarElectricityBreakdownChartData';
-import BreakdownChartTooltip from '../tooltips/BreakdownChartTooltip';
+
 import BarBreakdownEmissionsChart from './BarBreakdownEmissionsChart';
 import BarElectricityBreakdownChart from './BarElectricityBreakdownChart';
-import EmptyBarBreakdownChart from './EmptyBarBreakdownChart';
 import BySource from './elements/BySource';
+import EmptyBarBreakdownChart from './EmptyBarBreakdownChart';
+import useBarBreakdownChartData from '../hooks/useBarElectricityBreakdownChartData';
+import BreakdownChartTooltip from '../tooltips/BreakdownChartTooltip';
 
 const X_PADDING = 9;
 

--- a/web/src/features/charts/bar-breakdown/BarBreakdownEmissionsChart.stories.ts
+++ b/web/src/features/charts/bar-breakdown/BarBreakdownEmissionsChart.stories.ts
@@ -1,7 +1,8 @@
 import type { Meta, StoryObj } from '@storybook/react';
+import { zoneDetailMock } from 'stories/mockData';
+
 import BarBreakdownEmissionsChart from './BarBreakdownEmissionsChart';
 import type { ExchangeDataType, ProductionDataType } from './utils';
-import { zoneDetailMock } from 'stories/mockData';
 
 const meta: Meta<typeof BarBreakdownEmissionsChart> = {
   title: 'charts/BarBreakdownEmissionsChart',

--- a/web/src/features/charts/bar-breakdown/BarBreakdownEmissionsChart.tsx
+++ b/web/src/features/charts/bar-breakdown/BarBreakdownEmissionsChart.tsx
@@ -1,12 +1,13 @@
+import { useMemo } from 'react';
+
 import { CountryFlag } from 'components/Flag';
 import { max as d3Max } from 'd3-array';
-
 import { scaleLinear } from 'd3-scale';
-import { useMemo } from 'react';
 import { useTranslation } from 'translation/translation';
 import { ElectricityModeType, ZoneDetail, ZoneKey } from 'types';
 import { modeColor } from 'utils/constants';
 import { formatCo2 } from 'utils/formatting';
+
 import { LABEL_MAX_WIDTH, PADDING_X } from './constants';
 import Axis from './elements/Axis';
 import HorizontalBar from './elements/HorizontalBar';

--- a/web/src/features/charts/bar-breakdown/BarElectricityBreakdownChart.stories.ts
+++ b/web/src/features/charts/bar-breakdown/BarElectricityBreakdownChart.stories.ts
@@ -1,8 +1,9 @@
 import type { Meta, StoryObj } from '@storybook/react';
-import BarElectricityBreakdownChart from './BarElectricityBreakdownChart';
-import type { ZoneDetails } from 'types';
-import { ExchangeDataType, ProductionDataType } from './utils';
 import { zoneDetailMock } from 'stories/mockData';
+import type { ZoneDetails } from 'types';
+
+import BarElectricityBreakdownChart from './BarElectricityBreakdownChart';
+import { ExchangeDataType, ProductionDataType } from './utils';
 
 const meta: Meta<typeof BarElectricityBreakdownChart> = {
   title: 'charts/BarElectricityBreakdownChart',

--- a/web/src/features/charts/bar-breakdown/BarElectricityBreakdownChart.tsx
+++ b/web/src/features/charts/bar-breakdown/BarElectricityBreakdownChart.tsx
@@ -1,13 +1,14 @@
+import { useMemo } from 'react';
+
 import { CountryFlag } from 'components/Flag';
 import { max as d3Max, min as d3Min } from 'd3-array';
-
 import { scaleLinear } from 'd3-scale';
 import { useCo2ColorScale } from 'hooks/theme';
-import { useMemo } from 'react';
 import { useTranslation } from 'translation/translation';
 import { ElectricityModeType, ZoneDetail, ZoneDetails, ZoneKey } from 'types';
 import { modeColor } from 'utils/constants';
 import { formatEnergy } from 'utils/formatting';
+
 import { LABEL_MAX_WIDTH, PADDING_X } from './constants';
 import Axis from './elements/Axis';
 import HorizontalBar from './elements/HorizontalBar';

--- a/web/src/features/charts/bar-breakdown/EmptyBarBreakdownChart.stories.ts
+++ b/web/src/features/charts/bar-breakdown/EmptyBarBreakdownChart.stories.ts
@@ -1,4 +1,5 @@
 import { Meta, StoryObj } from '@storybook/react';
+
 import EmptyBarBreakdownChart from './EmptyBarBreakdownChart';
 
 const meta: Meta<typeof EmptyBarBreakdownChart> = {

--- a/web/src/features/charts/bar-breakdown/EmptyBarBreakdownChart.tsx
+++ b/web/src/features/charts/bar-breakdown/EmptyBarBreakdownChart.tsx
@@ -1,13 +1,15 @@
-import { scaleLinear } from 'd3-scale';
 import { useMemo } from 'react';
+
+import { scaleLinear } from 'd3-scale';
 import { useTranslation } from 'translation/translation';
 import { modeOrder } from 'utils/constants';
+import { PowerUnits } from 'utils/units';
+
 import { LABEL_MAX_WIDTH, PADDING_X } from './constants';
 import Axis from './elements/Axis';
 import HorizontalBar from './elements/HorizontalBar';
 import Row from './elements/Row';
 import { getDataBlockPositions } from './utils';
-import { PowerUnits } from 'utils/units';
 
 interface EmptyBarBreakdownChartProps {
   height: number;

--- a/web/src/features/charts/bar-breakdown/elements/Axis.tsx
+++ b/web/src/features/charts/bar-breakdown/elements/Axis.tsx
@@ -1,4 +1,5 @@
 import { ScaleLinear } from 'd3-scale';
+
 import { LABEL_MAX_WIDTH, SCALE_TICKS, X_AXIS_HEIGHT } from '../constants';
 
 type Props = {

--- a/web/src/features/charts/bar-breakdown/elements/HorizontalBar.tsx
+++ b/web/src/features/charts/bar-breakdown/elements/HorizontalBar.tsx
@@ -1,5 +1,6 @@
 import { ScaleLinear } from 'd3-scale';
 import { Maybe } from 'types';
+
 import { LABEL_MAX_WIDTH, RECT_OPACITY, ROW_HEIGHT } from '../constants';
 
 type Props = {

--- a/web/src/features/charts/bar-breakdown/elements/Row.tsx
+++ b/web/src/features/charts/bar-breakdown/elements/Row.tsx
@@ -1,7 +1,9 @@
-import { ScaleLinear } from 'd3-scale';
 import { MouseEventHandler } from 'react';
-import { LABEL_MAX_WIDTH, PADDING_Y, ROW_HEIGHT, TEXT_ADJUST_Y } from '../constants';
+
+import { ScaleLinear } from 'd3-scale';
 import type { Maybe } from 'types';
+
+import { LABEL_MAX_WIDTH, PADDING_Y, ROW_HEIGHT, TEXT_ADJUST_Y } from '../constants';
 
 type Props = {
   children: React.ReactNode;

--- a/web/src/features/charts/bar-breakdown/utils.test.ts
+++ b/web/src/features/charts/bar-breakdown/utils.test.ts
@@ -1,3 +1,5 @@
+import { Mode } from 'utils/constants';
+
 import {
   getDataBlockPositions,
   getProductionData,
@@ -7,7 +9,6 @@ import {
   getExchangeData,
   getExchangeCo2Intensity,
 } from './utils';
-import { Mode } from 'utils/constants';
 
 const zoneDetailsData = {
   co2intensity: 187.32,

--- a/web/src/features/charts/bar-breakdown/utils.ts
+++ b/web/src/features/charts/bar-breakdown/utils.ts
@@ -9,6 +9,7 @@ import {
 } from 'types';
 import { Mode, modeOrder } from 'utils/constants';
 import { getProductionCo2Intensity } from 'utils/helpers';
+
 import exchangesToExclude from '../../../../config/excludedAggregatedExchanges.json';
 
 const LABEL_MAX_WIDTH = 102;

--- a/web/src/features/charts/elements/AreaGraph.tsx
+++ b/web/src/features/charts/elements/AreaGraph.tsx
@@ -1,22 +1,24 @@
 /* eslint-disable unicorn/no-null */
 /* eslint-disable react/display-name */
+import React, { useMemo, useState } from 'react';
+
 import { scaleLinear } from 'd3-scale';
 import { stack, stackOffsetDiverging } from 'd3-shape';
 import TimeAxis from 'features/time/TimeAxis'; // TODO: Move to a shared folder
 import { useAtom } from 'jotai';
-import React, { useMemo, useState } from 'react';
 import { ZoneDetail } from 'types';
 import { TimeAverages } from 'utils/constants';
 import { selectedDatetimeIndexAtom } from 'utils/state/atoms';
 import { useBreakpoint } from 'utils/styling';
 import { useReferenceWidthHeightObserver } from 'utils/viewport';
-import { getTimeScale, isEmpty } from '../graphUtils';
-import AreaGraphTooltip from '../tooltips/AreaGraphTooltip';
-import { AreaGraphElement, FillFunction, InnerAreaGraphTooltipProps } from '../types';
+
 import AreaGraphLayers from './AreaGraphLayers';
 import GraphBackground from './GraphBackground';
 import GraphHoverLine from './GraphHoverline';
 import ValueAxis from './ValueAxis';
+import { getTimeScale, isEmpty } from '../graphUtils';
+import AreaGraphTooltip from '../tooltips/AreaGraphTooltip';
+import { AreaGraphElement, FillFunction, InnerAreaGraphTooltipProps } from '../types';
 
 const X_AXIS_HEIGHT = 20;
 const Y_AXIS_WIDTH = 40;

--- a/web/src/features/charts/elements/AreaGraphLayers.tsx
+++ b/web/src/features/charts/elements/AreaGraphLayers.tsx
@@ -1,11 +1,13 @@
 /* eslint-disable unicorn/no-null */
 /* eslint-disable react/jsx-handler-names */
-import { area, curveStepAfter } from 'd3-shape';
 import React from 'react';
+
+import { area, curveStepAfter } from 'd3-shape';
+import { ElectricityModeType } from 'types';
+import { modeColor } from 'utils/constants';
+
 import { detectHoveredDatapointIndex, getNextDatetime, noop } from '../graphUtils';
 import { AreaGraphElement } from '../types';
-import { modeColor } from 'utils/constants';
-import { ElectricityModeType } from 'types';
 
 interface AreaGraphLayersProps {
   layers: any[];

--- a/web/src/features/charts/elements/GraphBackground.tsx
+++ b/web/src/features/charts/elements/GraphBackground.tsx
@@ -2,6 +2,7 @@
 /* eslint-disable unicorn/no-null */
 /* eslint-disable react/display-name */
 import React from 'react';
+
 import { detectHoveredDatapointIndex, noop } from '../graphUtils';
 
 const GraphBackground = React.memo(

--- a/web/src/features/charts/elements/ValueAxis.tsx
+++ b/web/src/features/charts/elements/ValueAxis.tsx
@@ -1,6 +1,7 @@
 /* eslint-disable react/display-name */
-import { ScaleLinear } from 'd3-scale';
 import React from 'react';
+
+import { ScaleLinear } from 'd3-scale';
 
 interface ValueAxisProps {
   scale: ScaleLinear<number, number, never>;

--- a/web/src/features/charts/graphUtils.test.ts
+++ b/web/src/features/charts/graphUtils.test.ts
@@ -1,11 +1,12 @@
+import { ZoneDetail } from 'types';
 import { Mode } from 'utils/constants';
+
 import {
   getElectricityProductionValue,
   getRatioPercent,
   getTotalEmissions,
   getTotalElectricity,
 } from './graphUtils';
-import { ZoneDetail } from 'types';
 
 describe('getRatioPercent', () => {
   it('handles 0 of 0', () => {

--- a/web/src/features/charts/hooks/useBarElectricityBreakdownChartData.ts
+++ b/web/src/features/charts/hooks/useBarElectricityBreakdownChartData.ts
@@ -7,6 +7,7 @@ import {
   selectedDatetimeIndexAtom,
   spatialAggregateAtom,
 } from 'utils/state/atoms';
+
 import {
   getDataBlockPositions,
   getExchangeData,

--- a/web/src/features/charts/hooks/useBreakdownChartData.ts
+++ b/web/src/features/charts/hooks/useBreakdownChartData.ts
@@ -3,14 +3,13 @@ import { max as d3Max } from 'd3-array';
 import type { ScaleLinear } from 'd3-scale';
 import { useCo2ColorScale } from 'hooks/theme';
 import { useAtom } from 'jotai';
+import { useParams } from 'react-router-dom';
 import {
   ElectricityModeType,
   ElectricityStorageKeyType,
   ElectricityStorageType,
   ZoneDetail,
 } from 'types';
-
-import { useParams } from 'react-router-dom';
 import { Mode, SpatialAggregate, modeColor, modeOrder } from 'utils/constants';
 import { scalePower } from 'utils/formatting';
 import {
@@ -18,6 +17,7 @@ import {
   productionConsumptionAtom,
   spatialAggregateAtom,
 } from 'utils/state/atoms';
+
 import { getExchangesToDisplay } from '../bar-breakdown/utils';
 import {
   getGenerationTypeKey,

--- a/web/src/features/charts/hooks/useCarbonChartData.ts
+++ b/web/src/features/charts/hooks/useCarbonChartData.ts
@@ -1,9 +1,9 @@
 import useGetZone from 'api/getZone';
 import { useCo2ColorScale } from 'hooks/theme';
-
 import { useAtom } from 'jotai';
 import { getCO2IntensityByMode } from 'utils/helpers';
 import { productionConsumptionAtom } from 'utils/state/atoms';
+
 import { AreaGraphElement } from '../types';
 
 export function useCarbonChartData() {

--- a/web/src/features/charts/hooks/useEmissionChartData.ts
+++ b/web/src/features/charts/hooks/useEmissionChartData.ts
@@ -3,6 +3,7 @@ import { max as d3Max } from 'd3-array';
 import { scaleLinear } from 'd3-scale';
 import { useAtom } from 'jotai';
 import { productionConsumptionAtom } from 'utils/state/atoms';
+
 import { getTotalEmissions } from '../graphUtils';
 import { AreaGraphElement } from '../types';
 

--- a/web/src/features/charts/hooks/useNetExchangeChartData.ts
+++ b/web/src/features/charts/hooks/useNetExchangeChartData.ts
@@ -1,12 +1,13 @@
 import useGetZone from 'api/getZone';
 import { max as d3Max, min as d3Min } from 'd3-array';
 import { scaleLinear } from 'd3-scale';
-import { AreaGraphElement } from '../types';
-import { getNetExchange, round } from 'utils/helpers';
+import { useAtom } from 'jotai';
 import { ZoneDetail } from 'types';
 import { scalePower } from 'utils/formatting';
+import { getNetExchange, round } from 'utils/helpers';
 import { displayByEmissionsAtom } from 'utils/state/atoms';
-import { useAtom } from 'jotai';
+
+import { AreaGraphElement } from '../types';
 
 export function getFills(data: AreaGraphElement[]) {
   const netExchangeMaxValue =

--- a/web/src/features/charts/hooks/usePriceChartData.ts
+++ b/web/src/features/charts/hooks/usePriceChartData.ts
@@ -2,8 +2,9 @@ import useGetZone from 'api/getZone';
 import getSymbolFromCurrency from 'currency-symbol-map';
 import { max as d3Max, min as d3Min } from 'd3-array';
 import { scaleLinear } from 'd3-scale';
-import { AreaGraphElement } from '../types';
 import { EnergyUnits } from 'utils/units';
+
+import { AreaGraphElement } from '../types';
 
 export function getFills(data: AreaGraphElement[]) {
   const priceMaxValue =

--- a/web/src/features/charts/tooltipCalculations.test.ts
+++ b/web/src/features/charts/tooltipCalculations.test.ts
@@ -1,6 +1,7 @@
 import { ZoneDetail } from 'types';
-import { getExchangeTooltipData, getProductionTooltipData } from './tooltipCalculations';
 import { Mode } from 'utils/constants';
+
+import { getExchangeTooltipData, getProductionTooltipData } from './tooltipCalculations';
 
 const zoneDetailsData = {
   _isFinestGranularity: true,

--- a/web/src/features/charts/tooltipCalculations.ts
+++ b/web/src/features/charts/tooltipCalculations.ts
@@ -4,13 +4,14 @@ import {
   GenerationType,
   ZoneDetail,
 } from 'types';
+import { Mode } from 'utils/constants';
 import { getProductionCo2Intensity } from 'utils/helpers';
+
 import {
   getElectricityProductionValue,
   getTotalEmissions,
   getTotalElectricity,
 } from './graphUtils';
-import { Mode } from 'utils/constants';
 
 export function getProductionTooltipData(
   selectedLayerKey: ElectricityModeType,

--- a/web/src/features/charts/tooltips/AreaGraphTooltip.tsx
+++ b/web/src/features/charts/tooltips/AreaGraphTooltip.tsx
@@ -1,7 +1,9 @@
-import * as Portal from '@radix-ui/react-portal';
 import type { ReactElement } from 'react';
+
+import * as Portal from '@radix-ui/react-portal';
 import { HiXMark } from 'react-icons/hi2';
 import { ZoneDetail } from 'types';
+
 import { getOffsetTooltipPosition } from '../../../components/tooltips/utilities';
 import { AreaGraphElement, InnerAreaGraphTooltipProps } from '../types';
 

--- a/web/src/features/charts/tooltips/BreakdownChartTooltip.stories.ts
+++ b/web/src/features/charts/tooltips/BreakdownChartTooltip.stories.ts
@@ -1,5 +1,6 @@
 import { Meta, StoryObj } from '@storybook/react';
 import { TimeAverages } from 'utils/constants';
+
 import { BreakdownChartTooltipContent } from './BreakdownChartTooltip';
 
 const meta: Meta<typeof BreakdownChartTooltipContent> = {

--- a/web/src/features/charts/tooltips/BreakdownChartTooltip.tsx
+++ b/web/src/features/charts/tooltips/BreakdownChartTooltip.tsx
@@ -13,10 +13,11 @@ import {
   productionConsumptionAtom,
   timeAverageAtom,
 } from 'utils/state/atoms';
+
+import AreaGraphToolTipHeader from './AreaGraphTooltipHeader';
 import { getGenerationTypeKey, getRatioPercent } from '../graphUtils';
 import { getExchangeTooltipData, getProductionTooltipData } from '../tooltipCalculations';
 import { InnerAreaGraphTooltipProps, LayerKey } from '../types';
-import AreaGraphToolTipHeader from './AreaGraphTooltipHeader';
 
 function calculateTooltipContentData(
   selectedLayerKey: LayerKey,

--- a/web/src/features/charts/tooltips/CarbonChartTooltip.stories.ts
+++ b/web/src/features/charts/tooltips/CarbonChartTooltip.stories.ts
@@ -1,6 +1,7 @@
 /* eslint-disable unicorn/no-null */
 import { Meta, StoryObj } from '@storybook/react';
 import { zoneDetailMock } from 'stories/mockData';
+
 import CarbonChartTooltip from './CarbonChartTooltip';
 
 const meta: Meta<typeof CarbonChartTooltip> = {

--- a/web/src/features/charts/tooltips/CarbonChartTooltip.tsx
+++ b/web/src/features/charts/tooltips/CarbonChartTooltip.tsx
@@ -6,8 +6,9 @@ import { useTranslation } from 'translation/translation';
 import { Mode } from 'utils/constants';
 import { getCarbonIntensity } from 'utils/helpers';
 import { productionConsumptionAtom, timeAverageAtom } from 'utils/state/atoms';
-import { InnerAreaGraphTooltipProps } from '../types';
+
 import AreaGraphToolTipHeader from './AreaGraphTooltipHeader';
+import { InnerAreaGraphTooltipProps } from '../types';
 
 export default function CarbonChartTooltip({ zoneDetail }: InnerAreaGraphTooltipProps) {
   const [timeAverage] = useAtom(timeAverageAtom);

--- a/web/src/features/charts/tooltips/ChartTooltips.cy.tsx
+++ b/web/src/features/charts/tooltips/ChartTooltips.cy.tsx
@@ -1,5 +1,6 @@
 import { zoneDetailMock } from 'stories/mockData';
 import { CarbonUnits } from 'utils/units';
+
 import BreakdownChartTooltip from './BreakdownChartTooltip';
 import CarbonChartTooltip from './CarbonChartTooltip';
 import EmissionChartTooltip from './EmissionChartTooltip';

--- a/web/src/features/charts/tooltips/EmissionChartTooltip.tsx
+++ b/web/src/features/charts/tooltips/EmissionChartTooltip.tsx
@@ -1,10 +1,11 @@
 import { useAtom } from 'jotai';
 import { useTranslation } from 'translation/translation';
+import { formatCo2 } from 'utils/formatting';
 import { productionConsumptionAtom, timeAverageAtom } from 'utils/state/atoms';
+
+import AreaGraphToolTipHeader from './AreaGraphTooltipHeader';
 import { getTotalEmissions } from '../graphUtils';
 import { InnerAreaGraphTooltipProps } from '../types';
-import AreaGraphToolTipHeader from './AreaGraphTooltipHeader';
-import { formatCo2 } from 'utils/formatting';
 
 export default function EmissionChartTooltip({ zoneDetail }: InnerAreaGraphTooltipProps) {
   const [timeAverage] = useAtom(timeAverageAtom);

--- a/web/src/features/charts/tooltips/NetExchangeChartTooltip.tsx
+++ b/web/src/features/charts/tooltips/NetExchangeChartTooltip.tsx
@@ -1,10 +1,11 @@
 import { useAtom } from 'jotai';
 import { useTranslation } from 'translation/translation';
+import { formatCo2, scalePower } from 'utils/formatting';
 import { getNetExchange, round } from 'utils/helpers';
 import { displayByEmissionsAtom, timeAverageAtom } from 'utils/state/atoms';
-import { InnerAreaGraphTooltipProps } from '../types';
+
 import AreaGraphToolTipHeader from './AreaGraphTooltipHeader';
-import { formatCo2, scalePower } from 'utils/formatting';
+import { InnerAreaGraphTooltipProps } from '../types';
 
 export default function NetExchangeChartTooltip({
   zoneDetail,

--- a/web/src/features/charts/tooltips/PriceChartTooltip.stories.ts
+++ b/web/src/features/charts/tooltips/PriceChartTooltip.stories.ts
@@ -1,6 +1,7 @@
 import { Meta, StoryObj } from '@storybook/react';
-import PriceChartTooltip from './PriceChartTooltip';
 import { zoneDetailMock } from 'stories/mockData';
+
+import PriceChartTooltip from './PriceChartTooltip';
 
 const meta: Meta<typeof PriceChartTooltip> = {
   title: 'tooltips/PriceChartTooltip',

--- a/web/src/features/charts/tooltips/PriceChartTooltip.tsx
+++ b/web/src/features/charts/tooltips/PriceChartTooltip.tsx
@@ -3,8 +3,9 @@ import { useAtom } from 'jotai';
 import { useTranslation } from 'translation/translation';
 import { timeAverageAtom } from 'utils/state/atoms';
 import { EnergyUnits } from 'utils/units';
-import { InnerAreaGraphTooltipProps } from '../types';
+
 import AreaGraphToolTipHeader from './AreaGraphTooltipHeader';
+import { InnerAreaGraphTooltipProps } from '../types';
 
 export default function PriceChartTooltip({ zoneDetail }: InnerAreaGraphTooltipProps) {
   const [timeAverage] = useAtom(timeAverageAtom);

--- a/web/src/features/exchanges/ExchangeArrow.tsx
+++ b/web/src/features/exchanges/ExchangeArrow.tsx
@@ -1,12 +1,14 @@
 /* eslint-disable unicorn/no-null */
+import { useEffect, useMemo } from 'react';
+
 import MobileTooltipWrapper from 'components/tooltips/MobileTooltipWrapper';
 import TooltipWrapper from 'components/tooltips/TooltipWrapper';
 import { mapMovingAtom } from 'features/map/mapAtoms';
 import { useSetAtom } from 'jotai';
-import { useEffect, useMemo } from 'react';
 import { MapboxMap } from 'react-map-gl';
 import { resolvePath } from 'react-router-dom';
 import { ExchangeArrowData } from 'types';
+
 import ExchangeTooltip from './ExchangeTooltip';
 import MobileExchangeTooltip from './MobileExchangeTooltip';
 import { quantizedCo2IntensityScale, quantizedExchangeSpeedScale } from './scales';

--- a/web/src/features/exchanges/ExchangeLayer.tsx
+++ b/web/src/features/exchanges/ExchangeLayer.tsx
@@ -1,10 +1,12 @@
+import React from 'react';
+
 import { mapMovingAtom } from 'features/map/mapAtoms';
-import { colorblindModeAtom } from 'utils/state/atoms';
 import { useExchangeArrowsData } from 'hooks/arrows';
 import { useAtom } from 'jotai';
-import React from 'react';
 import { MapboxMap } from 'react-map-gl';
+import { colorblindModeAtom } from 'utils/state/atoms';
 import { useReferenceWidthHeightObserver } from 'utils/viewport';
+
 import ExchangeArrow from './ExchangeArrow';
 
 function ExchangeLayer({ map }: { map?: MapboxMap }) {

--- a/web/src/features/exchanges/ExchangeTooltip.tsx
+++ b/web/src/features/exchanges/ExchangeTooltip.tsx
@@ -1,6 +1,7 @@
+import type { ReactElement } from 'react';
+
 import { CarbonIntensityDisplay } from 'components/CarbonIntensityDisplay';
 import { ZoneName } from 'components/ZoneName';
-import type { ReactElement } from 'react';
 import { useTranslation } from 'translation/translation';
 import { ExchangeArrowData } from 'types';
 import { formatEnergy } from 'utils/formatting';

--- a/web/src/features/exchanges/MobileExchangeTooltip.tsx
+++ b/web/src/features/exchanges/MobileExchangeTooltip.tsx
@@ -1,6 +1,7 @@
+import type { ReactElement } from 'react';
+
 import { CarbonIntensityDisplay } from 'components/CarbonIntensityDisplay';
 import { ZoneName } from 'components/ZoneName';
-import type { ReactElement } from 'react';
 import { useTranslation } from 'translation/translation';
 import { ExchangeArrowData } from 'types';
 import { formatEnergy } from 'utils/formatting';

--- a/web/src/features/feature-flags/FeatureFlagsManager.tsx
+++ b/web/src/features/feature-flags/FeatureFlagsManager.tsx
@@ -2,6 +2,7 @@ import * as Switch from '@radix-ui/react-switch';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { QUERY_KEYS } from 'api/helpers';
 import { useSearchParams } from 'react-router-dom';
+
 import { useFeatureFlags } from './api';
 import { FeatureFlags } from './types';
 

--- a/web/src/features/feature-flags/api.ts
+++ b/web/src/features/feature-flags/api.ts
@@ -1,5 +1,6 @@
 import { useQuery } from '@tanstack/react-query';
 import { QUERY_KEYS, getBasePath, getHeaders } from 'api/helpers';
+
 import { FeatureFlags } from './types';
 
 export async function getFeatureFlags(): Promise<FeatureFlags> {

--- a/web/src/features/header/Header.tsx
+++ b/web/src/features/header/Header.tsx
@@ -2,6 +2,7 @@ import { Capacitor } from '@capacitor/core';
 import * as NavigationMenu from '@radix-ui/react-navigation-menu';
 import { twMerge } from 'tailwind-merge';
 import trackEvent from 'utils/analytics';
+
 import Logo from './Logo';
 
 interface MenuLinkProps {

--- a/web/src/features/map-controls/ConsumptionProductionToggle.tsx
+++ b/web/src/features/map-controls/ConsumptionProductionToggle.tsx
@@ -1,6 +1,7 @@
+import type { ReactElement } from 'react';
+
 import ToggleButton from 'components/ToggleButton';
 import { useAtom } from 'jotai';
-import type { ReactElement } from 'react';
 import trackEvent from 'utils/analytics';
 import { Mode } from 'utils/constants';
 import { productionConsumptionAtom } from 'utils/state/atoms';

--- a/web/src/features/map-controls/LanguageSelector.tsx
+++ b/web/src/features/map-controls/LanguageSelector.tsx
@@ -1,7 +1,9 @@
 import { useState } from 'react';
+
 import { HiLanguage } from 'react-icons/hi2';
 import { languageNames } from 'translation/locales';
 import { useTranslation } from 'translation/translation';
+
 import MapButton from './MapButton';
 import MapOptionSelector from './MapOptionSelector';
 

--- a/web/src/features/map-controls/MapButton.tsx
+++ b/web/src/features/map-controls/MapButton.tsx
@@ -1,4 +1,5 @@
 import * as Toggle from '@radix-ui/react-toggle';
+
 import TooltipWrapper from '../../components/tooltips/TooltipWrapper';
 
 interface MapButtonProperties {

--- a/web/src/features/map-controls/MapControls.tsx
+++ b/web/src/features/map-controls/MapControls.tsx
@@ -18,6 +18,7 @@ import {
   windLayerAtom,
   windLayerLoadingAtom,
 } from 'utils/state/atoms';
+
 import ConsumptionProductionToggle from './ConsumptionProductionToggle';
 import { LanguageSelector } from './LanguageSelector';
 import MapButton from './MapButton';

--- a/web/src/features/map-controls/MapOptionSelector.tsx
+++ b/web/src/features/map-controls/MapOptionSelector.tsx
@@ -1,5 +1,6 @@
-import { Arrow, Content, Root, Trigger } from '@radix-ui/react-dropdown-menu';
 import { useState } from 'react';
+
+import { Arrow, Content, Root, Trigger } from '@radix-ui/react-dropdown-menu';
 import { twMerge } from 'tailwind-merge';
 import { useTranslation } from 'translation/translation';
 

--- a/web/src/features/map-controls/SpatialAggregatesToggle.tsx
+++ b/web/src/features/map-controls/SpatialAggregatesToggle.tsx
@@ -1,6 +1,7 @@
+import type { ReactElement } from 'react';
+
 import ToggleButton from 'components/ToggleButton';
 import { useAtom } from 'jotai';
-import type { ReactElement } from 'react';
 import trackEvent from 'utils/analytics';
 import { SpatialAggregate } from 'utils/constants';
 import { spatialAggregateAtom } from 'utils/state/atoms';

--- a/web/src/features/map-controls/ZoomControls.tsx
+++ b/web/src/features/map-controls/ZoomControls.tsx
@@ -1,4 +1,5 @@
 import { ReactElement } from 'react';
+
 import { NavigationControl } from 'react-map-gl';
 
 export default function ZoomControls(): ReactElement {

--- a/web/src/features/map/Map.tsx
+++ b/web/src/features/map/Map.tsx
@@ -1,9 +1,6 @@
-import mapboxgl from 'mapbox-gl';
-import maplibregl from 'maplibre-gl';
-import 'maplibre-gl/dist/maplibre-gl.css';
 import { ReactElement, useEffect, useMemo, useRef, useState } from 'react';
-import { Layer, Map, MapRef, Source } from 'react-map-gl';
-import { useCo2ColorScale, useTheme } from '../../hooks/theme';
+
+import 'maplibre-gl/dist/maplibre-gl.css';
 
 import useGetState from 'api/getState';
 import ExchangeLayer from 'features/exchanges/ExchangeLayer';
@@ -12,10 +9,14 @@ import { leftPanelOpenAtom } from 'features/panels/panelAtoms';
 import SolarLayer from 'features/weather-layers/solar/SolarLayer';
 import WindLayer from 'features/weather-layers/wind-layer/WindLayer';
 import { useAtom, useSetAtom } from 'jotai';
+import mapboxgl from 'mapbox-gl';
+import maplibregl from 'maplibre-gl';
+import { Layer, Map, MapRef, Source } from 'react-map-gl';
 import { matchPath, useLocation, useNavigate } from 'react-router-dom';
 import { Mode } from 'utils/constants';
 import { createToWithState, getCO2IntensityByMode } from 'utils/helpers';
 import { productionConsumptionAtom, selectedDatetimeIndexAtom } from 'utils/state/atoms';
+
 import CustomLayer from './map-utils/CustomLayer';
 import { useGetGeometries } from './map-utils/getMapGrid';
 import {
@@ -25,6 +26,7 @@ import {
   mousePositionAtom,
 } from './mapAtoms';
 import { FeatureId } from './mapTypes';
+import { useCo2ColorScale, useTheme } from '../../hooks/theme';
 
 const ZONE_SOURCE = 'zones-clickable';
 const SOUTHERN_LATITUDE_BOUND = -78;

--- a/web/src/features/map/MapTooltip.tsx
+++ b/web/src/features/map/MapTooltip.tsx
@@ -1,11 +1,10 @@
 import * as Portal from '@radix-ui/react-portal';
-import { useAtom } from 'jotai';
-
 import useGetState from 'api/getState';
 import CarbonIntensitySquare from 'components/CarbonIntensitySquare';
 import { CircularGauge } from 'components/CircularGauge';
-import { ZoneName } from 'components/ZoneName';
 import { getSafeTooltipPosition } from 'components/tooltips/utilities';
+import { ZoneName } from 'components/ZoneName';
+import { useAtom } from 'jotai';
 import { useTranslation } from 'translation/translation';
 import { StateZoneData } from 'types';
 import { Mode } from 'utils/constants';
@@ -16,6 +15,7 @@ import {
   selectedDatetimeIndexAtom,
   timeAverageAtom,
 } from 'utils/state/atoms';
+
 import { hoveredZoneAtom, mapMovingAtom, mousePositionAtom } from './mapAtoms';
 
 function TooltipInner({

--- a/web/src/features/map/MapWrapper.tsx
+++ b/web/src/features/map/MapWrapper.tsx
@@ -1,10 +1,12 @@
+import { useEffect } from 'react';
+
 import MapControls from 'features/map-controls/MapControls';
 import { useAtom } from 'jotai';
-import { useEffect } from 'react';
+
 import Map from './Map';
+import { loadingMapAtom } from './mapAtoms';
 import MapFallback, { isOldIOSVersion } from './MapFallback';
 import MapTooltip from './MapTooltip';
-import { loadingMapAtom } from './mapAtoms';
 
 export default function MapWrapper() {
   const shouldShowFallback = isOldIOSVersion();

--- a/web/src/features/map/map-utils/CustomLayer.tsx
+++ b/web/src/features/map/map-utils/CustomLayer.tsx
@@ -1,7 +1,8 @@
 /* eslint-disable unicorn/no-null */
 /* eslint-disable unicorn/consistent-function-scoping */
-import { IControl } from 'mapbox-gl';
 import React, { useState } from 'react';
+
+import { IControl } from 'mapbox-gl';
 import { MapboxMap, useControl } from 'react-map-gl';
 
 class OverlayControl implements IControl {

--- a/web/src/features/map/map-utils/generateTopos.ts
+++ b/web/src/features/map/map-utils/generateTopos.ts
@@ -2,6 +2,7 @@ import { multiPolygon } from '@turf/helpers';
 import { merge } from 'topojson-client';
 import { GeometryProperties, MapGeometries, MapTheme } from 'types';
 import { SpatialAggregate } from 'utils/constants';
+
 import topo from '../../../../config/world.json';
 // TODO: Investigate if we can move this step to buildtime geo scripts
 export interface TopoObject {

--- a/web/src/features/map/map-utils/getMapGrid.ts
+++ b/web/src/features/map/map-utils/getMapGrid.ts
@@ -1,7 +1,8 @@
+import { useMemo } from 'react';
+
 import generateTopos from 'features/map/map-utils/generateTopos';
 import { useTheme } from 'hooks/theme';
 import { useAtom } from 'jotai';
-import { useMemo } from 'react';
 import { MapGeometries } from 'types';
 import { spatialAggregateAtom } from 'utils/state/atoms';
 

--- a/web/src/features/map/mapAtoms.ts
+++ b/web/src/features/map/mapAtoms.ts
@@ -1,4 +1,5 @@
 import { atom } from 'jotai';
+
 import { HoveredZone } from './mapTypes';
 
 export const loadingMapAtom = atom(true);

--- a/web/src/features/modals/FAQModal.tsx
+++ b/web/src/features/modals/FAQModal.tsx
@@ -2,6 +2,7 @@ import Modal from 'components/Modal';
 import FAQContent from 'features/panels/faq/FAQContent';
 import { useAtom } from 'jotai';
 import { useTranslation } from 'translation/translation';
+
 import { isFAQModalOpenAtom } from './modalAtoms';
 
 export function FAQModalContent() {

--- a/web/src/features/modals/InfoModal.tsx
+++ b/web/src/features/modals/InfoModal.tsx
@@ -9,6 +9,7 @@ import {
   FaTwitter,
 } from 'react-icons/fa';
 import { useTranslation } from 'translation/translation';
+
 import { isFAQModalOpenAtom, isInfoModalOpenAtom } from './modalAtoms';
 
 const ICON_SIZE = 16;

--- a/web/src/features/modals/SettingsModal.tsx
+++ b/web/src/features/modals/SettingsModal.tsx
@@ -15,6 +15,7 @@ import {
   selectedDatetimeIndexAtom,
   timeAverageAtom,
 } from 'utils/state/atoms';
+
 import { isSettingsModalOpenAtom } from './modalAtoms';
 
 function WeatherToggleButton({

--- a/web/src/features/modals/TotalEnergyIntroModal.tsx
+++ b/web/src/features/modals/TotalEnergyIntroModal.tsx
@@ -1,12 +1,11 @@
-import {
-  hasOnboardingBeenSeenAtom,
-  hasTotalEnergyIntroBeenSeenAtom,
-} from 'utils/state/atoms';
-
 import Modal from 'components/Modal';
 import { useAtom } from 'jotai';
 import { resolvePath, useSearchParams } from 'react-router-dom';
 import { useTranslation } from 'translation/translation';
+import {
+  hasOnboardingBeenSeenAtom,
+  hasTotalEnergyIntroBeenSeenAtom,
+} from 'utils/state/atoms';
 
 export function InfoModalContent() {
   const { __ } = useTranslation();

--- a/web/src/features/panels/LeftPanel.tsx
+++ b/web/src/features/panels/LeftPanel.tsx
@@ -12,10 +12,10 @@ import {
   useSearchParams,
 } from 'react-router-dom';
 import { useTranslation } from 'translation/translation';
+
 import FAQPanel from './faq/FAQPanel';
 import { leftPanelOpenAtom } from './panelAtoms';
 import RankingPanel from './ranking-panel/RankingPanel';
-
 import ZoneDetails from './zone/ZoneDetails';
 
 function HandleLegacyRoutes() {

--- a/web/src/features/panels/faq/FAQPanel.tsx
+++ b/web/src/features/panels/faq/FAQPanel.tsx
@@ -1,8 +1,10 @@
 import { ReactElement } from 'react';
+
 import { HiArrowLeft } from 'react-icons/hi2';
 import { Link, useLocation, useNavigate } from 'react-router-dom';
-import { useTranslation } from '../../../translation/translation';
+
 import FAQContent from './FAQContent';
+import { useTranslation } from '../../../translation/translation';
 
 export default function FAQPanel(): ReactElement {
   const { __ } = useTranslation();

--- a/web/src/features/panels/ranking-panel/InfoText.tsx
+++ b/web/src/features/panels/ranking-panel/InfoText.tsx
@@ -1,5 +1,4 @@
 import { Link } from 'react-router-dom';
-
 import { useTranslation } from 'translation/translation';
 import { createToWithState } from 'utils/helpers';
 

--- a/web/src/features/panels/ranking-panel/RankingPanel.tsx
+++ b/web/src/features/panels/ranking-panel/RankingPanel.tsx
@@ -1,18 +1,20 @@
+import { ReactElement, useState } from 'react';
+
 import useGetState from 'api/getState';
 import { useCo2ColorScale } from 'hooks/theme';
 import { useAtom } from 'jotai';
-import { ReactElement, useState } from 'react';
 import {
   productionConsumptionAtom,
   selectedDatetimeIndexAtom,
   spatialAggregateAtom,
 } from 'utils/state/atoms';
-import { useTranslation } from '../../../translation/translation';
+
 import { getRankedState } from './getRankingPanelData';
 import InfoText from './InfoText';
 import SearchBar from './SearchBar';
 import SocialButtons from './SocialButtons';
 import ZoneList from './ZoneList';
+import { useTranslation } from '../../../translation/translation';
 
 export default function RankingPanel(): ReactElement {
   const { __ } = useTranslation();

--- a/web/src/features/panels/ranking-panel/ZoneList.tsx
+++ b/web/src/features/panels/ranking-panel/ZoneList.tsx
@@ -1,6 +1,7 @@
+import type { ReactElement } from 'react';
+
 import { CountryFlag } from 'components/Flag';
 import InternalLink from 'components/InternalLink';
-import type { ReactElement } from 'react';
 import { HiChevronRight } from 'react-icons/hi2';
 import { GridState } from 'types';
 

--- a/web/src/features/panels/ranking-panel/getRankingPanelData.ts
+++ b/web/src/features/panels/ranking-panel/getRankingPanelData.ts
@@ -1,9 +1,10 @@
 import { getCountryName, getZoneName } from 'translation/translation';
 import type { GridState, ZoneKey } from 'types';
+import { SpatialAggregate } from 'utils/constants';
 import { getCO2IntensityByMode } from 'utils/helpers';
+
 import { ZoneRowType } from './ZoneList';
 import { getHasSubZones } from '../zone/util';
-import { SpatialAggregate } from 'utils/constants';
 
 function filterZonesBySpatialAggregation(
   zoneKey: ZoneKey,

--- a/web/src/features/panels/zone/AreaGraphContainer.tsx
+++ b/web/src/features/panels/zone/AreaGraphContainer.tsx
@@ -1,10 +1,11 @@
 import BreakdownChart from 'features/charts/BreakdownChart';
 import CarbonChart from 'features/charts/CarbonChart';
 import EmissionChart from 'features/charts/EmissionChart';
+import NetExchangeChart from 'features/charts/NetExchangeChart';
 import PriceChart from 'features/charts/PriceChart';
 import { TimeAverages } from 'utils/constants';
+
 import Divider from './Divider';
-import NetExchangeChart from 'features/charts/NetExchangeChart';
 
 export default function AreaGraphContainer({
   datetimes,

--- a/web/src/features/panels/zone/Attribution.tsx
+++ b/web/src/features/panels/zone/Attribution.tsx
@@ -1,10 +1,12 @@
 import { useMemo } from 'react';
+
 import { useAtom } from 'jotai';
 import { useTranslation } from 'translation/translation';
-import { formatDataSources } from 'utils/formatting';
-import { getContributors } from './util';
-import { selectedDatetimeIndexAtom } from 'utils/state/atoms';
 import { ZoneDetails } from 'types';
+import { formatDataSources } from 'utils/formatting';
+import { selectedDatetimeIndexAtom } from 'utils/state/atoms';
+
+import { getContributors } from './util';
 export function removeDuplicateSources(source: string | undefined) {
   if (!source) {
     return [''];

--- a/web/src/features/panels/zone/DisplayByEmissionToggle.tsx
+++ b/web/src/features/panels/zone/DisplayByEmissionToggle.tsx
@@ -1,6 +1,7 @@
+import type { ReactElement } from 'react';
+
 import ToggleButton from 'components/ToggleButton';
 import { useAtom } from 'jotai';
-import type { ReactElement } from 'react';
 import trackEvent from 'utils/analytics';
 import { Mode, LeftPanelToggleOptions } from 'utils/constants';
 import { displayByEmissionsAtom, productionConsumptionAtom } from 'utils/state/atoms';

--- a/web/src/features/panels/zone/ZoneDetails.tsx
+++ b/web/src/features/panels/zone/ZoneDetails.tsx
@@ -1,7 +1,8 @@
+import { useEffect } from 'react';
+
 import useGetZone from 'api/getZone';
 import BarBreakdownChart from 'features/charts/bar-breakdown/BarBreakdownChart';
 import { useAtom } from 'jotai';
-import { useEffect } from 'react';
 import { Navigate, useParams } from 'react-router-dom';
 import { SpatialAggregate, TimeAverages } from 'utils/constants';
 import {
@@ -10,13 +11,14 @@ import {
   spatialAggregateAtom,
   timeAverageAtom,
 } from 'utils/state/atoms';
+
 import AreaGraphContainer from './AreaGraphContainer';
 import Attribution from './Attribution';
 import DisplayByEmissionToggle from './DisplayByEmissionToggle';
 import Divider from './Divider';
 import NoInformationMessage from './NoInformationMessage';
-import { ZoneHeaderGauges } from './ZoneHeaderGauges';
 import { ZoneDataStatus, getHasSubZones, getZoneDataStatus } from './util';
+import { ZoneHeaderGauges } from './ZoneHeaderGauges';
 import ZoneHeaderTitle from './ZoneHeaderTitle';
 
 export default function ZoneDetails(): JSX.Element {

--- a/web/src/features/panels/zone/ZoneHeaderGauges.tsx
+++ b/web/src/features/panels/zone/ZoneHeaderGauges.tsx
@@ -1,12 +1,12 @@
 import CarbonIntensitySquare from 'components/CarbonIntensitySquare';
 import { CircularGauge } from 'components/CircularGauge';
 import { useAtom } from 'jotai';
+import { HiExclamationTriangle } from 'react-icons/hi2';
 import { useTranslation } from 'translation/translation';
+import { ZoneDetails } from 'types';
 import { Mode } from 'utils/constants';
 import { getCarbonIntensity, getFossilFuelRatio, getRenewableRatio } from 'utils/helpers';
 import { productionConsumptionAtom, selectedDatetimeIndexAtom } from 'utils/state/atoms';
-import { ZoneDetails } from 'types';
-import { HiExclamationTriangle } from 'react-icons/hi2';
 
 function LowCarbonTooltip() {
   const { __ } = useTranslation();

--- a/web/src/features/panels/zone/ZoneHeaderTitle.tsx
+++ b/web/src/features/panels/zone/ZoneHeaderTitle.tsx
@@ -6,6 +6,7 @@ import { HiArrowLeft } from 'react-icons/hi2';
 import { Link } from 'react-router-dom';
 import { getCountryName, getZoneName, useTranslation } from 'translation/translation';
 import { createToWithState } from 'utils/helpers';
+
 import { getDisclaimer } from './util';
 
 interface ZoneHeaderTitleProps {

--- a/web/src/features/panels/zone/util.ts
+++ b/web/src/features/panels/zone/util.ts
@@ -1,4 +1,5 @@
 import { ZoneDetails } from 'types';
+
 import zonesConfigJSON from '../../../../config/zones.json'; // Todo: improve how to handle json configs
 
 type zoneConfigItem = {

--- a/web/src/features/time/TimeAxis.tsx
+++ b/web/src/features/time/TimeAxis.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from 'react-i18next';
 import PulseLoader from 'react-spinners/PulseLoader';
 import { TimeAverages } from 'utils/constants';
 import { useReferenceWidthHeightObserver } from 'utils/viewport';
+
 import { formatDateTick } from '../../utils/formatting';
 
 // Frequency at which values are displayed for a tick

--- a/web/src/features/time/TimeController.tsx
+++ b/web/src/features/time/TimeController.tsx
@@ -1,12 +1,14 @@
+import { useEffect, useMemo, useState } from 'react';
+
 import useGetState from 'api/getState';
 import TimeAverageToggle from 'components/TimeAverageToggle';
 import TimeSlider from 'components/TimeSlider';
 import { useAtom } from 'jotai';
-import { useEffect, useMemo, useState } from 'react';
 import trackEvent from 'utils/analytics';
 import { TimeAverages } from 'utils/constants';
 import { dateToDatetimeString } from 'utils/helpers';
 import { selectedDatetimeIndexAtom, timeAverageAtom } from 'utils/state/atoms';
+
 import TimeAxis from './TimeAxis';
 import TimeHeader from './TimeHeader';
 

--- a/web/src/features/time/TimeControllerWrapper.tsx
+++ b/web/src/features/time/TimeControllerWrapper.tsx
@@ -3,6 +3,7 @@ import { useAtom } from 'jotai';
 import { BottomSheet } from 'react-spring-bottom-sheet';
 import { hasOnboardingBeenSeenAtom } from 'utils/state/atoms';
 import { useBreakpoint } from 'utils/styling';
+
 import TimeController from './TimeController';
 import TimeHeader from './TimeHeader';
 

--- a/web/src/features/weather-layers/hooks.ts
+++ b/web/src/features/weather-layers/hooks.ts
@@ -1,8 +1,8 @@
+import { GfsForecastResponse, WeatherType } from 'api/getWeatherData';
 import { interpolate } from 'd3-interpolate';
 import { formatDistance } from 'date-fns';
-
-import { GfsForecastResponse, WeatherType } from 'api/getWeatherData';
 import { Maybe } from 'types';
+
 import { getReferenceTime, getTargetTime } from './grib';
 
 export function useInterpolatedData(

--- a/web/src/features/weather-layers/solar/SolarLayer.tsx
+++ b/web/src/features/weather-layers/solar/SolarLayer.tsx
@@ -1,8 +1,8 @@
+import { useEffect } from 'react';
+
 import { useGetSolar } from 'api/getWeatherData';
 import { mapMovingAtom } from 'features/map/mapAtoms';
 import { useAtom, useSetAtom } from 'jotai';
-
-import { useEffect } from 'react';
 import { MapboxMap } from 'react-map-gl';
 import { ToggleOptions } from 'utils/constants';
 import {
@@ -11,6 +11,7 @@ import {
   solarLayerLoadingAtom,
 } from 'utils/state/atoms';
 import { useReferenceWidthHeightObserver } from 'utils/viewport';
+
 import { stackBlurImageOpacity } from './stackBlurImageOpacity';
 import {
   opacityToSolarIntensity,

--- a/web/src/features/weather-layers/wind-layer/WindLayer.tsx
+++ b/web/src/features/weather-layers/wind-layer/WindLayer.tsx
@@ -1,7 +1,8 @@
+import { useEffect, useMemo, useState } from 'react';
+
 import { useGetWind } from 'api/getWeatherData';
 import { mapMovingAtom } from 'features/map/mapAtoms';
 import { useAtom, useSetAtom } from 'jotai';
-import { useEffect, useMemo, useState } from 'react';
 import { MapboxMap } from 'react-map-gl';
 import { Maybe } from 'types';
 import { ToggleOptions } from 'utils/constants';
@@ -11,6 +12,7 @@ import {
   windLayerLoadingAtom,
 } from 'utils/state/atoms';
 import { useReferenceWidthHeightObserver } from 'utils/viewport';
+
 import Windy from './windy';
 
 type WindyType = ReturnType<typeof Windy>;

--- a/web/src/features/weather-layers/wind-layer/windy.test.ts
+++ b/web/src/features/weather-layers/wind-layer/windy.test.ts
@@ -1,4 +1,5 @@
 import { round } from 'utils/helpers';
+
 import { bilinearInterpolateVector, windIntensityColorScale } from './windy';
 describe('windIntensityColorScale', () => {
   it('should return an array of colors', () => {

--- a/web/src/hooks/arrows.ts
+++ b/web/src/hooks/arrows.ts
@@ -1,7 +1,8 @@
 /* eslint-disable unicorn/no-array-reduce */
+import { useMemo } from 'react';
+
 import useGetState from 'api/getState';
 import { useAtom } from 'jotai';
-import { useMemo } from 'react';
 import { ExchangeArrowData, ExchangeResponse } from 'types';
 import { SpatialAggregate, TimeAverages } from 'utils/constants';
 import {
@@ -10,6 +11,7 @@ import {
   spatialAggregateAtom,
   timeAverageAtom,
 } from 'utils/state/atoms';
+
 import exchangesConfigJSON from '../../config/exchanges.json'; // do something globally
 import exchangesToExclude from '../../config/excludedAggregatedExchanges.json'; // do something globally
 

--- a/web/src/hooks/nightTimes.ts
+++ b/web/src/hooks/nightTimes.ts
@@ -1,3 +1,5 @@
+import { useEffect, useState } from 'react';
+
 import useGetZone from 'api/getZone';
 import {
   addDays,
@@ -10,7 +12,6 @@ import {
   subDays,
 } from 'date-fns';
 import { useGetGeometries } from 'features/map/map-utils/getMapGrid';
-import { useEffect, useState } from 'react';
 import { getSunrise, getSunset } from 'sunrise-sunset-js';
 import { getZoneFromPath } from 'utils/helpers';
 

--- a/web/src/hooks/theme.ts
+++ b/web/src/hooks/theme.ts
@@ -1,11 +1,13 @@
+import { useMemo } from 'react';
+
 import { scaleLinear } from 'd3-scale';
 import { useAtom } from 'jotai';
-import { useMemo } from 'react';
 import { MapTheme } from 'types';
-import { colors } from './colors';
-import { colorblindModeAtom, themeAtom } from 'utils/state/atoms';
-import { ThemeOptions } from 'utils/constants';
 import { useMediaQuery } from 'utils';
+import { ThemeOptions } from 'utils/constants';
+import { colorblindModeAtom, themeAtom } from 'utils/state/atoms';
+
+import { colors } from './colors';
 
 /**
  * This hook listens for changes to the selected theme or system appearance preferences

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -1,12 +1,13 @@
 import { StrictMode } from 'react';
+
 import * as Sentry from '@sentry/react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import App from 'App';
 import { createRoot } from 'react-dom/client';
 import { BrowserRouter } from 'react-router-dom';
 import { createConsoleGreeting } from 'utils/createConsoleGreeting';
-import { refetchDataOnHourChange } from 'utils/refetching';
 import enableErrorsInOverlay from 'utils/errorOverlay';
+import { refetchDataOnHourChange } from 'utils/refetching';
 //import { registerSW } from 'virtual:pwa-register';
 
 const isProduction = import.meta.env.PROD;

--- a/web/src/testing/setupTests.ts
+++ b/web/src/testing/setupTests.ts
@@ -1,5 +1,6 @@
 import '@testing-library/jest-dom';
 import mediaQuery from 'css-mediaquery';
+
 import server from './mocks/server';
 import { DESKTOP_RESOLUTION_HEIGHT, DESKTOP_RESOLUTION_WIDTH } from './testUtils';
 import 'whatwg-fetch';

--- a/web/src/testing/testUtils.tsx
+++ b/web/src/testing/testUtils.tsx
@@ -1,6 +1,7 @@
+import type { PropsWithChildren, ReactElement } from 'react';
+
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { render } from '@testing-library/react';
-import type { PropsWithChildren, ReactElement } from 'react';
 import { BrowserRouter } from 'react-router-dom';
 
 const queryClient = new QueryClient({

--- a/web/src/translation/translation.ts
+++ b/web/src/translation/translation.ts
@@ -1,5 +1,6 @@
 import { useTranslation as useTranslationHook } from 'react-i18next';
 import { vsprintf } from 'sprintf-js';
+
 import i18next from './i18n';
 
 // Todo: We should get rid of vsprintf and use i18next interpolation instead

--- a/web/src/utils/formatting.test.ts
+++ b/web/src/utils/formatting.test.ts
@@ -1,4 +1,5 @@
 import { removeDuplicateSources } from 'features/panels/zone/Attribution';
+
 import { formatCo2, formatDataSources, formatEnergy, formatPower } from './formatting';
 
 describe('formatEnergy', () => {

--- a/web/src/utils/formatting.ts
+++ b/web/src/utils/formatting.ts
@@ -1,4 +1,5 @@
 import * as d3 from 'd3-format';
+
 import { TimeAverages } from './constants';
 import { EnergyUnits } from './units';
 

--- a/web/src/utils/helpers.test.ts
+++ b/web/src/utils/helpers.test.ts
@@ -1,3 +1,5 @@
+import { zoneDetailMock } from 'stories/mockData';
+
 import {
   getCO2IntensityByMode,
   dateToDatetimeString,
@@ -6,8 +8,6 @@ import {
   getCarbonIntensity,
   getRenewableRatio,
 } from './helpers';
-
-import { zoneDetailMock } from 'stories/mockData';
 
 describe('getCO2IntensityByMode', () => {
   // Tests for consumption

--- a/web/src/utils/helpers.ts
+++ b/web/src/utils/helpers.ts
@@ -1,10 +1,10 @@
+import { useParams, useMatch } from 'react-router-dom';
 import {
   ElectricityModeType,
   ElectricityStorageKeyType,
   GenerationType,
   ZoneDetail,
 } from 'types';
-import { useParams, useMatch } from 'react-router-dom';
 
 export function getZoneFromPath() {
   const { zoneId } = useParams();

--- a/web/src/utils/refetching.ts
+++ b/web/src/utils/refetching.ts
@@ -1,5 +1,6 @@
 import type { QueryClient } from '@tanstack/react-query';
 import { ONE_MINUTE, QUERY_KEYS } from 'api/helpers';
+
 import { TimeAverages } from './constants';
 
 /**

--- a/web/src/utils/state/atoms.ts
+++ b/web/src/utils/state/atoms.ts
@@ -1,5 +1,6 @@
 import { atom } from 'jotai';
 import { atomWithStorage } from 'jotai/utils';
+
 import {
   Mode,
   SpatialAggregate,

--- a/web/src/utils/styling.test.ts
+++ b/web/src/utils/styling.test.ts
@@ -1,4 +1,5 @@
 import { act, renderHook } from '@testing-library/react';
+
 import { useMediaQuery } from './styling';
 
 const BELOW_MIN_WIDTH = 599;


### PR DESCRIPTION
## Issue
Manually sorted imports 📚 

We've started doing more import sorting in PRs, this is great but it can add extra noise for reviewers so I think it's nice to agree to a sorting pattern and apply it across the repo in one fell swoop.

## Description
This PR adds some sorting config to the eslintrc.

Sorting order is up for discussion so feel free to provide suggestions.

This is the most logic sorting pattern I could find online (it's not perfect, see node imports and non-relative internal imports and bundled with external imports. But consistent is better than perfect 🙏 )


### Double check

- [x] I have tested my parser changes locally with `poetry run test_parser "zone_key"`
- [x] I have run `pnpx prettier --write .` and `poetry run format` to format my changes.
