### PR TITLE
Refactor ZA parser

### DIFF
--- a/config/zones/ZA.yaml
+++ b/config/zones/ZA.yaml
@@ -216,5 +216,5 @@ isRenewable:
   unknown:
     value: 1
 parsers:
-  production: ZA.fetch_production
+  production: ESKOM.fetch_production
 timezone: Africa/Johannesburg

--- a/parsers/ESKOM.py
+++ b/parsers/ESKOM.py
@@ -71,6 +71,7 @@ def fetch_production(
             )
 
     res: Response = session.get(get_url())
+    breakpoint()
     if not res.ok:
         raise ParserException(
             "ZA.py",

--- a/parsers/ESKOM.py
+++ b/parsers/ESKOM.py
@@ -75,7 +75,7 @@ def fetch_production(
     res: Response = session.get(get_url())
     if not res.ok:
         raise ParserException(
-            "ZA.py",
+            "ESKOM.py",
             f"Exception when fetching production for {zone_key}: error when calling url={get_url()}",
             zone_key=zone_key,
         )

--- a/parsers/ZA.py
+++ b/parsers/ZA.py
@@ -13,6 +13,7 @@ from parsers.lib.exceptions import ParserException
 pp = PrettyPrinter(indent=4)
 
 TIMEZONE = "Africa/Johannesburg"
+SOURCE = "eskom.co.za"
 
 # Mapping columns to keys
 # Helpful: https://www.eskom.co.za/dataportal/glossary/
@@ -117,7 +118,7 @@ def fetch_production(
                 "datetime": returned_datetime,
                 "production": production,
                 "storage": storage,
-                "source": "eskom.co.za",
+                "source": SOURCE,
             }
         )
 


### PR DESCRIPTION
## Issue

Use new event datastructure for the ZA parser and match new parser names.

## Description

- Rename parser to ESKOM
- Use new parser event datastructure.

### Double check

- [ ] I have tested my parser changes locally with `poetry run test_parser "zone_key"`
- [ ] I have run `pnpx prettier --write .` and `poetry run format` to format my changes.
