### PR TITLE
remove disclaimer for JP-ON

### DIFF
--- a/config/zones/JP-ON.yaml
+++ b/config/zones/JP-ON.yaml
@@ -16,7 +16,6 @@ capacity:
   nuclear: 0
   oil: 189.78
   wind: 28
-disclaimer: The data provider (Okiden Electric Power Co.,Inc.) provides live data only for solar and unknown. We are working on improving the data quality for this zone.
 emissionFactors:
   lifecycle:
     unknown:


### PR DESCRIPTION
## Issue

After including an estimation method for JP-ON, we no longer need the disclaimer shown on the app that data is incomplete for this zone. 

## Description
We remove the disclaimer for JP-ON
### Preview
N/A
### Double check

- [X] I have tested my parser changes locally with `poetry run test_parser "zone_key"`
- [X] I have run `pnpx prettier --write .` and `poetry run format` to format my changes.
