### PR TITLE
Ensure modal is always closeable

### DIFF
--- a/web/src/components/Modal.tsx
+++ b/web/src/components/Modal.tsx
@@ -26,7 +26,7 @@ export default function Modal({
           // Avoid close button being auto-focused initially, as pressing space will otherwise close the modal
           onOpenAutoFocus={(event: Event) => event.preventDefault()}
           data-test-id={testId}
-          className={`fixed left-[50%] top-[50%] z-40 w-[98vw] max-w-2xl -translate-x-[50%] -translate-y-[50%] rounded-xl bg-white/90 shadow-md backdrop-blur-sm dark:bg-gray-800/90 sm:w-[90vw] ${
+          className={`fixed left-[50%] top-[50%] z-40 max-h-full w-[98vw] max-w-2xl -translate-x-[50%] -translate-y-[50%] rounded-xl bg-white/90 shadow-md backdrop-blur-sm dark:bg-gray-800/90 sm:w-[90vw] ${
             fullWidth ? 'p-0' : 'p-4'
           }`}
         >

--- a/web/src/features/modals/TotalEnergyIntroModal.tsx
+++ b/web/src/features/modals/TotalEnergyIntroModal.tsx
@@ -14,7 +14,7 @@ export function InfoModalContent() {
   return (
     <>
       <div
-        className={`block h-72 w-full rounded-t-xl bg-auto bg-top bg-no-repeat`}
+        className={`block w-full rounded-t-xl bg-auto bg-top bg-no-repeat xs:h-60 sm:h-72 md:h-80 lg:h-96`}
         style={{
           backgroundImage: `url("${image}")`,
           backgroundSize: `cover`,
@@ -27,7 +27,7 @@ export function InfoModalContent() {
         <h2 className="mb-2 text-base sm:text-xl">
           Now showing total electricity usage over time!
         </h2>
-        <div className="px-12 text-sm sm:text-base">
+        <div className="text-sm sm:px-12 sm:text-base">
           <p className="mb-4">
             Instead of showing average numbers for the daily, monthly and yearly periods,
             the app now displays the <strong>total amount of electricity</strong>{' '}

--- a/web/tailwind.config.cjs
+++ b/web/tailwind.config.cjs
@@ -1,3 +1,4 @@
+const defaultTheme = require('tailwindcss/defaultTheme');
 const defaultConfig = require('tailwindcss/defaultConfig');
 const formsPlugin = require('@tailwindcss/forms');
 const radix = require('tailwindcss-radix');
@@ -9,6 +10,9 @@ const config = {
   darkMode: 'class',
   theme: {
     extend: {
+      screens: {
+        xs: '475px',
+      },
       animation: {
         'slide-down': 'slide-down 0.3s cubic-bezier(0.87, 0, 0.13, 1)',
         'slide-up': 'slide-up 0.3s cubic-bezier(0.87, 0, 0.13, 1)',


### PR DESCRIPTION
## Issue

On small screens (iPhone SE) the new total intro modal cannot be closed.

## Description

This ensures that the close button is always visible (by setting a max-height on modals), and hides the image on small screens. Also scales up the size of it depending on screen size.

Note: I tried getting a scrollbar in place when content is higher than screen, but couldn't get it working in a nice way - so rolling with this first step for now.

### Preview

Now it should be closeable even on a watch!

![Screenshot 2023-09-14 at 10 11 38](https://github.com/electricitymaps/electricitymaps-contrib/assets/3296643/4ceb3783-aab6-4077-8966-05adcebad7c4)


### Double check

- [x] I have run `pnpx prettier --write .` and `poetry run format` to format my changes.
