### PR TITLE
Fix NP config

### DIFF
--- a/config/zones/NP.yaml
+++ b/config/zones/NP.yaml
@@ -1,8 +1,8 @@
 bounding_box:
-  - - 26.33196174127239
-    - 83.31609381672638
-  - - 29.2389869272311
-    - 84.17810344629932
+  - - 83.31609381672638
+    - 26.33196174127239
+  - - 84.17810344629932
+    - 29.2389869272311
 capacity:
   biomass: 0
   coal: 0
@@ -14,4 +14,4 @@ capacity:
   wind: 0
 contributors:
   - Subarna578
-timezone: America/Guatemala
+timezone: Asia/Kathmandu


### PR DESCRIPTION
## Issue

The Nepalese bounding box is inverted, timezone is not correct as well.

## Description

Well, fix that

### Preview

<!-- Please add screenshots and/or gif that shows visual changes (if applicable) -->

### Double check

- [ ] I have tested my parser changes locally with `poetry run test_parser "zone_key"`
- [ ] I have run `pnpx prettier --write .` and `poetry run format` to format my changes.
