### PR TITLE
set PH nuclear subzone capacity to 0

### DIFF
--- a/config/zones/PH-LU.yaml
+++ b/config/zones/PH-LU.yaml
@@ -10,6 +10,7 @@ capacity:
   gas: 3731
   hydro: 1806
   hydro storage: 736
+  nuclear: 0
   oil: 2357
   solar: 960
   wind: 337

--- a/config/zones/PH-MI.yaml
+++ b/config/zones/PH-MI.yaml
@@ -9,6 +9,7 @@ capacity:
   coal: 2268
   gas: 0
   hydro: 1191
+  nuclear: 0
   oil: 833
   solar: 84
 contributors:

--- a/config/zones/PH-VI.yaml
+++ b/config/zones/PH-VI.yaml
@@ -9,6 +9,7 @@ capacity:
   coal: 1412
   gas: 1
   hydro: 36
+  nuclear: 0
   oil: 644
   solar: 487
   wind: 90


### PR DESCRIPTION
## Issue

Since nuclear capacity was not explicitly set to 0 we where showing a question mark instead of 0 as PH don't have any nuclear production.

## Description

Just sets the subzone nuclear capacities to 0 (parent config was already 0).

### Double check

- [x] I have tested my parser changes locally with `poetry run test_parser "zone_key"`
- [x] I have run `pnpx prettier --write .` and `poetry run format` to format my changes.
