### PR TITLE
Include MX-BCS into MX aggreagation

### DIFF
--- a/config/zones/MX.yaml
+++ b/config/zones/MX.yaml
@@ -10,6 +10,7 @@ parsers:
   production: CENACE.fetch_production
 subZoneNames:
   - MX-BC
+  - MX-BCS
   - MX-CE
   - MX-NE
   - MX-NO

--- a/web/public/locales/en.json
+++ b/web/public/locales/en.json
@@ -1192,6 +1192,10 @@
       "countryName": "Mexico",
       "zoneName": "Baja California"
     },
+    "MX-BCS": {
+      "countryName": "Mexico",
+      "zoneName": "Baja California Sur"
+    },
     "MX-CE": {
       "countryName": "Mexico",
       "zoneName": "Central"


### PR DESCRIPTION
## Issue

MX-BCS is not included in the country level aggregation for Mexico, but it should be.

## Description

Including MX-BCS in the subzones for MX.
Adding missing translation for the zone.

### Double check

- [ ] I have tested my parser changes locally with `poetry run test_parser "zone_key"`
- [ ] I have run `pnpx prettier --write .` and `poetry run format` to format my changes.
