### PR TITLE
Remove KW `fetch_production`

### DIFF
--- a/config/zones/KW.yaml
+++ b/config/zones/KW.yaml
@@ -80,5 +80,4 @@ fallbackZoneMixes:
         wind: 0.0
 parsers:
   consumption: KW.fetch_consumption
-  production: KW.fetch_production
 timezone: Asia/Kuwait

--- a/parsers/KW.py
+++ b/parsers/KW.py
@@ -15,33 +15,6 @@ import arrow
 from requests import Session
 
 
-def fetch_production(
-    zone_key: str = "KW",
-    session: Session | None = None,
-    target_datetime: datetime | None = None,
-    logger: Logger = getLogger(__name__),
-):
-    if target_datetime:
-        raise NotImplementedError("This parser is not yet able to parse past dates")
-
-    # Kuwait very rarely imports power, so we assume that production is equal to consumption
-    # "Kuwait imports power in an emergency and only for a few hours at a time"
-    # See https://github.com/electricitymaps/electricitymaps-contrib/pull/2457#pullrequestreview-408781556
-    consumption_dict = fetch_consumption(
-        zone_key=zone_key, session=session, logger=logger
-    )
-    consumption = consumption_dict["consumption"]
-
-    datapoint = {
-        "zoneKey": zone_key,
-        "datetime": arrow.now("Asia/Kuwait").datetime,
-        "production": {"unknown": consumption},
-        "source": "mew.gov.kw",
-    }
-
-    return datapoint
-
-
 def fetch_consumption(
     zone_key: str = "KW",
     session: Session | None = None,


### PR DESCRIPTION
## Issue

The parser for KW is creating parser data making assumptions based on the consumption to create production data. We want to avoid this. Parser should just collect the data available from datasources and format it to electricityMaps format.

The conversion from consumption to production in selected zones will be handled by one of our estimation models with a clear disclaimer that the data is estimated and not measured.

## Description

- remove `fetch_production` from KW parser.

Initially I was intending on removing it from TH as well as we are facing similar issues but the change is a bit more complex as it is generation data and not consumption data. Will do a follow up PR later.

### Double check

- [ ] I have tested my parser changes locally with `poetry run test_parser "zone_key"`
- [ ] I have run `pnpx prettier --write .` and `poetry run format` to format my changes.
