### PR TITLE
Hide specific aggregates for specific zones

### DIFF
--- a/config/zones/HK.yaml
+++ b/config/zones/HK.yaml
@@ -1,3 +1,5 @@
+aggregates_displayed:
+  - yearly
 bounding_box:
   - - 113.337331576
     - 21.677069403000075

--- a/config/zones/ID.yaml
+++ b/config/zones/ID.yaml
@@ -1,3 +1,5 @@
+aggregates_displayed:
+  - yearly
 bounding_box:
   - - 94.51270592500003
     - -11.422621351999908

--- a/electricitymap/contrib/config/model.py
+++ b/electricitymap/contrib/config/model.py
@@ -108,6 +108,7 @@ class Zone(StrictBaseModelWithAlias):
     disclaimer: str | None
     parsers: Parsers = Parsers()
     price_displayed: bool | None
+    aggregates_displayed: list[str] | None
     sub_zone_names: list[ZoneKey] | None = Field(None, alias="subZoneNames")
     timezone: str | None
     key: ZoneKey  # This is not part of zones/{zone_key}.yaml, but added here to enable self referencing

--- a/web/public/locales/en.json
+++ b/web/public/locales/en.json
@@ -66,6 +66,7 @@
     "aggregatedTooltip": "The data for this zone is aggregated based on historical hourly values",
     "helpUs": "Help us identify the problem by taking a look at the <a href=\"%s\" target=\"_blank\">runtime logs</a> or contact the data provider.",
     "noParserInfo": "We do not yet have any information about this area.<br/> Want to help fix this? You can contribute by <a href=\"%s\" target=\"_blank\">adding area data</a>.",
+    "aggregationDisabled": "Data is not available for the selected time period due to missing granular breakdown. Try a broader time period.",
     "now": "Now",
     "by-source": {
       "emissions": "Carbon emissions by source",

--- a/web/src/features/panels/zone/NoInformationMessage.tsx
+++ b/web/src/features/panels/zone/NoInformationMessage.tsx
@@ -1,16 +1,35 @@
 import { useTranslation } from 'translation/translation';
+import { ZoneDataStatus } from './util';
 
-export default function NoInformationMessage() {
+const translations = {
+  [ZoneDataStatus.NO_INFORMATION]: {
+    name: 'country-panel.noParserInfo',
+    args: [
+      'https://github.com/electricitymaps/electricitymaps-contrib/wiki/Getting-started',
+    ],
+  },
+  [ZoneDataStatus.AGGREGATE_DISABLED]: {
+    name: 'country-panel.aggregationDisabled',
+    args: [],
+  },
+};
+
+type PossibleStatusTypes =
+  | ZoneDataStatus.NO_INFORMATION
+  | ZoneDataStatus.AGGREGATE_DISABLED;
+export default function NoInformationMessage({ status }: { status: ZoneDataStatus }) {
   const { __ } = useTranslation();
+
+  const translationKey =
+    translations[status as PossibleStatusTypes] ??
+    translations[ZoneDataStatus.NO_INFORMATION];
+
   return (
     <div data-test-id="no-parser-message" className="pt-4 text-center text-base">
       <span
         className="prose text-sm dark:prose-invert prose-a:text-sky-600 prose-a:no-underline hover:prose-a:underline"
         dangerouslySetInnerHTML={{
-          __html: __(
-            'country-panel.noParserInfo',
-            'https://github.com/electricitymaps/electricitymaps-contrib/wiki/Getting-started'
-          ),
+          __html: __(translationKey.name, ...translationKey.args),
         }}
       />
     </div>

--- a/web/src/features/panels/zone/ZoneDetails.tsx
+++ b/web/src/features/panels/zone/ZoneDetails.tsx
@@ -16,8 +16,8 @@ import DisplayByEmissionToggle from './DisplayByEmissionToggle';
 import Divider from './Divider';
 import NoInformationMessage from './NoInformationMessage';
 import { ZoneHeaderGauges } from './ZoneHeaderGauges';
-import { ZoneDataStatus, getHasSubZones, getZoneDataStatus } from './util';
 import ZoneHeaderTitle from './ZoneHeaderTitle';
+import { ZoneDataStatus, getHasSubZones, getZoneDataStatus } from './util';
 
 export default function ZoneDetails(): JSX.Element {
   const { zoneId } = useParams();
@@ -51,7 +51,7 @@ export default function ZoneDetails(): JSX.Element {
     }
   }, []);
 
-  const zoneDataStatus = getZoneDataStatus(zoneId, data);
+  const zoneDataStatus = getZoneDataStatus(zoneId, data, timeAverage);
 
   const datetimes = Object.keys(data?.zoneStates || {})?.map((key) => new Date(key));
 
@@ -69,7 +69,10 @@ export default function ZoneDetails(): JSX.Element {
       />
       <div className="h-[calc(100%-110px)] overflow-y-scroll p-4 pb-40 pt-2 sm:h-[calc(100%-130px)]">
         <ZoneHeaderGauges data={data} />
-        {zoneDataStatus !== ZoneDataStatus.NO_INFORMATION && <DisplayByEmissionToggle />}
+        {zoneDataStatus !== ZoneDataStatus.NO_INFORMATION &&
+          zoneDataStatus !== ZoneDataStatus.AGGREGATE_DISABLED && (
+            <DisplayByEmissionToggle />
+          )}
         <ZoneDetailsContent
           isLoading={isLoading}
           isError={isError}
@@ -121,8 +124,12 @@ function ZoneDetailsContent({
     );
   }
 
-  if (zoneDataStatus === ZoneDataStatus.NO_INFORMATION) {
-    return <NoInformationMessage />;
+  if (
+    [ZoneDataStatus.NO_INFORMATION, ZoneDataStatus.AGGREGATE_DISABLED].includes(
+      zoneDataStatus
+    )
+  ) {
+    return <NoInformationMessage status={zoneDataStatus} />;
   }
 
   return children as JSX.Element;

--- a/web/src/features/panels/zone/util.ts
+++ b/web/src/features/panels/zone/util.ts
@@ -1,7 +1,9 @@
 import { ZoneDetails } from 'types';
 import zonesConfigJSON from '../../../../config/zones.json'; // Todo: improve how to handle json configs
+import { TimeAverages } from 'utils/constants';
 
 type zoneConfigItem = {
+  aggregates_displayed?: string[];
   contributors?: string[];
   capacity?: any;
   disclaimer?: string;
@@ -25,6 +27,7 @@ export const getHasSubZones = (zoneId?: string) => {
 };
 
 export enum ZoneDataStatus {
+  AGGREGATE_DISABLED = 'aggregate_disabled',
   NO_INFORMATION = 'no_information',
   NO_REAL_TIME_DATA = 'dark',
   AVAILABLE = 'available',
@@ -34,7 +37,8 @@ export enum ZoneDataStatus {
 const zonesConfig: Record<string, zoneConfigItem | undefined> = zonesConfigJSON;
 export const getZoneDataStatus = (
   zoneId: string,
-  zoneDetails: ZoneDetails | undefined
+  zoneDetails: ZoneDetails | undefined,
+  timeAverage: TimeAverages
 ) => {
   // If there is no zoneDetails, we do not make any assumptions and return unknown
   if (!zoneDetails) {
@@ -52,6 +56,10 @@ export const getZoneDataStatus = (
     console.log(config);
 
     return ZoneDataStatus.NO_INFORMATION;
+  }
+
+  if (config.aggregates_displayed && !config.aggregates_displayed.includes(timeAverage)) {
+    return ZoneDataStatus.AGGREGATE_DISABLED;
   }
 
   // If there are no production parsers or no defined estimation method in the config,


### PR DESCRIPTION
## Description

Following discussions prompted by #5780, we have decided to not show hourly data for zones where we don't actually have hourly data.

For Indonesia and Hong Kong specifically, we have an estimation model in place that takes a yearly value and averages it over lower periods all the way down to the hour. While this is useful on the API, we do not believe it portrays the two zones fairly on the map. Therefore we will hide data on zones that only support a higher aggregation than the one shown.

This means that if the zone only have daily data, we will hide it from the hourly view and only show it on the daily, monthly and yearly view.

As such the two particular zones should only show yearly data in the app.

Note that this unfortunately **does not** mean we can now support parsers with non-hourly data, as our infrastructure is still build around storing data on an hourly granularity.

### Preview

![Screenshot 2023-09-19 at 15 25 35](https://github.com/electricitymaps/electricitymaps-contrib/assets/3296643/834c8773-338b-4967-8d81-e721cf5e6822)
![Screenshot 2023-09-19 at 15 25 39](https://github.com/electricitymaps/electricitymaps-contrib/assets/3296643/05cadf2f-7bb6-4f90-9094-2177ae81934b)


### Double check

- [x] I have run `pnpx prettier --write .` and `poetry run format` to format my changes.
