### PR TITLE
Update Mexico's emission factors

### DIFF
--- a/config/zones/MX-BC.yaml
+++ b/config/zones/MX-BC.yaml
@@ -11,6 +11,17 @@ fallbackZoneMixes:
       gas: 0.923
       wind: 0.077
   source: "Electricity Maps & Dra. Gabriela Mu\xF1oz Mel\xE9ndez"
+emissionFactors:
+  direct:
+    unknown:
+      - datetime: '2017-01-01'
+        source: "Electricity Maps & Dra. Gabriela Mu\xF1oz Mel\xE9ndez"
+        value: 453
+  lifecycle:
+    unknown:
+      - datetime: '2017-01-01'
+        source: "Electricity Maps & Dra. Gabriela Mu\xF1oz Mel\xE9ndez"
+        value: 342
 parsers:
   consumption: CENACE.fetch_consumption
 timezone: America/Tijuana

--- a/config/zones/MX-CE.yaml
+++ b/config/zones/MX-CE.yaml
@@ -4,5 +4,18 @@ bounding_box:
   - - -96.22812130395499
     - 21.325344143417453
 timezone: America/Mexico_City
+emissionFactors:
+  direct:
+    unknown:
+      - datetime: '2020-01-01'
+        source: "https://www.iea.org/data-and-statistics/charts/electricity-generation-mix-in-mexico-1-jan-30-sep-2019-and-2020"
+        comment: "Assumes a mix of 3.6% nuclear, 8.8% hydro, 8.4% oil, 63.4% gas, 4.2% coal, 4.3%solar, 5.9% wind, 1.5% other renewables with default IPCC2014 values."
+        value: 305
+  lifecycle:
+    unknown:
+      - datetime: '2020-01-01'
+        source: "https://www.iea.org/data-and-statistics/charts/electricity-generation-mix-in-mexico-1-jan-30-sep-2019-and-2020"
+        comment: "Assumes a mix of 3.6% nuclear, 8.8% hydro, 8.4% oil, 63.4% gas, 4.2% coal, 4.3%solar, 5.9% wind, 1.5% other renewables with default IPCC2014 values."
+        value: 411
 parsers:
   consumption: CENACE.fetch_consumption

--- a/config/zones/MX-NE.yaml
+++ b/config/zones/MX-NE.yaml
@@ -4,5 +4,18 @@ bounding_box:
   - - -96.63927161399994
     - 28.293549303557484
 timezone: America/Mexico_City
+emissionFactors:
+  direct:
+    unknown:
+      - datetime: '2020-01-01'
+        source: "https://www.iea.org/data-and-statistics/charts/electricity-generation-mix-in-mexico-1-jan-30-sep-2019-and-2020"
+        comment: "Assumes a mix of 3.6% nuclear, 8.8% hydro, 8.4% oil, 63.4% gas, 4.2% coal, 4.3%solar, 5.9% wind, 1.5% other renewables with default IPCC2014 values."
+        value: 305
+  lifecycle:
+    unknown:
+      - datetime: '2020-01-01'
+        source: "https://www.iea.org/data-and-statistics/charts/electricity-generation-mix-in-mexico-1-jan-30-sep-2019-and-2020"
+        comment: "Assumes a mix of 3.6% nuclear, 8.8% hydro, 8.4% oil, 63.4% gas, 4.2% coal, 4.3%solar, 5.9% wind, 1.5% other renewables with default IPCC2014 values."
+        value: 411
 parsers:
   consumption: CENACE.fetch_consumption

--- a/config/zones/MX-NO.yaml
+++ b/config/zones/MX-NO.yaml
@@ -4,5 +4,18 @@ bounding_box:
   - - -99.30696277711047
     - 32.277751364000025
 timezone: America/Mexico_City
+emissionFactors:
+  direct:
+    unknown:
+      - datetime: '2020-01-01'
+        source: "https://www.iea.org/data-and-statistics/charts/electricity-generation-mix-in-mexico-1-jan-30-sep-2019-and-2020"
+        comment: "Assumes a mix of 3.6% nuclear, 8.8% hydro, 8.4% oil, 63.4% gas, 4.2% coal, 4.3%solar, 5.9% wind, 1.5% other renewables with default IPCC2014 values."
+        value: 305
+  lifecycle:
+    unknown:
+      - datetime: '2020-01-01'
+        source: "https://www.iea.org/data-and-statistics/charts/electricity-generation-mix-in-mexico-1-jan-30-sep-2019-and-2020"
+        comment: "Assumes a mix of 3.6% nuclear, 8.8% hydro, 8.4% oil, 63.4% gas, 4.2% coal, 4.3%solar, 5.9% wind, 1.5% other renewables with default IPCC2014 values."
+        value: 411
 parsers:
   consumption: CENACE.fetch_consumption

--- a/config/zones/MX-NW.yaml
+++ b/config/zones/MX-NW.yaml
@@ -4,5 +4,18 @@ bounding_box:
   - - -104.88862626838755
     - 32.99936330200008
 timezone: America/Mexico_City
+emissionFactors:
+  direct:
+    unknown:
+      - datetime: '2020-01-01'
+        source: "https://www.iea.org/data-and-statistics/charts/electricity-generation-mix-in-mexico-1-jan-30-sep-2019-and-2020"
+        comment: "Assumes a mix of 3.6% nuclear, 8.8% hydro, 8.4% oil, 63.4% gas, 4.2% coal, 4.3%solar, 5.9% wind, 1.5% other renewables with default IPCC2014 values."
+        value: 305
+  lifecycle:
+    unknown:
+      - datetime: '2020-01-01'
+        source: "https://www.iea.org/data-and-statistics/charts/electricity-generation-mix-in-mexico-1-jan-30-sep-2019-and-2020"
+        comment: "Assumes a mix of 3.6% nuclear, 8.8% hydro, 8.4% oil, 63.4% gas, 4.2% coal, 4.3%solar, 5.9% wind, 1.5% other renewables with default IPCC2014 values."
+        value: 411
 parsers:
   consumption: CENACE.fetch_consumption

--- a/config/zones/MX-OC.yaml
+++ b/config/zones/MX-OC.yaml
@@ -4,5 +4,18 @@ bounding_box:
   - - -97.5001883613038
     - 25.66554433840048
 timezone: America/Mexico_City
+emissionFactors:
+  direct:
+    unknown:
+      - datetime: '2020-01-01'
+        source: "https://www.iea.org/data-and-statistics/charts/electricity-generation-mix-in-mexico-1-jan-30-sep-2019-and-2020"
+        comment: "Assumes a mix of 3.6% nuclear, 8.8% hydro, 8.4% oil, 63.4% gas, 4.2% coal, 4.3%solar, 5.9% wind, 1.5% other renewables with default IPCC2014 values."
+        value: 305
+  lifecycle:
+    unknown:
+      - datetime: '2020-01-01'
+        source: "https://www.iea.org/data-and-statistics/charts/electricity-generation-mix-in-mexico-1-jan-30-sep-2019-and-2020"
+        comment: "Assumes a mix of 3.6% nuclear, 8.8% hydro, 8.4% oil, 63.4% gas, 4.2% coal, 4.3%solar, 5.9% wind, 1.5% other renewables with default IPCC2014 values."
+        value: 411
 parsers:
   consumption: CENACE.fetch_consumption

--- a/config/zones/MX-OR.yaml
+++ b/config/zones/MX-OR.yaml
@@ -4,5 +4,18 @@ bounding_box:
   - - -89.87985327199993
     - 22.98054026911808
 timezone: America/Mexico_City
+emissionFactors:
+  direct:
+    unknown:
+      - datetime: '2020-01-01'
+        source: "https://www.iea.org/data-and-statistics/charts/electricity-generation-mix-in-mexico-1-jan-30-sep-2019-and-2020"
+        comment: "Assumes a mix of 3.6% nuclear, 8.8% hydro, 8.4% oil, 63.4% gas, 4.2% coal, 4.3%solar, 5.9% wind, 1.5% other renewables with default IPCC2014 values."
+        value: 305
+  lifecycle:
+    unknown:
+      - datetime: '2020-01-01'
+        source: "https://www.iea.org/data-and-statistics/charts/electricity-generation-mix-in-mexico-1-jan-30-sep-2019-and-2020"
+        comment: "Assumes a mix of 3.6% nuclear, 8.8% hydro, 8.4% oil, 63.4% gas, 4.2% coal, 4.3%solar, 5.9% wind, 1.5% other renewables with default IPCC2014 values."
+        value: 411
 parsers:
   consumption: CENACE.fetch_consumption

--- a/config/zones/MX-PN.yaml
+++ b/config/zones/MX-PN.yaml
@@ -4,5 +4,18 @@ bounding_box:
   - - -86.20059160099993
     - 22.123439846000053
 timezone: America/Mexico_City
+emissionFactors:
+  direct:
+    unknown:
+      - datetime: '2020-01-01'
+        source: "https://www.iea.org/data-and-statistics/charts/electricity-generation-mix-in-mexico-1-jan-30-sep-2019-and-2020"
+        comment: "Assumes a mix of 3.6% nuclear, 8.8% hydro, 8.4% oil, 63.4% gas, 4.2% coal, 4.3%solar, 5.9% wind, 1.5% other renewables with default IPCC2014 values."
+        value: 305
+  lifecycle:
+    unknown:
+      - datetime: '2020-01-01'
+        source: "https://www.iea.org/data-and-statistics/charts/electricity-generation-mix-in-mexico-1-jan-30-sep-2019-and-2020"
+        comment: "Assumes a mix of 3.6% nuclear, 8.8% hydro, 8.4% oil, 63.4% gas, 4.2% coal, 4.3%solar, 5.9% wind, 1.5% other renewables with default IPCC2014 values."
+        value: 411
 parsers:
   consumption: CENACE.fetch_consumption

--- a/config/zones/MX.yaml
+++ b/config/zones/MX.yaml
@@ -8,6 +8,19 @@ contributors:
   - scriptator
 parsers:
   production: CENACE.fetch_production
+emissionFactors:
+  direct:
+    unknown:
+      - datetime: '2020-01-01'
+        source: "https://www.iea.org/data-and-statistics/charts/electricity-generation-mix-in-mexico-1-jan-30-sep-2019-and-2020"
+        comment: "Assumes a mix of 3.6% nuclear, 8.8% hydro, 8.4% oil, 63.4% gas, 4.2% coal, 4.3%solar, 5.9% wind, 1.5% other renewables with default IPCC2014 values."
+        value: 305
+  lifecycle:
+    unknown:
+      - datetime: '2020-01-01'
+        source: "https://www.iea.org/data-and-statistics/charts/electricity-generation-mix-in-mexico-1-jan-30-sep-2019-and-2020"
+        comment: "Assumes a mix of 3.6% nuclear, 8.8% hydro, 8.4% oil, 63.4% gas, 4.2% coal, 4.3%solar, 5.9% wind, 1.5% other renewables with default IPCC2014 values."
+        value: 411
 subZoneNames:
   - MX-BC
   - MX-BCS


### PR DESCRIPTION
## Issue

Since we are now using an estimation for mexico based on it's consumption we should adjust the emission factors of the region for unknown. For now we are going to use the annual breakdown from the IEA from 2020 until a more recent and better source can be used.

## Description

Update the emission factor of all Mexico zones based on the annual breakdown.

### Double check

- [ ] I have tested my parser changes locally with `poetry run test_parser "zone_key"`
- [ ] I have run `pnpx prettier --write .` and `poetry run format` to format my changes.
