### PR TITLE
Link Get our data to /get-our-data

### DIFF
--- a/web/src/features/header/Header.tsx
+++ b/web/src/features/header/Header.tsx
@@ -91,7 +91,7 @@ export default function Header(): JSX.Element {
             Blog
           </MenuLink>
           <MenuLink
-            href="https://electricitymaps.com?utm_source=app.electricitymaps.com&utm_medium=referral"
+            href="https://electricitymaps.com/get-our-data?utm_source=app.electricitymaps.com&utm_medium=referral"
             id="get-data"
             isExternal
           >


### PR DESCRIPTION
## Issue

The get our data link actually link to the homepage.

## Description

Changes the link to link to https://www.electricitymaps.com/get-our-data

### Double check

- [x] I have run `pnpx prettier --write .` and `poetry run format` to format my changes.
