### PR TITLE
Fix CA-NS parser

### DIFF
--- a/parsers/CA_NS.py
+++ b/parsers/CA_NS.py
@@ -1,10 +1,9 @@
 #!/usr/bin/env python3
 
-# The arrow library is used to handle datetimes
-from datetime import datetime
+# The datetime library is used to handle datetimes
+from datetime import datetime, timezone
 from logging import Logger, getLogger
 
-import arrow
 from requests import Session
 
 
@@ -18,12 +17,12 @@ def _get_ns_info(requests_obj, logger: Logger):
         # The validation JS reports error when Solid Fuel (coal) is over 85%,
         # but as far as I can tell, that can actually be a valid result, I've seen it a few times.
         # Use 98% instead.
-        "coal": (0.25, 0.98),
+        "coal": (0, 0.98),
         "gas": (0, 0.5),
         "biomass": (0, 0.15),
         "hydro": (0, 0.60),
         "wind": (0, 0.55),
-        "imports": (0, 0.20),
+        "imports": (0, 0.50),
     }
 
     # Sanity checks: verify that reported production doesn't exceed listed capacity by a lot.
@@ -58,7 +57,7 @@ def _get_ns_info(requests_obj, logger: Logger):
         # datetime is in format '/Date(1493924400000)/'
         # get the timestamp 1493924400 (cutting out last three zeros as well)
         data_timestamp = int(mix["datetime"][6:-5])
-        data_date = arrow.get(data_timestamp).datetime
+        data_date = datetime.fromtimestamp(data_timestamp, tz=timezone.utc)
 
         # validate
         valid = True


### PR DESCRIPTION
## Description
Nova Scotia data is missing for some hours:

![Screenshot_20231004_220430](https://github.com/electricitymaps/electricitymaps-contrib/assets/84802276/9644736e-7eb1-461f-8af1-6758ae044d07)

This is caused by the validation done inside the parser, which was written 6 years ago. It seems the production has changed a bit since, which makes the checks fail.
 I've updated the checks, but I think we could consider removing the validation altogether to avoid a similar situation in the future. The opinion of @jarek could be useful, as he made the validation part. Especially since the link in the documentation throws a 404.

Looking around I've found #3206, an interesting discussion regarding this, but that didn't spawn a PR. I think this could be merged to stop discarding data automatically, and implement whatever solution emerges from other discussions later on.

I've used the opportunity to also remove the arrow dependency from this parser

### Double check

- [x] I have tested my parser changes locally with `poetry run test_parser "zone_key"`
- [X] I have run `pnpx prettier --write .` and `poetry run format` to format my changes.
