### PR TITLE
Revive: updated lifecycle estimates for CA-ON

### DIFF
--- a/config/zones/CA-ON.yaml
+++ b/config/zones/CA-ON.yaml
@@ -87,33 +87,26 @@ emissionFactors:
       - datetime: '2021-01-01'
         source: Electricity Maps, 2021 average
         value: 57.47323263502428
+    gas:
+      datetime: '2015-01-01'
+      source: Mallia, E., Lewis, G. "Life cycle greenhouse gas emissions of electricity
+        generation in the province of Ontario, Canada." (2013)
+      value: 497 
     hydro discharge:
-      - datetime: '2015-01-01'
-        source: Electricity Maps, 2015 average
-        value: 53.48322359927377
-      - datetime: '2016-01-01'
-        source: Electricity Maps, 2016 average
-        value: 53.48323094170299
-      - datetime: '2017-01-01'
-        source: Electricity Maps, 2017 average
-        value: 53.03166247658179
-      - datetime: '2018-01-01'
-        source: Electricity Maps, 2018 average
-        value: 48.27082098236083
-      - datetime: '2019-01-01'
-        source: Electricity Maps, 2019 average
-        value: 47.473184887281725
-      - datetime: '2020-01-01'
-        source: Electricity Maps, 2020 average
-        value: 48.54750352993932
-      - datetime: '2021-01-01'
-        source: Electricity Maps, 2021 average
-        value: 57.47323263502428
+      datetime: '2015-01-01'
+      source: Mallia, E., Lewis, G. "Life cycle greenhouse gas emissions of electricity
+        generation in the province of Ontario, Canada." (2013)
+      value: 22
     nuclear:
-      datetime: '2013-01-01'
+      datetime: '2015-01-01'
       source: Mallia, E., Lewis, G. "Life cycle greenhouse gas emissions of electricity
         generation in the province of Ontario, Canada." (2013)
       value: 4.8
+    wind:
+      datetime: '2015-01-01'
+      source: Mallia, E., Lewis, G. "Life cycle greenhouse gas emissions of electricity
+        generation in the province of Ontario, Canada." (2013)
+      value: 10.69
 fallbackZoneMixes:
   powerOriginRatios:
     - _source: Electricity Maps, 2015 average

--- a/config/zones/CA-ON.yaml
+++ b/config/zones/CA-ON.yaml
@@ -88,22 +88,44 @@ emissionFactors:
         source: Electricity Maps, 2021 average
         value: 57.47323263502428
     gas:
-      datetime: '2015-01-01'
+      datetime: '2008-01-01'
       source: Mallia, E., Lewis, G. "Life cycle greenhouse gas emissions of electricity
         generation in the province of Ontario, Canada." (2013)
-      value: 497 
+      value: 497
     hydro discharge:
-      datetime: '2015-01-01'
+      - datetime: '2015-01-01'
+        source: Electricity Maps, 2015 average
+        value: 53.48322359927377
+      - datetime: '2016-01-01'
+        source: Electricity Maps, 2016 average
+        value: 53.48323094170299
+      - datetime: '2017-01-01'
+        source: Electricity Maps, 2017 average
+        value: 53.03166247658179
+      - datetime: '2018-01-01'
+        source: Electricity Maps, 2018 average
+        value: 48.27082098236083
+      - datetime: '2019-01-01'
+        source: Electricity Maps, 2019 average
+        value: 47.473184887281725
+      - datetime: '2020-01-01'
+        source: Electricity Maps, 2020 average
+        value: 48.54750352993932
+      - datetime: '2021-01-01'
+        source: Electricity Maps, 2021 average
+        value: 57.47323263502428
+    hydro:
+      datetime: '2008-01-01'
       source: Mallia, E., Lewis, G. "Life cycle greenhouse gas emissions of electricity
         generation in the province of Ontario, Canada." (2013)
       value: 22
     nuclear:
-      datetime: '2015-01-01'
+      datetime: '2008-01-01'
       source: Mallia, E., Lewis, G. "Life cycle greenhouse gas emissions of electricity
         generation in the province of Ontario, Canada." (2013)
       value: 4.8
     wind:
-      datetime: '2015-01-01'
+      datetime: '2008-01-01'
       source: Mallia, E., Lewis, G. "Life cycle greenhouse gas emissions of electricity
         generation in the province of Ontario, Canada." (2013)
       value: 10.69

--- a/config/zones/CA-ON.yaml
+++ b/config/zones/CA-ON.yaml
@@ -89,7 +89,7 @@ emissionFactors:
         value: 57.47323263502428
     gas:
       datetime: '2008-01-01'
-      source: Mallia, E., Lewis, G. "Life cycle greenhouse gas emissions of electricity
+      source: Mallia, E., Lewis, G. "Life cycle greenhouse gas emissions of electricity \n
         generation in the province of Ontario, Canada." (2013)
       value: 497
     hydro discharge:
@@ -116,17 +116,17 @@ emissionFactors:
         value: 57.47323263502428
     hydro:
       datetime: '2008-01-01'
-      source: Mallia, E., Lewis, G. "Life cycle greenhouse gas emissions of electricity
+      source: Mallia, E., Lewis, G. "Life cycle greenhouse gas emissions of electricity \n
         generation in the province of Ontario, Canada." (2013)
       value: 22
     nuclear:
       datetime: '2008-01-01'
-      source: Mallia, E., Lewis, G. "Life cycle greenhouse gas emissions of electricity
+      source: Mallia, E., Lewis, G. "Life cycle greenhouse gas emissions of electricity \n
         generation in the province of Ontario, Canada." (2013)
       value: 4.8
     wind:
       datetime: '2008-01-01'
-      source: Mallia, E., Lewis, G. "Life cycle greenhouse gas emissions of electricity
+      source: Mallia, E., Lewis, G. "Life cycle greenhouse gas emissions of electricity \n
         generation in the province of Ontario, Canada." (2013)
       value: 10.69
 fallbackZoneMixes:
@@ -225,8 +225,7 @@ parsers:
   price: CA_ON.fetch_price
   production: CA_ON.fetch_production
 sources:
-  ? "Mallia, E., Lewis, G. \"Life cycle greenhouse gas emissions of electricity generation\
-    \ in the province of Ontario, Canada.\" Int J Life Cycle Assess 18, 377\u2013\
-    391 (2013)"
+  ? Mallia, Eric, and Geoffrey Lewis. "Life cycle greenhouse gas emissions of electricity generation in the province of Ontario, Canada."
+  The International Journal of Life Cycle Assessment 18.2 (2013)":" 377-391.
   : link: https://doi.org/10.1007/s11367-012-0501-0
 timezone: America/Toronto

--- a/config/zones/CA-ON.yaml
+++ b/config/zones/CA-ON.yaml
@@ -89,8 +89,7 @@ emissionFactors:
         value: 57.47323263502428
     gas:
       datetime: '2008-01-01'
-      source: Mallia, E., Lewis, G. "Life cycle greenhouse gas emissions of electricity
-        generation in the province of Ontario, Canada." (2013)
+      source: 'Mallia, E., Lewis, G. "Life cycle greenhouse gas emissions of electricity generation in the province of Ontario, Canada." Int J Life Cycle Assess 18, 377–391 (2013)'
       value: 497
     hydro discharge:
       - datetime: '2015-01-01'
@@ -116,18 +115,15 @@ emissionFactors:
         value: 57.47323263502428
     hydro:
       datetime: '2008-01-01'
-      source: Mallia, E., Lewis, G. "Life cycle greenhouse gas emissions of electricity
-        generation in the province of Ontario, Canada." (2013)
+      source: 'Mallia, E., Lewis, G. "Life cycle greenhouse gas emissions of electricity generation in the province of Ontario, Canada." Int J Life Cycle Assess 18, 377–391 (2013)'
       value: 22
     nuclear:
       datetime: '2008-01-01'
-      source: Mallia, E., Lewis, G. "Life cycle greenhouse gas emissions of electricity
-        generation in the province of Ontario, Canada." (2013)
+      source: 'Mallia, E., Lewis, G. "Life cycle greenhouse gas emissions of electricity generation in the province of Ontario, Canada." Int J Life Cycle Assess 18, 377–391 (2013)'
       value: 4.8
     wind:
       datetime: '2008-01-01'
-      source: Mallia, E., Lewis, G. "Life cycle greenhouse gas emissions of electricity
-        generation in the province of Ontario, Canada." (2013)
+      source: 'Mallia, E., Lewis, G. "Life cycle greenhouse gas emissions of electricity generation in the province of Ontario, Canada." Int J Life Cycle Assess 18, 377–391 (2013)'
       value: 10.69
 fallbackZoneMixes:
   powerOriginRatios:

--- a/config/zones/CA-ON.yaml
+++ b/config/zones/CA-ON.yaml
@@ -89,7 +89,7 @@ emissionFactors:
         value: 57.47323263502428
     gas:
       datetime: '2008-01-01'
-      source: Mallia, E., Lewis, G. "Life cycle greenhouse gas emissions of electricity \n
+      source: Mallia, E., Lewis, G. "Life cycle greenhouse gas emissions of electricity
         generation in the province of Ontario, Canada." (2013)
       value: 497
     hydro discharge:
@@ -116,17 +116,17 @@ emissionFactors:
         value: 57.47323263502428
     hydro:
       datetime: '2008-01-01'
-      source: Mallia, E., Lewis, G. "Life cycle greenhouse gas emissions of electricity \n
+      source: Mallia, E., Lewis, G. "Life cycle greenhouse gas emissions of electricity
         generation in the province of Ontario, Canada." (2013)
       value: 22
     nuclear:
       datetime: '2008-01-01'
-      source: Mallia, E., Lewis, G. "Life cycle greenhouse gas emissions of electricity \n
+      source: Mallia, E., Lewis, G. "Life cycle greenhouse gas emissions of electricity
         generation in the province of Ontario, Canada." (2013)
       value: 4.8
     wind:
       datetime: '2008-01-01'
-      source: Mallia, E., Lewis, G. "Life cycle greenhouse gas emissions of electricity \n
+      source: Mallia, E., Lewis, G. "Life cycle greenhouse gas emissions of electricity
         generation in the province of Ontario, Canada." (2013)
       value: 10.69
 fallbackZoneMixes:
@@ -225,7 +225,8 @@ parsers:
   price: CA_ON.fetch_price
   production: CA_ON.fetch_production
 sources:
-  ? Mallia, Eric, and Geoffrey Lewis. "Life cycle greenhouse gas emissions of electricity generation in the province of Ontario, Canada."
-  The International Journal of Life Cycle Assessment 18.2 (2013)":" 377-391.
+  ? "Mallia, E., Lewis, G. \"Life cycle greenhouse gas emissions of electricity generation\
+    \ in the province of Ontario, Canada.\" Int J Life Cycle Assess 18, 377\u2013\
+    391 (2013)"
   : link: https://doi.org/10.1007/s11367-012-0501-0
 timezone: America/Toronto


### PR DESCRIPTION
## Issue

Closes #4886.

## Description

Following on from and building on work from existing pull request #4926, this changeset adds lifecycle emission factors for the three production sources (gas, hydro, wind) in Ontario, Canada presented in the paper ["Life cycle greenhouse gas emissions of electricity generation in the province of Ontario, Canada" by E. Mallia and G. Lewis](https://link.springer.com/article/10.1007/s11367-012-0501-0).

As mentioned in the issue report, this paper has previously been discussed [here](https://github.com/electricitymaps/electricitymaps-contrib/discussions/4869) and [here](https://github.com/electricitymaps/electricitymaps-contrib/discussions/4791#discussioncomment-4295383).

Most of the pull request was in good shape; getting the source references to match is the main change and was verified locally using the following small Python script:

```python
import yaml

with open('config/zones/CA-ON.yaml') as f:
    content = f.read()

c = yaml.safe_load(content)
ref1 = list(c['sources'].keys())[0]
ref2 = c['emissionFactors']['lifecycle']['gas']['source']
assert ref1 == ref2, "verification failed"
```

### Preview

N/A

### Double check

- [ ] ~~I have tested my parser changes locally with `poetry run test_parser "zone_key"`~~
- [ ] ~~I have run `pnpx prettier --write .` and `poetry run format` to format my changes.~~
