### PR TITLE
Bar chart tooltips are not rendered from the correct hover location

### DIFF
--- a/web/src/features/charts/graphUtils.ts
+++ b/web/src/features/charts/graphUtils.ts
@@ -16,10 +16,14 @@ export const detectHoveredDatapointIndex = (
   if (datetimes.length === 0) {
     return null;
   }
+  const timeIntervalWidth = timeScale(datetimes[1]) - timeScale(datetimes[0]);
+
   const dx = event_.pageX
     ? event_.pageX - svgNode.getBoundingClientRect().left
-    : pointer(event_); // TODO: check if this works
-  const datetime = timeScale.invert(dx);
+    : pointer(event_)[0];
+  const adjustedDx = dx - timeIntervalWidth / 2;
+  const datetime = timeScale.invert(adjustedDx);
+
   // Find data point closest to
   let index = bisectLeft(datetimes, datetime);
   if (index > 0 && datetime - datetimes[index - 1] < datetimes[index] - datetime) {


### PR DESCRIPTION
## Issue
Currently we anchor the chart tick and render tooltips from a mouse hover that is 0.5 width to the left of the bar being hovered
## Description
This PR updates our detect hover point function to detect the hover event 0.5 * bar width to the right.


### Double check

- [x] I have tested my parser changes locally with `poetry run test_parser "zone_key"`
- [x] I have run `pnpx prettier --write .` and `poetry run format` to format my changes.
