### PR TITLE
Make chart tick fill gray when co2 value is 0

### DIFF
--- a/web/src/features/charts/elements/GraphHoverline.tsx
+++ b/web/src/features/charts/elements/GraphHoverline.tsx
@@ -41,7 +41,6 @@ const GraphHoverLine = React.memo(
 
     const showVerticalLine = Number.isFinite(x);
     const showMarker = Number.isFinite(x) && Number.isFinite(y);
-
     // Marker callbacks
     useEffect(() => {
       if (showMarker) {
@@ -94,7 +93,7 @@ const GraphHoverLine = React.memo(
             style={{
               display: 'block',
               pointerEvents: 'none',
-              shapeRendering: 'crispEdges',
+              shapeRendering: 'geometricPrecision',
               stroke: 'black',
               strokeWidth: 1.5,
               fill: typeof fill === 'function' ? fill(datapoint) : fill,

--- a/web/src/features/charts/hooks/useCarbonChartData.ts
+++ b/web/src/features/charts/hooks/useCarbonChartData.ts
@@ -35,9 +35,12 @@ export function useCarbonChartData() {
     }
   );
 
-  const layerFill = (key: string) => (d: { data: AreaGraphElement }) =>
-    co2ColorScale(d.data.layerData[key]);
-
+  const layerFill = (key: string) => (d: { data: AreaGraphElement }) => {
+    if (d.data.layerData[key] === 0) {
+      return co2ColorScale(Number.NaN);
+    }
+    return co2ColorScale(d.data.layerData[key]);
+  };
   const result = {
     chartData,
     layerKeys: ['carbonIntensity'],


### PR DESCRIPTION
## Issue

![image](https://github.com/electricitymaps/electricitymaps-contrib/assets/18622768/2986d9fb-8571-4426-a6a5-96c749ebf08a)
## Description

This PR sets CO2 intensity on the carbon chart to show as our default gray colour when it's 0. 

Also made the edges of our carbon tick indicator smoother.


### Double check

- [x] I have tested my parser changes locally with `poetry run test_parser "zone_key"`
- [x] I have run `pnpx prettier --write .` and `poetry run format` to format my changes.
