### PR TITLE
Update US-FLA-FPL->US-FLA-HST rotation

### DIFF
--- a/config/exchanges/US-FLA-FPL_US-FLA-HST.yaml
+++ b/config/exchanges/US-FLA-FPL_US-FLA-HST.yaml
@@ -3,4 +3,4 @@ lonlat:
   - 25.9004800000001
 parsers:
   exchange: EIA.fetch_exchange
-rotation: -24
+rotation: 156


### PR DESCRIPTION
## Issue
The exchange arrow is inverted.
![image](https://github.com/electricitymaps/electricitymaps-contrib/assets/38283096/2d99f056-fdd3-4f43-b9ca-c19ee8ac85da)