### PR TITLE
Optimise misc parsers for refetch

### DIFF
--- a/config/exchanges/MY-WM_SG.yaml
+++ b/config/exchanges/MY-WM_SG.yaml
@@ -5,5 +5,5 @@ lonlat:
   - 103.539048
   - 2.016154
 parsers:
-  exchange: MY_WM.fetch_exchange
+  exchange: GSO.fetch_exchange
 rotation: 155

--- a/config/exchanges/MY-WM_TH.yaml
+++ b/config/exchanges/MY-WM_TH.yaml
@@ -5,5 +5,5 @@ lonlat:
   - 101.454422
   - 5.867743
 parsers:
-  exchange: MY_WM.fetch_exchange
+  exchange: GSO.fetch_exchange
 rotation: 0

--- a/config/zones/MY-WM.yaml
+++ b/config/zones/MY-WM.yaml
@@ -130,6 +130,6 @@ fallbackZoneMixes:
         unknown: 0.010852222664167967
         wind: 2.829979460437189e-05
 parsers:
-  consumption: MY_WM.fetch_consumption
-  production: MY_WM.fetch_production
+  consumption: GSO.fetch_consumption
+  production: GSO.fetch_production
 timezone: null

--- a/parsers/ELEXON.py
+++ b/parsers/ELEXON.py
@@ -475,7 +475,7 @@ def fetch_exchange(
 
 
 # While using the FUELINST report we can increase the refetch frequency.
-@refetch_frequency(timedelta(hours=6))
+@refetch_frequency(timedelta(days=2))
 def fetch_production(
     zone_key: str = "GB",
     session: Session | None = None,

--- a/parsers/FO.py
+++ b/parsers/FO.py
@@ -46,7 +46,6 @@ def map_generation_type(raw_generation_type):
     return MAP_GENERATION.get(raw_generation_type, None)
 
 
-@refetch_frequency(timedelta(minutes=5))
 def fetch_production(
     zone_key: VALID_ZONE_KEYS = "FO",
     session: Session | None = None,

--- a/parsers/FO.py
+++ b/parsers/FO.py
@@ -1,13 +1,11 @@
 #!/usr/bin/env python3
 
-from datetime import datetime, timedelta
+from datetime import datetime
 from logging import Logger, getLogger
 from typing import Literal, TypedDict
 
 import arrow
 from requests import Response, Session
-
-from parsers.lib.config import refetch_frequency
 
 from .lib.exceptions import ParserException
 from .lib.validation import validate

--- a/parsers/GE.py
+++ b/parsers/GE.py
@@ -22,7 +22,7 @@ URL = urllib.parse.urlsplit("https://gse.com.ge/apps/gsebackend/rest")
 URL_STRING = URL.geturl()
 
 
-@config.refetch_frequency(timedelta(hours=1))
+@config.refetch_frequency(timedelta(days=1))
 def fetch_production(
     zone_key: str = "GE",
     session: Session | None = None,

--- a/parsers/IEMOP.py
+++ b/parsers/IEMOP.py
@@ -717,10 +717,11 @@ def convert_column_to_datetime(df: pd.DataFrame, datetime_column: str) -> pd.Dat
 @refetch_frequency(timedelta(days=1))
 def fetch_production(
     zone_key: ZoneKey = ZoneKey("PH-LU"),
-    session: Session = Session(),
+    session: Session | None = None,
     target_datetime: datetime | None = None,
     logger: Logger = getLogger(__name__),
 ) -> list:
+    session = session or Session()
     _validate_resource_name_to_mode_mapping()
     reports_items = get_all_market_reports_items(
         session, zone_key, "production", logger
@@ -761,10 +762,11 @@ def fetch_production(
 def fetch_exchange(
     zone_key1: ZoneKey,
     zone_key2: ZoneKey,
-    session: Session = Session(),
+    session: Session | None = None,
     target_datetime: datetime | None = None,
     logger: Logger = getLogger(__name__),
 ) -> list[dict] | dict:
+    session = session or Session()
     sorted_zone_keys = ZoneKey("->".join(sorted([zone_key1, zone_key2])))
 
     all_exchange_items = get_all_market_reports_items(

--- a/parsers/KPX.py
+++ b/parsers/KPX.py
@@ -53,7 +53,6 @@ pp = pprint.PrettyPrinter(indent=4)
 # Renewable: Solar, Wind power, Water power, ocean energy, Geothermal, Bio energy, etc.
 
 
-@refetch_frequency(timedelta(minutes=5))
 def fetch_consumption(
     zone_key: ZoneKey = ZoneKey("KR"),
     session: Session = Session(),
@@ -244,7 +243,7 @@ def get_historical_prod_data(
     return parse_chart_prod_data(res.text, zone_key, logger)
 
 
-@refetch_frequency(timedelta(hours=20))
+@refetch_frequency(timedelta(days=1))
 def fetch_production(
     zone_key: ZoneKey = ZoneKey("KR"),
     session: Session = Session(),

--- a/parsers/KPX.py
+++ b/parsers/KPX.py
@@ -55,10 +55,11 @@ pp = pprint.PrettyPrinter(indent=4)
 
 def fetch_consumption(
     zone_key: ZoneKey = ZoneKey("KR"),
-    session: Session = Session(),
+    session: Session | None = None,
     target_datetime: datetime | None = None,
     logger: Logger = getLogger(__name__),
 ) -> list[dict]:
+    session = session or Session()
     if target_datetime:
         raise ParserException(
             "KPX.py",
@@ -97,10 +98,11 @@ def fetch_consumption(
 @refetch_frequency(timedelta(hours=167))
 def fetch_price(
     zone_key: ZoneKey = ZoneKey("KR"),
-    session: Session = Session(),
+    session: Session | None = None,
     target_datetime: datetime | None = None,
     logger: Logger = getLogger(__name__),
 ) -> list[dict]:
+    session = session or Session()
     first_available_date = (
         arrow.now(TIMEZONE).shift(days=-6).floor("day").shift(hours=1)
     )
@@ -205,19 +207,21 @@ def parse_chart_prod_data(
 
 def get_real_time_prod_data(
     zone_key: ZoneKey = ZoneKey("KR"),
-    session: Session = Session(),
+    session: Session | None = None,
     logger: Logger = getLogger(__name__),
 ) -> ProductionBreakdownList:
+    session = session or Session()
     res = session.get(REAL_TIME_URL, verify=False)
     return parse_chart_prod_data(res.text, zone_key, logger)
 
 
 def get_historical_prod_data(
     zone_key: ZoneKey = ZoneKey("KR"),
-    session: Session = Session(),
+    session: Session | None = None,
     target_datetime: datetime | None = None,
     logger: Logger = getLogger(__name__),
 ) -> ProductionBreakdownList:
+    session = session or Session()
     target_datetime_formatted_daily = target_datetime.strftime("%Y-%m-%d")
 
     # CSRF token is needed to access the production data
@@ -246,10 +250,11 @@ def get_historical_prod_data(
 @refetch_frequency(timedelta(days=1))
 def fetch_production(
     zone_key: ZoneKey = ZoneKey("KR"),
-    session: Session = Session(),
+    session: Session | None = None,
     target_datetime: datetime | None = None,
     logger: Logger = getLogger(__name__),
 ) -> list[dict]:
+    session = session or Session()
     first_available_date = arrow.get(2021, 12, 22, 0, 0, 0, tzinfo=TIMEZONE)
     if target_datetime is not None and target_datetime < first_available_date:
         raise ParserException(

--- a/parsers/TH.py
+++ b/parsers/TH.py
@@ -1,13 +1,14 @@
-import datetime as dt
 import json
 import re
+from datetime import datetime, timedelta
 from logging import Logger, getLogger
 
-import arrow
 import pytz
 import requests
 from bs4 import BeautifulSoup
+from requests import Session
 
+from parsers.lib.config import refetch_frequency
 from parsers.lib.exceptions import ParserException
 
 EGAT_GENERATION_URL = "https://www.sothailand.com/sysgen/ws/sysgen"
@@ -18,90 +19,32 @@ MEA_URL = "www.mea.or.th"
 TZ = "Asia/Bangkok"
 
 
-def fetch_production(
-    zone_key: str = "TH",
-    session: requests.Session | None = None,
-    target_datetime: dt.datetime | None = None,
-    logger: Logger = getLogger(__name__),
-) -> list[dict]:
-    """Request the last known production mix (in MW) of a given country."""
-    data = _fetch_data(_as_localtime(target_datetime), "actual")
-
-    production = []
-    for item in data:
-        production.append(
-            {
-                "zoneKey": zone_key,
-                "datetime": item["datetime"],
-                # All mapped to 'unknown' because there is no available breakdown.
-                "production": {"unknown": item["generation"]},
-                "source": EGAT_URL,
-            }
-        )
-    return production
-
-
-def fetch_consumption(
-    zone_key: str = "TH",
-    session: requests.Session | None = None,
-    target_datetime: dt.datetime | None = None,
-    logger: Logger = getLogger(__name__),
-) -> list[dict]:
-    """
-    Gets consumption for a specified zone.
-
-    We use the same value as the production for now.
-    But it would be better to include exchanged electricity data if available.
-    """
-    production = fetch_production(target_datetime=_as_localtime(target_datetime))
-    consumption = []
-    for item in production:
-        item["consumption"] = item["production"]["unknown"]
-        del item["production"]
-        consumption.append(item)
-    return consumption
-
-
-def fetch_generation_forecast(
-    zone_key: str = "TH",
-    session: requests.Session | None = None,
-    target_datetime: dt.datetime | None = None,
-    logger: Logger = getLogger(__name__),
-) -> list[dict]:
-    """Gets generation forecast for specified zone."""
-    data = _fetch_data(_as_localtime(target_datetime), "plan")
-
-    production = []
-    for item in data:
-        production.append(
-            {
-                "zoneKey": zone_key,
-                "datetime": item["datetime"],
-                # All mapped to unknown as there is no available breakdown
-                "production": {"unknown": item["generation"]},
-                "source": EGAT_URL,
-            }
-        )
-    return production
-
-
-def _as_localtime(datetime):
+def _as_localtime(dt: datetime) -> datetime:
     """
     If there is no datetime given, returns the current datetime with timezone.
     Otherwise, it interprets the datetime as the representation of local time
     since the API server supposes the local timezone instead of UTC.
     """
     tzinfo = pytz.timezone(TZ)
-    if datetime is None:
-        return dt.datetime.now(tz=tzinfo)
-    return datetime.astimezone(tzinfo)
+    if dt is None:
+        return datetime.now(tz=tzinfo)
+    return dt.astimezone(tzinfo)
 
 
-def _fetch_data(target_datetime: dt.datetime, data_type: str) -> list[dict]:
+def _seconds_to_time(target_datetime: datetime, seconds_in_day: int) -> datetime:
+    """Convert a given seconds integer to a datetime value."""
+    today = target_datetime.replace(hour=0, minute=0, second=0, microsecond=0)
+    dt = today + timedelta(seconds=seconds_in_day)
+    return dt
+
+
+def _fetch_data(
+    session: Session, target_datetime: datetime, data_type: str
+) -> list[dict]:
     """Fetch actual or planning generation data from the EGAT API endpoint."""
     url = f"{EGAT_GENERATION_URL}/{data_type}"
     if target_datetime is None:
-        target_datetime = arrow.now(TZ).datetime
+        target_datetime = _as_localtime(datetime.now())
 
     if data_type == "actual":
         params = {"name": "SYSTEM_GEN(MW)", "day": target_datetime.strftime("%d-%m-%Y")}
@@ -114,7 +57,7 @@ def _fetch_data(target_datetime: dt.datetime, data_type: str) -> list[dict]:
     # Example: [[0, 12345], [60, 12345.6], ...]
     # - The first integer is the seconds number since 00:00 am (i.e. 900 == 00:15 am)
     # - The second integer is the total generation (MW)
-    raw_text = requests.post(url, data=params).text
+    raw_text = session.post(url, data=params).text
 
     # Fix programming error of the returned value.
     # This API server returns a invalid string if the list is empty.
@@ -142,17 +85,82 @@ def _fetch_data(target_datetime: dt.datetime, data_type: str) -> list[dict]:
     return data
 
 
-def _seconds_to_time(target_datetime: dt.datetime, seconds_in_day: int) -> dt.datetime:
-    """Convert a given seconds integer to a datetime value."""
-    today = target_datetime.replace(hour=0, minute=0, second=0, microsecond=0)
-    datetime = today + dt.timedelta(seconds=seconds_in_day)
-    return datetime
+@refetch_frequency(timedelta(days=1))
+def fetch_production(
+    zone_key: str = "TH",
+    session: requests.Session = Session(),
+    target_datetime: datetime | None = None,
+    logger: Logger = getLogger(__name__),
+) -> list[dict]:
+    """Request the last known production mix (in MW) of a given country."""
+    data = _fetch_data(session, _as_localtime(target_datetime), "actual")
+
+    production = []
+    for item in data:
+        production.append(
+            {
+                "zoneKey": zone_key,
+                "datetime": item["datetime"],
+                # All mapped to 'unknown' because there is no available breakdown.
+                "production": {"unknown": item["generation"]},
+                "source": EGAT_URL,
+            }
+        )
+    return production
+
+
+@refetch_frequency(timedelta(days=1))
+def fetch_consumption(
+    zone_key: str = "TH",
+    session: requests.Session = Session(),
+    target_datetime: datetime | None = None,
+    logger: Logger = getLogger(__name__),
+) -> list[dict]:
+    """
+    Gets consumption for a specified zone.
+
+    We use the same value as the production for now.
+    But it would be better to include exchanged electricity data if available.
+    """
+    production = fetch_production(
+        session=session, target_datetime=_as_localtime(target_datetime)
+    )
+    consumption = []
+    for item in production:
+        item["consumption"] = item["production"]["unknown"]
+        del item["production"]
+        consumption.append(item)
+    return consumption
+
+
+@refetch_frequency(timedelta(days=1))
+def fetch_generation_forecast(
+    zone_key: str = "TH",
+    session: requests.Session = Session(),
+    target_datetime: datetime | None = None,
+    logger: Logger = getLogger(__name__),
+) -> list[dict]:
+    """Gets generation forecast for specified zone."""
+    data = _fetch_data(session, _as_localtime(target_datetime), "plan")
+
+    production = []
+    for item in data:
+        production.append(
+            {
+                "zoneKey": zone_key,
+                "datetime": item["datetime"],
+                # All mapped to unknown as there is no available breakdown
+                "production": {"unknown": item["generation"]},
+                "source": EGAT_URL,
+            }
+        )
+    return production
 
 
 def fetch_price(
     zone_key: str = "TH",
-    session: requests.Session | None = None,
-    target_datetime: dt.datetime | None = None,
+    session: requests.Session = Session(),
+    target_datetime: datetime | None = None,
     logger: Logger = getLogger(__name__),
 ) -> dict:
     """
@@ -172,8 +180,15 @@ def fetch_price(
 
     # Fetch price from MEA table.
     # `price_base` is 'Over 400 kWh (up from 401st)' from Table 1.1
-    with requests.get(MEA_BASEPRICE_URL) as response:
+    with session.get(MEA_BASEPRICE_URL) as response:
         soup_base = BeautifulSoup(response.content, "lxml")
+
+    if response.status_code != 200:
+        raise ParserException(
+            parser="TH.py",
+            message=f"{MEA_BASEPRICE_URL} returned {response.status_code}",
+            zone_key=zone_key,
+        )
 
     unit_price_table = soup_base.find_all("table")[1]
     price_base = unit_price_table.find_all("td")[19].text
@@ -181,11 +196,18 @@ def fetch_price(
     # Available Ft pricing history dated back as far as September 2535 B.E. (1992 C.E.)
     # `price_ft` slot's is 0+(month number), additional +13 is needed if that slot is " "
     # For 2023 multi-Ft rates, we assumed the household rate.
-    with requests.get(MEA_FT_URL) as response:
+    with session.get(MEA_FT_URL) as response:
         soup_ft = BeautifulSoup(response.content, "lxml")
 
+    if response.status_code != 200:
+        raise ParserException(
+            parser="TH.py",
+            message=f"{MEA_FT_URL} returned {response.status_code}",
+            zone_key=zone_key,
+        )
+
     ft_rate_table = soup_ft.find_all("table")[1]
-    curr_ft_month = arrow.now(TZ).month
+    curr_ft_month = _as_localtime(datetime.now()).month
     price_ft = ft_rate_table.find_all("td")[curr_ft_month].text
 
     if price_ft == "\xa0":
@@ -196,7 +218,7 @@ def fetch_price(
     return {
         "zoneKey": zone_key,
         "currency": "THB",
-        "datetime": arrow.now(TZ).datetime,
+        "datetime": _as_localtime(datetime.now()),
         "price": float(price_base) * 1000 + float(price_ft) * 10,
         "source": MEA_URL,
     }

--- a/parsers/TH.py
+++ b/parsers/TH.py
@@ -74,10 +74,10 @@ def _fetch_data(
         seconds_in_day = item[0]
         generation = item[1]
 
-        datetime = _seconds_to_time(target_datetime, seconds_in_day)
+        dt = _seconds_to_time(target_datetime, seconds_in_day)
         data.append(
             {
-                "datetime": datetime,
+                "datetime": dt,
                 "generation": generation,
             }
         )

--- a/parsers/TH.py
+++ b/parsers/TH.py
@@ -4,7 +4,6 @@ from datetime import datetime, timedelta
 from logging import Logger, getLogger
 
 import pytz
-import requests
 from bs4 import BeautifulSoup
 from requests import Session
 
@@ -88,10 +87,11 @@ def _fetch_data(
 @refetch_frequency(timedelta(days=1))
 def fetch_production(
     zone_key: str = "TH",
-    session: requests.Session = Session(),
+    session: Session | None = None,
     target_datetime: datetime | None = None,
     logger: Logger = getLogger(__name__),
 ) -> list[dict]:
+    session = session or Session()
     """Request the last known production mix (in MW) of a given country."""
     data = _fetch_data(session, _as_localtime(target_datetime), "actual")
 
@@ -112,7 +112,7 @@ def fetch_production(
 @refetch_frequency(timedelta(days=1))
 def fetch_consumption(
     zone_key: str = "TH",
-    session: requests.Session = Session(),
+    session: Session | None = None,
     target_datetime: datetime | None = None,
     logger: Logger = getLogger(__name__),
 ) -> list[dict]:
@@ -122,6 +122,7 @@ def fetch_consumption(
     We use the same value as the production for now.
     But it would be better to include exchanged electricity data if available.
     """
+    session = session or Session()
     production = fetch_production(
         session=session, target_datetime=_as_localtime(target_datetime)
     )
@@ -136,11 +137,12 @@ def fetch_consumption(
 @refetch_frequency(timedelta(days=1))
 def fetch_generation_forecast(
     zone_key: str = "TH",
-    session: requests.Session = Session(),
+    session: Session | None = None,
     target_datetime: datetime | None = None,
     logger: Logger = getLogger(__name__),
 ) -> list[dict]:
     """Gets generation forecast for specified zone."""
+    session = session or Session()
     data = _fetch_data(session, _as_localtime(target_datetime), "plan")
 
     production = []
@@ -159,7 +161,7 @@ def fetch_generation_forecast(
 
 def fetch_price(
     zone_key: str = "TH",
-    session: requests.Session = Session(),
+    session: Session | None = None,
     target_datetime: datetime | None = None,
     logger: Logger = getLogger(__name__),
 ) -> dict:
@@ -175,6 +177,7 @@ def fetch_price(
     **While actual BasePrice is done in a progressive manner, For Electricity Maps -
       we use "AmountDue" at 1MWh calculated at the highest pricing bracket for simplification.
     """
+    session = session or Session()
     if target_datetime is not None:
         raise NotImplementedError("This parser is not yet able to parse past dates")
 


### PR DESCRIPTION
## Issue

Some of our parsers have wrongful `refetch_frequency` decorators which make our historical refetches super slow.

## Description

* Fix these decorators
* Some misc parser improvements

### Preview

Tested them individually

### Double check

- [x] I have tested my parser changes locally with `poetry run test_parser "zone_key"`
- [x] I have run `pnpx prettier --write .` and `poetry run format` to format my changes.
