### PR TITLE
wfix solar layer crash from bookmark launch

### DIFF
--- a/web/src/features/weather-layers/solar/SolarLayer.tsx
+++ b/web/src/features/weather-layers/solar/SolarLayer.tsx
@@ -58,7 +58,7 @@ export default function SolarLayer({ map }: { map?: MapboxMap }) {
   }, [solarData?.header.nx, solarData?.header.ny]);
 
   useEffect(() => {
-    if (!node || !map) {
+    if (!node || !map?.isStyleLoaded()) {
       return;
     }
     const north = gudermannian(convertYToLat(node.height - 1, 0));


### PR DESCRIPTION
## Issue
Opening the app from a bookmark in chrome and firefox can cause crashes

## Description
See the error below from the `src/features/weather-layers/solar/SolarLayer`
```

Error: Style is not done loading.

React ErrorBoundary Error: Style is not done loading.
```
I think we could improve this further by not loading the layer until it's ready to be loaded but this solves the issue for users effected by this now.

### Double check

- [x] I have tested my parser changes locally with `poetry run test_parser "zone_key"`
- [x] I have run `pnpx prettier --write .` and `poetry run format` to format my changes.
