### PR TITLE
fix solar layer part 2

### DIFF
--- a/web/src/features/weather-layers/solar/SolarLayer.tsx
+++ b/web/src/features/weather-layers/solar/SolarLayer.tsx
@@ -84,7 +84,7 @@ export default function SolarLayer({ map }: { map?: MapboxMap }) {
   }, [map, node]);
 
   useEffect(() => {
-    if (!node || !map || !isVisibleReference.current) {
+    if (!node || !map?.isStyleLoaded() || !isVisibleReference.current) {
       return;
     }
     if (!map.getLayer('solar-point')) {
@@ -101,7 +101,7 @@ export default function SolarLayer({ map }: { map?: MapboxMap }) {
 
   // Render the processed solar forecast image into the canvas.
   useEffect(() => {
-    if (!map || !node || !solarData || !isVisibleReference.current) {
+    if (!map?.isStyleLoaded() || !node || !solarData || !isVisibleReference.current) {
       return;
     }
     const canvas = node.getContext('2d');

--- a/web/src/features/weather-layers/solar/SolarLayer.tsx
+++ b/web/src/features/weather-layers/solar/SolarLayer.tsx
@@ -101,7 +101,7 @@ export default function SolarLayer({ map }: { map?: MapboxMap }) {
 
   // Render the processed solar forecast image into the canvas.
   useEffect(() => {
-    if (!map?.isStyleLoaded() || !node || !solarData || !isVisibleReference.current) {
+    if (!map || !node || !solarData || !isVisibleReference.current) {
       return;
     }
     const canvas = node.getContext('2d');


### PR DESCRIPTION
## Issue
App crashing when launching from bookmark

## Description
This bug was reduced in #6030 but still showing up. 

This PR adds a check for the styles to be loaded when ever getLayer is called in the solar layer


### Double check

- [x] I have tested my parser changes locally with `poetry run test_parser "zone_key"`
- [x] I have run `pnpx prettier --write .` and `poetry run format` to format my changes.
