### PR TITLE
fix(parser): Add expected range for gas to Peru

### DIFF
--- a/parsers/PE.py
+++ b/parsers/PE.py
@@ -103,6 +103,9 @@ def fetch_production(
                 x,
                 logger,
                 required=["gas"],
+                expected_range={
+                    "gas": (100, 6000),
+                },
                 floor=0.0,
             )
             is not None,


### PR DESCRIPTION
The Peru parser has been outputting incomplete data:
<img width="407" alt="image" src="https://github.com/electricitymaps/electricitymaps-contrib/assets/12124251/bbaef424-c1db-4dc6-bbb5-c1460b4f5e8b">

The bounds were based on the the max/min values from the database:
Highest values:
<img width="681" alt="image" src="https://github.com/electricitymaps/electricitymaps-contrib/assets/12124251/6c39d944-bab4-4a4f-885f-7a2a56ce2571">

Lowest values:
<img width="681" alt="image" src="https://github.com/electricitymaps/electricitymaps-contrib/assets/12124251/36fbb3e5-c727-429b-aeb2-d67586093ae9">
