### PR TITLE
add compressed us states matching our geometries

### DIFF
--- a/web/geo/generateTopojson.ts
+++ b/web/geo/generateTopojson.ts
@@ -66,7 +66,9 @@ function generateTopojson(
   const newObjects = {} as typeof topo.objects;
   for (const geo of objects.geometries) {
     // Remove countryName as it is not used in the frontend
-    delete geo.properties.countryName;
+    if (geo.properties?.countryName) {
+      delete geo.properties.countryName;
+    }
     // Precompute center for enable centering on the zone
     geo.properties.center = getCenter(fc, geo.properties.zoneName);
 

--- a/web/geo/generateWorld.ts
+++ b/web/geo/generateWorld.ts
@@ -33,13 +33,6 @@ export const STATES_CONFIG = {
     fileURLToPath(new URL('../config/usa-states.json', import.meta.url))
   ),
   ERROR_PATH: path.resolve(fileURLToPath(new URL('.', import.meta.url))),
-  // TODO: The numbers here may not line up with the expected values in validateGeometry, as these numbers seem to be
-  // somewhat arbitrarily picked to make the validation pass. We should probably revisit these numbers and see if they
-  // can be improved.
-  MIN_AREA_HOLES: 5_000_000,
-  MAX_CONVEX_DEVIATION: 0.708,
-  MIN_AREA_INTERSECTION: 6_000_000,
-  SLIVER_RATIO: 0.0001, // ratio of length and area to determine if the polygon is a sliver and should be ignored
   verifyNoUpdates: process.env.VERIFY_NO_UPDATES !== undefined,
 } as const;
 

--- a/web/geo/usa-states.geojson
+++ b/web/geo/usa-states.geojson
@@ -4,9 +4,7 @@
   "features": [
     {
       "type": "Feature",
-      "properties": {
-        "zoneName": "Alabama"
-      },
+      "properties": { "zoneName": "Alabama", "stateId": "AL" },
       "geometry": {
         "type": "MultiPolygon",
         "coordinates": [
@@ -52,9 +50,7 @@
     },
     {
       "type": "Feature",
-      "properties": {
-        "zoneName": "Arizona"
-      },
+      "properties": { "zoneName": "Arizona", "stateId": "AZ" },
       "geometry": {
         "type": "MultiPolygon",
         "coordinates": [
@@ -99,9 +95,7 @@
     },
     {
       "type": "Feature",
-      "properties": {
-        "zoneName": "Arkansas"
-      },
+      "properties": { "zoneName": "Arkansas", "stateId": "AR" },
       "geometry": {
         "type": "MultiPolygon",
         "coordinates": [
@@ -151,9 +145,7 @@
     },
     {
       "type": "Feature",
-      "properties": {
-        "zoneName": "California"
-      },
+      "properties": { "zoneName": "California", "stateId": "CA" },
       "geometry": {
         "type": "MultiPolygon",
         "coordinates": [
@@ -259,9 +251,7 @@
     },
     {
       "type": "Feature",
-      "properties": {
-        "zoneName": "Colorado"
-      },
+      "properties": { "zoneName": "Colorado", "stateId": "CO" },
       "geometry": {
         "type": "MultiPolygon",
         "coordinates": [
@@ -290,9 +280,7 @@
     },
     {
       "type": "Feature",
-      "properties": {
-        "zoneName": "Connecticut"
-      },
+      "properties": { "zoneName": "Connecticut", "stateId": "CT" },
       "geometry": {
         "type": "MultiPolygon",
         "coordinates": [
@@ -321,9 +309,7 @@
     },
     {
       "type": "Feature",
-      "properties": {
-        "zoneName": "Delaware"
-      },
+      "properties": { "zoneName": "Delaware", "stateId": "DE" },
       "geometry": {
         "type": "MultiPolygon",
         "coordinates": [
@@ -349,9 +335,7 @@
     },
     {
       "type": "Feature",
-      "properties": {
-        "zoneName": "District of Columbia"
-      },
+      "properties": { "zoneName": "District of Columbia", "stateId": "Unknown" },
       "geometry": {
         "type": "MultiPolygon",
         "coordinates": [
@@ -369,9 +353,7 @@
     },
     {
       "type": "Feature",
-      "properties": {
-        "zoneName": "Georgia"
-      },
+      "properties": { "zoneName": "Georgia", "stateId": "GA" },
       "geometry": {
         "type": "MultiPolygon",
         "coordinates": [
@@ -436,9 +418,7 @@
     },
     {
       "type": "Feature",
-      "properties": {
-        "zoneName": "Idaho"
-      },
+      "properties": { "zoneName": "Idaho", "stateId": "ID" },
       "geometry": {
         "type": "MultiPolygon",
         "coordinates": [
@@ -517,9 +497,7 @@
     },
     {
       "type": "Feature",
-      "properties": {
-        "zoneName": "Illinois"
-      },
+      "properties": { "zoneName": "Illinois", "stateId": "IL" },
       "geometry": {
         "type": "MultiPolygon",
         "coordinates": [
@@ -599,9 +577,7 @@
     },
     {
       "type": "Feature",
-      "properties": {
-        "zoneName": "Indiana"
-      },
+      "properties": { "zoneName": "Indiana", "stateId": "IN" },
       "geometry": {
         "type": "MultiPolygon",
         "coordinates": [
@@ -660,9 +636,7 @@
     },
     {
       "type": "Feature",
-      "properties": {
-        "zoneName": "Iowa"
-      },
+      "properties": { "zoneName": "Iowa", "stateId": "IA" },
       "geometry": {
         "type": "MultiPolygon",
         "coordinates": [
@@ -725,9 +699,7 @@
     },
     {
       "type": "Feature",
-      "properties": {
-        "zoneName": "Kansas"
-      },
+      "properties": { "zoneName": "Kansas", "stateId": "KS" },
       "geometry": {
         "type": "MultiPolygon",
         "coordinates": [
@@ -753,9 +725,7 @@
     },
     {
       "type": "Feature",
-      "properties": {
-        "zoneName": "Kentucky"
-      },
+      "properties": { "zoneName": "Kentucky", "stateId": "KY" },
       "geometry": {
         "type": "MultiPolygon",
         "coordinates": [
@@ -843,9 +813,7 @@
     },
     {
       "type": "Feature",
-      "properties": {
-        "zoneName": "Maine"
-      },
+      "properties": { "zoneName": "Maine", "stateId": "ME" },
       "geometry": {
         "type": "MultiPolygon",
         "coordinates": [
@@ -927,9 +895,7 @@
     },
     {
       "type": "Feature",
-      "properties": {
-        "zoneName": "Maryland"
-      },
+      "properties": { "zoneName": "Maryland", "stateId": "MD" },
       "geometry": {
         "type": "MultiPolygon",
         "coordinates": [
@@ -1002,9 +968,7 @@
     },
     {
       "type": "Feature",
-      "properties": {
-        "zoneName": "Massachusetts"
-      },
+      "properties": { "zoneName": "Massachusetts", "stateId": "MA" },
       "geometry": {
         "type": "MultiPolygon",
         "coordinates": [
@@ -1052,9 +1016,7 @@
     },
     {
       "type": "Feature",
-      "properties": {
-        "zoneName": "Michigan"
-      },
+      "properties": { "zoneName": "Michigan", "stateId": "MI" },
       "geometry": {
         "type": "MultiPolygon",
         "coordinates": [
@@ -1211,7 +1173,7 @@
     },
     {
       "type": "Feature",
-      "properties": { "zoneName": "" },
+      "properties": { "zoneName": "", "stateId": "Unknown" },
       "geometry": {
         "type": "MultiPolygon",
         "coordinates": [
@@ -1231,9 +1193,7 @@
     },
     {
       "type": "Feature",
-      "properties": {
-        "zoneName": "Minnesota"
-      },
+      "properties": { "zoneName": "Minnesota", "stateId": "MN" },
       "geometry": {
         "type": "MultiPolygon",
         "coordinates": [
@@ -1336,9 +1296,7 @@
     },
     {
       "type": "Feature",
-      "properties": {
-        "zoneName": "Mississippi"
-      },
+      "properties": { "zoneName": "Mississippi", "stateId": "MS" },
       "geometry": {
         "type": "MultiPolygon",
         "coordinates": [
@@ -1397,9 +1355,7 @@
     },
     {
       "type": "Feature",
-      "properties": {
-        "zoneName": "Missouri"
-      },
+      "properties": { "zoneName": "Missouri", "stateId": "MO" },
       "geometry": {
         "type": "MultiPolygon",
         "coordinates": [
@@ -1465,9 +1421,7 @@
     },
     {
       "type": "Feature",
-      "properties": {
-        "zoneName": "Montana"
-      },
+      "properties": { "zoneName": "Montana", "stateId": "MT" },
       "geometry": {
         "type": "MultiPolygon",
         "coordinates": [
@@ -1532,9 +1486,7 @@
     },
     {
       "type": "Feature",
-      "properties": {
-        "zoneName": "Nebraska"
-      },
+      "properties": { "zoneName": "Nebraska", "stateId": "NE" },
       "geometry": {
         "type": "MultiPolygon",
         "coordinates": [
@@ -1576,9 +1528,7 @@
     },
     {
       "type": "Feature",
-      "properties": {
-        "zoneName": "Nevada"
-      },
+      "properties": { "zoneName": "Nevada", "stateId": "NV" },
       "geometry": {
         "type": "MultiPolygon",
         "coordinates": [
@@ -1612,9 +1562,7 @@
     },
     {
       "type": "Feature",
-      "properties": {
-        "zoneName": "New Hampshire"
-      },
+      "properties": { "zoneName": "New Hampshire", "stateId": "NH" },
       "geometry": {
         "type": "MultiPolygon",
         "coordinates": [
@@ -1655,9 +1603,7 @@
     },
     {
       "type": "Feature",
-      "properties": {
-        "zoneName": "New Jersey"
-      },
+      "properties": { "zoneName": "New Jersey", "stateId": "NJ" },
       "geometry": {
         "type": "MultiPolygon",
         "coordinates": [
@@ -1702,9 +1648,7 @@
     },
     {
       "type": "Feature",
-      "properties": {
-        "zoneName": "New Mexico"
-      },
+      "properties": { "zoneName": "New Mexico", "stateId": "NM" },
       "geometry": {
         "type": "MultiPolygon",
         "coordinates": [
@@ -1734,9 +1678,7 @@
     },
     {
       "type": "Feature",
-      "properties": {
-        "zoneName": "New York"
-      },
+      "properties": { "zoneName": "New York", "stateId": "NY" },
       "geometry": {
         "type": "MultiPolygon",
         "coordinates": [
@@ -1817,9 +1759,7 @@
     },
     {
       "type": "Feature",
-      "properties": {
-        "zoneName": "North Carolina"
-      },
+      "properties": { "zoneName": "North Carolina", "stateId": "NC" },
       "geometry": {
         "type": "MultiPolygon",
         "coordinates": [
@@ -1902,9 +1842,7 @@
     },
     {
       "type": "Feature",
-      "properties": {
-        "zoneName": "North Dakota"
-      },
+      "properties": { "zoneName": "North Dakota", "stateId": "ND" },
       "geometry": {
         "type": "MultiPolygon",
         "coordinates": [
@@ -1933,9 +1871,7 @@
     },
     {
       "type": "Feature",
-      "properties": {
-        "zoneName": "Ohio"
-      },
+      "properties": { "zoneName": "Ohio", "stateId": "OH" },
       "geometry": {
         "type": "MultiPolygon",
         "coordinates": [
@@ -1995,9 +1931,7 @@
     },
     {
       "type": "Feature",
-      "properties": {
-        "zoneName": "Oklahoma"
-      },
+      "properties": { "zoneName": "Oklahoma", "stateId": "OK" },
       "geometry": {
         "type": "MultiPolygon",
         "coordinates": [
@@ -2055,9 +1989,7 @@
     },
     {
       "type": "Feature",
-      "properties": {
-        "zoneName": "Oregon"
-      },
+      "properties": { "zoneName": "Oregon", "stateId": "OR" },
       "geometry": {
         "type": "MultiPolygon",
         "coordinates": [
@@ -2126,9 +2058,7 @@
     },
     {
       "type": "Feature",
-      "properties": {
-        "zoneName": "Pennsylvania"
-      },
+      "properties": { "zoneName": "Pennsylvania", "stateId": "PA" },
       "geometry": {
         "type": "MultiPolygon",
         "coordinates": [
@@ -2174,9 +2104,7 @@
     },
     {
       "type": "Feature",
-      "properties": {
-        "zoneName": "Rhode Island"
-      },
+      "properties": { "zoneName": "Rhode Island", "stateId": "RI" },
       "geometry": {
         "type": "MultiPolygon",
         "coordinates": [
@@ -2213,9 +2141,7 @@
     },
     {
       "type": "Feature",
-      "properties": {
-        "zoneName": "South Carolina"
-      },
+      "properties": { "zoneName": "South Carolina", "stateId": "SC" },
       "geometry": {
         "type": "MultiPolygon",
         "coordinates": [
@@ -2272,9 +2198,7 @@
     },
     {
       "type": "Feature",
-      "properties": {
-        "zoneName": "South Dakota"
-      },
+      "properties": { "zoneName": "South Dakota", "stateId": "SD" },
       "geometry": {
         "type": "MultiPolygon",
         "coordinates": [
@@ -2316,9 +2240,7 @@
     },
     {
       "type": "Feature",
-      "properties": {
-        "zoneName": "Tennessee"
-      },
+      "properties": { "zoneName": "Tennessee", "stateId": "TN" },
       "geometry": {
         "type": "MultiPolygon",
         "coordinates": [
@@ -2374,9 +2296,7 @@
     },
     {
       "type": "Feature",
-      "properties": {
-        "zoneName": "Texas"
-      },
+      "properties": { "zoneName": "Texas", "stateId": "TX" },
       "geometry": {
         "type": "MultiPolygon",
         "coordinates": [
@@ -2541,9 +2461,7 @@
     },
     {
       "type": "Feature",
-      "properties": {
-        "zoneName": "Utah"
-      },
+      "properties": { "zoneName": "Utah", "stateId": "UT" },
       "geometry": {
         "type": "MultiPolygon",
         "coordinates": [
@@ -2568,9 +2486,7 @@
     },
     {
       "type": "Feature",
-      "properties": {
-        "zoneName": "Vermont"
-      },
+      "properties": { "zoneName": "Vermont", "stateId": "VT" },
       "geometry": {
         "type": "MultiPolygon",
         "coordinates": [
@@ -2611,9 +2527,7 @@
     },
     {
       "type": "Feature",
-      "properties": {
-        "zoneName": "Virginia"
-      },
+      "properties": { "zoneName": "Virginia", "stateId": "VA" },
       "geometry": {
         "type": "MultiPolygon",
         "coordinates": [
@@ -2706,9 +2620,7 @@
     },
     {
       "type": "Feature",
-      "properties": {
-        "zoneName": "Washington"
-      },
+      "properties": { "zoneName": "Washington", "stateId": "WA" },
       "geometry": {
         "type": "MultiPolygon",
         "coordinates": [
@@ -2782,9 +2694,7 @@
     },
     {
       "type": "Feature",
-      "properties": {
-        "zoneName": "West Virginia"
-      },
+      "properties": { "zoneName": "West Virginia", "stateId": "WV" },
       "geometry": {
         "type": "MultiPolygon",
         "coordinates": [
@@ -2862,9 +2772,7 @@
     },
     {
       "type": "Feature",
-      "properties": {
-        "zoneName": "Wisconsin"
-      },
+      "properties": { "zoneName": "Wisconsin", "stateId": "WI" },
       "geometry": {
         "type": "MultiPolygon",
         "coordinates": [
@@ -2952,9 +2860,7 @@
     },
     {
       "type": "Feature",
-      "properties": {
-        "zoneName": "Wyoming"
-      },
+      "properties": { "zoneName": "Wyoming", "stateId": "WY" },
       "geometry": {
         "type": "MultiPolygon",
         "coordinates": [
@@ -2980,9 +2886,7 @@
     },
     {
       "type": "Feature",
-      "properties": {
-        "zoneName": "Florida"
-      },
+      "properties": { "zoneName": "Florida", "stateId": "FL" },
       "geometry": {
         "type": "MultiPolygon",
         "coordinates": [
@@ -3074,9 +2978,7 @@
     },
     {
       "type": "Feature",
-      "properties": {
-        "zoneName": "Louisiana"
-      },
+      "properties": { "zoneName": "Louisiana", "stateId": "LA" },
       "geometry": {
         "type": "MultiPolygon",
         "coordinates": [

--- a/web/geo/usa-states.geojson
+++ b/web/geo/usa-states.geojson
@@ -5,8 +5,7 @@
     {
       "type": "Feature",
       "properties": {
-        "name": "Alabama",
-        "layer": "USA Borders"
+        "zoneName": "Alabama"
       },
       "geometry": {
         "type": "MultiPolygon",
@@ -54,8 +53,7 @@
     {
       "type": "Feature",
       "properties": {
-        "name": "Arizona",
-        "layer": "USA Borders"
+        "zoneName": "Arizona"
       },
       "geometry": {
         "type": "MultiPolygon",
@@ -102,8 +100,7 @@
     {
       "type": "Feature",
       "properties": {
-        "name": "Arkansas",
-        "layer": "USA Borders"
+        "zoneName": "Arkansas"
       },
       "geometry": {
         "type": "MultiPolygon",
@@ -155,8 +152,7 @@
     {
       "type": "Feature",
       "properties": {
-        "name": "California",
-        "layer": "USA Borders"
+        "zoneName": "California"
       },
       "geometry": {
         "type": "MultiPolygon",
@@ -264,8 +260,7 @@
     {
       "type": "Feature",
       "properties": {
-        "name": "Colorado",
-        "layer": "USA Borders"
+        "zoneName": "Colorado"
       },
       "geometry": {
         "type": "MultiPolygon",
@@ -296,8 +291,7 @@
     {
       "type": "Feature",
       "properties": {
-        "name": "Connecticut",
-        "layer": "USA Borders"
+        "zoneName": "Connecticut"
       },
       "geometry": {
         "type": "MultiPolygon",
@@ -328,8 +322,7 @@
     {
       "type": "Feature",
       "properties": {
-        "name": "Delaware",
-        "layer": "USA Borders"
+        "zoneName": "Delaware"
       },
       "geometry": {
         "type": "MultiPolygon",
@@ -357,8 +350,7 @@
     {
       "type": "Feature",
       "properties": {
-        "name": "District of Columbia",
-        "layer": "USA Borders"
+        "zoneName": "District of Columbia"
       },
       "geometry": {
         "type": "MultiPolygon",
@@ -378,40 +370,7 @@
     {
       "type": "Feature",
       "properties": {
-        "name": "Florida",
-        "layer": "USA Borders"
-      },
-      "geometry": { "type": "MultiPolygon", "coordinates": [] }
-    },
-    {
-      "type": "Feature",
-      "properties": {
-        "name": "Hawaii",
-        "layer": "USA Borders"
-      },
-      "geometry": { "type": "MultiPolygon", "coordinates": [] }
-    },
-    {
-      "type": "Feature",
-      "properties": {
-        "name": "Louisiana",
-        "layer": "USA Borders"
-      },
-      "geometry": { "type": "MultiPolygon", "coordinates": [] }
-    },
-    {
-      "type": "Feature",
-      "properties": {
-        "name": "Puerto Rico",
-        "layer": "USA Borders"
-      },
-      "geometry": { "type": "MultiPolygon", "coordinates": [] }
-    },
-    {
-      "type": "Feature",
-      "properties": {
-        "name": "Georgia",
-        "layer": "USA Borders"
+        "zoneName": "Georgia"
       },
       "geometry": {
         "type": "MultiPolygon",
@@ -478,40 +437,7 @@
     {
       "type": "Feature",
       "properties": {
-        "name": "Florida",
-        "layer": "USA Borders"
-      },
-      "geometry": { "type": "MultiPolygon", "coordinates": [] }
-    },
-    {
-      "type": "Feature",
-      "properties": {
-        "name": "Hawaii",
-        "layer": "USA Borders"
-      },
-      "geometry": { "type": "MultiPolygon", "coordinates": [] }
-    },
-    {
-      "type": "Feature",
-      "properties": {
-        "name": "Louisiana",
-        "layer": "USA Borders"
-      },
-      "geometry": { "type": "MultiPolygon", "coordinates": [] }
-    },
-    {
-      "type": "Feature",
-      "properties": {
-        "name": "Puerto Rico",
-        "layer": "USA Borders"
-      },
-      "geometry": { "type": "MultiPolygon", "coordinates": [] }
-    },
-    {
-      "type": "Feature",
-      "properties": {
-        "name": "Idaho",
-        "layer": "USA Borders"
+        "zoneName": "Idaho"
       },
       "geometry": {
         "type": "MultiPolygon",
@@ -592,8 +518,7 @@
     {
       "type": "Feature",
       "properties": {
-        "name": "Illinois",
-        "layer": "USA Borders"
+        "zoneName": "Illinois"
       },
       "geometry": {
         "type": "MultiPolygon",
@@ -675,8 +600,7 @@
     {
       "type": "Feature",
       "properties": {
-        "name": "Indiana",
-        "layer": "USA Borders"
+        "zoneName": "Indiana"
       },
       "geometry": {
         "type": "MultiPolygon",
@@ -737,8 +661,7 @@
     {
       "type": "Feature",
       "properties": {
-        "name": "Iowa",
-        "layer": "USA Borders"
+        "zoneName": "Iowa"
       },
       "geometry": {
         "type": "MultiPolygon",
@@ -803,8 +726,7 @@
     {
       "type": "Feature",
       "properties": {
-        "name": "Kansas",
-        "layer": "USA Borders"
+        "zoneName": "Kansas"
       },
       "geometry": {
         "type": "MultiPolygon",
@@ -832,8 +754,7 @@
     {
       "type": "Feature",
       "properties": {
-        "name": "Kentucky",
-        "layer": "USA Borders"
+        "zoneName": "Kentucky"
       },
       "geometry": {
         "type": "MultiPolygon",
@@ -923,40 +844,7 @@
     {
       "type": "Feature",
       "properties": {
-        "name": "Florida",
-        "layer": "USA Borders"
-      },
-      "geometry": { "type": "MultiPolygon", "coordinates": [] }
-    },
-    {
-      "type": "Feature",
-      "properties": {
-        "name": "Hawaii",
-        "layer": "USA Borders"
-      },
-      "geometry": { "type": "MultiPolygon", "coordinates": [] }
-    },
-    {
-      "type": "Feature",
-      "properties": {
-        "name": "Louisiana",
-        "layer": "USA Borders"
-      },
-      "geometry": { "type": "MultiPolygon", "coordinates": [] }
-    },
-    {
-      "type": "Feature",
-      "properties": {
-        "name": "Puerto Rico",
-        "layer": "USA Borders"
-      },
-      "geometry": { "type": "MultiPolygon", "coordinates": [] }
-    },
-    {
-      "type": "Feature",
-      "properties": {
-        "name": "Maine",
-        "layer": "USA Borders"
+        "zoneName": "Maine"
       },
       "geometry": {
         "type": "MultiPolygon",
@@ -1040,8 +928,7 @@
     {
       "type": "Feature",
       "properties": {
-        "name": "Maryland",
-        "layer": "USA Borders"
+        "zoneName": "Maryland"
       },
       "geometry": {
         "type": "MultiPolygon",
@@ -1116,8 +1003,7 @@
     {
       "type": "Feature",
       "properties": {
-        "name": "Massachusetts",
-        "layer": "USA Borders"
+        "zoneName": "Massachusetts"
       },
       "geometry": {
         "type": "MultiPolygon",
@@ -1167,8 +1053,7 @@
     {
       "type": "Feature",
       "properties": {
-        "name": "Michigan",
-        "layer": "USA Borders"
+        "zoneName": "Michigan"
       },
       "geometry": {
         "type": "MultiPolygon",
@@ -1326,9 +1211,7 @@
     },
     {
       "type": "Feature",
-      "properties": {
-        "layer": "USA Borders"
-      },
+      "properties": { "zoneName": "" },
       "geometry": {
         "type": "MultiPolygon",
         "coordinates": [
@@ -1349,8 +1232,7 @@
     {
       "type": "Feature",
       "properties": {
-        "name": "Minnesota",
-        "layer": "USA Borders"
+        "zoneName": "Minnesota"
       },
       "geometry": {
         "type": "MultiPolygon",
@@ -1455,8 +1337,7 @@
     {
       "type": "Feature",
       "properties": {
-        "name": "Mississippi",
-        "layer": "USA Borders"
+        "zoneName": "Mississippi"
       },
       "geometry": {
         "type": "MultiPolygon",
@@ -1517,8 +1398,7 @@
     {
       "type": "Feature",
       "properties": {
-        "name": "Missouri",
-        "layer": "USA Borders"
+        "zoneName": "Missouri"
       },
       "geometry": {
         "type": "MultiPolygon",
@@ -1586,8 +1466,7 @@
     {
       "type": "Feature",
       "properties": {
-        "name": "Montana",
-        "layer": "USA Borders"
+        "zoneName": "Montana"
       },
       "geometry": {
         "type": "MultiPolygon",
@@ -1654,8 +1533,7 @@
     {
       "type": "Feature",
       "properties": {
-        "name": "Nebraska",
-        "layer": "USA Borders"
+        "zoneName": "Nebraska"
       },
       "geometry": {
         "type": "MultiPolygon",
@@ -1699,8 +1577,7 @@
     {
       "type": "Feature",
       "properties": {
-        "name": "Nevada",
-        "layer": "USA Borders"
+        "zoneName": "Nevada"
       },
       "geometry": {
         "type": "MultiPolygon",
@@ -1736,8 +1613,7 @@
     {
       "type": "Feature",
       "properties": {
-        "name": "New Hampshire",
-        "layer": "USA Borders"
+        "zoneName": "New Hampshire"
       },
       "geometry": {
         "type": "MultiPolygon",
@@ -1780,8 +1656,7 @@
     {
       "type": "Feature",
       "properties": {
-        "name": "New Jersey",
-        "layer": "USA Borders"
+        "zoneName": "New Jersey"
       },
       "geometry": {
         "type": "MultiPolygon",
@@ -1828,8 +1703,7 @@
     {
       "type": "Feature",
       "properties": {
-        "name": "New Mexico",
-        "layer": "USA Borders"
+        "zoneName": "New Mexico"
       },
       "geometry": {
         "type": "MultiPolygon",
@@ -1861,8 +1735,7 @@
     {
       "type": "Feature",
       "properties": {
-        "name": "New York",
-        "layer": "USA Borders"
+        "zoneName": "New York"
       },
       "geometry": {
         "type": "MultiPolygon",
@@ -1945,8 +1818,7 @@
     {
       "type": "Feature",
       "properties": {
-        "name": "North Carolina",
-        "layer": "USA Borders"
+        "zoneName": "North Carolina"
       },
       "geometry": {
         "type": "MultiPolygon",
@@ -2031,8 +1903,7 @@
     {
       "type": "Feature",
       "properties": {
-        "name": "North Dakota",
-        "layer": "USA Borders"
+        "zoneName": "North Dakota"
       },
       "geometry": {
         "type": "MultiPolygon",
@@ -2063,8 +1934,7 @@
     {
       "type": "Feature",
       "properties": {
-        "name": "Ohio",
-        "layer": "USA Borders"
+        "zoneName": "Ohio"
       },
       "geometry": {
         "type": "MultiPolygon",
@@ -2126,8 +1996,7 @@
     {
       "type": "Feature",
       "properties": {
-        "name": "Oklahoma",
-        "layer": "USA Borders"
+        "zoneName": "Oklahoma"
       },
       "geometry": {
         "type": "MultiPolygon",
@@ -2187,8 +2056,7 @@
     {
       "type": "Feature",
       "properties": {
-        "name": "Oregon",
-        "layer": "USA Borders"
+        "zoneName": "Oregon"
       },
       "geometry": {
         "type": "MultiPolygon",
@@ -2259,8 +2127,7 @@
     {
       "type": "Feature",
       "properties": {
-        "name": "Pennsylvania",
-        "layer": "USA Borders"
+        "zoneName": "Pennsylvania"
       },
       "geometry": {
         "type": "MultiPolygon",
@@ -2308,8 +2175,7 @@
     {
       "type": "Feature",
       "properties": {
-        "name": "Rhode Island",
-        "layer": "USA Borders"
+        "zoneName": "Rhode Island"
       },
       "geometry": {
         "type": "MultiPolygon",
@@ -2348,8 +2214,7 @@
     {
       "type": "Feature",
       "properties": {
-        "name": "South Carolina",
-        "layer": "USA Borders"
+        "zoneName": "South Carolina"
       },
       "geometry": {
         "type": "MultiPolygon",
@@ -2408,8 +2273,7 @@
     {
       "type": "Feature",
       "properties": {
-        "name": "South Dakota",
-        "layer": "USA Borders"
+        "zoneName": "South Dakota"
       },
       "geometry": {
         "type": "MultiPolygon",
@@ -2453,8 +2317,7 @@
     {
       "type": "Feature",
       "properties": {
-        "name": "Tennessee",
-        "layer": "USA Borders"
+        "zoneName": "Tennessee"
       },
       "geometry": {
         "type": "MultiPolygon",
@@ -2512,8 +2375,7 @@
     {
       "type": "Feature",
       "properties": {
-        "name": "Texas",
-        "layer": "USA Borders"
+        "zoneName": "Texas"
       },
       "geometry": {
         "type": "MultiPolygon",
@@ -2680,8 +2542,7 @@
     {
       "type": "Feature",
       "properties": {
-        "name": "Utah",
-        "layer": "USA Borders"
+        "zoneName": "Utah"
       },
       "geometry": {
         "type": "MultiPolygon",
@@ -2708,8 +2569,7 @@
     {
       "type": "Feature",
       "properties": {
-        "name": "Vermont",
-        "layer": "USA Borders"
+        "zoneName": "Vermont"
       },
       "geometry": {
         "type": "MultiPolygon",
@@ -2752,8 +2612,7 @@
     {
       "type": "Feature",
       "properties": {
-        "name": "Virginia",
-        "layer": "USA Borders"
+        "zoneName": "Virginia"
       },
       "geometry": {
         "type": "MultiPolygon",
@@ -2848,8 +2707,7 @@
     {
       "type": "Feature",
       "properties": {
-        "name": "Washington",
-        "layer": "USA Borders"
+        "zoneName": "Washington"
       },
       "geometry": {
         "type": "MultiPolygon",
@@ -2925,8 +2783,7 @@
     {
       "type": "Feature",
       "properties": {
-        "name": "West Virginia",
-        "layer": "USA Borders"
+        "zoneName": "West Virginia"
       },
       "geometry": {
         "type": "MultiPolygon",
@@ -3006,8 +2863,7 @@
     {
       "type": "Feature",
       "properties": {
-        "name": "Wisconsin",
-        "layer": "USA Borders"
+        "zoneName": "Wisconsin"
       },
       "geometry": {
         "type": "MultiPolygon",
@@ -3097,8 +2953,7 @@
     {
       "type": "Feature",
       "properties": {
-        "name": "Wyoming",
-        "layer": "USA Borders"
+        "zoneName": "Wyoming"
       },
       "geometry": {
         "type": "MultiPolygon",
@@ -3126,44 +2981,7 @@
     {
       "type": "Feature",
       "properties": {
-        "name": "Florida",
-        "layer": "USA Borders"
-      },
-      "geometry": { "type": "MultiPolygon", "coordinates": [] }
-    },
-    {
-      "type": "Feature",
-      "properties": {
-        "name": "Hawaii",
-        "layer": "USA Borders"
-      },
-      "geometry": { "type": "MultiPolygon", "coordinates": [] }
-    },
-    {
-      "type": "Feature",
-      "properties": {
-        "name": "Louisiana",
-        "layer": "USA Borders"
-      },
-      "geometry": { "type": "MultiPolygon", "coordinates": [] }
-    },
-    {
-      "type": "Feature",
-      "properties": {
-        "name": "Puerto Rico",
-        "layer": "USA Borders"
-      },
-      "geometry": { "type": "MultiPolygon", "coordinates": [] }
-    },
-    {
-      "type": "Feature",
-      "properties": {
-        "name": "Florida",
-        "layer": null,
-        "path": null,
-
-        "layer_2": null,
-        "path_2": null
+        "zoneName": "Florida"
       },
       "geometry": {
         "type": "MultiPolygon",
@@ -3257,12 +3075,7 @@
     {
       "type": "Feature",
       "properties": {
-        "name": "Louisiana",
-        "layer": null,
-        "path": null,
-
-        "layer_2": null,
-        "path_2": null
+        "zoneName": "Louisiana"
       },
       "geometry": {
         "type": "MultiPolygon",


### PR DESCRIPTION
## Issue
Compress states geojson to topojson

## Description
This PR modifies our generate world script to also process the new state border geojson to topojson


Notes, the geojson coordinates are already compressed to 4dp and I've skipped the validation step
### Double check

- [x] I have tested my parser changes locally with `poetry run test_parser "zone_key"`
- [x] I have run `pnpx prettier --write .` and `poetry run format` to format my changes.
