### PR TITLE
fix(parser): Drop last datapoint for PE if it contains incomplete data

### DIFF
--- a/parsers/PE.py
+++ b/parsers/PE.py
@@ -105,10 +105,19 @@ def fetch_production(
     # We only run this check when target_datetime is None, as to not affect refetches
     # TODO: remove this in the future, when this is automatically detected by QA layer
     data = sorted(data, key=lambda d: d["datetime"])
-    total_production_per_datapoint = list(map(lambda d: sum(d["production"].values()),data))
-    mean_production = sum(total_production_per_datapoint) / len(total_production_per_datapoint)
-    if total_production_per_datapoint[-1] < mean_production * 0.9 and target_datetime is None:
-        logger.warning("Dropping last datapoint as it is probably incomplete. Total production is less than 90% of the mean.")
+    total_production_per_datapoint = list(
+        map(lambda d: sum(d["production"].values()), data)
+    )
+    mean_production = sum(total_production_per_datapoint) / len(
+        total_production_per_datapoint
+    )
+    if (
+        total_production_per_datapoint[-1] < mean_production * 0.9
+        and target_datetime is None
+    ):
+        logger.warning(
+            "Dropping last datapoint as it is probably incomplete. Total production is less than 90% of the mean."
+        )
         data = data[:-1]
 
     return list(


### PR DESCRIPTION
Sometimes the last datapoint for PE contains incomplete data which breaks estimations. This adds a hacky check to verify that the last datapoint isn't significantly lower than the mean. It's not really a good check, but it should capture the error case and if it triggers a false positive, the dropped event would be included when the next datapoint comes in.
![image](https://github.com/electricitymaps/electricitymaps-contrib/assets/12124251/c675fefa-07f8-482b-a366-5381f8c640c4)
