### PR TITLE
typo_fixed_CONTRIBUTING

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -44,7 +44,7 @@ The zone configurations hold information such as the installed capacity, which p
 
 ## Parser guidelines
 
-To get stated with editing the parsers use the following steps:
+To get started with editing the parsers use the following steps:
 
 1. Run `poetry install -E parsers` to install all needed dependencies.
 2. Use `poetry run test_parser ZONE_KEY` to test any parser changes.


### PR DESCRIPTION
## Issue
Typo error in CONTRIBUTING.md file
<!-- If you want to close an issue automatically when your PR is merged, write "Closes X" where X is the PR number. For example: Closes #000 -->

## Description
As I am new to this project, I was reading the CONTRIBUTING.md file. I found a typo on line 47 and changed "stated" to "started". 
<!-- Explains the goal of this PR -->

### Preview
![os](https://github.com/electricitymaps/electricitymaps-contrib/assets/77086747/5a091361-9c41-4ee8-98b3-f86e61a59212)

<!-- Please add screenshots and/or gif that shows visual changes (if applicable) -->

### Double check

- [ Y] I have tested my parser changes locally with `poetry run test_parser "zone_key"`
- [ Y] I have run `pnpx prettier --write .` and `poetry run format` to format my changes.
