### PR TITLE
Capacity parser - GB

### DIFF
--- a/electricitymap/contrib/capacity_parsers/GB.py
+++ b/electricitymap/contrib/capacity_parsers/GB.py
@@ -1,0 +1,50 @@
+from datetime import datetime
+
+from bs4 import BeautifulSoup
+from requests import Response, Session
+
+from electricitymap.contrib.config import ZoneKey
+
+MODE_MAPPING = {
+    '"Wind Onshore"': "wind",
+    '"Wind Offshore"': "wind",
+    '"Solar"': "solar",
+    '"Other renewable"': "unknown",
+    '"Other"': "unknown",
+    '"Nuclear"': "nuclear",
+    '"Hydro Run-of-river and poundage"': "hydro",
+    '"Fossil Hard coal"': "coal",
+    '"Fossil Gas"': "gas",
+    '"Biomass"': "biomass",
+    '"Hydro Pumped Storage"': "hydro storage",
+}
+
+
+def fetch_production_capacity(zone_key:ZoneKey, target_datetime: datetime) -> dict:
+    url = f"https://www.bmreports.com/bmrs/?q=ajax/year/B1410/{target_datetime.year}/"
+    r: Response = Session().get(url)
+
+    if r.status_code == 200:
+        soup = BeautifulSoup(r.text, "lxml")
+        items = soup.find_all("item")
+        capacity = {}
+        for item in items:
+            mode = item.find("powersystemresourcetype").string
+            mode = MODE_MAPPING[mode]
+            if mode in capacity:
+                capacity[mode]["value"] += int(item.find("quantity").string)
+            else:
+                capacity[mode] = {
+                    "datetime": target_datetime.strftime("%Y-%m-%d"),
+                    "value": int(item.find("quantity").string),
+                    "source": "bmreports.com",
+                }
+        print(f"Fetched capacity for {zone_key} on {target_datetime.date()}: \n{capacity}")
+        return capacity
+    else:
+        raise ValueError(
+            f"GB: No capacity data available for year {target_datetime.year}"
+        )
+
+if __name__=="__main__":
+    fetch_production_capacity("GB", datetime(2023,1,1))

--- a/electricitymap/contrib/capacity_parsers/GB.py
+++ b/electricitymap/contrib/capacity_parsers/GB.py
@@ -20,7 +20,7 @@ MODE_MAPPING = {
 }
 
 
-def fetch_production_capacity(zone_key:ZoneKey, target_datetime: datetime) -> dict:
+def fetch_production_capacity(zone_key: ZoneKey, target_datetime: datetime) -> dict:
     url = f"https://www.bmreports.com/bmrs/?q=ajax/year/B1410/{target_datetime.year}/"
     r: Response = Session().get(url)
 
@@ -39,12 +39,15 @@ def fetch_production_capacity(zone_key:ZoneKey, target_datetime: datetime) -> di
                     "value": int(item.find("quantity").string),
                     "source": "bmreports.com",
                 }
-        print(f"Fetched capacity for {zone_key} on {target_datetime.date()}: \n{capacity}")
+        print(
+            f"Fetched capacity for {zone_key} on {target_datetime.date()}: \n{capacity}"
+        )
         return capacity
     else:
         raise ValueError(
             f"GB: No capacity data available for year {target_datetime.year}"
         )
 
-if __name__=="__main__":
-    fetch_production_capacity("GB", datetime(2023,1,1))
+
+if __name__ == "__main__":
+    fetch_production_capacity("GB", datetime(2023, 1, 1))


### PR DESCRIPTION
## Issue

This is part of the outlier detection project where the aim is to flag data points that are above installed capacity. 
When possible, a capacity_parser will be developed so that we can update as many capacity configurations as possible can be updated automatically. 

The aim of this project is to enable collecting historical capacity so that the outlier detection can run on the whole time series. This is why the capacity configuration format is updated and follows the same structure as the emission factors configurations:
capacity
```
capacity
├── wind
    ├── datetime: "2023-01-01"
    ├── source: "ENTSOE"
    └── value: 5233
```

## Description

This PR includes a capacity parser for GB

### Preview

<img width="867" alt="image" src="https://github.com/electricitymaps/electricitymaps-contrib/assets/107848894/f8ca6dee-6397-4459-a9d1-8fe54ae6a87f">

### Double check

- [ ] I have tested my parser changes locally with `poetry run test_parser "zone_key"`
- [ ] I have run `pnpx prettier --write .` and `poetry run format` to format my changes.
