### PR TITLE
Moving IN-WE to a new API which has 24 hour datetime data unlike 12 hour

### DIFF
--- a/parsers/IN_WE.py
+++ b/parsers/IN_WE.py
@@ -18,153 +18,144 @@ from electricitymap.contrib.lib.types import ZoneKey
 from parsers.lib.config import refetch_frequency
 from parsers.lib.exceptions import ParserException
 
+"""
+This module is used to read the exchange values on a hourly basis for a day from India West to North, East, South. 
+This module also calculates the total electricity consumption by India West.
+The data is fetched from https://www.wrldc.in using APIs which provide data in JSON format
+India West constitutes of Gujrat, Madhya Pradesh, Chattishgarh, Maharashtra, Goa, DD, DNH
+
+These APIs return the data in 24 hour format from midnight 12:00am to current time at which the parser is run  
+"""
+
+
 IN_WE_PROXY = "https://in-proxy-jfnx5klx2a-el.a.run.app"
-EXCHANGE_URL = f"{IN_WE_PROXY}/InterRegionalLinks_Data.aspx/Get_InterRegionalLinks_Region_Wise?host=https://www.wrldc.in"
-CONSUMPTION_URL = f"{IN_WE_PROXY}/OnlinestateTest1.aspx/GetRealTimeData_state_Wise?host=https://www.wrldc.in"
+IN_TZ = "Asia/Kolkata"
+
+""" 
+Exchange data parser
+source: https://www.wrldc.in/content/166_1_FlowsonInterRegionalLinks.aspx
+API : https://www.wrldc.in/InterRegionalLinks_Data.aspx/Get_InterRegionalLinks_Data
+"""
+EXCHANGE_URL = f"{IN_WE_PROXY}/InterRegionalLinks_Data.aspx/Get_InterRegionalLinks_Data?host=https://www.wrldc.in"
+
+"""
+Consumption data parser
+source: https://www.wrldc.in/content/164_1_StateScheduleVsActual.aspx
+API: https://www.wrldc.in/OnlinestateTest1.aspx/GetRealTimeData
+"""
+CONSUMPTION_URL = (
+    f"{IN_WE_PROXY}/OnlinestateTest1.aspx/GetRealTimeData?host=https://www.wrldc.in"
+)
 
 EXCHANGES_MAPPING = {
-    "WR-SR": "IN-SO->IN-WE",
-    "WR-ER": "IN-EA->IN-WE",
-    "WR-NR": "IN-NO->IN-WE",
-}
-
-KIND_MAPPING = {
-    "exchange": {"url": EXCHANGE_URL, "datetime_column": "lastUpdate"},
-    "consumption": {"url": CONSUMPTION_URL, "datetime_column": "current_datetime"},
+    "IN-SO->IN-WE": "WR-SR",
+    "IN-EA->IN-WE": "WR-ER",
+    "IN-NO->IN-WE": "WR-NR",
 }
 
 
-def get_date_range(dt: datetime):
-    return pd.date_range(
-        arrow.get(dt).floor("day").datetime,
-        arrow.get(dt).ceil("day").floor("hour").datetime,
-        freq="H",
-    ).to_pydatetime()
-
-
-def fetch_data(
-    kind: str | None = None,
-    session: Session | None = None,
-    target_datetime: datetime | None = None,
-) -> dict:
-    """- get production data from wrldc.in
-    - filter all rows with same hour as target_datetime"""
+def fetch_data(url: str, session: Session, target_datetime: datetime) -> dict:
+    """
+    get data from wrldc.in
+    """
     assert target_datetime is not None
-    assert kind is not None
 
     r = session or Session()
-    payload = {"date": target_datetime.strftime("%Y-%m-%d")}
+    payload = {"date": target_datetime.strftime("%Y-%m-%d"), "Flag": 24}
 
-    resp: Response = r.post(url=KIND_MAPPING[kind]["url"], json=payload)
+    resp: Response = r.post(url=url, json=payload)
 
     try:
         data = json.loads(resp.json().get("d", {}))
     except json.decoder.JSONDecodeError:
         raise ParserException(
             parser="IN_WE.py",
-            message=f"{target_datetime}: {kind} data is not available",
+            message=f"{target_datetime}: {url} data is not available",
         )
-
-    datetime_col = KIND_MAPPING[kind]["datetime_column"]
-    for item in data:
-        item[datetime_col] = datetime.strptime(item[datetime_col], "%Y-%d-%m %H:%M:%S")
-        dt = arrow.get(item[datetime_col])
-        if dt.second >= 30:
-            item[datetime_col] = dt.shift(minutes=1).floor("minute").datetime
-        else:
-            item[datetime_col] = dt.floor("minute").datetime
     return data
 
 
-def filter_raw_data(
-    kind: str,
-    data: dict,
-    target_datetime: datetime,
-) -> pd.DataFrame:
+def process_exchanges_data(
+    data: dict, zone_key1: str, zone_key2: str, logger: Logger
+) -> ExchangeList:
     """
-    Filters out correct datetimes (source data is 12 hour format)
+    Processes exchanges data:
+    - filter out the records that correspond to the zone_key
+    - convert the datetime field to contain only date and hour(remove minute and secods)
+    - set timezone to IST for datetime field
+    - average all data points grouping by target_datetime hour
+    - generate the Exchange list from the Current_Loading column
     """
-    assert len(data) > 0
-    assert kind != ""
 
-    dt_12_hour = arrow.get(target_datetime.strftime("%Y-%m-%d %I:%M")).datetime
-    datetime_col = KIND_MAPPING[kind]["datetime_column"]
-    filtered_data = pd.DataFrame(
-        [item for item in data if item[datetime_col].hour == dt_12_hour.hour]
-    )
-    return filtered_data
-
-
-def format_exchanges_data(
-    data: dict, zone_key1: str, zone_key2: str, target_datetime: datetime
-) -> float:
-    """format exchanges data:
-    - filters out correct datetimes (source data is 12 hour format)
-    - average all data points in the target_datetime hour"""
-    assert target_datetime is not None
     assert len(data) > 0
 
-    sortedZoneKeys = "->".join(sorted([zone_key1, zone_key2]))
-    filtered_data = filter_raw_data(
-        kind="exchange", data=data, target_datetime=target_datetime
+    datetime_column = "lastUpdate"
+    value_column = "Current_Loading"
+    zone_key = "->".join(sorted([zone_key1, zone_key2]))
+
+    df = pd.DataFrame(data, columns=["Region_Name", datetime_column, value_column])
+    df = df[df["Region_Name"] == EXCHANGES_MAPPING[zone_key]]
+    df[datetime_column] = (
+        pd.to_datetime(df[datetime_column], format="%Y-%m-%d %H:%M:%S")
+        .dt.tz_localize(IN_TZ)
+        .dt.floor("h")
     )
+    df = df.groupby(["Region_Name", datetime_column]).mean().round(3)
+    df[value_column] = -df[value_column]
 
-    filtered_data["zone_key"] = filtered_data["Region_Name"].map(EXCHANGES_MAPPING)
-    df_exchanges = filtered_data.loc[filtered_data["zone_key"] == sortedZoneKeys]
-
-    if target_datetime.hour >= 12:
-        df_exchanges = df_exchanges.drop_duplicates(
-            subset=["Region_Name", "lastUpdate"], keep="last"
+    df = df.reset_index()
+    exchange_list = ExchangeList(logger)
+    for _, row in df.iterrows():
+        exchange_list.append(
+            zoneKey=ZoneKey(zone_key),
+            datetime=row[datetime_column].to_pydatetime(),
+            netFlow=row[value_column],
+            source="wrldc.in",
         )
-    else:
-        df_exchanges = filtered_data.drop_duplicates(
-            subset=["Region_Name", "lastUpdate"], keep="first"
-        )
-    df_exchanges.loc[:, "target_datetime"] = target_datetime
-    df_exchanges = (
-        df_exchanges.groupby(["Region_Name", "target_datetime"])
-        .mean(numeric_only=True)
-        .reset_index()
-    )
-    net_flow = -round(df_exchanges.iloc[0].get("Current_Loading", 0), 3)
-
-    return net_flow
+    return exchange_list
 
 
-def format_consumption_data(
-    data: dict, zone_key: str, target_datetime: datetime
-) -> float:
-    """format consumption data:
-    - filters out correct datetimes (source data is 12 hour format)
-    - average all data points in the target_datetime hour"""
-    assert target_datetime is not None
+def process_consumption_data(
+    data: dict, zone_key: ZoneKey, logger: Logger
+) -> TotalConsumptionList:
+    """
+    Processes consumption data:
+    - convert the datetime field to contain only date and hour(remove minute and secods)
+    - set timezone to IST for datetime field
+    - average all data points grouping by target_datetime hour and state
+    - sum the datapoints from each state grouping by target_datetime hour
+    - generate the Total Consumption list from the Demand column
+    """
+
     assert len(data) > 0
 
-    filtered_data = filter_raw_data(
-        kind="consumption",
-        data=data,
-        target_datetime=target_datetime,
+    datetime_column = "current_datetime"
+    value_column = "Demand"
+
+    df = pd.DataFrame(data, columns=["StateName", datetime_column, value_column])
+    df[datetime_column] = (
+        pd.to_datetime(df[datetime_column], format="%Y-%m-%d %H:%M:%S")
+        .dt.tz_localize(IN_TZ)
+        .dt.floor("h")
+    )
+    df = (
+        df.groupby([datetime_column, "StateName"])
+        .mean()
+        .groupby([datetime_column])
+        .sum()
+        .round(3)
     )
 
-    if target_datetime.hour >= 12:
-        df_consumption = filtered_data.drop_duplicates(
-            subset=["StateName", "current_datetime"], keep="last"
+    df = df.reset_index()
+    consumptionList = TotalConsumptionList(logger)
+    for _, row in df.iterrows():
+        consumptionList.append(
+            zoneKey=zone_key,
+            datetime=row[datetime_column].to_pydatetime(),
+            consumption=row[value_column],
+            source="wrldc.in",
         )
-    else:
-        df_consumption = filtered_data.drop_duplicates(
-            subset=["StateName", "current_datetime"], keep="first"
-        )
-    df_consumption.loc[:, "target_datetime"] = target_datetime
-    df_consumption = (
-        df_consumption.groupby(["StateName", "target_datetime"])
-        .mean(numeric_only=True)
-        .reset_index()
-    )
-
-    consumption_value = round(
-        df_consumption.groupby(["target_datetime"])["Demand"].sum().values[0], 3
-    )
-    return consumption_value
+    return consumptionList
 
 
 @refetch_frequency(timedelta(days=1))
@@ -175,29 +166,17 @@ def fetch_exchange(
     target_datetime: datetime | None = None,
     logger: Logger = getLogger(__name__),
 ) -> list[dict[str, Any]]:
+    """This method is called by IN-EA, IN-SO, IN-NO zone's parsers to get the exchange data with IN-WA zone."""
+
     if target_datetime is None:
         target_datetime = arrow.utcnow().datetime
 
-    sortedZoneKeys = "->".join(sorted([zone_key1, zone_key2]))
     data = fetch_data(
-        kind="exchange",
-        session=session,
-        target_datetime=target_datetime,
+        url=EXCHANGE_URL, session=session, target_datetime=target_datetime
     )
-    exchange_list = ExchangeList(logger)
-    for dt in get_date_range(target_datetime):
-        net_flow = format_exchanges_data(
-            zone_key1=zone_key1,
-            zone_key2=zone_key2,
-            data=data,
-            target_datetime=dt,
-        )
-        exchange_list.append(
-            zoneKey=ZoneKey(sortedZoneKeys),
-            datetime=arrow.get(dt).replace(tzinfo="Asia/Kolkata").datetime,
-            netFlow=net_flow,
-            source="wrldc.in",
-        )
+    exchange_list = process_exchanges_data(
+        zone_key1=zone_key1, zone_key2=zone_key2, data=data, logger=logger
+    )
 
     return exchange_list.to_list()
 
@@ -209,24 +188,14 @@ def fetch_consumption(
     target_datetime: datetime | None = None,
     logger: Logger = getLogger(__name__),
 ) -> list[dict[str, Any]]:
+    """This method is used to fetch the consumption data for IN-WA zone."""
+
     if target_datetime is None:
         target_datetime = arrow.utcnow().datetime
     data = fetch_data(
-        kind="consumption",
-        session=session,
-        target_datetime=target_datetime,
+        url=CONSUMPTION_URL, session=session, target_datetime=target_datetime
     )
-    consumption_list = TotalConsumptionList(logger)
-    for dt in get_date_range(target_datetime):
-        consumption_data_point = format_consumption_data(
-            zone_key=zone_key, data=data, target_datetime=dt
-        )
-        consumption_list.append(
-            zoneKey=zone_key,
-            datetime=arrow.get(dt).replace(tzinfo="Asia/Kolkata").datetime,
-            consumption=consumption_data_point,
-            source="wrldc.in",
-        )
+    consumption_list = process_consumption_data(data, zone_key, logger)
     return consumption_list.to_list()
 
 


### PR DESCRIPTION
## Description
The older API endpoints provided data in 12 hour format without AM and PM, because of which there was quite a lot of logic in code to parse that data.

The new APIs from the same data source provide data in 24 hour format which is more correct and simple to process.

Also made changes to methods to use Pandas groupby on datetime hour which simplified the code even further and fixed some bugs which would arise in the earlier version for missing datapoints from the source
<!-- Explains the goal of this PR -->


### Double check

- [X] I have tested my parser changes locally with `poetry run test_parser "zone_key"`
- [X]  `poetry run test_parser IN-WE consumption`
- [X]  `poetry run test_parser "IN-NO->IN-WE" exchange`
- [X] I have run `pnpx prettier --write .` and `poetry run format` to format my changes.
