### PR TITLE
Changes to use Node v20 (and not pin to 20.6)

### DIFF
--- a/web/Earthfile
+++ b/web/Earthfile
@@ -1,5 +1,5 @@
-VERSION 0.7
-FROM node:20.6
+VERSION --use-visited-upfront-hash-collection 0.7
+FROM node:20
 WORKDIR /contrib/web
 
 src-files:


### PR DESCRIPTION
## Description

Turns out Node v20.6 has problems, so pinning more losely to just v20.

See nice explanation of why here: https://github.com/electricitymaps/electricitymaps-contrib/issues/5984#issuecomment-1792467142
