### PR TITLE
Paint map when zones source not fully loaded

### DIFF
--- a/web/src/features/map/Map.tsx
+++ b/web/src/features/map/Map.tsx
@@ -114,7 +114,6 @@ export default function MapPage(): ReactElement {
     // An issue where the map has not loaded source yet causing map errors
     const isSourceLoaded =
       map.getSource('zones-clickable') !== undefined &&
-      map.isSourceLoaded('zones-clickable') &&
       map.getSource('states') !== undefined &&
       map.isSourceLoaded('states');
 


### PR DESCRIPTION
## Issue
The aggregate toggle was not colouring previously un-rendered zones. 

## Description
This PR removes the check for the zone source layer to be loaded in the useEffect that colours the zones. 

This fixes the bug but it can be improved a lot to reduce the # of renders and complexity of this useEffect. I'll update this in the map.tsx refactor I'm currently working on. 

### Double check

- [x] I have tested my parser changes locally with `poetry run test_parser "zone_key"`
- [x] I have run `pnpx prettier --write .` and `poetry run format` to format my changes.
