### PR TITLE
Add support for None values in netFlow, value, and consumption fields

### DIFF
--- a/electricitymap/contrib/lib/models/event_lists.py
+++ b/electricitymap/contrib/lib/models/event_lists.py
@@ -142,7 +142,7 @@ class ExchangeList(AggregatableEventList):
         zoneKey: ZoneKey,
         datetime: datetime,
         source: str,
-        netFlow: float,
+        netFlow: float | None,
         sourceType: EventSourceType = EventSourceType.measured,
     ):
         event = Exchange.create(
@@ -253,7 +253,7 @@ class TotalProductionList(EventList):
         zoneKey: ZoneKey,
         datetime: datetime,
         source: str,
-        value: float,
+        value: float | None,
         sourceType: EventSourceType = EventSourceType.measured,
     ):
         event = TotalProduction.create(
@@ -271,7 +271,7 @@ class TotalConsumptionList(EventList):
         zoneKey: ZoneKey,
         datetime: datetime,
         source: str,
-        consumption: float,
+        consumption: float | None,
         sourceType: EventSourceType = EventSourceType.measured,
     ):
         event = TotalConsumption.create(
@@ -289,7 +289,7 @@ class PriceList(EventList):
         zoneKey: ZoneKey,
         datetime: datetime,
         source: str,
-        price: float,
+        price: float | None,
         currency: str,
         sourceType: EventSourceType = EventSourceType.measured,
     ):

--- a/electricitymap/contrib/lib/models/events.py
+++ b/electricitymap/contrib/lib/models/events.py
@@ -16,6 +16,15 @@ from electricitymap.contrib.lib.types import ZoneKey
 LOWER_DATETIME_BOUND = datetime(2000, 1, 1, tzinfo=timezone.utc)
 
 
+def _none_safe_round(value: float | None, precision: int = 6) -> float | None:
+    """
+    Rounds a value to the provided precision.
+    If the value is None, it is returned as is.
+    The default precision is 6 decimal places, which gives us a precision of 1 W.
+    """
+    return None if value is None else round(value, precision)
+
+
 class Mix(BaseModel, ABC):
     def add_value(
         self,
@@ -31,10 +40,10 @@ class Mix(BaseModel, ABC):
         if existing_value is not None:
             value = 0 if value is None else value
             self.__setattr__(
-                mode, round(existing_value + value, 6)
+                mode, _none_safe_round(existing_value + value)
             )  # 6 decimal places gives us a precision of 1 W.
         else:
-            self.__setattr__(mode, value if value is None else round(value, 6))
+            self.__setattr__(mode, _none_safe_round(value))
 
     @classmethod
     def merge(cls, mixes: list["Mix"]) -> "Mix":
@@ -329,7 +338,7 @@ class Exchange(Event):
     Negative otherwise.
     """
 
-    netFlow: float
+    netFlow: float | None
 
     @validator("zoneKey")
     def _validate_zone_key(cls, v: str):
@@ -344,6 +353,8 @@ class Exchange(Event):
 
     @validator("netFlow")
     def _validate_value(cls, v: float):
+        if v is None:
+            raise ValueError(f"Exchange cannot be None: {v}")
         # TODO in the future those checks should be performed in the data quality layer.
         if abs(v) > 100000:
             raise ValueError(f"Exchange is implausibly high, above 100GW: {v}")
@@ -355,7 +366,7 @@ class Exchange(Event):
         zoneKey: ZoneKey,
         datetime: datetime,
         source: str,
-        netFlow: float,
+        netFlow: float | None,
         sourceType: EventSourceType = EventSourceType.measured,
     ) -> Optional["Exchange"]:
         try:
@@ -363,11 +374,18 @@ class Exchange(Event):
                 zoneKey=zoneKey,
                 datetime=datetime,
                 source=source,
-                netFlow=netFlow,
+                netFlow=_none_safe_round(netFlow),
                 sourceType=sourceType,
             )
         except ValidationError as e:
-            logger.error(f"Error(s) creating exchange Event {datetime}: {e}")
+            logger.error(
+                f"Error(s) creating exchange Event {datetime}: {e}",
+                extra={
+                    "zoneKey": zoneKey,
+                    "datetime": datetime.strftime("%Y-%m-%dT%H:%M:%SZ"),
+                    "kind": "exchange",
+                },
+            )
 
     def to_dict(self) -> dict[str, Any]:
         return {
@@ -382,10 +400,12 @@ class Exchange(Event):
 class TotalProduction(Event):
     """Represents the total production of a zone at a given time. The value is in MW."""
 
-    value: float
+    value: float | None
 
     @validator("value")
     def _validate_value(cls, v: float):
+        if v is None:
+            raise ValueError(f"Total production cannot be None: {v}")
         if v < 0:
             raise ValueError(f"Total production cannot be negative: {v}")
         # TODO in the future those checks should be performed in the data quality layer.
@@ -399,7 +419,7 @@ class TotalProduction(Event):
         zoneKey: ZoneKey,
         datetime: datetime,
         source: str,
-        value: float,
+        value: float | None,
         sourceType: EventSourceType = EventSourceType.measured,
     ) -> Optional["TotalProduction"]:
         try:
@@ -407,11 +427,18 @@ class TotalProduction(Event):
                 zoneKey=zoneKey,
                 datetime=datetime,
                 source=source,
-                value=value,
+                value=_none_safe_round(value),
                 sourceType=sourceType,
             )
         except ValidationError as e:
-            logger.error(f"Error(s) creating total production Event {datetime}: {e}")
+            logger.error(
+                f"Error(s) creating total production Event {datetime}: {e}",
+                extra={
+                    "zoneKey": zoneKey,
+                    "datetime": datetime.strftime("%Y-%m-%dT%H:%M:%SZ"),
+                    "kind": "production",
+                },
+            )
 
     def to_dict(self) -> dict[str, Any]:
         return {
@@ -472,7 +499,12 @@ class ProductionBreakdown(AggregatableEvent):
             )
         except ValidationError as e:
             logger.error(
-                f"Error(s) creating production breakdown Event {datetime}: {e}"
+                f"Error(s) creating production breakdown Event {datetime}: {e}",
+                extra={
+                    "zoneKey": zoneKey,
+                    "datetime": datetime.strftime("%Y-%m-%dT%H:%M:%SZ"),
+                    "kind": "production breakdown",
+                },
             )
 
     @staticmethod
@@ -535,10 +567,12 @@ class ProductionBreakdown(AggregatableEvent):
 class TotalConsumption(Event):
     """Reprensent the total consumption of a zone. The total consumption is expressed in MW."""
 
-    consumption: float
+    consumption: float | None
 
     @validator("consumption")
     def _validate_consumption(cls, v: float):
+        if v is None:
+            raise ValueError(f"Total consumption cannot be None: {v}")
         if v < 0:
             raise ValueError(f"Total consumption cannot be negative: {v}")
         # TODO in the future those checks should be performed in the data quality layer.
@@ -554,7 +588,7 @@ class TotalConsumption(Event):
         zoneKey: ZoneKey,
         datetime: datetime,
         source: str,
-        consumption: float,
+        consumption: float | None,
         sourceType: EventSourceType = EventSourceType.measured,
     ) -> Optional["TotalConsumption"]:
         try:
@@ -562,7 +596,7 @@ class TotalConsumption(Event):
                 zoneKey=zoneKey,
                 datetime=datetime,
                 source=source,
-                consumption=consumption,
+                consumption=_none_safe_round(consumption),
                 sourceType=sourceType,
             )
         except ValidationError as e:
@@ -586,7 +620,7 @@ class TotalConsumption(Event):
 
 
 class Price(Event):
-    price: float
+    price: float | None
     currency: str
 
     @validator("currency")
@@ -604,13 +638,20 @@ class Price(Event):
             raise ValueError(f"Date is before 2000, this is not plausible: {v}")
         return v
 
+    @validator("price")
+    def _validate_price(cls, v: float | None) -> float:
+        """Prices can be negative but not None, so we should only check for None values"""
+        if v is None:
+            raise ValueError(f"Price cannot be None: {v}")
+        return v
+
     @staticmethod
     def create(
         logger: Logger,
         zoneKey: ZoneKey,
         datetime: datetime,
         source: str,
-        price: float,
+        price: float | None,
         currency: str,
         sourceType: EventSourceType = EventSourceType.measured,
     ) -> Optional["Price"]:
@@ -624,7 +665,14 @@ class Price(Event):
                 sourceType=sourceType,
             )
         except ValidationError as e:
-            logger.error(f"Error(s) creating price Event {datetime}: {e}")
+            logger.error(
+                f"Error(s) creating price Event {datetime}: {e}",
+                extra={
+                    "zoneKey": zoneKey,
+                    "datetime": datetime.strftime("%Y-%m-%dT%H:%M:%SZ"),
+                    "kind": "price",
+                },
+            )
 
     def to_dict(self) -> dict[str, Any]:
         return {


### PR DESCRIPTION
This pull request adds support for None values in the netFlow, value, and consumption fields of the Exchange, TotalProduction, and TotalConsumption classes. This allows for more flexibility in data input and better handling of missing data. The _none_safe_round function has also been added to safely round values that may be None.

This is more of a personal preference rather than hard requirement so I'm open to discussion about this. However this unifies how we handle values passed in append (both StorageMix and ProductionMix can already be None) and moves more logic to the classes rather than requirering it in the parsers.

If we want to go forward with it I'll create and update the tests for it.