### PR TITLE
Change pytz to timezone.utc and ZoneInfo

### DIFF
--- a/electricitymap/contrib/lib/tests/test_events.py
+++ b/electricitymap/contrib/lib/tests/test_events.py
@@ -2,9 +2,9 @@ import logging
 import unittest
 from datetime import datetime, timezone
 from unittest.mock import patch
+from zoneinfo import ZoneInfo
 
 import freezegun
-from zoneinfo import ZoneInfo
 
 from electricitymap.contrib.config.constants import PRODUCTION_MODES, STORAGE_MODES
 from electricitymap.contrib.lib.models.events import (

--- a/electricitymap/contrib/lib/tests/test_events.py
+++ b/electricitymap/contrib/lib/tests/test_events.py
@@ -4,7 +4,7 @@ from datetime import datetime, timezone
 from unittest.mock import patch
 
 import freezegun
-import pytz
+from zoneinfo import ZoneInfo
 
 from electricitymap.contrib.config.constants import PRODUCTION_MODES, STORAGE_MODES
 from electricitymap.contrib.lib.models.events import (
@@ -346,12 +346,12 @@ class TestProductionBreakdown(unittest.TestCase):
         mix = ProductionMix(wind=10)
         breakdown = ProductionBreakdown(
             zoneKey=ZoneKey("DE"),
-            datetime=datetime(2023, 1, 1, 5, tzinfo=pytz.timezone("Asia/Tokyo")),
+            datetime=datetime(2023, 1, 1, 5, tzinfo=ZoneInfo("Asia/Tokyo")),
             production=mix,
             source="trust.me",
         )
         assert breakdown.datetime == datetime(
-            2023, 1, 1, 5, tzinfo=pytz.timezone("Asia/Tokyo")
+            2023, 1, 1, 5, tzinfo=ZoneInfo("Asia/Tokyo")
         )
 
     def test_static_create_logs_error(self):

--- a/parsers/AW.py
+++ b/parsers/AW.py
@@ -66,9 +66,8 @@ def fetch_production(
     )
     # We're using Fossil data to get timestamp in correct time zone
     local_date_time = datetime.strptime(
-            top_data["total_bio_gas"]["timestamp"], "%Y-%m-%d %H:%M:%S.%f"
-        ).replace(tzinfo=TIMEZONE)
-
+        top_data["total_bio_gas"]["timestamp"], "%Y-%m-%d %H:%M:%S.%f"
+    ).replace(tzinfo=TIMEZONE)
 
     production_list = ProductionBreakdownList(logger)
     production_list.append(

--- a/parsers/AW.py
+++ b/parsers/AW.py
@@ -4,7 +4,7 @@ from datetime import datetime
 from logging import Logger, getLogger
 from typing import Any
 
-from pytz import timezone
+from zoneinfo import ZoneInfo
 from requests import Session
 
 from electricitymap.contrib.lib.models.event_lists import ProductionBreakdownList
@@ -19,7 +19,7 @@ FUEL_MAPPING = {
     "TotalSolar": "solar",
     "total_bio_gas": "biomass",
 }
-TIMEZONE = timezone("America/Aruba")
+TIMEZONE = ZoneInfo("America/Aruba")
 PRODUCTION_URL = (
     "https://www.webaruba.com/renewable-energy-dashboard/app/rest/results.json"
 )

--- a/parsers/AW.py
+++ b/parsers/AW.py
@@ -65,11 +65,10 @@ def fetch_production(
         "unknown", reported_total - sources_total, correct_negative_with_zero=True
     )
     # We're using Fossil data to get timestamp in correct time zone
-    local_date_time = TIMEZONE.localize(
-        datetime.strptime(
+    local_date_time = datetime.strptime(
             top_data["total_bio_gas"]["timestamp"], "%Y-%m-%d %H:%M:%S.%f"
-        )
-    )
+        ).replace(tzinfo=TIMEZONE)
+
 
     production_list = ProductionBreakdownList(logger)
     production_list.append(

--- a/parsers/AW.py
+++ b/parsers/AW.py
@@ -3,8 +3,8 @@
 from datetime import datetime
 from logging import Logger, getLogger
 from typing import Any
-
 from zoneinfo import ZoneInfo
+
 from requests import Session
 
 from electricitymap.contrib.lib.models.event_lists import ProductionBreakdownList

--- a/parsers/AX.py
+++ b/parsers/AX.py
@@ -3,13 +3,13 @@ from logging import Logger, getLogger
 from re import findall
 
 from bs4 import BeautifulSoup
-from pytz import timezone
+from zoneinfo import ZoneInfo
 from requests import Response, Session
 
 from .lib.exceptions import ParserException
 
 IFRAME_URL = "https://grafik.kraftnat.ax/grafer/tot_inm_24h_15.php"
-TIME_ZONE = "Europe/Mariehamn"
+TIME_ZONE = ZoneInfo("Europe/Mariehamn")
 SOURCE = "kraftnat.ax"
 
 
@@ -74,7 +74,7 @@ def formated_data(
     """Format data to Electricity Map standards."""
     data_list = fetch_data(session, logger)
     data_list.reverse()
-    date_time = datetime.now(timezone(TIME_ZONE))
+    date_time = datetime.now(TIME_ZONE)
     date = date_time.replace(
         hour=int(data_list[0]["time"].split(":")[0]),
         minute=int(data_list[0]["time"].split(":")[1]),

--- a/parsers/AX.py
+++ b/parsers/AX.py
@@ -1,9 +1,9 @@
 from datetime import datetime, timedelta
 from logging import Logger, getLogger
 from re import findall
+from zoneinfo import ZoneInfo
 
 from bs4 import BeautifulSoup
-from zoneinfo import ZoneInfo
 from requests import Response, Session
 
 from .lib.exceptions import ParserException

--- a/parsers/BD.py
+++ b/parsers/BD.py
@@ -3,9 +3,9 @@
 from datetime import datetime, timedelta
 from logging import Logger, getLogger
 from typing import Any
+from zoneinfo import ZoneInfo
 
 import arrow
-from zoneinfo import ZoneInfo
 from bs4 import BeautifulSoup, Tag
 from requests import Response, Session
 

--- a/parsers/BD.py
+++ b/parsers/BD.py
@@ -5,7 +5,7 @@ from logging import Logger, getLogger
 from typing import Any
 
 import arrow
-import pytz
+from zoneinfo import ZoneInfo
 from bs4 import BeautifulSoup, Tag
 from requests import Response, Session
 
@@ -16,7 +16,7 @@ from parsers.lib.exceptions import ParserException
 # Has table (also historical) of production, consumption and exchange.
 # This table gets updated batch-wise every few hours, so most of the time, the delay will be >2h.
 
-tz = pytz.timezone("Asia/Dhaka")
+tz = ZoneInfo("Asia/Dhaka")
 latest_url = "https://erp.pgcb.gov.bd/web/generations/view_generations"
 url_by_date = (
     "https://erp.pgcb.gov.bd/web/generations/view_generations?search="  # DD-MM-YYYY

--- a/parsers/CA_BC.py
+++ b/parsers/CA_BC.py
@@ -4,10 +4,10 @@
 from datetime import datetime, timedelta
 from logging import Logger, getLogger
 from typing import Any
+from zoneinfo import ZoneInfo
 
 import arrow
 import pandas as pd
-from zoneinfo import ZoneInfo
 from requests import Response, Session
 
 from electricitymap.contrib.config import ZONES_CONFIG

--- a/parsers/CA_BC.py
+++ b/parsers/CA_BC.py
@@ -7,7 +7,7 @@ from typing import Any
 
 import arrow
 import pandas as pd
-import pytz
+from zoneinfo import ZoneInfo
 from requests import Response, Session
 
 from electricitymap.contrib.config import ZONES_CONFIG
@@ -24,7 +24,7 @@ from parsers.lib.exceptions import ParserException
 
 HISTORICAL_LOAD_REPORTS = "https://www.bchydro.com/content/dam/BCHydro/customer-portal/documents/corporate/suppliers/transmission-system/balancing_authority_load_data/Historical%20Transmission%20Data/BalancingAuthorityLoad{0}.xls"
 EXCHANGES_URL = "https://www.bchydro.com/bctc/system_cms/actual_flow/latest_values.txt"
-TIMEZONE = pytz.timezone(ZONES_CONFIG.get(ZoneKey("CA-BC")).get("timezone"))
+TIMEZONE = ZoneInfo(ZONES_CONFIG.get(ZoneKey("CA-BC"), {}).get("timezone"))
 SOURCE = "bchydro.com"
 PUBLICATION_DELAY = timedelta(days=31)
 

--- a/parsers/CA_QC.py
+++ b/parsers/CA_QC.py
@@ -5,7 +5,7 @@ from typing import Any
 
 # The arrow library is used to handle datetimes
 import arrow
-from pytz import timezone
+from zoneinfo import ZoneInfo
 from requests import Session
 
 from electricitymap.contrib.lib.models.event_lists import (
@@ -21,7 +21,7 @@ DATA_PATH = "data/documents-donnees/donnees-ouvertes/json"
 PRODUCTION_URL = f"{US_PROXY}/{DATA_PATH}/production.json{HOST_PARAM}"
 CONSUMPTION_URL = f"{US_PROXY}/{DATA_PATH}/demande.json{HOST_PARAM}"
 SOURCE = "hydroquebec.com"
-TIMEZONE = timezone("America/Montreal")
+TIMEZONE = ZoneInfo("America/Montreal")
 
 
 def fetch_production(

--- a/parsers/CA_QC.py
+++ b/parsers/CA_QC.py
@@ -2,10 +2,10 @@ from datetime import datetime
 from logging import Logger, getLogger
 from pprint import pprint
 from typing import Any
+from zoneinfo import ZoneInfo
 
 # The arrow library is used to handle datetimes
 import arrow
-from zoneinfo import ZoneInfo
 from requests import Session
 
 from electricitymap.contrib.lib.models.event_lists import (

--- a/parsers/CR.py
+++ b/parsers/CR.py
@@ -3,8 +3,8 @@
 
 from datetime import datetime, time, timedelta
 from logging import Logger, getLogger
-
 from zoneinfo import ZoneInfo
+
 from requests import Session
 
 from parsers.lib.config import refetch_frequency

--- a/parsers/CR.py
+++ b/parsers/CR.py
@@ -4,13 +4,13 @@
 from datetime import datetime, time, timedelta
 from logging import Logger, getLogger
 
-from pytz import timezone
+from zoneinfo import ZoneInfo
 from requests import Session
 
 from parsers.lib.config import refetch_frequency
 from parsers.lib.exceptions import ParserException
 
-TIMEZONE = "America/Costa_Rica"
+TIMEZONE = ZoneInfo("America/Costa_Rica")
 EXCHANGE_URL = (
     "https://mapa.enteoperador.org/WebServiceScadaEORRest/webresources/generic"
 )
@@ -32,9 +32,8 @@ EXCHANGE_JSON_MAPPING = {
 
 def _to_local_datetime(dt: datetime) -> datetime:
     if dt.tzinfo is None:
-        tz = timezone(TIMEZONE)
-        return tz.localize(dt)
-    return dt.astimezone(timezone(TIMEZONE))
+        return dt.replace(tzinfo=TIMEZONE)
+    return dt.astimezone(TIMEZONE)
 
 
 def empty_record(zone_key: str):

--- a/parsers/ELEXON.py
+++ b/parsers/ELEXON.py
@@ -11,13 +11,12 @@ https://bscdocs.elexon.co.uk/guidance-notes/bmrs-api-and-data-push-user-guide
 """
 
 import re
-from datetime import date, datetime, time, timedelta
+from datetime import date, datetime, time, timedelta, timezone
 from io import StringIO
 from logging import Logger, getLogger
 
 import arrow
 import pandas as pd
-import pytz
 from requests import Session
 
 from electricitymap.contrib.config.constants import PRODUCTION_MODES
@@ -116,7 +115,7 @@ def query_additional_eso_data(
 ) -> list[dict]:
     begin = (target_datetime - timedelta(days=1)).strftime("%Y-%m-%d")
     end = (target_datetime + timedelta(days=1)).strftime("%Y-%m-%d")
-    if target_datetime > (datetime.now(tz=pytz.UTC) - timedelta(days=30)):
+    if target_datetime > (datetime.now(tz=timezone.utc) - timedelta(days=30)):
         report_id = ESO_DEMAND_DATA_UPDATE_ID
     else:
         index = _create_eso_historical_demand_index(session)

--- a/parsers/ENTSOE.py
+++ b/parsers/ENTSOE.py
@@ -1141,9 +1141,9 @@ def fetch_production_per_units(
 
     # If no target_datetime is specified, or the target datetime is less
     # than 5 days ago we set the target_datetime to 5 days ago.
-    if target_datetime is None or target_datetime > datetime.now(tz=timezone.utc) - timedelta(
-        days=5
-    ):
+    if target_datetime is None or target_datetime > datetime.now(
+        tz=timezone.utc
+    ) - timedelta(days=5):
         logger.info(
             "This dataset has a publishing guideline of 5 days from the current MTU, setting the target_datetime to 5 days ago to get the latest data."
         )

--- a/parsers/ENTSOE.py
+++ b/parsers/ENTSOE.py
@@ -13,7 +13,7 @@ Consumption Forecast
 """
 import itertools
 import re
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from logging import Logger, getLogger
 from random import shuffle
 from typing import Any
@@ -21,7 +21,6 @@ from typing import Any
 import arrow
 import numpy as np
 from bs4 import BeautifulSoup
-from pytz import utc
 from requests import Response, Session
 
 from electricitymap.contrib.config import ZoneKey
@@ -1142,13 +1141,13 @@ def fetch_production_per_units(
 
     # If no target_datetime is specified, or the target datetime is less
     # than 5 days ago we set the target_datetime to 5 days ago.
-    if target_datetime is None or target_datetime > datetime.now(tz=utc) - timedelta(
+    if target_datetime is None or target_datetime > datetime.now(tz=timezone.utc) - timedelta(
         days=5
     ):
         logger.info(
             "This dataset has a publishing guideline of 5 days from the current MTU, setting the target_datetime to 5 days ago to get the latest data."
         )
-        target_datetime = datetime.now(tz=utc) - timedelta(days=5)
+        target_datetime = datetime.now(tz=timezone.utc) - timedelta(days=5)
 
     domain = ENTSOE_EIC_MAPPING[zone_key]
     data = []

--- a/parsers/ESIOS.py
+++ b/parsers/ESIOS.py
@@ -3,10 +3,10 @@
 from datetime import datetime, timedelta
 from logging import Logger, getLogger
 from urllib.parse import urlencode
+from zoneinfo import ZoneInfo
 
 # The arrow library is used to handle datetimes
 import arrow
-from zoneinfo import ZoneInfo
 from requests import Response, Session
 
 from electricitymap.contrib.lib.models.event_lists import ExchangeList

--- a/parsers/ESIOS.py
+++ b/parsers/ESIOS.py
@@ -6,7 +6,7 @@ from urllib.parse import urlencode
 
 # The arrow library is used to handle datetimes
 import arrow
-import pytz
+from zoneinfo import ZoneInfo
 from requests import Response, Session
 
 from electricitymap.contrib.lib.models.event_lists import ExchangeList
@@ -15,7 +15,7 @@ from electricitymap.contrib.lib.types import ZoneKey
 from .lib.exceptions import ParserException
 from .lib.utils import get_token
 
-TIMEZONE = pytz.timezone("Europe/Madrid")
+TIMEZONE = ZoneInfo("Europe/Madrid")
 
 # Map each exchange to the ID used in the API
 EXCHANGE_ID_MAP = {

--- a/parsers/ESKOM.py
+++ b/parsers/ESKOM.py
@@ -4,7 +4,7 @@ from logging import Logger, getLogger
 from pprint import PrettyPrinter
 
 from numpy import nan
-from pytz import timezone
+from zoneinfo import ZoneInfo
 from requests import Response, Session
 
 from electricitymap.contrib.lib.models.event_lists import ProductionBreakdownList
@@ -14,7 +14,7 @@ from parsers.lib.exceptions import ParserException
 
 pp = PrettyPrinter(indent=4)
 
-TIMEZONE = "Africa/Johannesburg"
+TIMEZONE = ZoneInfo("Africa/Johannesburg")
 SOURCE = "eskom.co.za"
 
 # Mapping columns to keys
@@ -64,8 +64,8 @@ def fetch_production(
     logger: Logger = getLogger(__name__),
 ) -> list[dict]:
     if target_datetime is not None:
-        local_target_datetime = target_datetime.astimezone(timezone(TIMEZONE))
-        local_one_week_ago = datetime.now(timezone(TIMEZONE)) - timedelta(days=7)
+        local_target_datetime = target_datetime.astimezone(TIMEZONE)
+        local_one_week_ago = datetime.now(TIMEZONE) - timedelta(days=7)
 
         if local_target_datetime < local_one_week_ago:
             raise NotImplementedError(
@@ -89,7 +89,7 @@ def fetch_production(
             continue
 
         returned_datetime = datetime.fromisoformat(row[0]).replace(
-            tzinfo=timezone(TIMEZONE)
+            tzinfo=TIMEZONE
         )
 
         returned_production = row[1:]  # First column is datetime

--- a/parsers/ESKOM.py
+++ b/parsers/ESKOM.py
@@ -2,9 +2,9 @@ import csv
 from datetime import datetime, timedelta
 from logging import Logger, getLogger
 from pprint import PrettyPrinter
+from zoneinfo import ZoneInfo
 
 from numpy import nan
-from zoneinfo import ZoneInfo
 from requests import Response, Session
 
 from electricitymap.contrib.lib.models.event_lists import ProductionBreakdownList
@@ -88,9 +88,7 @@ def fetch_production(
         if row[0] == "Date_Time_Hour_Beginning":
             continue
 
-        returned_datetime = datetime.fromisoformat(row[0]).replace(
-            tzinfo=TIMEZONE
-        )
+        returned_datetime = datetime.fromisoformat(row[0]).replace(tzinfo=TIMEZONE)
 
         returned_production = row[1:]  # First column is datetime
 

--- a/parsers/GCCIA.py
+++ b/parsers/GCCIA.py
@@ -15,7 +15,6 @@ import re
 from datetime import datetime
 from logging import Logger, getLogger
 from sys import stderr
-
 from zoneinfo import ZoneInfo
 
 from requests import Session

--- a/parsers/GCCIA.py
+++ b/parsers/GCCIA.py
@@ -16,7 +16,8 @@ from datetime import datetime
 from logging import Logger, getLogger
 from sys import stderr
 
-from pytz import timezone
+from zoneinfo import ZoneInfo
+
 from requests import Session
 
 from electricitymap.contrib.lib.models.event_lists import TotalConsumptionList
@@ -36,12 +37,12 @@ COUNTRY_CODE_MAPPING = {
 }
 
 TIME_ZONE_MAPPING = {
-    "AE": timezone("Asia/Dubai"),
-    "BH": timezone("Asia/Bahrain"),
-    "KW": timezone("Asia/Kuwait"),
-    "OM": timezone("Asia/Muscat"),
-    "QA": timezone("Asia/Qatar"),
-    "SA": timezone("Asia/Riyadh"),
+    "AE": ZoneInfo("Asia/Dubai"),
+    "BH": ZoneInfo("Asia/Bahrain"),
+    "KW": ZoneInfo("Asia/Kuwait"),
+    "OM": ZoneInfo("Asia/Muscat"),
+    "QA": ZoneInfo("Asia/Qatar"),
+    "SA": ZoneInfo("Asia/Riyadh"),
 }
 
 

--- a/parsers/HN.py
+++ b/parsers/HN.py
@@ -3,7 +3,7 @@ from datetime import datetime, timedelta
 from logging import Logger, getLogger
 from typing import Any
 
-from pytz import timezone
+from zoneinfo import ZoneInfo
 from requests import Response, Session
 
 from parsers.lib.exceptions import ParserException
@@ -136,7 +136,7 @@ def get_datetime(date: str, hour: int) -> datetime:
     Returns a datetime object with the given date and hour
     """
     return datetime.strptime(date, "%m/%d/%Y").replace(
-        tzinfo=timezone("America/Tegucigalpa")
+        tzinfo=ZoneInfo("America/Tegucigalpa")
     ) + timedelta(hours=hour + 1)
 
 

--- a/parsers/HN.py
+++ b/parsers/HN.py
@@ -2,8 +2,8 @@ from csv import reader
 from datetime import datetime, timedelta
 from logging import Logger, getLogger
 from typing import Any
-
 from zoneinfo import ZoneInfo
+
 from requests import Response, Session
 
 from parsers.lib.exceptions import ParserException

--- a/parsers/IE.py
+++ b/parsers/IE.py
@@ -1,13 +1,13 @@
 from datetime import datetime, timedelta
 from logging import Logger, getLogger
+from zoneinfo import ZoneInfo
 
-import pytz
 from requests import Response, Session
 
 from parsers.lib.config import refetch_frequency
 from parsers.lib.exceptions import ParserException
 
-IE_TZ = pytz.timezone("Europe/Dublin")
+IE_TZ = ZoneInfo("Europe/Dublin")
 
 DEMAND_URL = "https://www.smartgriddashboard.com/DashboardService.svc/data?area=demandactual&region={zone}&datefrom={dt}+00%3A00&dateto={dt}+23%3A59"
 DEMAND_FORECAST_URL = "https://www.smartgriddashboard.com/DashboardService.svc/data?area=demandforecast&region={zone}&datefrom={dt}+00%3A00&dateto={dt}+23%3A59"
@@ -105,7 +105,7 @@ def fetch_production(
         data_point = {
             "zoneKey": zone_key,
             "datetime": datetime.strptime(dt, "%d-%b-%Y %H:%M:%S").replace(
-                tzinfo=pytz.timezone("Europe/Dublin")
+                tzinfo=IE_TZ
             ),
             "production": {
                 "unknown": item["Value"] - exchange - wind_prod,
@@ -160,7 +160,7 @@ def fetch_exchange(
             "sortedZoneKeys": sortedZoneKeys,
             "datetime": datetime.strptime(
                 item["EffectiveTime"], "%d-%b-%Y %H:%M:%S"
-            ).replace(tzinfo=pytz.timezone("Europe/Dublin")),
+            ).replace(tzinfo=IE_TZ),
             "source": "eirgridgroup.com",
         }
         exchange += [data_point]
@@ -194,7 +194,7 @@ def fetch_consumption(
             "consumption": item["Value"],
             "datetime": datetime.strptime(
                 item["EffectiveTime"], "%d-%b-%Y %H:%M:%S"
-            ).replace(tzinfo=pytz.timezone("Europe/Dublin")),
+            ).replace(tzinfo=IE_TZ),
             "source": "eirgridgroup.com",
         }
         demand += [data_point]
@@ -229,7 +229,7 @@ def fetch_consumption_forecast(
             "value": item["Value"],
             "datetime": datetime.strptime(
                 item["EffectiveTime"], "%d-%b-%Y %H:%M:%S"
-            ).replace(tzinfo=pytz.timezone("Europe/Dublin")),
+            ).replace(tzinfo=IE_TZ),
             "source": "eirgridgroup.com",
         }
         demand_forecast += [data_point]
@@ -265,7 +265,7 @@ def fetch_wind_forecasts(
             "production": {"wind": item["Value"]},
             "datetime": datetime.strptime(
                 item["EffectiveTime"], "%d-%b-%Y %H:%M:%S"
-            ).replace(tzinfo=pytz.timezone("Europe/Dublin")),
+            ).replace(tzinfo=IE_TZ),
             "source": "eirgridgroup.com",
         }
         wind_forecast += [data_point]

--- a/parsers/IN.py
+++ b/parsers/IN.py
@@ -3,7 +3,7 @@
 """Parser for all of India"""
 
 
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from logging import Logger, getLogger
 from typing import Any
 
@@ -11,7 +11,6 @@ import arrow
 import numpy as np
 import pandas as pd
 from bs4 import BeautifulSoup
-from pytz import UTC
 from requests import Response, Session
 
 from electricitymap.contrib.lib.models.event_lists import (
@@ -426,7 +425,7 @@ def fetch_production(
     logger: Logger = getLogger(__name__),
 ) -> list[dict[str, Any]]:
     if target_datetime is None:
-        target_datetime = get_start_of_day(dt=UTC.localize(datetime.now()))
+        target_datetime = get_start_of_day(dt=datetime.now(timezone.utc))
     else:
         target_datetime = get_start_of_day(dt=target_datetime)
         if target_datetime < START_DATE_RENEWABLE_DATA:

--- a/parsers/IN.py
+++ b/parsers/IN.py
@@ -6,6 +6,7 @@
 from datetime import datetime, timedelta, timezone
 from logging import Logger, getLogger
 from typing import Any
+from zoneinfo import ZoneInfo
 
 import arrow
 import numpy as np
@@ -21,7 +22,7 @@ from electricitymap.contrib.lib.models.events import ProductionMix
 from electricitymap.contrib.lib.types import ZoneKey
 from parsers.lib.exceptions import ParserException
 
-IN_TZ = "Asia/Kolkata"
+IN_TZ = ZoneInfo("Asia/Kolkata")
 START_DATE_RENEWABLE_DATA = arrow.get("2020-12-17", tzinfo=IN_TZ).datetime
 CONVERSION_GWH_MW = 0.024
 GENERATION_MAPPING = {
@@ -185,7 +186,7 @@ def fetch_live_production(
 
     data = {
         "zoneKey": zone_key,
-        "datetime": IN_TZ.localize(datetime.now()),
+        "datetime": datetime.now(tz=IN_TZ),
         "production": mapped_production,
         "storage": {},
         "source": "meritindia.in",

--- a/parsers/IN_EA.py
+++ b/parsers/IN_EA.py
@@ -3,7 +3,7 @@ from datetime import datetime, timedelta
 from logging import Logger, getLogger
 from typing import Any
 
-import pytz
+from zoneinfo import ZoneInfo
 from requests import Session
 
 from electricitymap.contrib.config import ZoneKey
@@ -15,7 +15,7 @@ IN_WE_PROXY = "https://in-proxy-jfnx5klx2a-el.a.run.app"
 HOST = "https://app.erldc.in"
 INTERNATIONAL_EXCHANGES_URL = "{proxy}/api/pspreportpsp/Get/pspreport_psp_transnationalexchange/GetByTwoDate?host={host}&firstDate={target_date}&secondDate={target_date}"
 INTERREGIONAL_EXCHANGES_URL = "{proxy}/api/pspreportpsp/Get/pspreport_psp_interregionalexchanges/GetByTwoDate?host={host}&firstDate={target_date}&secondDate={target_date}"
-IN_EA_TZ = pytz.timezone("Asia/Kolkata")
+IN_EA_TZ = ZoneInfo("Asia/Kolkata")
 
 INTERREGIONAL_EXCHANGES = {
     ZoneKey("IN-EA->IN-NO"): "Import/Export between EAST REGION and NORTH REGION",

--- a/parsers/IN_EA.py
+++ b/parsers/IN_EA.py
@@ -2,8 +2,8 @@ from collections.abc import Callable
 from datetime import datetime, timedelta
 from logging import Logger, getLogger
 from typing import Any
-
 from zoneinfo import ZoneInfo
+
 from requests import Session
 
 from electricitymap.contrib.config import ZoneKey

--- a/parsers/KPX.py
+++ b/parsers/KPX.py
@@ -6,11 +6,11 @@ import pprint
 import re
 from datetime import datetime, timedelta
 from logging import Logger, getLogger
+from zoneinfo import ZoneInfo
 
 import arrow
 import pandas as pd
 from bs4 import BeautifulSoup
-from zoneinfo import ZoneInfo
 from requests import Session
 
 from electricitymap.contrib.config import ZoneKey

--- a/parsers/KPX.py
+++ b/parsers/KPX.py
@@ -80,8 +80,9 @@ def fetch_consumption(
 
     consumption_date_list = soup.find("p", {"class": "info_top"}).text.split(" ")[:2]
     consumption_date_list[0] = consumption_date_list[0].replace(".", "-").split("(")[0]
-    consumption_date = datetime.strptime(" ".join(consumption_date_list), "%Y-%m-%d %H:%M").replace(tzinfo=TIMEZONE)
-
+    consumption_date = datetime.strptime(
+        " ".join(consumption_date_list), "%Y-%m-%d %H:%M"
+    ).replace(tzinfo=TIMEZONE)
 
     consumption_list = TotalConsumptionList(logger)
     consumption_list.append(
@@ -175,7 +176,9 @@ def parse_chart_prod_data(
         if item["regDate"] == "0":
             break
 
-        dt = datetime.strptime(item["regDate"], "%Y-%m-%d %H:%M").replace(tzinfo=TIMEZONE)
+        dt = datetime.strptime(item["regDate"], "%Y-%m-%d %H:%M").replace(
+            tzinfo=TIMEZONE
+        )
 
         production_mix = ProductionMix()
         storage_mix = StorageMix()

--- a/parsers/KPX.py
+++ b/parsers/KPX.py
@@ -80,9 +80,8 @@ def fetch_consumption(
 
     consumption_date_list = soup.find("p", {"class": "info_top"}).text.split(" ")[:2]
     consumption_date_list[0] = consumption_date_list[0].replace(".", "-").split("(")[0]
-    consumption_date = TIMEZONE.localize(
-        datetime.strptime(" ".join(consumption_date_list), "%Y-%m-%d %H:%M")
-    )
+    consumption_date = datetime.strptime(" ".join(consumption_date_list), "%Y-%m-%d %H:%M").replace(tzinfo=TIMEZONE)
+
 
     consumption_list = TotalConsumptionList(logger)
     consumption_list.append(
@@ -176,7 +175,7 @@ def parse_chart_prod_data(
         if item["regDate"] == "0":
             break
 
-        dt = TIMEZONE.localize(datetime.strptime(item["regDate"], "%Y-%m-%d %H:%M"))
+        dt = datetime.strptime(item["regDate"], "%Y-%m-%d %H:%M").replace(tzinfo=TIMEZONE)
 
         production_mix = ProductionMix()
         storage_mix = StorageMix()

--- a/parsers/KPX.py
+++ b/parsers/KPX.py
@@ -10,7 +10,7 @@ from logging import Logger, getLogger
 import arrow
 import pandas as pd
 from bs4 import BeautifulSoup
-from pytz import timezone
+from zoneinfo import ZoneInfo
 from requests import Session
 
 from electricitymap.contrib.config import ZoneKey
@@ -23,7 +23,7 @@ from electricitymap.contrib.lib.models.events import ProductionMix, StorageMix
 from parsers.lib.config import refetch_frequency
 from parsers.lib.exceptions import ParserException
 
-TIMEZONE = timezone("Asia/Seoul")
+TIMEZONE = ZoneInfo("Asia/Seoul")
 KR_CURRENCY = "KRW"
 KR_SOURCE = "new.kpx.or.kr"
 REAL_TIME_URL = "https://new.kpx.or.kr/powerinfoSubmain.es?mid=a10606030000"

--- a/parsers/MK_wrapper.py
+++ b/parsers/MK_wrapper.py
@@ -1,7 +1,6 @@
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from logging import Logger, getLogger
 
-from pytz import utc
 from requests import Session
 
 from . import ENTSOE
@@ -16,7 +15,7 @@ If no target_datetime is provided, the wrapper will provide a target datetime th
 
 def modify_target_datetime(target_datetime: datetime | None) -> datetime:
     if target_datetime is None:
-        return datetime.now(tz=utc) - timedelta(hours=24)
+        return datetime.now(tz=timezone.utc) - timedelta(hours=24)
     else:
         return target_datetime
 

--- a/parsers/MN.py
+++ b/parsers/MN.py
@@ -4,7 +4,7 @@ from datetime import datetime
 from logging import Logger, getLogger
 from typing import Any
 
-from pytz import timezone
+from zoneinfo import ZoneInfo
 from requests import Response, Session
 
 from electricitymap.contrib.config import ZoneKey
@@ -16,7 +16,7 @@ from electricitymap.contrib.lib.models.events import ProductionMix
 from parsers.lib.exceptions import ParserException
 
 NDC_GENERATION = "https://disnews.energy.mn/test/convert.php"
-TZ = timezone("Asia/Ulaanbaatar")  # UTC+8
+TZ = ZoneInfo("Asia/Ulaanbaatar")  # UTC+8
 
 # Query fields to web API fields
 JSON_QUERY_TO_SRC = {

--- a/parsers/MN.py
+++ b/parsers/MN.py
@@ -3,8 +3,8 @@
 from datetime import datetime
 from logging import Logger, getLogger
 from typing import Any
-
 from zoneinfo import ZoneInfo
+
 from requests import Response, Session
 
 from electricitymap.contrib.config import ZoneKey

--- a/parsers/NL.py
+++ b/parsers/NL.py
@@ -1,12 +1,11 @@
 #!/usr/bin/env python3
 
 from copy import copy
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from logging import Logger, getLogger
 
 import arrow
 import pandas as pd
-import pytz
 from requests import Session, get
 
 from electricitymap.contrib.config import ZONES_CONFIG
@@ -14,7 +13,7 @@ from parsers import DK, ENTSOE
 from parsers.lib.config import refetch_frequency
 
 ZONE_CONFIG = ZONES_CONFIG["NL"]
-UTC = pytz.UTC
+UTC = timezone.utc
 
 
 @refetch_frequency(timedelta(days=1))

--- a/parsers/NTESMO.py
+++ b/parsers/NTESMO.py
@@ -148,7 +148,7 @@ def parse_consumption(
             timestamp = timestamp + timedelta(days=1)
         data_point = {
             "zoneKey": "AU-NT",
-            "datetime": AUSTRALIA_TZ.localize(timestamp),
+            "datetime": timestamp.replace(tzinfo=AUSTRALIA_TZ),
             "source": "ntesmo.com.au",
         }
         if price:

--- a/parsers/NTESMO.py
+++ b/parsers/NTESMO.py
@@ -8,18 +8,19 @@ from collections.abc import Callable
 from datetime import datetime, time, timedelta
 from logging import Logger, getLogger
 from typing import TypedDict
+from zoneinfo import ZoneInfo
 
 import arrow
 import pandas as pd
 from bs4 import BeautifulSoup
-from pytz import timezone
+
 from requests import Session
 from requests.adapters import Retry
 
 from parsers.lib.config import refetch_frequency, retry_policy
 from parsers.lib.exceptions import ParserException
 
-AUSTRALIA_TZ = timezone("Australia/Darwin")
+AUSTRALIA_TZ = ZoneInfo("Australia/Darwin")
 
 INDEX_URL = "https://ntesmo.com.au/data/daily-trading/historical-daily-trading-data/{}-daily-trading-data"
 DEFAULT_URL = "https://ntesmo.com.au/data/daily-trading/historical-daily-trading-data"

--- a/parsers/NTESMO.py
+++ b/parsers/NTESMO.py
@@ -13,7 +13,6 @@ from zoneinfo import ZoneInfo
 import arrow
 import pandas as pd
 from bs4 import BeautifulSoup
-
 from requests import Session
 from requests.adapters import Retry
 

--- a/parsers/TAIPOWER.py
+++ b/parsers/TAIPOWER.py
@@ -1,9 +1,10 @@
 #!/usr/bin/env python3
 from datetime import datetime, timedelta, timezone
 from logging import Logger, getLogger
+from zoneinfo import ZoneInfo
 
 import pandas as pd
-from pytz import timezone
+
 from requests import Session
 
 from electricitymap.contrib.lib.models.event_lists import ProductionBreakdownList
@@ -12,7 +13,7 @@ from parsers.lib.config import refetch_frequency
 from parsers.lib.exceptions import ParserException
 
 SOURCE = "taipower.com.tw"
-TIMEZONE = timezone("Asia/Taipei")
+TIMEZONE = ZoneInfo("Asia/Taipei")
 PRODUCTION_URL = (
     "http://www.taipower.com.tw/d006/loadGraph/loadGraph/data/genary_eng.json"
 )

--- a/parsers/TAIPOWER.py
+++ b/parsers/TAIPOWER.py
@@ -4,7 +4,6 @@ from logging import Logger, getLogger
 from zoneinfo import ZoneInfo
 
 import pandas as pd
-
 from requests import Session
 
 from electricitymap.contrib.lib.models.event_lists import ProductionBreakdownList

--- a/parsers/TAIPOWER.py
+++ b/parsers/TAIPOWER.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-from datetime import datetime, timedelta, timezone
+from datetime import datetime, timedelta
 from logging import Logger, getLogger
 from zoneinfo import ZoneInfo
 
@@ -40,7 +40,7 @@ def fetch_production(
     dt = data[""]
     prodData = data["dataset"]
 
-    dt = TIMEZONE.localize(datetime.strptime(dt, "%Y-%m-%d %H:%M"))
+    dt = datetime.strptime(dt, "%Y-%m-%d %H:%M").replace(tzinfo=TIMEZONE)
 
     objData = pd.DataFrame(prodData)
 

--- a/parsers/TH.py
+++ b/parsers/TH.py
@@ -2,8 +2,8 @@ import json
 import re
 from datetime import datetime, timedelta
 from logging import Logger, getLogger
+from zoneinfo import ZoneInfo
 
-import pytz
 from bs4 import BeautifulSoup
 from requests import Session
 
@@ -15,7 +15,7 @@ EGAT_URL = "www.egat.co.th"
 MEA_BASEPRICE_URL = "https://www.mea.or.th/en/profile/109/111"
 MEA_FT_URL = "https://www.mea.or.th/content/detail/2985/2987/474"
 MEA_URL = "www.mea.or.th"
-TZ = "Asia/Bangkok"
+TZ = ZoneInfo("Asia/Bangkok")
 
 
 def _as_localtime(dt: datetime) -> datetime:
@@ -24,10 +24,9 @@ def _as_localtime(dt: datetime) -> datetime:
     Otherwise, it interprets the datetime as the representation of local time
     since the API server supposes the local timezone instead of UTC.
     """
-    tzinfo = pytz.timezone(TZ)
     if dt is None:
-        return datetime.now(tz=tzinfo)
-    return dt.astimezone(tzinfo)
+        return datetime.now(tz=TZ)
+    return dt.astimezone(TZ)
 
 
 def _seconds_to_time(target_datetime: datetime, seconds_in_day: int) -> datetime:

--- a/parsers/TR.py
+++ b/parsers/TR.py
@@ -1,9 +1,9 @@
 #!/usr/bin/env python3
 from datetime import datetime, timedelta
 from logging import Logger, getLogger
+from zoneinfo import ZoneInfo
 
 import arrow
-import pytz
 from requests import Response, Session
 
 from parsers.lib.config import refetch_frequency
@@ -11,7 +11,7 @@ from parsers.lib.exceptions import ParserException
 from parsers.lib.session import get_session_with_legacy_adapter
 from parsers.lib.validation import validate
 
-TR_TZ = pytz.timezone("Europe/Istanbul")
+TR_TZ = ZoneInfo("Europe/Istanbul")
 
 EPIAS_MAIN_URL = "https://seffaflik.epias.com.tr/transparency/service"
 KINDS_MAPPING = {

--- a/parsers/UA.py
+++ b/parsers/UA.py
@@ -5,7 +5,7 @@ import json
 from datetime import datetime, timedelta
 from logging import Logger, getLogger
 
-from pytz import timezone
+from zoneinfo import ZoneInfo
 from requests import Session
 
 from electricitymap.contrib.lib.models.event_lists import ProductionBreakdownList
@@ -36,7 +36,7 @@ IGNORED_VALUES = ["hour", "consumption", "consumption_diff"]
 
 SOURCE = "ua.energy"
 
-TZ = timezone("Europe/Kiev")
+TZ = ZoneInfo("Europe/Kiev")
 
 
 def fetch_production(

--- a/parsers/UA.py
+++ b/parsers/UA.py
@@ -4,8 +4,8 @@ import http.client
 import json
 from datetime import datetime, timedelta
 from logging import Logger, getLogger
-
 from zoneinfo import ZoneInfo
+
 from requests import Session
 
 from electricitymap.contrib.lib.models.event_lists import ProductionBreakdownList

--- a/parsers/US_CA.py
+++ b/parsers/US_CA.py
@@ -6,7 +6,6 @@ from logging import Logger, getLogger
 import arrow
 import numpy as np
 import pandas
-
 from requests import Session
 
 from electricitymap.contrib.lib.models.event_lists import (

--- a/parsers/US_CA.py
+++ b/parsers/US_CA.py
@@ -1,12 +1,12 @@
 #!/usr/bin/env python3
 
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from logging import Logger, getLogger
 
 import arrow
 import numpy as np
 import pandas
-import pytz
+
 from requests import Session
 
 from electricitymap.contrib.lib.models.event_lists import (
@@ -55,7 +55,7 @@ STORAGE_MAPPING = {"batteries": "battery"}
 
 def get_target_url(target_datetime: datetime | None, kind: str) -> str:
     if target_datetime is None:
-        target_datetime = datetime.now(tz=pytz.UTC)
+        target_datetime = datetime.now(tz=timezone.utc)
         target_url = REAL_TIME_URL_MAPPING[kind]
     else:
         target_url = f"{CAISO_PROXY}/outlook/SP/History/{target_datetime.strftime('%Y%m%d')}/{HISTORICAL_URL_MAPPING[kind]}.csv?host=https://www.caiso.com"

--- a/parsers/US_NEISO.py
+++ b/parsers/US_NEISO.py
@@ -7,8 +7,8 @@ import time
 from datetime import datetime, timedelta, timezone
 from logging import Logger, getLogger
 from typing import Any
+from zoneinfo import ZoneInfo
 
-import pytz
 from requests import Session
 
 from electricitymap.contrib.lib.models.event_lists import (
@@ -46,7 +46,7 @@ def get_json_data(
     epoch_time = str(int(time.time()))
 
     target_datetime = target_datetime or datetime.now(tz=timezone.utc)
-    target_ne = target_datetime.astimezone(tz=pytz.timezone("America/New_York"))
+    target_ne = target_datetime.astimezone(tz=ZoneInfo("America/New_York"))
     target_ne_day = target_ne.strftime("%m/%d/%Y")
 
     postdata = {

--- a/parsers/UY.py
+++ b/parsers/UY.py
@@ -8,7 +8,6 @@ from zoneinfo import ZoneInfo
 import arrow
 import pandas as pd
 
-
 # BeautifulSoup is used to parse HTML to get information
 from bs4 import BeautifulSoup
 from requests import Session

--- a/parsers/UY.py
+++ b/parsers/UY.py
@@ -3,10 +3,11 @@
 import io
 from datetime import datetime, timedelta
 from logging import Logger, getLogger
+from zoneinfo import ZoneInfo
 
 import arrow
 import pandas as pd
-import pytz
+
 
 # BeautifulSoup is used to parse HTML to get information
 from bs4 import BeautifulSoup
@@ -16,7 +17,7 @@ from electricitymap.contrib.config.constants import PRODUCTION_MODES
 from parsers.lib.config import refetch_frequency
 from parsers.lib.exceptions import ParserException
 
-UY_TZ = "America/Montevideo"
+UY_TZ = ZoneInfo("America/Montevideo")
 
 ADME_URL = "https://pronos.adme.com.uy/gpf.php?fecha_ini="
 PRODUCTION_MODE_MAPPING = {
@@ -132,7 +133,7 @@ def fetch_production(
                 production_dict[mode] = round(row.get("value"), 3)
         data_point = {
             "zoneKey": "UY",
-            "datetime": arrow.get(dt).datetime.replace(tzinfo=pytz.timezone(UY_TZ)),
+            "datetime": arrow.get(dt).datetime.replace(tzinfo=UY_TZ),
             "production": production_dict,
             "source": "pronos.adme.com.uy",
         }
@@ -166,7 +167,7 @@ def fetch_consumption(
     for dt in consumption:
         data_point = {
             "zoneKey": "UY",
-            "datetime": arrow.get(dt).datetime.replace(tzinfo=pytz.timezone(UY_TZ)),
+            "datetime": arrow.get(dt).datetime.replace(tzinfo=UY_TZ),
             "consumption": round(consumption[dt]["consumption"], 3),
             "source": "pronos.adme.com.uy",
         }
@@ -207,7 +208,7 @@ def fetch_exchange(
         data_point = {
             "netFlow": round(exchange[dt][sortedZoneKeys], 3),
             "sortedZoneKeys": sortedZoneKeys,
-            "datetime": arrow.get(dt).datetime.replace(tzinfo=pytz.timezone(UY_TZ)),
+            "datetime": arrow.get(dt).datetime.replace(tzinfo=UY_TZ),
             "source": "pronos.adme.com.uy",
         }
         all_data_points += [data_point]

--- a/parsers/VN.py
+++ b/parsers/VN.py
@@ -6,7 +6,6 @@ from typing import Any
 from zoneinfo import ZoneInfo
 
 import arrow
-
 from requests import Response, Session
 
 from parsers.lib.exceptions import ParserException

--- a/parsers/VN.py
+++ b/parsers/VN.py
@@ -3,9 +3,10 @@
 from datetime import datetime
 from logging import Logger, getLogger
 from typing import Any
+from zoneinfo import ZoneInfo
 
 import arrow
-import pytz
+
 from requests import Response, Session
 
 from parsers.lib.exceptions import ParserException
@@ -13,7 +14,7 @@ from parsers.lib.exceptions import ParserException
 ## Vietnamese National Load Dispatch Center https://www.nldc.evn.vn/
 # Access via day, can also parse historical data
 
-tz = pytz.timezone("Asia/Ho_Chi_Minh")
+tz = ZoneInfo("Asia/Ho_Chi_Minh")
 base_url_from_type = {
     "consumption": "https://www.nldc.evn.vn/PhuTaiHandle.ashx?d=",  # + dd/mm/yyyy
     "price": "https://www.nldc.evn.vn/GiaBienHandle.ashx?d=",  # + dd/mm/yyyy

--- a/parsers/archived/DK_old.py
+++ b/parsers/archived/DK_old.py
@@ -1,12 +1,11 @@
 # Archived reason: The SQL API is no longer available and a new DK parser was created.
 import json
 import time
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from logging import Logger, getLogger
 
 import arrow  # the arrow library is used to handle datetimes
 import pandas as pd
-import pytz
 from requests import Session, exceptions
 
 from parsers.lib.config import refetch_frequency
@@ -121,7 +120,7 @@ def fetch_production(
         }
 
         data["datetime"] = dt.to_pydatetime()
-        data["datetime"] = data["datetime"].replace(tzinfo=pytz.utc)
+        data["datetime"] = data["datetime"].replace(tzinfo=timezone.utc)
         for f in ["solar", "wind"] + fuels:
             data["production"][f] = df.loc[dt, f]
         output.append(data)
@@ -234,7 +233,7 @@ def fetch_exchange(
         }
 
         data["datetime"] = dt.to_pydatetime()
-        data["datetime"] = data["datetime"].replace(tzinfo=pytz.utc)
+        data["datetime"] = data["datetime"].replace(tzinfo=timezone.utc)
         data["netFlow"] = df.loc[dt, "netFlow"]
         output.append(data)
     return output

--- a/parsers/archived/SE.py
+++ b/parsers/archived/SE.py
@@ -4,7 +4,6 @@ import datetime
 from collections import defaultdict
 
 import arrow
-import pytz
 import requests
 
 from parsers.lib.config import refetch_frequency
@@ -74,7 +73,7 @@ def fetch_production(
         to_return.append(
             {
                 "production": dict(prod),
-                "datetime": dt.replace(minute=0).replace(tzinfo=pytz.utc),
+                "datetime": dt.replace(minute=0).replace(tzinfo=datetime.timezone.utc),
                 "zoneKey": "SE",
                 "storage": {},
                 "source": "svk.se",

--- a/parsers/examples/example_parser.py
+++ b/parsers/examples/example_parser.py
@@ -1,8 +1,7 @@
 from datetime import datetime
 from logging import Logger, getLogger
 from typing import Any
-
-from pytz import timezone
+from zoneinfo import ZoneInfo
 
 # The request library is used to fetch content through HTTP
 from requests import Response, Session
@@ -36,7 +35,7 @@ def fetch_production(
           provided, we should default it to now. If past data is not available,
           raise a ParserException. Beware that the provided target_datetime is
           UTC. To convert to local timezone, you can use
-          `target_datetime = target_datetime.astimezone(tz=timezone('America/New_York'))`.
+          `target_datetime = target_datetime.astimezone(tz=ZoneInfo('America/New_York'))`.
         logger: an instance of a `logging.Logger` that will be passed by the
           backend. Information logged will be publicly available so that correct
           execution of the logger can be checked. All Exceptions will automatically
@@ -70,7 +69,7 @@ def fetch_production(
         # WHEN HISTORICAL DATA IS AVAILABLE
         # convert target datetime to local datetime
         url_date = target_datetime.astimezone(
-            timezone("America/Argentina/Buenos_Aires")
+            ZoneInfo("America/Argentina/Buenos_Aires")
         ).strftime("%Y-%m-%d")
         url = f"https://api.someservice.com/v1/productionmix/{url_date}"
     else:
@@ -152,7 +151,7 @@ def fetch_price(
       provided, we should default it to now. If past data is not available,
       raise a ParserException. Beware that the provided target_datetime is
       UTC. To convert to local timezone, you can use
-      `target_datetime = target_datetime.astimezone(tz=timezone('America/New_York'))`.
+      `target_datetime = target_datetime.astimezone(tz=ZoneInfo('America/New_York'))`.
     logger: an instance of a `logging.Logger` that will be passed by the
       backend. Information logged will be publicly available so that correct
       execution of the logger can be checked. All Exceptions will automatically
@@ -223,7 +222,7 @@ def fetch_exchange(
       provided, we should default it to now. If past data is not available,
       raise a ParserException. Beware that the provided target_datetime is
       UTC. To convert to local timezone, you can use
-      `target_datetime = target_datetime.astimezone(tz=timezone('America/New_York'))`.
+      `target_datetime = target_datetime.astimezone(tz=ZoneInfo('America/New_York'))`.
     logger: an instance of a `logging.Logger` that will be passed by the
       backend. Information logged will be publicly available so that correct
       execution of the logger can be checked. All Exceptions will automatically
@@ -269,7 +268,7 @@ def fetch_exchange(
             # Here we assume that the net flow returned by the api is the flow from
             # country1 to country2. A positive flow indicates an export from country1
             # to country2. A negative flow indicates an import.
-            value=item["exchange"],
+            netFlow=item["exchange"],
             source="someservice.com",
         )
 
@@ -294,7 +293,7 @@ def fetch_consumption(
       provided, we should default it to now. If past data is not available,
       raise a ParserException. Beware that the provided target_datetime is
       UTC. To convert to local timezone, you can use
-      `target_datetime = target_datetime.astimezone(tz=timezone('America/New_York'))`.
+      `target_datetime = target_datetime.astimezone(tz=ZoneInfo('America/New_York'))`.
     logger: an instance of a `logging.Logger` that will be passed by the
       backend. Information logged will be publicly available so that correct
       execution of the logger can be checked. All Exceptions will automatically
@@ -359,7 +358,7 @@ def fetch_total_production(
         provided, we should default it to now. If past data is not available,
         raise a ParserException. Beware that the provided target_datetime is
         UTC. To convert to local timezone, you can use
-        `target_datetime = target_datetime.astimezone(tz=timezone('America/New_York'))`.
+        `target_datetime = target_datetime.astimezone(tz=ZoneInfo('America/New_York'))`.
     logger: an instance of a `logging.Logger` that will be passed by the
       backend. Information logged will be publicly available so that correct
       execution of the logger can be checked. All Exceptions will automatically

--- a/parsers/test/snapshots/snap_test_ESKOM.py
+++ b/parsers/test/snapshots/snap_test_ESKOM.py
@@ -8,7 +8,7 @@ snapshots = Snapshot()
 
 snapshots["test_production 1"] = [
     {
-        "datetime": "2023-09-11T00:00:00+01:52",
+        "datetime": "2023-09-11T00:00:00+02:00",
         "production": {
             "coal": 14487.159,
             "gas": 0.0,
@@ -25,7 +25,7 @@ snapshots["test_production 1"] = [
         "zoneKey": "ZA",
     },
     {
-        "datetime": "2023-09-11T01:00:00+01:52",
+        "datetime": "2023-09-11T01:00:00+02:00",
         "production": {
             "coal": 14231.943,
             "gas": 0.0,
@@ -42,7 +42,7 @@ snapshots["test_production 1"] = [
         "zoneKey": "ZA",
     },
     {
-        "datetime": "2023-09-11T02:00:00+01:52",
+        "datetime": "2023-09-11T02:00:00+02:00",
         "production": {
             "coal": 14354.055,
             "gas": 0.0,
@@ -59,7 +59,7 @@ snapshots["test_production 1"] = [
         "zoneKey": "ZA",
     },
     {
-        "datetime": "2023-09-11T03:00:00+01:52",
+        "datetime": "2023-09-11T03:00:00+02:00",
         "production": {
             "coal": 14436.056,
             "gas": 0.0,
@@ -76,7 +76,7 @@ snapshots["test_production 1"] = [
         "zoneKey": "ZA",
     },
     {
-        "datetime": "2023-09-11T04:00:00+01:52",
+        "datetime": "2023-09-11T04:00:00+02:00",
         "production": {
             "coal": 15399.591,
             "gas": 0.0,
@@ -93,7 +93,7 @@ snapshots["test_production 1"] = [
         "zoneKey": "ZA",
     },
     {
-        "datetime": "2023-09-11T05:00:00+01:52",
+        "datetime": "2023-09-11T05:00:00+02:00",
         "production": {
             "coal": 17525.653,
             "gas": 0.0,
@@ -110,7 +110,7 @@ snapshots["test_production 1"] = [
         "zoneKey": "ZA",
     },
     {
-        "datetime": "2023-09-11T06:00:00+01:52",
+        "datetime": "2023-09-11T06:00:00+02:00",
         "production": {
             "coal": 17923.763,
             "gas": 0.0,
@@ -127,7 +127,7 @@ snapshots["test_production 1"] = [
         "zoneKey": "ZA",
     },
     {
-        "datetime": "2023-09-11T07:00:00+01:52",
+        "datetime": "2023-09-11T07:00:00+02:00",
         "production": {
             "coal": 18112.266,
             "gas": 0.0,
@@ -144,7 +144,7 @@ snapshots["test_production 1"] = [
         "zoneKey": "ZA",
     },
     {
-        "datetime": "2023-09-11T08:00:00+01:52",
+        "datetime": "2023-09-11T08:00:00+02:00",
         "production": {
             "coal": 18188.291,
             "gas": 0.0,
@@ -161,7 +161,7 @@ snapshots["test_production 1"] = [
         "zoneKey": "ZA",
     },
     {
-        "datetime": "2023-09-11T09:00:00+01:52",
+        "datetime": "2023-09-11T09:00:00+02:00",
         "production": {
             "coal": 18128.402,
             "gas": 0.0,
@@ -178,7 +178,7 @@ snapshots["test_production 1"] = [
         "zoneKey": "ZA",
     },
     {
-        "datetime": "2023-09-11T10:00:00+01:52",
+        "datetime": "2023-09-11T10:00:00+02:00",
         "production": {
             "coal": 17748.255,
             "gas": 0.0,
@@ -195,7 +195,7 @@ snapshots["test_production 1"] = [
         "zoneKey": "ZA",
     },
     {
-        "datetime": "2023-09-11T11:00:00+01:52",
+        "datetime": "2023-09-11T11:00:00+02:00",
         "production": {
             "coal": 17492.406,
             "gas": 0.0,
@@ -212,7 +212,7 @@ snapshots["test_production 1"] = [
         "zoneKey": "ZA",
     },
     {
-        "datetime": "2023-09-11T12:00:00+01:52",
+        "datetime": "2023-09-11T12:00:00+02:00",
         "production": {
             "coal": 17337.569,
             "gas": 0.0,
@@ -229,7 +229,7 @@ snapshots["test_production 1"] = [
         "zoneKey": "ZA",
     },
     {
-        "datetime": "2023-09-11T13:00:00+01:52",
+        "datetime": "2023-09-11T13:00:00+02:00",
         "production": {
             "coal": 17367.756,
             "gas": 0.0,
@@ -246,7 +246,7 @@ snapshots["test_production 1"] = [
         "zoneKey": "ZA",
     },
     {
-        "datetime": "2023-09-11T14:00:00+01:52",
+        "datetime": "2023-09-11T14:00:00+02:00",
         "production": {
             "coal": 16786.084,
             "gas": 0.0,
@@ -263,7 +263,7 @@ snapshots["test_production 1"] = [
         "zoneKey": "ZA",
     },
     {
-        "datetime": "2023-09-11T15:00:00+01:52",
+        "datetime": "2023-09-11T15:00:00+02:00",
         "production": {
             "coal": 16304.325,
             "gas": 0.0,
@@ -280,7 +280,7 @@ snapshots["test_production 1"] = [
         "zoneKey": "ZA",
     },
     {
-        "datetime": "2023-09-11T16:00:00+01:52",
+        "datetime": "2023-09-11T16:00:00+02:00",
         "production": {
             "coal": 16336.383,
             "gas": 0.0,
@@ -297,7 +297,7 @@ snapshots["test_production 1"] = [
         "zoneKey": "ZA",
     },
     {
-        "datetime": "2023-09-11T17:00:00+01:52",
+        "datetime": "2023-09-11T17:00:00+02:00",
         "production": {
             "coal": 16499.066,
             "gas": 135.31,
@@ -314,7 +314,7 @@ snapshots["test_production 1"] = [
         "zoneKey": "ZA",
     },
     {
-        "datetime": "2023-09-11T18:00:00+01:52",
+        "datetime": "2023-09-11T18:00:00+02:00",
         "production": {
             "coal": 16904.072,
             "gas": 327.517,
@@ -331,7 +331,7 @@ snapshots["test_production 1"] = [
         "zoneKey": "ZA",
     },
     {
-        "datetime": "2023-09-11T19:00:00+01:52",
+        "datetime": "2023-09-11T19:00:00+02:00",
         "production": {
             "coal": 16994.121,
             "gas": 328.345,
@@ -348,7 +348,7 @@ snapshots["test_production 1"] = [
         "zoneKey": "ZA",
     },
     {
-        "datetime": "2023-09-11T20:00:00+01:52",
+        "datetime": "2023-09-11T20:00:00+02:00",
         "production": {
             "coal": 17140.437,
             "gas": 95.007,
@@ -365,7 +365,7 @@ snapshots["test_production 1"] = [
         "zoneKey": "ZA",
     },
     {
-        "datetime": "2023-09-11T21:00:00+01:52",
+        "datetime": "2023-09-11T21:00:00+02:00",
         "production": {
             "coal": 16475.758,
             "gas": 0.0,
@@ -382,7 +382,7 @@ snapshots["test_production 1"] = [
         "zoneKey": "ZA",
     },
     {
-        "datetime": "2023-09-11T22:00:00+01:52",
+        "datetime": "2023-09-11T22:00:00+02:00",
         "production": {
             "coal": 15568.751,
             "gas": 0.0,
@@ -399,7 +399,7 @@ snapshots["test_production 1"] = [
         "zoneKey": "ZA",
     },
     {
-        "datetime": "2023-09-11T23:00:00+01:52",
+        "datetime": "2023-09-11T23:00:00+02:00",
         "production": {
             "coal": 15110.876,
             "gas": 0.0,
@@ -416,7 +416,7 @@ snapshots["test_production 1"] = [
         "zoneKey": "ZA",
     },
     {
-        "datetime": "2023-09-12T00:00:00+01:52",
+        "datetime": "2023-09-12T00:00:00+02:00",
         "production": {
             "coal": 14860.657,
             "gas": 0.0,
@@ -433,7 +433,7 @@ snapshots["test_production 1"] = [
         "zoneKey": "ZA",
     },
     {
-        "datetime": "2023-09-12T01:00:00+01:52",
+        "datetime": "2023-09-12T01:00:00+02:00",
         "production": {
             "coal": 14673.783,
             "gas": 0.0,
@@ -450,7 +450,7 @@ snapshots["test_production 1"] = [
         "zoneKey": "ZA",
     },
     {
-        "datetime": "2023-09-12T02:00:00+01:52",
+        "datetime": "2023-09-12T02:00:00+02:00",
         "production": {
             "coal": 15097.239,
             "gas": 0.0,
@@ -467,7 +467,7 @@ snapshots["test_production 1"] = [
         "zoneKey": "ZA",
     },
     {
-        "datetime": "2023-09-12T03:00:00+01:52",
+        "datetime": "2023-09-12T03:00:00+02:00",
         "production": {
             "coal": 15131.653,
             "gas": 0.0,
@@ -484,7 +484,7 @@ snapshots["test_production 1"] = [
         "zoneKey": "ZA",
     },
     {
-        "datetime": "2023-09-12T04:00:00+01:52",
+        "datetime": "2023-09-12T04:00:00+02:00",
         "production": {
             "coal": 16554.638,
             "gas": 0.0,
@@ -501,7 +501,7 @@ snapshots["test_production 1"] = [
         "zoneKey": "ZA",
     },
     {
-        "datetime": "2023-09-12T05:00:00+01:52",
+        "datetime": "2023-09-12T05:00:00+02:00",
         "production": {
             "coal": 17710.869,
             "gas": 0.0,
@@ -518,7 +518,7 @@ snapshots["test_production 1"] = [
         "zoneKey": "ZA",
     },
     {
-        "datetime": "2023-09-12T06:00:00+01:52",
+        "datetime": "2023-09-12T06:00:00+02:00",
         "production": {
             "coal": 17687.172,
             "gas": 0.0,
@@ -535,7 +535,7 @@ snapshots["test_production 1"] = [
         "zoneKey": "ZA",
     },
     {
-        "datetime": "2023-09-12T07:00:00+01:52",
+        "datetime": "2023-09-12T07:00:00+02:00",
         "production": {
             "coal": 17811.809,
             "gas": 0.0,
@@ -552,7 +552,7 @@ snapshots["test_production 1"] = [
         "zoneKey": "ZA",
     },
     {
-        "datetime": "2023-09-12T08:00:00+01:52",
+        "datetime": "2023-09-12T08:00:00+02:00",
         "production": {
             "coal": 17838.704,
             "gas": 0.0,
@@ -569,7 +569,7 @@ snapshots["test_production 1"] = [
         "zoneKey": "ZA",
     },
     {
-        "datetime": "2023-09-12T09:00:00+01:52",
+        "datetime": "2023-09-12T09:00:00+02:00",
         "production": {
             "coal": 17864.873,
             "gas": 0.0,
@@ -586,7 +586,7 @@ snapshots["test_production 1"] = [
         "zoneKey": "ZA",
     },
     {
-        "datetime": "2023-09-12T10:00:00+01:52",
+        "datetime": "2023-09-12T10:00:00+02:00",
         "production": {
             "coal": 17882.139,
             "gas": 0.0,
@@ -603,7 +603,7 @@ snapshots["test_production 1"] = [
         "zoneKey": "ZA",
     },
     {
-        "datetime": "2023-09-12T11:00:00+01:52",
+        "datetime": "2023-09-12T11:00:00+02:00",
         "production": {
             "coal": 17675.814,
             "gas": 0.0,
@@ -620,7 +620,7 @@ snapshots["test_production 1"] = [
         "zoneKey": "ZA",
     },
     {
-        "datetime": "2023-09-12T12:00:00+01:52",
+        "datetime": "2023-09-12T12:00:00+02:00",
         "production": {
             "coal": 17565.959,
             "gas": 0.0,
@@ -637,7 +637,7 @@ snapshots["test_production 1"] = [
         "zoneKey": "ZA",
     },
     {
-        "datetime": "2023-09-12T13:00:00+01:52",
+        "datetime": "2023-09-12T13:00:00+02:00",
         "production": {
             "coal": 17459.714,
             "gas": 0.0,
@@ -654,7 +654,7 @@ snapshots["test_production 1"] = [
         "zoneKey": "ZA",
     },
     {
-        "datetime": "2023-09-12T14:00:00+01:52",
+        "datetime": "2023-09-12T14:00:00+02:00",
         "production": {
             "coal": 17616.844,
             "gas": 0.0,
@@ -671,7 +671,7 @@ snapshots["test_production 1"] = [
         "zoneKey": "ZA",
     },
     {
-        "datetime": "2023-09-12T15:00:00+01:52",
+        "datetime": "2023-09-12T15:00:00+02:00",
         "production": {
             "coal": 17668.651,
             "gas": 0.0,
@@ -688,7 +688,7 @@ snapshots["test_production 1"] = [
         "zoneKey": "ZA",
     },
     {
-        "datetime": "2023-09-12T16:00:00+01:52",
+        "datetime": "2023-09-12T16:00:00+02:00",
         "production": {
             "coal": 17737.191,
             "gas": 0.0,
@@ -705,7 +705,7 @@ snapshots["test_production 1"] = [
         "zoneKey": "ZA",
     },
     {
-        "datetime": "2023-09-12T17:00:00+01:52",
+        "datetime": "2023-09-12T17:00:00+02:00",
         "production": {
             "coal": 18014.672,
             "gas": 0.0,
@@ -722,7 +722,7 @@ snapshots["test_production 1"] = [
         "zoneKey": "ZA",
     },
     {
-        "datetime": "2023-09-12T18:00:00+01:52",
+        "datetime": "2023-09-12T18:00:00+02:00",
         "production": {
             "coal": 18249.954,
             "gas": 0.0,
@@ -739,7 +739,7 @@ snapshots["test_production 1"] = [
         "zoneKey": "ZA",
     },
     {
-        "datetime": "2023-09-12T19:00:00+01:52",
+        "datetime": "2023-09-12T19:00:00+02:00",
         "production": {
             "coal": 18301.757,
             "gas": 0.0,
@@ -756,7 +756,7 @@ snapshots["test_production 1"] = [
         "zoneKey": "ZA",
     },
     {
-        "datetime": "2023-09-12T20:00:00+01:52",
+        "datetime": "2023-09-12T20:00:00+02:00",
         "production": {
             "coal": 17914.454,
             "gas": 0.0,
@@ -773,7 +773,7 @@ snapshots["test_production 1"] = [
         "zoneKey": "ZA",
     },
     {
-        "datetime": "2023-09-12T21:00:00+01:52",
+        "datetime": "2023-09-12T21:00:00+02:00",
         "production": {
             "coal": 16085.443,
             "gas": 0.0,
@@ -790,7 +790,7 @@ snapshots["test_production 1"] = [
         "zoneKey": "ZA",
     },
     {
-        "datetime": "2023-09-12T22:00:00+01:52",
+        "datetime": "2023-09-12T22:00:00+02:00",
         "production": {
             "coal": 15555.347,
             "gas": 0.0,
@@ -807,7 +807,7 @@ snapshots["test_production 1"] = [
         "zoneKey": "ZA",
     },
     {
-        "datetime": "2023-09-12T23:00:00+01:52",
+        "datetime": "2023-09-12T23:00:00+02:00",
         "production": {
             "coal": 15172.027,
             "gas": 0.0,
@@ -824,7 +824,7 @@ snapshots["test_production 1"] = [
         "zoneKey": "ZA",
     },
     {
-        "datetime": "2023-09-13T00:00:00+01:52",
+        "datetime": "2023-09-13T00:00:00+02:00",
         "production": {
             "coal": 15176.669,
             "gas": 0.0,
@@ -841,7 +841,7 @@ snapshots["test_production 1"] = [
         "zoneKey": "ZA",
     },
     {
-        "datetime": "2023-09-13T01:00:00+01:52",
+        "datetime": "2023-09-13T01:00:00+02:00",
         "production": {
             "coal": 15309.956,
             "gas": 0.0,
@@ -858,7 +858,7 @@ snapshots["test_production 1"] = [
         "zoneKey": "ZA",
     },
     {
-        "datetime": "2023-09-13T02:00:00+01:52",
+        "datetime": "2023-09-13T02:00:00+02:00",
         "production": {
             "coal": 15437.735,
             "gas": 0.0,
@@ -875,7 +875,7 @@ snapshots["test_production 1"] = [
         "zoneKey": "ZA",
     },
     {
-        "datetime": "2023-09-13T03:00:00+01:52",
+        "datetime": "2023-09-13T03:00:00+02:00",
         "production": {
             "coal": 15875.269,
             "gas": 0.0,
@@ -892,7 +892,7 @@ snapshots["test_production 1"] = [
         "zoneKey": "ZA",
     },
     {
-        "datetime": "2023-09-13T04:00:00+01:52",
+        "datetime": "2023-09-13T04:00:00+02:00",
         "production": {
             "coal": 17470.17,
             "gas": 0.0,
@@ -909,7 +909,7 @@ snapshots["test_production 1"] = [
         "zoneKey": "ZA",
     },
     {
-        "datetime": "2023-09-13T05:00:00+01:52",
+        "datetime": "2023-09-13T05:00:00+02:00",
         "production": {
             "coal": 18460.216,
             "gas": 0.0,
@@ -926,7 +926,7 @@ snapshots["test_production 1"] = [
         "zoneKey": "ZA",
     },
     {
-        "datetime": "2023-09-13T06:00:00+01:52",
+        "datetime": "2023-09-13T06:00:00+02:00",
         "production": {
             "coal": 18340.358,
             "gas": 0.0,
@@ -943,7 +943,7 @@ snapshots["test_production 1"] = [
         "zoneKey": "ZA",
     },
     {
-        "datetime": "2023-09-13T07:00:00+01:52",
+        "datetime": "2023-09-13T07:00:00+02:00",
         "production": {
             "coal": 18178.856,
             "gas": 0.0,
@@ -960,7 +960,7 @@ snapshots["test_production 1"] = [
         "zoneKey": "ZA",
     },
     {
-        "datetime": "2023-09-13T08:00:00+01:52",
+        "datetime": "2023-09-13T08:00:00+02:00",
         "production": {
             "coal": 18348.253,
             "gas": 0.0,
@@ -977,7 +977,7 @@ snapshots["test_production 1"] = [
         "zoneKey": "ZA",
     },
     {
-        "datetime": "2023-09-13T09:00:00+01:52",
+        "datetime": "2023-09-13T09:00:00+02:00",
         "production": {
             "coal": 18101.21,
             "gas": 0.0,
@@ -994,7 +994,7 @@ snapshots["test_production 1"] = [
         "zoneKey": "ZA",
     },
     {
-        "datetime": "2023-09-13T10:00:00+01:52",
+        "datetime": "2023-09-13T10:00:00+02:00",
         "production": {
             "coal": 17775.894,
             "gas": 0.0,
@@ -1011,7 +1011,7 @@ snapshots["test_production 1"] = [
         "zoneKey": "ZA",
     },
     {
-        "datetime": "2023-09-13T11:00:00+01:52",
+        "datetime": "2023-09-13T11:00:00+02:00",
         "production": {
             "coal": 16760.894,
             "gas": 0.0,
@@ -1028,7 +1028,7 @@ snapshots["test_production 1"] = [
         "zoneKey": "ZA",
     },
     {
-        "datetime": "2023-09-13T12:00:00+01:52",
+        "datetime": "2023-09-13T12:00:00+02:00",
         "production": {
             "coal": 16888.327,
             "gas": 0.0,
@@ -1045,7 +1045,7 @@ snapshots["test_production 1"] = [
         "zoneKey": "ZA",
     },
     {
-        "datetime": "2023-09-13T13:00:00+01:52",
+        "datetime": "2023-09-13T13:00:00+02:00",
         "production": {
             "coal": 16397.378,
             "gas": 0.0,
@@ -1062,7 +1062,7 @@ snapshots["test_production 1"] = [
         "zoneKey": "ZA",
     },
     {
-        "datetime": "2023-09-13T14:00:00+01:52",
+        "datetime": "2023-09-13T14:00:00+02:00",
         "production": {
             "coal": 16487.899,
             "gas": 0.0,
@@ -1079,7 +1079,7 @@ snapshots["test_production 1"] = [
         "zoneKey": "ZA",
     },
     {
-        "datetime": "2023-09-13T15:00:00+01:52",
+        "datetime": "2023-09-13T15:00:00+02:00",
         "production": {
             "coal": 17244.343,
             "gas": 0.0,
@@ -1096,7 +1096,7 @@ snapshots["test_production 1"] = [
         "zoneKey": "ZA",
     },
     {
-        "datetime": "2023-09-13T16:00:00+01:52",
+        "datetime": "2023-09-13T16:00:00+02:00",
         "production": {
             "coal": 17855.056,
             "gas": 0.0,
@@ -1113,7 +1113,7 @@ snapshots["test_production 1"] = [
         "zoneKey": "ZA",
     },
     {
-        "datetime": "2023-09-13T17:00:00+01:52",
+        "datetime": "2023-09-13T17:00:00+02:00",
         "production": {
             "coal": 17838.575,
             "gas": 0.0,
@@ -1130,7 +1130,7 @@ snapshots["test_production 1"] = [
         "zoneKey": "ZA",
     },
     {
-        "datetime": "2023-09-13T18:00:00+01:52",
+        "datetime": "2023-09-13T18:00:00+02:00",
         "production": {
             "coal": 17982.06,
             "gas": 0.0,
@@ -1147,7 +1147,7 @@ snapshots["test_production 1"] = [
         "zoneKey": "ZA",
     },
     {
-        "datetime": "2023-09-13T19:00:00+01:52",
+        "datetime": "2023-09-13T19:00:00+02:00",
         "production": {
             "coal": 18134.697,
             "gas": 0.0,
@@ -1164,7 +1164,7 @@ snapshots["test_production 1"] = [
         "zoneKey": "ZA",
     },
     {
-        "datetime": "2023-09-13T20:00:00+01:52",
+        "datetime": "2023-09-13T20:00:00+02:00",
         "production": {
             "coal": 18002.872,
             "gas": 0.0,
@@ -1181,7 +1181,7 @@ snapshots["test_production 1"] = [
         "zoneKey": "ZA",
     },
     {
-        "datetime": "2023-09-13T21:00:00+01:52",
+        "datetime": "2023-09-13T21:00:00+02:00",
         "production": {
             "coal": 17601.118,
             "gas": 0.0,
@@ -1198,7 +1198,7 @@ snapshots["test_production 1"] = [
         "zoneKey": "ZA",
     },
     {
-        "datetime": "2023-09-13T22:00:00+01:52",
+        "datetime": "2023-09-13T22:00:00+02:00",
         "production": {
             "coal": 16850.659,
             "gas": 0.0,
@@ -1215,7 +1215,7 @@ snapshots["test_production 1"] = [
         "zoneKey": "ZA",
     },
     {
-        "datetime": "2023-09-13T23:00:00+01:52",
+        "datetime": "2023-09-13T23:00:00+02:00",
         "production": {
             "coal": 15743.68,
             "gas": 0.0,
@@ -1232,7 +1232,7 @@ snapshots["test_production 1"] = [
         "zoneKey": "ZA",
     },
     {
-        "datetime": "2023-09-14T00:00:00+01:52",
+        "datetime": "2023-09-14T00:00:00+02:00",
         "production": {
             "coal": 15305.423,
             "gas": 0.0,
@@ -1249,7 +1249,7 @@ snapshots["test_production 1"] = [
         "zoneKey": "ZA",
     },
     {
-        "datetime": "2023-09-14T01:00:00+01:52",
+        "datetime": "2023-09-14T01:00:00+02:00",
         "production": {
             "coal": 14799.503,
             "gas": 0.0,
@@ -1266,7 +1266,7 @@ snapshots["test_production 1"] = [
         "zoneKey": "ZA",
     },
     {
-        "datetime": "2023-09-14T02:00:00+01:52",
+        "datetime": "2023-09-14T02:00:00+02:00",
         "production": {
             "coal": 14717.302,
             "gas": 0.0,
@@ -1283,7 +1283,7 @@ snapshots["test_production 1"] = [
         "zoneKey": "ZA",
     },
     {
-        "datetime": "2023-09-14T03:00:00+01:52",
+        "datetime": "2023-09-14T03:00:00+02:00",
         "production": {
             "coal": 15175.184,
             "gas": 0.0,
@@ -1300,7 +1300,7 @@ snapshots["test_production 1"] = [
         "zoneKey": "ZA",
     },
     {
-        "datetime": "2023-09-14T04:00:00+01:52",
+        "datetime": "2023-09-14T04:00:00+02:00",
         "production": {
             "coal": 16455.666,
             "gas": 0.0,
@@ -1317,7 +1317,7 @@ snapshots["test_production 1"] = [
         "zoneKey": "ZA",
     },
     {
-        "datetime": "2023-09-14T05:00:00+01:52",
+        "datetime": "2023-09-14T05:00:00+02:00",
         "production": {
             "coal": 18363.392,
             "gas": 0.0,
@@ -1334,7 +1334,7 @@ snapshots["test_production 1"] = [
         "zoneKey": "ZA",
     },
     {
-        "datetime": "2023-09-14T06:00:00+01:52",
+        "datetime": "2023-09-14T06:00:00+02:00",
         "production": {
             "coal": 18541.7,
             "gas": 0.0,
@@ -1351,7 +1351,7 @@ snapshots["test_production 1"] = [
         "zoneKey": "ZA",
     },
     {
-        "datetime": "2023-09-14T07:00:00+01:52",
+        "datetime": "2023-09-14T07:00:00+02:00",
         "production": {
             "coal": 18524.118,
             "gas": 0.0,
@@ -1368,7 +1368,7 @@ snapshots["test_production 1"] = [
         "zoneKey": "ZA",
     },
     {
-        "datetime": "2023-09-14T08:00:00+01:52",
+        "datetime": "2023-09-14T08:00:00+02:00",
         "production": {
             "coal": 18601.263,
             "gas": 0.0,
@@ -1385,7 +1385,7 @@ snapshots["test_production 1"] = [
         "zoneKey": "ZA",
     },
     {
-        "datetime": "2023-09-14T09:00:00+01:52",
+        "datetime": "2023-09-14T09:00:00+02:00",
         "production": {
             "coal": 18589.592,
             "gas": 0.0,
@@ -1402,7 +1402,7 @@ snapshots["test_production 1"] = [
         "zoneKey": "ZA",
     },
     {
-        "datetime": "2023-09-14T10:00:00+01:52",
+        "datetime": "2023-09-14T10:00:00+02:00",
         "production": {
             "coal": 17969.672,
             "gas": 0.0,
@@ -1419,7 +1419,7 @@ snapshots["test_production 1"] = [
         "zoneKey": "ZA",
     },
     {
-        "datetime": "2023-09-14T11:00:00+01:52",
+        "datetime": "2023-09-14T11:00:00+02:00",
         "production": {
             "coal": 17167.775,
             "gas": 0.0,
@@ -1436,7 +1436,7 @@ snapshots["test_production 1"] = [
         "zoneKey": "ZA",
     },
     {
-        "datetime": "2023-09-14T12:00:00+01:52",
+        "datetime": "2023-09-14T12:00:00+02:00",
         "production": {
             "coal": 17174.739,
             "gas": 0.0,
@@ -1453,7 +1453,7 @@ snapshots["test_production 1"] = [
         "zoneKey": "ZA",
     },
     {
-        "datetime": "2023-09-14T13:00:00+01:52",
+        "datetime": "2023-09-14T13:00:00+02:00",
         "production": {
             "coal": 16933.638,
             "gas": 0.0,
@@ -1470,7 +1470,7 @@ snapshots["test_production 1"] = [
         "zoneKey": "ZA",
     },
     {
-        "datetime": "2023-09-14T14:00:00+01:52",
+        "datetime": "2023-09-14T14:00:00+02:00",
         "production": {
             "coal": 17033.444,
             "gas": 0.0,
@@ -1487,7 +1487,7 @@ snapshots["test_production 1"] = [
         "zoneKey": "ZA",
     },
     {
-        "datetime": "2023-09-14T15:00:00+01:52",
+        "datetime": "2023-09-14T15:00:00+02:00",
         "production": {
             "coal": 17707.67,
             "gas": 0.0,
@@ -1504,7 +1504,7 @@ snapshots["test_production 1"] = [
         "zoneKey": "ZA",
     },
     {
-        "datetime": "2023-09-14T16:00:00+01:52",
+        "datetime": "2023-09-14T16:00:00+02:00",
         "production": {
             "coal": 18335.622,
             "gas": 0.0,
@@ -1521,7 +1521,7 @@ snapshots["test_production 1"] = [
         "zoneKey": "ZA",
     },
     {
-        "datetime": "2023-09-14T17:00:00+01:52",
+        "datetime": "2023-09-14T17:00:00+02:00",
         "production": {
             "coal": 18505.351,
             "gas": 0.0,
@@ -1538,7 +1538,7 @@ snapshots["test_production 1"] = [
         "zoneKey": "ZA",
     },
     {
-        "datetime": "2023-09-14T18:00:00+01:52",
+        "datetime": "2023-09-14T18:00:00+02:00",
         "production": {
             "coal": 18506.525,
             "gas": 0.0,
@@ -1555,7 +1555,7 @@ snapshots["test_production 1"] = [
         "zoneKey": "ZA",
     },
     {
-        "datetime": "2023-09-14T19:00:00+01:52",
+        "datetime": "2023-09-14T19:00:00+02:00",
         "production": {
             "coal": 18482.875,
             "gas": 0.0,
@@ -1572,7 +1572,7 @@ snapshots["test_production 1"] = [
         "zoneKey": "ZA",
     },
     {
-        "datetime": "2023-09-14T20:00:00+01:52",
+        "datetime": "2023-09-14T20:00:00+02:00",
         "production": {
             "coal": 18418.464,
             "gas": 0.0,
@@ -1589,7 +1589,7 @@ snapshots["test_production 1"] = [
         "zoneKey": "ZA",
     },
     {
-        "datetime": "2023-09-14T21:00:00+01:52",
+        "datetime": "2023-09-14T21:00:00+02:00",
         "production": {
             "coal": 18089.856,
             "gas": 0.0,
@@ -1606,7 +1606,7 @@ snapshots["test_production 1"] = [
         "zoneKey": "ZA",
     },
     {
-        "datetime": "2023-09-14T22:00:00+01:52",
+        "datetime": "2023-09-14T22:00:00+02:00",
         "production": {
             "coal": 17487.196,
             "gas": 0.0,
@@ -1623,7 +1623,7 @@ snapshots["test_production 1"] = [
         "zoneKey": "ZA",
     },
     {
-        "datetime": "2023-09-14T23:00:00+01:52",
+        "datetime": "2023-09-14T23:00:00+02:00",
         "production": {
             "coal": 16436.021,
             "gas": 0.0,
@@ -1640,7 +1640,7 @@ snapshots["test_production 1"] = [
         "zoneKey": "ZA",
     },
     {
-        "datetime": "2023-09-15T00:00:00+01:52",
+        "datetime": "2023-09-15T00:00:00+02:00",
         "production": {
             "coal": 16161.578,
             "gas": 0.0,
@@ -1657,7 +1657,7 @@ snapshots["test_production 1"] = [
         "zoneKey": "ZA",
     },
     {
-        "datetime": "2023-09-15T01:00:00+01:52",
+        "datetime": "2023-09-15T01:00:00+02:00",
         "production": {
             "coal": 15331.948,
             "gas": 0.0,
@@ -1674,7 +1674,7 @@ snapshots["test_production 1"] = [
         "zoneKey": "ZA",
     },
     {
-        "datetime": "2023-09-15T02:00:00+01:52",
+        "datetime": "2023-09-15T02:00:00+02:00",
         "production": {
             "coal": 15202.563,
             "gas": 0.0,
@@ -1691,7 +1691,7 @@ snapshots["test_production 1"] = [
         "zoneKey": "ZA",
     },
     {
-        "datetime": "2023-09-15T03:00:00+01:52",
+        "datetime": "2023-09-15T03:00:00+02:00",
         "production": {
             "coal": 15449.089,
             "gas": 0.0,
@@ -1708,7 +1708,7 @@ snapshots["test_production 1"] = [
         "zoneKey": "ZA",
     },
     {
-        "datetime": "2023-09-15T04:00:00+01:52",
+        "datetime": "2023-09-15T04:00:00+02:00",
         "production": {
             "coal": 16558.105,
             "gas": 0.0,
@@ -1725,7 +1725,7 @@ snapshots["test_production 1"] = [
         "zoneKey": "ZA",
     },
     {
-        "datetime": "2023-09-15T05:00:00+01:52",
+        "datetime": "2023-09-15T05:00:00+02:00",
         "production": {
             "coal": 18493.692,
             "gas": 0.0,
@@ -1742,7 +1742,7 @@ snapshots["test_production 1"] = [
         "zoneKey": "ZA",
     },
     {
-        "datetime": "2023-09-15T06:00:00+01:52",
+        "datetime": "2023-09-15T06:00:00+02:00",
         "production": {
             "coal": 19208.302,
             "gas": 0.0,
@@ -1759,7 +1759,7 @@ snapshots["test_production 1"] = [
         "zoneKey": "ZA",
     },
     {
-        "datetime": "2023-09-15T07:00:00+01:52",
+        "datetime": "2023-09-15T07:00:00+02:00",
         "production": {
             "coal": 18859.361,
             "gas": 0.0,
@@ -1776,7 +1776,7 @@ snapshots["test_production 1"] = [
         "zoneKey": "ZA",
     },
     {
-        "datetime": "2023-09-15T08:00:00+01:52",
+        "datetime": "2023-09-15T08:00:00+02:00",
         "production": {
             "coal": 19189.161,
             "gas": 0.0,
@@ -1793,7 +1793,7 @@ snapshots["test_production 1"] = [
         "zoneKey": "ZA",
     },
     {
-        "datetime": "2023-09-15T09:00:00+01:52",
+        "datetime": "2023-09-15T09:00:00+02:00",
         "production": {
             "coal": 18092.421,
             "gas": 0.0,
@@ -1810,7 +1810,7 @@ snapshots["test_production 1"] = [
         "zoneKey": "ZA",
     },
     {
-        "datetime": "2023-09-15T10:00:00+01:52",
+        "datetime": "2023-09-15T10:00:00+02:00",
         "production": {
             "coal": 17567.777,
             "gas": 0.0,
@@ -1827,7 +1827,7 @@ snapshots["test_production 1"] = [
         "zoneKey": "ZA",
     },
     {
-        "datetime": "2023-09-15T11:00:00+01:52",
+        "datetime": "2023-09-15T11:00:00+02:00",
         "production": {
             "coal": 17200.022,
             "gas": 0.0,
@@ -1844,7 +1844,7 @@ snapshots["test_production 1"] = [
         "zoneKey": "ZA",
     },
     {
-        "datetime": "2023-09-15T12:00:00+01:52",
+        "datetime": "2023-09-15T12:00:00+02:00",
         "production": {
             "coal": 17266.279,
             "gas": 0.0,
@@ -1861,7 +1861,7 @@ snapshots["test_production 1"] = [
         "zoneKey": "ZA",
     },
     {
-        "datetime": "2023-09-15T13:00:00+01:52",
+        "datetime": "2023-09-15T13:00:00+02:00",
         "production": {
             "coal": 16634.255,
             "gas": 0.0,
@@ -1878,7 +1878,7 @@ snapshots["test_production 1"] = [
         "zoneKey": "ZA",
     },
     {
-        "datetime": "2023-09-15T14:00:00+01:52",
+        "datetime": "2023-09-15T14:00:00+02:00",
         "production": {
             "coal": 17157.189,
             "gas": 0.0,
@@ -1895,7 +1895,7 @@ snapshots["test_production 1"] = [
         "zoneKey": "ZA",
     },
     {
-        "datetime": "2023-09-15T15:00:00+01:52",
+        "datetime": "2023-09-15T15:00:00+02:00",
         "production": {
             "coal": 17042.097,
             "gas": 0.0,
@@ -1912,7 +1912,7 @@ snapshots["test_production 1"] = [
         "zoneKey": "ZA",
     },
     {
-        "datetime": "2023-09-15T16:00:00+01:52",
+        "datetime": "2023-09-15T16:00:00+02:00",
         "production": {
             "coal": 18037.438,
             "gas": 0.0,
@@ -1929,7 +1929,7 @@ snapshots["test_production 1"] = [
         "zoneKey": "ZA",
     },
     {
-        "datetime": "2023-09-15T17:00:00+01:52",
+        "datetime": "2023-09-15T17:00:00+02:00",
         "production": {
             "coal": 18476.201,
             "gas": 0.0,
@@ -1946,7 +1946,7 @@ snapshots["test_production 1"] = [
         "zoneKey": "ZA",
     },
     {
-        "datetime": "2023-09-15T18:00:00+01:52",
+        "datetime": "2023-09-15T18:00:00+02:00",
         "production": {
             "coal": 18699.786,
             "gas": 0.0,
@@ -1963,7 +1963,7 @@ snapshots["test_production 1"] = [
         "zoneKey": "ZA",
     },
     {
-        "datetime": "2023-09-15T19:00:00+01:52",
+        "datetime": "2023-09-15T19:00:00+02:00",
         "production": {
             "coal": 18745.702,
             "gas": 0.0,
@@ -1980,7 +1980,7 @@ snapshots["test_production 1"] = [
         "zoneKey": "ZA",
     },
     {
-        "datetime": "2023-09-15T20:00:00+01:52",
+        "datetime": "2023-09-15T20:00:00+02:00",
         "production": {
             "coal": 18941.121,
             "gas": 0.0,
@@ -1997,7 +1997,7 @@ snapshots["test_production 1"] = [
         "zoneKey": "ZA",
     },
     {
-        "datetime": "2023-09-15T21:00:00+01:52",
+        "datetime": "2023-09-15T21:00:00+02:00",
         "production": {
             "coal": 18704.597,
             "gas": 0.0,
@@ -2014,7 +2014,7 @@ snapshots["test_production 1"] = [
         "zoneKey": "ZA",
     },
     {
-        "datetime": "2023-09-15T22:00:00+01:52",
+        "datetime": "2023-09-15T22:00:00+02:00",
         "production": {
             "coal": 18024.109,
             "gas": 0.0,
@@ -2031,7 +2031,7 @@ snapshots["test_production 1"] = [
         "zoneKey": "ZA",
     },
     {
-        "datetime": "2023-09-15T23:00:00+01:52",
+        "datetime": "2023-09-15T23:00:00+02:00",
         "production": {
             "coal": 16735.131,
             "gas": 0.0,
@@ -2048,7 +2048,7 @@ snapshots["test_production 1"] = [
         "zoneKey": "ZA",
     },
     {
-        "datetime": "2023-09-16T00:00:00+01:52",
+        "datetime": "2023-09-16T00:00:00+02:00",
         "production": {
             "coal": 16126.908,
             "gas": 0.0,
@@ -2065,7 +2065,7 @@ snapshots["test_production 1"] = [
         "zoneKey": "ZA",
     },
     {
-        "datetime": "2023-09-16T01:00:00+01:52",
+        "datetime": "2023-09-16T01:00:00+02:00",
         "production": {
             "coal": 15676.344,
             "gas": 0.0,
@@ -2082,7 +2082,7 @@ snapshots["test_production 1"] = [
         "zoneKey": "ZA",
     },
     {
-        "datetime": "2023-09-16T02:00:00+01:52",
+        "datetime": "2023-09-16T02:00:00+02:00",
         "production": {
             "coal": 15965.595,
             "gas": 0.0,
@@ -2099,7 +2099,7 @@ snapshots["test_production 1"] = [
         "zoneKey": "ZA",
     },
     {
-        "datetime": "2023-09-16T03:00:00+01:52",
+        "datetime": "2023-09-16T03:00:00+02:00",
         "production": {
             "coal": 15841.17,
             "gas": 0.0,
@@ -2116,7 +2116,7 @@ snapshots["test_production 1"] = [
         "zoneKey": "ZA",
     },
     {
-        "datetime": "2023-09-16T04:00:00+01:52",
+        "datetime": "2023-09-16T04:00:00+02:00",
         "production": {
             "coal": 16519.489,
             "gas": 0.0,
@@ -2133,7 +2133,7 @@ snapshots["test_production 1"] = [
         "zoneKey": "ZA",
     },
     {
-        "datetime": "2023-09-16T05:00:00+01:52",
+        "datetime": "2023-09-16T05:00:00+02:00",
         "production": {
             "coal": 16883.615,
             "gas": 0.0,
@@ -2150,7 +2150,7 @@ snapshots["test_production 1"] = [
         "zoneKey": "ZA",
     },
     {
-        "datetime": "2023-09-16T06:00:00+01:52",
+        "datetime": "2023-09-16T06:00:00+02:00",
         "production": {
             "coal": 18174.918,
             "gas": 0.0,
@@ -2167,7 +2167,7 @@ snapshots["test_production 1"] = [
         "zoneKey": "ZA",
     },
     {
-        "datetime": "2023-09-16T07:00:00+01:52",
+        "datetime": "2023-09-16T07:00:00+02:00",
         "production": {
             "coal": 18929.041,
             "gas": 0.0,
@@ -2184,7 +2184,7 @@ snapshots["test_production 1"] = [
         "zoneKey": "ZA",
     },
     {
-        "datetime": "2023-09-16T08:00:00+01:52",
+        "datetime": "2023-09-16T08:00:00+02:00",
         "production": {
             "coal": 19332.959,
             "gas": 0.0,
@@ -2201,7 +2201,7 @@ snapshots["test_production 1"] = [
         "zoneKey": "ZA",
     },
     {
-        "datetime": "2023-09-16T09:00:00+01:52",
+        "datetime": "2023-09-16T09:00:00+02:00",
         "production": {
             "coal": 18468.08,
             "gas": 0.0,
@@ -2218,7 +2218,7 @@ snapshots["test_production 1"] = [
         "zoneKey": "ZA",
     },
     {
-        "datetime": "2023-09-16T10:00:00+01:52",
+        "datetime": "2023-09-16T10:00:00+02:00",
         "production": {
             "coal": 18338.591,
             "gas": 0.0,
@@ -2235,7 +2235,7 @@ snapshots["test_production 1"] = [
         "zoneKey": "ZA",
     },
     {
-        "datetime": "2023-09-16T11:00:00+01:52",
+        "datetime": "2023-09-16T11:00:00+02:00",
         "production": {
             "coal": 18134.099,
             "gas": 0.0,
@@ -2252,7 +2252,7 @@ snapshots["test_production 1"] = [
         "zoneKey": "ZA",
     },
     {
-        "datetime": "2023-09-16T12:00:00+01:52",
+        "datetime": "2023-09-16T12:00:00+02:00",
         "production": {
             "coal": 17961.997,
             "gas": 0.0,
@@ -2269,7 +2269,7 @@ snapshots["test_production 1"] = [
         "zoneKey": "ZA",
     },
     {
-        "datetime": "2023-09-16T13:00:00+01:52",
+        "datetime": "2023-09-16T13:00:00+02:00",
         "production": {
             "coal": 17694.423,
             "gas": 0.0,
@@ -2286,7 +2286,7 @@ snapshots["test_production 1"] = [
         "zoneKey": "ZA",
     },
     {
-        "datetime": "2023-09-16T14:00:00+01:52",
+        "datetime": "2023-09-16T14:00:00+02:00",
         "production": {
             "coal": 17442.099,
             "gas": 0.0,
@@ -2303,7 +2303,7 @@ snapshots["test_production 1"] = [
         "zoneKey": "ZA",
     },
     {
-        "datetime": "2023-09-16T15:00:00+01:52",
+        "datetime": "2023-09-16T15:00:00+02:00",
         "production": {
             "coal": 17387.199,
             "gas": 0.0,
@@ -2320,7 +2320,7 @@ snapshots["test_production 1"] = [
         "zoneKey": "ZA",
     },
     {
-        "datetime": "2023-09-16T16:00:00+01:52",
+        "datetime": "2023-09-16T16:00:00+02:00",
         "production": {
             "coal": 17826.078,
             "gas": 0.0,
@@ -2337,7 +2337,7 @@ snapshots["test_production 1"] = [
         "zoneKey": "ZA",
     },
     {
-        "datetime": "2023-09-16T17:00:00+01:52",
+        "datetime": "2023-09-16T17:00:00+02:00",
         "production": {
             "coal": 18734.611,
             "gas": 0.0,
@@ -2354,7 +2354,7 @@ snapshots["test_production 1"] = [
         "zoneKey": "ZA",
     },
     {
-        "datetime": "2023-09-16T18:00:00+01:52",
+        "datetime": "2023-09-16T18:00:00+02:00",
         "production": {
             "coal": 19057.29,
             "gas": 0.0,
@@ -2371,7 +2371,7 @@ snapshots["test_production 1"] = [
         "zoneKey": "ZA",
     },
     {
-        "datetime": "2023-09-16T19:00:00+01:52",
+        "datetime": "2023-09-16T19:00:00+02:00",
         "production": {
             "coal": 18894.618,
             "gas": 0.0,
@@ -2388,7 +2388,7 @@ snapshots["test_production 1"] = [
         "zoneKey": "ZA",
     },
     {
-        "datetime": "2023-09-16T20:00:00+01:52",
+        "datetime": "2023-09-16T20:00:00+02:00",
         "production": {
             "coal": 18819.52,
             "gas": 0.0,
@@ -2405,7 +2405,7 @@ snapshots["test_production 1"] = [
         "zoneKey": "ZA",
     },
     {
-        "datetime": "2023-09-16T21:00:00+01:52",
+        "datetime": "2023-09-16T21:00:00+02:00",
         "production": {
             "coal": 18535.428,
             "gas": 0.0,
@@ -2422,7 +2422,7 @@ snapshots["test_production 1"] = [
         "zoneKey": "ZA",
     },
     {
-        "datetime": "2023-09-16T22:00:00+01:52",
+        "datetime": "2023-09-16T22:00:00+02:00",
         "production": {
             "coal": 18150.259,
             "gas": 0.0,
@@ -2439,7 +2439,7 @@ snapshots["test_production 1"] = [
         "zoneKey": "ZA",
     },
     {
-        "datetime": "2023-09-16T23:00:00+01:52",
+        "datetime": "2023-09-16T23:00:00+02:00",
         "production": {
             "coal": 17406.885,
             "gas": 0.0,

--- a/parsers/test/test_CENACE.py
+++ b/parsers/test/test_CENACE.py
@@ -1,8 +1,8 @@
 from datetime import datetime
 from unittest import TestCase
+from zoneinfo import ZoneInfo
 
 import freezegun
-from zoneinfo import ZoneInfo
 from requests import Session
 from requests_mock import ANY, Adapter
 

--- a/parsers/test/test_CENACE.py
+++ b/parsers/test/test_CENACE.py
@@ -2,7 +2,7 @@ from datetime import datetime
 from unittest import TestCase
 
 import freezegun
-import pytz
+from zoneinfo import ZoneInfo
 from requests import Session
 from requests_mock import ANY, Adapter
 
@@ -23,7 +23,7 @@ class TestFetchConsumption(TestCase):
 
         data = fetch_consumption(ZoneKey("MX-OC"), self.session)
         assert data[0]["zoneKey"] == "MX-OC"
-        assert data[0]["datetime"] == datetime.now(pytz.timezone("America/Mexico_City"))
+        assert data[0]["datetime"] == datetime.now(ZoneInfo("America/Mexico_City"))
         assert data[0]["consumption"] == 8519.0
 
     @freezegun.freeze_time("2021-01-01 00:00:00")
@@ -31,7 +31,7 @@ class TestFetchConsumption(TestCase):
 
         data = fetch_consumption(ZoneKey("MX-BC"), self.session)
         assert data[0]["zoneKey"] == "MX-BC"
-        assert data[0]["datetime"] == datetime.now(pytz.timezone("America/Tijuana"))
+        assert data[0]["datetime"] == datetime.now(ZoneInfo("America/Tijuana"))
         assert data[0]["consumption"] == 1587.0
 
     @freezegun.freeze_time("2021-01-01 00:00:00")

--- a/parsers/test/test_EIA.py
+++ b/parsers/test/test_EIA.py
@@ -1,10 +1,9 @@
 import json
 import os
 import unittest
-from datetime import datetime
+from datetime import datetime, timezone
 from importlib import resources
 
-from pytz import utc
 from requests import Session
 from requests_mock import ANY, GET, Adapter
 
@@ -376,7 +375,7 @@ class TestEIAProduction(TestEIA):
             },
         ]
         self.assertEqual(
-            datetime(2022, 10, 31, 11, 0, tzinfo=utc), data_list[0]["datetime"]
+            datetime(2022, 10, 31, 11, 0, tzinfo=timezone.utc), data_list[0]["datetime"]
         )
         self.check_production_matches(data_list, expected)
 
@@ -398,19 +397,19 @@ class TestEIAExchanges(TestEIA):
         expected = [
             {
                 "source": "eia.gov",
-                "datetime": datetime(2022, 2, 28, 22, 0, tzinfo=utc),
+                "datetime": datetime(2022, 2, 28, 22, 0, tzinfo=timezone.utc),
                 "sortedZoneKeys": "US-NW-BPAT->US-NW-NWMT",
                 "netFlow": -12,
             },
             {
                 "source": "eia.gov",
-                "datetime": datetime(2022, 2, 28, 23, 0, tzinfo=utc),
+                "datetime": datetime(2022, 2, 28, 23, 0, tzinfo=timezone.utc),
                 "sortedZoneKeys": "US-NW-BPAT->US-NW-NWMT",
                 "netFlow": -11,
             },
             {
                 "source": "eia.gov",
-                "datetime": datetime(2022, 3, 1, 0, 0, tzinfo=utc),
+                "datetime": datetime(2022, 3, 1, 0, 0, tzinfo=timezone.utc),
                 "sortedZoneKeys": "US-NW-BPAT->US-NW-NWMT",
                 "netFlow": -2,
             },
@@ -438,12 +437,12 @@ class TestEIAConsumption(TestEIA):
         expected = [
             {
                 "source": "eia.gov",
-                "datetime": datetime(2023, 5, 1, 9, 0, tzinfo=utc),
+                "datetime": datetime(2023, 5, 1, 9, 0, tzinfo=timezone.utc),
                 "consumption": 4792,
             },
             {
                 "source": "eia.gov",
-                "datetime": datetime(2023, 5, 1, 10, 0, tzinfo=utc),
+                "datetime": datetime(2023, 5, 1, 10, 0, tzinfo=timezone.utc),
                 "consumption": 6215,
             },
         ]
@@ -467,12 +466,12 @@ class TestEIAConsumption(TestEIA):
         expected = [
             {
                 "source": "eia.gov",
-                "datetime": datetime(2023, 5, 1, 9, 0, tzinfo=utc),
+                "datetime": datetime(2023, 5, 1, 9, 0, tzinfo=timezone.utc),
                 "consumption": 4792,
             },
             {
                 "source": "eia.gov",
-                "datetime": datetime(2023, 5, 1, 10, 0, tzinfo=utc),
+                "datetime": datetime(2023, 5, 1, 10, 0, tzinfo=timezone.utc),
                 "consumption": 6215,
             },
         ]

--- a/parsers/test/test_ENTSOE.py
+++ b/parsers/test/test_ENTSOE.py
@@ -70,7 +70,8 @@ class TestFetchProduction(TestENTSOE):
             self.assertEqual(production[0]["zoneKey"], "FI")
             self.assertEqual(production[0]["source"], "entsoe.eu")
             self.assertEqual(
-                production[0]["datetime"], datetime(2023, 5, 8, 7, 0, tzinfo=timezone.utc)
+                production[0]["datetime"],
+                datetime(2023, 5, 8, 7, 0, tzinfo=timezone.utc),
             )
             self.assertEqual(production[0]["production"]["biomass"], 543 + 7)
             self.assertEqual(production[0]["production"]["coal"], 154 + 180)
@@ -83,7 +84,8 @@ class TestFetchProduction(TestENTSOE):
 
             self.assertEqual(production[1]["source"], "entsoe.eu")
             self.assertEqual(
-                production[1]["datetime"], datetime(2023, 5, 8, 8, 0, tzinfo=timezone.utc)
+                production[1]["datetime"],
+                datetime(2023, 5, 8, 8, 0, tzinfo=timezone.utc),
             )
             self.assertEqual(production[1]["production"]["biomass"], 558 + 7)
             self.assertEqual(production[1]["production"]["coal"], 155 + 158)
@@ -96,7 +98,8 @@ class TestFetchProduction(TestENTSOE):
 
             self.assertEqual(production[-1]["source"], "entsoe.eu")
             self.assertEqual(
-                production[-1]["datetime"], datetime(2023, 5, 10, 6, 0, tzinfo=timezone.utc)
+                production[-1]["datetime"],
+                datetime(2023, 5, 10, 6, 0, tzinfo=timezone.utc),
             )
             self.assertEqual(production[-1]["production"]["biomass"], 515 + 20)
             self.assertEqual(production[-1]["production"]["coal"], 111 + 124)
@@ -116,7 +119,8 @@ class TestFetchProduction(TestENTSOE):
             self.assertEqual(production[0]["zoneKey"], "NO-NO5")
             self.assertEqual(production[0]["source"], "entsoe.eu")
             self.assertEqual(
-                production[0]["datetime"], datetime(2023, 5, 9, 9, 0, tzinfo=timezone.utc)
+                production[0]["datetime"],
+                datetime(2023, 5, 9, 9, 0, tzinfo=timezone.utc),
             )
             self.assertEqual(production[0]["storage"]["hydro"], -61)
             self.assertEqual(production[0]["production"]["gas"], 0)
@@ -140,7 +144,8 @@ class TestFetchProduction(TestENTSOE):
                 self.assertEqual(production[0]["zoneKey"], "NO-NO5")
                 self.assertEqual(production[0]["source"], "entsoe.eu")
                 self.assertEqual(
-                    production[0]["datetime"], datetime(2023, 5, 9, 9, 0, tzinfo=timezone.utc)
+                    production[0]["datetime"],
+                    datetime(2023, 5, 9, 9, 0, tzinfo=timezone.utc),
                 )
                 # Small negative values have been set to 0.
                 self.assertEqual(production[0]["production"]["gas"], 0)
@@ -148,7 +153,8 @@ class TestFetchProduction(TestENTSOE):
 
                 # Large negative values have been set to None.
                 self.assertEqual(
-                    production[-1]["datetime"], datetime(2023, 5, 11, 7, 0, tzinfo=timezone.utc)
+                    production[-1]["datetime"],
+                    datetime(2023, 5, 11, 7, 0, tzinfo=timezone.utc),
                 )
                 self.assertEqual(production[-1]["production"]["gas"], None)
                 # A warning has been logged for this.

--- a/parsers/test/test_ENTSOE.py
+++ b/parsers/test/test_ENTSOE.py
@@ -1,11 +1,10 @@
 import logging
 import os
 import unittest
-from datetime import datetime
+from datetime import datetime, timezone
 from unittest import mock
 from unittest.mock import patch
 
-from pytz import utc
 from requests import Session
 from requests_mock import ANY, GET, Adapter
 
@@ -36,7 +35,7 @@ class TestFetchPrices(TestENTSOE):
             self.assertEqual(prices[0]["source"], "entsoe.eu")
             self.assertEqual(prices[0]["currency"], "EUR")
             self.assertEqual(
-                prices[0]["datetime"], datetime(2023, 5, 6, 22, 0, tzinfo=utc)
+                prices[0]["datetime"], datetime(2023, 5, 6, 22, 0, tzinfo=timezone.utc)
             )
 
     def test_fetch_prices_integrated_zone(self):
@@ -52,7 +51,7 @@ class TestFetchPrices(TestENTSOE):
             self.assertEqual(prices[0]["source"], "entsoe.eu")
             self.assertEqual(prices[0]["currency"], "EUR")
             self.assertEqual(
-                prices[0]["datetime"], datetime(2023, 5, 6, 22, 0, tzinfo=utc)
+                prices[0]["datetime"], datetime(2023, 5, 6, 22, 0, tzinfo=timezone.utc)
             )
 
 
@@ -71,7 +70,7 @@ class TestFetchProduction(TestENTSOE):
             self.assertEqual(production[0]["zoneKey"], "FI")
             self.assertEqual(production[0]["source"], "entsoe.eu")
             self.assertEqual(
-                production[0]["datetime"], datetime(2023, 5, 8, 7, 0, tzinfo=utc)
+                production[0]["datetime"], datetime(2023, 5, 8, 7, 0, tzinfo=timezone.utc)
             )
             self.assertEqual(production[0]["production"]["biomass"], 543 + 7)
             self.assertEqual(production[0]["production"]["coal"], 154 + 180)
@@ -84,7 +83,7 @@ class TestFetchProduction(TestENTSOE):
 
             self.assertEqual(production[1]["source"], "entsoe.eu")
             self.assertEqual(
-                production[1]["datetime"], datetime(2023, 5, 8, 8, 0, tzinfo=utc)
+                production[1]["datetime"], datetime(2023, 5, 8, 8, 0, tzinfo=timezone.utc)
             )
             self.assertEqual(production[1]["production"]["biomass"], 558 + 7)
             self.assertEqual(production[1]["production"]["coal"], 155 + 158)
@@ -97,7 +96,7 @@ class TestFetchProduction(TestENTSOE):
 
             self.assertEqual(production[-1]["source"], "entsoe.eu")
             self.assertEqual(
-                production[-1]["datetime"], datetime(2023, 5, 10, 6, 0, tzinfo=utc)
+                production[-1]["datetime"], datetime(2023, 5, 10, 6, 0, tzinfo=timezone.utc)
             )
             self.assertEqual(production[-1]["production"]["biomass"], 515 + 20)
             self.assertEqual(production[-1]["production"]["coal"], 111 + 124)
@@ -117,7 +116,7 @@ class TestFetchProduction(TestENTSOE):
             self.assertEqual(production[0]["zoneKey"], "NO-NO5")
             self.assertEqual(production[0]["source"], "entsoe.eu")
             self.assertEqual(
-                production[0]["datetime"], datetime(2023, 5, 9, 9, 0, tzinfo=utc)
+                production[0]["datetime"], datetime(2023, 5, 9, 9, 0, tzinfo=timezone.utc)
             )
             self.assertEqual(production[0]["storage"]["hydro"], -61)
             self.assertEqual(production[0]["production"]["gas"], 0)
@@ -141,7 +140,7 @@ class TestFetchProduction(TestENTSOE):
                 self.assertEqual(production[0]["zoneKey"], "NO-NO5")
                 self.assertEqual(production[0]["source"], "entsoe.eu")
                 self.assertEqual(
-                    production[0]["datetime"], datetime(2023, 5, 9, 9, 0, tzinfo=utc)
+                    production[0]["datetime"], datetime(2023, 5, 9, 9, 0, tzinfo=timezone.utc)
                 )
                 # Small negative values have been set to 0.
                 self.assertEqual(production[0]["production"]["gas"], 0)
@@ -149,7 +148,7 @@ class TestFetchProduction(TestENTSOE):
 
                 # Large negative values have been set to None.
                 self.assertEqual(
-                    production[-1]["datetime"], datetime(2023, 5, 11, 7, 0, tzinfo=utc)
+                    production[-1]["datetime"], datetime(2023, 5, 11, 7, 0, tzinfo=timezone.utc)
                 )
                 self.assertEqual(production[-1]["production"]["gas"], None)
                 # A warning has been logged for this.

--- a/parsers/test/test_IN_EA.py
+++ b/parsers/test/test_IN_EA.py
@@ -2,7 +2,6 @@ from datetime import datetime
 from zoneinfo import ZoneInfo
 
 import pytest
-
 from requests import Session
 from requests_mock import GET, Adapter
 

--- a/parsers/test/test_IN_EA.py
+++ b/parsers/test/test_IN_EA.py
@@ -1,7 +1,8 @@
 from datetime import datetime
+from zoneinfo import ZoneInfo
 
 import pytest
-from pytz import timezone
+
 from requests import Session
 from requests_mock import GET, Adapter
 
@@ -24,7 +25,7 @@ def test_exchanges(neighbour_zone_key: ZoneKey):
     session = Session()
     adapter = Adapter()
     session.mount("https://", adapter)
-    target_date = datetime(2023, 6, 25, 0, 0, tzinfo=timezone("Asia/Kolkata"))
+    target_date = datetime(2023, 6, 25, 0, 0, tzinfo=ZoneInfo("Asia/Kolkata"))
     sorted_zone_keys = ZoneKey("->".join(sorted([neighbour_zone_key, "IN-EA"])))
     url, _ = IN_EA.get_fetch_function(sorted_zone_keys)
     filename = (
@@ -46,11 +47,11 @@ def test_exchanges(neighbour_zone_key: ZoneKey):
         ZoneKey("IN-EA"),
         neighbour_zone_key,
         session,
-        datetime(2023, 6, 25, 0, 0, tzinfo=timezone("Asia/Kolkata")),
+        datetime(2023, 6, 25, 0, 0, tzinfo=ZoneInfo("Asia/Kolkata")),
     )
 
     assert exchanges[0]["datetime"] == datetime(
-        2023, 6, 25, 0, 0, tzinfo=timezone("Asia/Kolkata")
+        2023, 6, 25, 0, 0, tzinfo=ZoneInfo("Asia/Kolkata")
     )
     assert exchanges[0]["netFlow"] == NETFLOWS[sorted_zone_keys]
     assert exchanges[0]["sortedZoneKeys"] == sorted_zone_keys

--- a/parsers/test/test_NTESMO.py
+++ b/parsers/test/test_NTESMO.py
@@ -1,13 +1,13 @@
 import unittest
 from datetime import datetime
+from zoneinfo import ZoneInfo
 
-from pytz import timezone
 from requests import Session
 from requests_mock import ANY, Adapter
 
 from parsers import NTESMO
 
-australia = timezone("Australia/Darwin")
+australia = ZoneInfo("Australia/Darwin")
 
 
 class TestNTESMO(unittest.TestCase):

--- a/parsers/test/test_NTESMO.py
+++ b/parsers/test/test_NTESMO.py
@@ -83,11 +83,15 @@ class TestNTESMO(unittest.TestCase):
 
         self.assertEqual(
             data_list[0]["datetime"],
-            australia.localize(datetime(year=2022, month=12, day=1, hour=4, minute=30)),
+            datetime(year=2022, month=12, day=1, hour=4, minute=30).replace(
+                tzinfo=australia
+            ),
         )
         self.assertEqual(
             data_list[-1]["datetime"],
-            australia.localize(datetime(year=2022, month=12, day=2, hour=4, minute=00)),
+            datetime(year=2022, month=12, day=2, hour=4, minute=00).replace(
+                tzinfo=australia
+            ),
         )
 
     def test_fetch_consumption(self):
@@ -109,9 +113,13 @@ class TestNTESMO(unittest.TestCase):
         # Check that the dates corresponds to two days:
         self.assertEqual(
             data_list[0]["datetime"],
-            australia.localize(datetime(year=2022, month=12, day=1, hour=4, minute=30)),
+            datetime(year=2022, month=12, day=1, hour=4, minute=30).replace(
+                tzinfo=australia
+            ),
         )
         self.assertEqual(
             data_list[-1]["datetime"],
-            australia.localize(datetime(year=2022, month=12, day=2, hour=4, minute=00)),
+            datetime(year=2022, month=12, day=2, hour=4, minute=00).replace(
+                tzinfo=australia
+            ),
         )


### PR DESCRIPTION
This PR updates all python code to use timezone.utc and ZoneInfo instead of pytz for better compatibility, consistency and speed.

Arrow is next 😉