### PR TITLE
Allow selected zone to appear above state layer

### DIFF
--- a/web/src/features/map/map-layers/StatesLayer.tsx
+++ b/web/src/features/map/map-layers/StatesLayer.tsx
@@ -34,6 +34,7 @@ export default function StatesLayer() {
     <Source id="states" type="geojson" data={statesGeometries}>
       <Layer
         id="states-border"
+        beforeId="zones-selectable-layer"
         type="line"
         paint={statesBorderStyle}
         minzoom={2.5}

--- a/web/src/features/map/map-layers/ZonesLayer.tsx
+++ b/web/src/features/map/map-layers/ZonesLayer.tsx
@@ -21,7 +21,7 @@ export default function ZonesLayer() {
         'line-width': [
           'case',
           ['boolean', ['feature-state', 'selected'], false],
-          theme.strokeWidth * 10,
+          theme.strokeWidth * 12,
           ['boolean', ['feature-state', 'hover'], false],
           theme.strokeWidth * 10,
           theme.strokeWidth,
@@ -39,7 +39,22 @@ export default function ZonesLayer() {
         'fill-color': '#FFFFFF',
         'fill-opacity': ['case', ['boolean', ['feature-state', 'hover'], false], 0.3, 0],
       } as mapboxgl.FillPaint,
+      zonesSelected: {
+        'fill-color': [
+          'coalesce',
+          ['feature-state', 'color'],
+          ['get', 'color'],
+          theme.clickableFill,
+        ],
+        'fill-opacity': [
+          'case',
+          ['boolean', ['feature-state', 'selected'], false],
+          0.8,
+          0,
+        ],
+      } as mapboxgl.FillPaint,
     }),
+
     [theme]
   );
 
@@ -51,6 +66,11 @@ export default function ZonesLayer() {
         paint={zoneLayerStyles.zonesClickable}
       />
       <Layer id="zones-hoverable-layer" type="fill" paint={zoneLayerStyles.zonesHover} />
+      <Layer
+        id="zones-selectable-layer"
+        type="fill"
+        paint={zoneLayerStyles.zonesSelected}
+      />
       <Layer id="zones-border" type="line" paint={zoneLayerStyles.zonesBorder} />
     </Source>
   );

--- a/web/src/features/map/map-layers/ZonesLayer.tsx
+++ b/web/src/features/map/map-layers/ZonesLayer.tsx
@@ -49,7 +49,7 @@ export default function ZonesLayer() {
         'fill-opacity': [
           'case',
           ['boolean', ['feature-state', 'selected'], false],
-          0.8,
+          0.7,
           0,
         ],
       } as mapboxgl.FillPaint,


### PR DESCRIPTION
## Issue
The selected zone is not clearly visible from the new state border layer

## Description
This PR adds a new layer to the map that is transparent unless the zone is selected. 

The state border layer is positioned behind this new layer.

Also update the selected zone border thickness to add clarity to the selected zone. 
### Double check

- [x] I have tested my parser changes locally with `poetry run test_parser "zone_key"`
- [x] I have run `pnpx prettier --write .` and `poetry run format` to format my changes.
