### PR TITLE
Ignore pylint for no class member

### DIFF
--- a/electricitymap/contrib/lib/models/events.py
+++ b/electricitymap/contrib/lib/models/events.py
@@ -1,3 +1,4 @@
+# pylint: disable=no-member
 import datetime as dt
 from abc import ABC, abstractmethod
 from datetime import datetime, timedelta, timezone


### PR DESCRIPTION
## Issue
Linting error when running on earthly CI

## Description
This PR ignores checking a class member exists in events module this enables us to run the test quite on earthly CI's satellite.

- [x] I have tested my parser changes locally with `poetry run test_parser "zone_key"`
- [x] I have run `pnpx prettier --write .` and `poetry run format` to format my changes.
