### PR TITLE
Capacity parsers - update return type again

### DIFF
--- a/electricitymap/contrib/capacity_parsers/CA_ON.py
+++ b/electricitymap/contrib/capacity_parsers/CA_ON.py
@@ -1,5 +1,6 @@
 from datetime import datetime
 from logging import INFO, basicConfig, getLogger
+from typing import Any
 
 import pandas as pd
 from requests import Response, Session
@@ -39,7 +40,7 @@ def get_data_from_url(session: Session, target_datetime: datetime) -> pd.DataFra
 
 def fetch_production_capacity(
     zone_key: ZoneKey, target_datetime: datetime, session: Session
-) -> dict:
+) -> dict[str, Any]:
     df = get_data_from_url(session, target_datetime)
 
     df = df.rename(

--- a/electricitymap/contrib/capacity_parsers/CL_SEN.py
+++ b/electricitymap/contrib/capacity_parsers/CL_SEN.py
@@ -1,5 +1,6 @@
 from datetime import datetime
 from logging import INFO, basicConfig, getLogger
+from typing import Any
 
 import pandas as pd
 from bs4 import BeautifulSoup
@@ -28,7 +29,7 @@ SOURCE = "coordinador.cl"
 
 def fetch_production_capacity(
     zone_key: ZoneKey, target_datetime: datetime, session: Session
-) -> dict | None:
+) -> dict[str, Any] | None:
     url = "https://www.coordinador.cl/reportes-y-estadisticas/#Estadisticas"
     r: Response = session.get(url)
     soup = BeautifulSoup(r.text, "html.parser")

--- a/electricitymap/contrib/capacity_parsers/EIA.py
+++ b/electricitymap/contrib/capacity_parsers/EIA.py
@@ -1,6 +1,7 @@
 import calendar
 from datetime import datetime
 from logging import getLogger
+from typing import Any
 
 import pandas as pd
 from requests import Response, Session
@@ -46,7 +47,7 @@ TECHNOLOGY_TO_MODE = {
 }
 
 
-def format_capacity(df: pd.DataFrame, target_datetime: datetime) -> dict:
+def format_capacity(df: pd.DataFrame, target_datetime: datetime) -> dict[str, Any]:
     df = df.copy()
     df = df.loc[df["statusDescription"] == "Operating"]
     df["mode"] = df["technology"].map(TECHNOLOGY_TO_MODE)
@@ -69,7 +70,7 @@ def fetch_production_capacity(
     zone_key: ZoneKey,
     target_datetime: datetime,
     session: Session,
-) -> dict | None:
+) -> dict[str, Any] | None:
     url_prefix = CAPACITY_URL.format(REGIONS[zone_key])
     start_date = target_datetime.strftime("%Y-%m-01")
     end_date = target_datetime.replace(
@@ -94,7 +95,7 @@ def fetch_production_capacity(
 
 def fetch_production_capacity_for_all_zones(
     target_datetime: datetime, session: Session | None = None
-) -> dict:
+) -> dict[str, Any]:
     eia_capacity = {}
     if session is None:
         session = Session()

--- a/electricitymap/contrib/capacity_parsers/EMBER.py
+++ b/electricitymap/contrib/capacity_parsers/EMBER.py
@@ -1,6 +1,7 @@
 import io
 from datetime import datetime
 from logging import getLogger
+from typing import Any
 
 import pandas as pd
 import pycountry
@@ -133,7 +134,7 @@ def format_ember_data(df: pd.DataFrame, year: int) -> pd.DataFrame:
     return df_capacity
 
 
-def get_capacity_dict_from_df(df_capacity: pd.DataFrame) -> dict:
+def get_capacity_dict_from_df(df_capacity: pd.DataFrame) -> dict[str, Any]:
     all_capacity = {}
     for zone in df_capacity.index.unique():
         df_zone = df_capacity.loc[zone]
@@ -150,7 +151,7 @@ def get_capacity_dict_from_df(df_capacity: pd.DataFrame) -> dict:
 
 def fetch_production_capacity_for_all_zones(
     target_datetime: datetime, session: Session
-) -> dict:
+) -> dict[str, Any]:
     df_capacity = get_data_from_url(session)
     df_capacity = format_ember_data(df_capacity, target_datetime.year)
     all_capacity = get_capacity_dict_from_df(df_capacity)
@@ -160,7 +161,7 @@ def fetch_production_capacity_for_all_zones(
 
 def fetch_production_capacity(
     target_datetime: datetime, zone_key: ZoneKey, session: Session
-) -> dict | None:
+) -> dict[str, Any] | None:
     all_capacity = fetch_production_capacity_for_all_zones(target_datetime, session)
     if zone_key in all_capacity:
         zone_capacity = all_capacity[zone_key]

--- a/electricitymap/contrib/capacity_parsers/ENTSOE.py
+++ b/electricitymap/contrib/capacity_parsers/ENTSOE.py
@@ -1,5 +1,6 @@
 from datetime import datetime
 from logging import getLogger
+from typing import Any
 
 from bs4 import BeautifulSoup
 from requests import Session
@@ -87,7 +88,7 @@ def query_capacity(
 
 def fetch_production_capacity(
     zone_key: ZoneKey, target_datetime: datetime, session: Session
-) -> dict | None:
+) -> dict[str, Any] | None:
     xml_str = query_capacity(ENTSOE_DOMAIN_MAPPINGS[zone_key], session, target_datetime)
     soup = BeautifulSoup(xml_str, "html.parser")
     # Each time series is dedicated to a different fuel type.
@@ -124,7 +125,7 @@ def fetch_production_capacity(
 
 def fetch_production_capacity_for_all_zones(
     target_datetime: datetime, session: Session | None = None
-) -> dict:
+) -> dict[str, Any]:
     capacity_dict = {}
     if session is None:
         session = Session()

--- a/electricitymap/contrib/capacity_parsers/GB.py
+++ b/electricitymap/contrib/capacity_parsers/GB.py
@@ -1,5 +1,6 @@
 from datetime import datetime
 from logging import getLogger
+from typing import Any
 
 from bs4 import BeautifulSoup
 from requests import Response, Session
@@ -27,7 +28,7 @@ BMREPORTS_URL = "https://www.bmreports.com/bmrs/?q=ajax/year/B1410/{year}/"
 
 def fetch_production_capacity(
     zone_key: ZoneKey, target_datetime: datetime, session: Session
-) -> dict | None:
+) -> dict[str, Any] | None:
     url = BMREPORTS_URL.format(year=target_datetime.year)
     r: Response = session.get(url)
 

--- a/electricitymap/contrib/capacity_parsers/IRENA.py
+++ b/electricitymap/contrib/capacity_parsers/IRENA.py
@@ -1,6 +1,7 @@
 import json
 from datetime import datetime
 from logging import getLogger
+from typing import Any
 
 import pycountry
 from requests import Response, Session
@@ -127,7 +128,7 @@ def get_capacity_data_for_all_zones(
 
 def fetch_production_capacity(
     target_datetime: datetime, zone_key: ZoneKey, session: Session
-) -> dict | None:
+) -> dict[str, Any] | None:
     all_capacity = get_capacity_data_for_all_zones(target_datetime, session)
     zone_capacity = all_capacity[zone_key]
 
@@ -142,7 +143,7 @@ def fetch_production_capacity(
 
 def fetch_production_capacity_for_all_zones(
     target_datetime: datetime, session: Session
-) -> dict | None:
+) -> dict[str, Any] | None:
     all_capacity = get_capacity_data_for_all_zones(target_datetime, session)
 
     all_capacity = {k: v for k, v in all_capacity.items() if k in IRENA_ZONES}

--- a/electricitymap/contrib/capacity_parsers/MY_WM.py
+++ b/electricitymap/contrib/capacity_parsers/MY_WM.py
@@ -1,6 +1,7 @@
 import json
 from datetime import datetime
 from logging import INFO, basicConfig, getLogger
+from typing import Any
 
 import pandas as pd
 from bs4 import BeautifulSoup
@@ -34,7 +35,7 @@ def get_capacity_datetime(session: Session) -> datetime:
 
 def fetch_production_capacity(
     zone_key: ZoneKey, session: Session, target_datetime: datetime | None = None
-) -> dict:
+) -> dict[str, Any]:
     if target_datetime is not None:
         raise ValueError("MY-WM capacity parser not enabled for past dates")
     target_datetime = datetime.now()

--- a/electricitymap/contrib/capacity_parsers/ONS.py
+++ b/electricitymap/contrib/capacity_parsers/ONS.py
@@ -1,5 +1,6 @@
 from datetime import datetime
 from logging import getLogger
+from typing import Any
 
 import pandas as pd
 from requests import Response, Session
@@ -55,7 +56,7 @@ def filter_data_by_date(data: pd.DataFrame, target_datetime: datetime) -> pd.Dat
 
 def fetch_production_capacity_for_all_zones(
     target_datetime: datetime, session: Session | None = None
-) -> dict | None:
+) -> dict[str, Any] | None:
     session = session or Session()
     r: Response = session.get(CAPACITY_URL)
     df = pd.read_csv(r.url, sep=";")
@@ -114,7 +115,7 @@ def fetch_production_capacity_for_all_zones(
 
 def fetch_production_capacity(
     zone_key: ZoneKey, target_datetime: datetime, session: Session | None = None
-) -> dict | None:
+) -> dict[str, Any] | None:
     session = session or Session()
     capacity = fetch_production_capacity_for_all_zones(target_datetime, session)[
         zone_key

--- a/electricitymap/contrib/capacity_parsers/OPENNEM.py
+++ b/electricitymap/contrib/capacity_parsers/OPENNEM.py
@@ -1,5 +1,6 @@
 from datetime import datetime
 from logging import getLogger
+from typing import Any
 
 import pandas as pd
 from requests import Response, Session
@@ -36,7 +37,7 @@ FUEL_MAPPING = {
 CAPACITY_URL = "https://api.opennem.org.au/facility/"
 
 
-def get_opennem_capacity_data(session: Session) -> dict:
+def get_opennem_capacity_data(session: Session) -> dict[str, Any]:
     r: Response = session.get(CAPACITY_URL)
     data = r.json()
     capacity_df = pd.json_normalize(data)
@@ -84,7 +85,7 @@ def filter_capacity_data_by_datetime(
 
 def fetch_production_capacity_for_all_zones(
     target_datetime: datetime, session: Session | None = None
-) -> dict:
+) -> dict[str, Any]:
     session = session or Session()
     capacity_df = get_opennem_capacity_data(session)
     capacity_df = filter_capacity_data_by_datetime(capacity_df, target_datetime)
@@ -112,7 +113,7 @@ def fetch_production_capacity_for_all_zones(
 
 def fetch_production_capacity(
     zone_key: ZoneKey, target_datetime: datetime, session: Session | None = None
-) -> dict | None:
+) -> dict[str, Any] | None:
     session = session or Session()
     capacity = fetch_production_capacity_for_all_zones(target_datetime, session)[
         zone_key

--- a/electricitymap/contrib/capacity_parsers/REE.py
+++ b/electricitymap/contrib/capacity_parsers/REE.py
@@ -1,5 +1,6 @@
 from datetime import datetime
 from logging import getLogger
+from typing import Any
 
 from requests import Response, Session
 
@@ -54,7 +55,7 @@ ZONE_KEY_TO_GEO_LIMIT = {
 
 def fetch_production_capacity(
     zone_key: ZoneKey, target_datetime: datetime, session: Session
-) -> dict | None:
+) -> dict[str, Any] | None:
     geo_limit = ZONE_KEY_TO_GEO_LIMIT[zone_key]
     geo_ids = GEO_LIMIT_TO_GEO_IDS[geo_limit]
     url = "https://apidatos.ree.es/es/datos/generacion/potencia-instalada"
@@ -97,7 +98,7 @@ def fetch_production_capacity(
 
 def fetch_production_capacity_for_all_zones(
     target_datetime: datetime, session: Session | None = None
-) -> dict:
+) -> dict[str, Any]:
     if session is None:
         session = Session()
     ree_capacity = {}


### PR DESCRIPTION
## Issue
The return types allowed are as follows: 
<img width="717" alt="image" src="https://github.com/electricitymaps/electricitymaps-contrib/assets/107848894/ab31060e-0de9-490f-ae5c-c6c40cfa1864">

## Description

In order to comply with the allowed return types, the capacity parser `fetch_production_capacity` need to be update from `dict | None` to `dict[str, Any] | None`

### Preview

NA

### Double check

- [ ] I have tested my parser changes locally with `poetry run test_parser "zone_key"`
- [ ] I have run `pnpx prettier --write .` and `poetry run format` to format my changes.
