### PR TITLE
Capacity parsers - add productionCapacity parser 

### DIFF
--- a/electricitymap/contrib/config/model.py
+++ b/electricitymap/contrib/config/model.py
@@ -68,8 +68,14 @@ class ParsersBaseModel(StrictBaseModel):
             Optional[Callable]: parser function
         """
         function_str = getattr(self, type)
+        _type_to_parser_folder = (
+            lambda parser_key: "electricitymap.contrib.capacity_parsers"
+            if parser_key == "productionCapacity"
+            else "parsers"
+        )
+
         if function_str:
-            return import_string(f"parsers.{function_str}")
+            return import_string(f"{_type_to_parser_folder(type)}.{function_str}")
 
 
 class Parsers(ParsersBaseModel):
@@ -80,6 +86,7 @@ class Parsers(ParsersBaseModel):
     price: str | None
     production: str | None
     productionPerUnit: str | None
+    productionCapacity: str | None
 
 
 class Source(StrictBaseModel):

--- a/parsers/lib/parsers.py
+++ b/parsers/lib/parsers.py
@@ -12,6 +12,7 @@ PRICE_PARSERS = {}
 CONSUMPTION_FORECAST_PARSERS = {}
 GENERATION_FORECAST_PARSERS = {}
 EXCHANGE_FORECAST_PARSERS = {}
+PRODUCTION_CAPACITY_PARSERS = {}
 
 PARSER_KEY_TO_DICT = {
     "consumption": CONSUMPTION_PARSERS,
@@ -23,14 +24,24 @@ PARSER_KEY_TO_DICT = {
     "consumptionForecast": CONSUMPTION_FORECAST_PARSERS,
     "generationForecast": GENERATION_FORECAST_PARSERS,
     "exchangeForecast": EXCHANGE_FORECAST_PARSERS,
+    "productionCapacity": PRODUCTION_CAPACITY_PARSERS,
 }
+
+_parser_key_to_parser_folder = (
+    lambda parser_key: "electricitymap.contrib.capacity_parsers"
+    if parser_key == "productionCapacity"
+    else "parsers"
+)
 
 # Read all zones
 for zone_id, zone_config in ZONES_CONFIG.items():
     for parser_key, v in zone_config.get("parsers", {}).items():
         mod_name, fun_name = v.split(".")
-        mod = importlib.import_module("parsers.%s" % mod_name)
+        mod = importlib.import_module(
+            f"{_parser_key_to_parser_folder(parser_key)}.%s" % mod_name
+        )
         PARSER_KEY_TO_DICT[parser_key][zone_id] = getattr(mod, fun_name)
+
 
 # Read all exchanges
 for exchange_id, exchange_config in EXCHANGES_CONFIG.items():

--- a/tests/test_parser_interface.py
+++ b/tests/test_parser_interface.py
@@ -11,6 +11,7 @@ from electricitymap.contrib.config.model import CONFIG_MODEL
 PARSER_FOLDERS = Path(__file__).parent.resolve() / "../parsers"
 PARSER_FILES_GLOB = f"{PARSER_FOLDERS.resolve()}/*.py"
 _PARSER_FUNCTION_ARGS = ["zone_key", "session", "target_datetime", "logger"]
+_CAPACITY_PARSER_FUNCTION_ARGS = ["zone_key", "target_datetime", "session"]
 _EXCHANGE_FUNCTION_ARGS = [
     "zone_key1",
     "zone_key2",
@@ -28,6 +29,7 @@ EXPECTED_MODE_FUNCTION_ARGS = {
     "production": _PARSER_FUNCTION_ARGS,
     "productionPerModeForecast": _PARSER_FUNCTION_ARGS,
     "productionPerUnit": _PARSER_FUNCTION_ARGS,
+    "productionCapacity": _CAPACITY_PARSER_FUNCTION_ARGS,
 }
 _RETURN_PARSER_TYPE = [
     dict,
@@ -38,6 +40,7 @@ _RETURN_PARSER_TYPE = [
     list[dict] | dict,
     dict[str, Any],
     dict[str, Any] | list[dict[str, Any]],
+    dict[str, Any] | None,
 ]
 EXPECTED_MODE_RETURN_ANNOTATIONS = {
     "consumption": _RETURN_PARSER_TYPE,
@@ -49,6 +52,7 @@ EXPECTED_MODE_RETURN_ANNOTATIONS = {
     "production": _RETURN_PARSER_TYPE,
     "productionPerModeForecast": _RETURN_PARSER_TYPE,
     "productionPerUnit": _RETURN_PARSER_TYPE,
+    "productionCapacity": _RETURN_PARSER_TYPE,
 }
 
 
@@ -135,8 +139,8 @@ class ParserInterfaceTestcase(unittest.TestCase):
             )
 
             self.assertEqual(
-                [a for a in args],
-                EXPECTED_MODE_FUNCTION_ARGS[_mode],
+                sorted([a for a in args]),
+                sorted(EXPECTED_MODE_FUNCTION_ARGS[_mode]),
                 f"invalid args for {function_name}, arg_spec={arg_spec}",
             )
 
@@ -147,7 +151,7 @@ class ParserInterfaceTestcase(unittest.TestCase):
                 )
                 self.assertTrue(
                     correct_annotations,
-                    f"expected annotation for {function_name} to be in {expected} not {annotations}",
+                    f"expected annotation for {function_name} to be in {expected} not {annotations['return']}",
                 )
 
     def test_unused_files(self):


### PR DESCRIPTION
## Issue

The purpose of this PR is to prepare the update of the `parsers`config (see [draft PR](https://github.com/electricitymaps/electricitymaps-contrib/pull/6147) )

## Description

- Created a parser `productionCapacity` in the Parsers class in `model.py`
- Updated `get_function` in `ParsersBaseModel` to ensure that we point to the right parser folder
- update `test_parser_interface` with function arguments and expected return types

This PR will enable the update of all configuration files and make sure that the tests don't crash 
### Preview

NA

### Double check

- [ ] I have tested my parser changes locally with `poetry run test_parser "zone_key"`
- [ ] I have run `pnpx prettier --write .` and `poetry run format` to format my changes.
