### PR TITLE
Capacity update - create function to read new format

### DIFF
--- a/electricitymap/contrib/config/capacity.py
+++ b/electricitymap/contrib/config/capacity.py
@@ -1,0 +1,38 @@
+from datetime import datetime
+
+
+def get_capacity_data(capacity_config: dict, dt: datetime) -> dict[str, float]:
+    """Gets the capacity data for a given zone and datetime from ZONES_CONFIG."""
+    capacity = {}
+    for mode, capacity_value in capacity_config.items():
+        if isinstance(capacity_value, (int, float)):
+            # TODO: This part is used for the old capacity format. It shoud be removed once all capacity configs are updated
+            capacity[mode] = capacity_value
+        else:
+            capacity[mode] = get_capacity_value_with_datetime(capacity_value, dt)
+    return capacity
+
+
+def get_capacity_value_with_datetime(
+    mode_capacity: list | dict, dt: datetime
+) -> float | None:
+    capacity = None
+    if isinstance(mode_capacity, dict):
+        capacity = mode_capacity["value"]
+    elif isinstance(mode_capacity, list):
+        datetime_keys = sorted(
+            [datetime.fromisoformat(d["datetime"]) for d in mode_capacity]
+        )
+
+        if dt <= min(datetime_keys):
+            capacity_dt = min(datetime_keys)
+        else:
+            # valid datetime is the min of the 2 datetime_keys surrounding dt
+            capacity_dt = max([d for d in datetime_keys if d <= dt])
+
+        capacity = [
+            d["value"]
+            for d in mode_capacity
+            if d["datetime"] == capacity_dt.strftime("%Y-%m-%d")
+        ][0]
+    return capacity

--- a/tests/test_capacity.py
+++ b/tests/test_capacity.py
@@ -1,0 +1,40 @@
+from datetime import datetime
+
+import pytest
+
+from electricitymap.contrib.config.capacity import get_capacity_data
+
+
+def test_get_capacity_data():
+    capacity_data = {}
+    capacity_data_1 = {"solar": 3, "wind": 4}
+    capacity_data_2 = {
+        "coal": {"datetime": "2022-01-01", "value": 5},
+        "gas": {"datetime": "2022-01-01", "value": 6},
+    }
+    capacity_data_3 = {
+        "coal": [
+            {"datetime": "2022-01-01", "value": 5},
+            {"datetime": "2023-06-01", "value": 8},
+        ],
+        "gas": [
+            {"datetime": "2022-01-01", "value": 6},
+            {"datetime": "2023-06-01", "value": 7},
+        ],
+    }
+    assert get_capacity_data(capacity_data, datetime(2023, 1, 1)) == {}
+    assert get_capacity_data(capacity_data_1, datetime(2023, 1, 1)) == {
+        "solar": 3,
+        "wind": 4,
+    }
+    assert get_capacity_data(capacity_data_2, datetime(2022, 6, 1)) == {
+        "coal": 5,
+        "gas": 6,
+    }
+    assert get_capacity_data(capacity_data_3, datetime(2023, 6, 1)) == {
+        "coal": 8,
+        "gas": 7,
+    }
+
+    with pytest.raises(ValueError):
+        get_capacity_data(capacity_data_2, datetime(2023, 0, 1))


### PR DESCRIPTION
## Issue

see [PR 4265](https://github.com/electricitymaps/electricitymaps/pull/4265) where we discussed migrating the `get_capacity_data` to the contrib config

## Description

- create `get_capacity_data` to extract the capacity data depending on the format and given datetime
-  tests

@FelixDQ as mentioned we want to make this 
`        capacity = [
            d["value"]
            for d in mode_capacity
            if d["datetime"] == capacity_dt.strftime("%Y-%m-%d")
        ][0]`
more robust :)

### Preview

<!-- Please add screenshots and/or gif that shows visual changes (if applicable) -->

### Double check

- [ ] I have tested my parser changes locally with `poetry run test_parser "zone_key"`
- [ ] I have run `pnpx prettier --write .` and `poetry run format` to format my changes.
