### PR TITLE
bug(web): Match style of language selector button to theme selector

### DIFF
--- a/web/src/features/map-controls/LanguageSelector.tsx
+++ b/web/src/features/map-controls/LanguageSelector.tsx
@@ -24,7 +24,7 @@ export function LanguageSelector({ isMobile }: { isMobile?: boolean }) {
     <MapOptionSelector
       trigger={
         isMobile ? (
-          <div className="flex w-fit min-w-[232px] items-center justify-center gap-x-2 dark:border dark:border-gray-700 dark:bg-gray-800 ">
+          <div className="flex w-fit min-w-[232px] items-center justify-center gap-x-2 ">
             <HiLanguage size={21} />
             {__('tooltips.selectLanguage')}
           </div>


### PR DESCRIPTION
## Issue
<img width="377" alt="image" src="https://github.com/electricitymaps/electricitymaps-contrib/assets/18622768/6392cfed-85af-4584-a2f0-39147cbd30ab">
## Description
Updates the mobile buttons to match in dark and light mode

### Preview
<img width="382" alt="image" src="https://github.com/electricitymaps/electricitymaps-contrib/assets/18622768/206b2b93-bb1f-4b63-973e-2cad03511a44">

### Double check

- [x] I have tested my parser changes locally with `poetry run test_parser "zone_key"`
- [x] I have run `pnpx prettier --write .` and `poetry run format` to format my changes.
