### PR TITLE
bug(web): Remove check for loaded source (again)

### DIFF
--- a/web/src/features/map/Map.tsx
+++ b/web/src/features/map/Map.tsx
@@ -86,7 +86,6 @@ export default function MapPage({ onMapLoad }: MapPageProps): ReactElement {
     const isSourceLoaded =
       map &&
       map.getSource(ZONE_SOURCE) !== undefined &&
-      map.isSourceLoaded(ZONE_SOURCE) &&
       map.getSource('states') !== undefined &&
       map.isSourceLoaded('states');
 


### PR DESCRIPTION
## Issue
This bug is back: #6109 reintroduced here: #6114 🤦 

## Description
Remove the check that the is source loaded before painting the map, this means we also paint the no visible zones in the background so the toggle between zone and country works as expected.

### Double check

- [x] I have tested my parser changes locally with `poetry run test_parser "zone_key"`
- [x] I have run `pnpx prettier --write .` and `poetry run format` to format my changes.
