### PR TITLE
UX(web): tweak state border transition

### DIFF
--- a/web/src/features/map/map-layers/StatesLayer.tsx
+++ b/web/src/features/map/map-layers/StatesLayer.tsx
@@ -37,7 +37,6 @@ export default function StatesLayer() {
         beforeId="zones-selectable-layer"
         type="line"
         paint={statesBorderStyle}
-        // minzoom={2.5}
         source="states"
       />
       <Layer

--- a/web/src/features/map/map-layers/StatesLayer.tsx
+++ b/web/src/features/map/map-layers/StatesLayer.tsx
@@ -10,8 +10,8 @@ export default function StatesLayer() {
   const statesBorderStyle = {
     'line-color': theme.stateBorderColor,
     'line-width': 1.4,
-    'line-opacity': 0.9,
     'line-dasharray': [1, 1],
+    'line-opacity': ['interpolate', ['linear'], ['zoom'], 2.8, 0, 3, 0.9],
   } as mapboxgl.LinePaint;
 
   const stateLabelLayout = {
@@ -37,7 +37,7 @@ export default function StatesLayer() {
         beforeId="zones-selectable-layer"
         type="line"
         paint={statesBorderStyle}
-        minzoom={2.5}
+        // minzoom={2.5}
         source="states"
       />
       <Layer
@@ -61,7 +61,7 @@ export default function StatesLayer() {
         }}
         paint={stateLabelPaint}
         maxzoom={4.5}
-        minzoom={3}
+        minzoom={2.9}
       />
     </Source>
   );


### PR DESCRIPTION
## Issue
States border flashes in

## Description
This PR adds a soft transition of the states border layer and fades in the state labels as the borders transition in

### Double check

- [x] I have tested my parser changes locally with `poetry run test_parser "zone_key"`
- [x] I have run `pnpx prettier --write .` and `poetry run format` to format my changes.
