### PR TITLE
Update BE solar capacity

### DIFF
--- a/config/zones/BE.yaml
+++ b/config/zones/BE.yaml
@@ -13,7 +13,7 @@ capacity:
   hydro storage: 1308
   nuclear: 3928
   oil: 455
-  solar: 7762
+  solar: 8595
   wind: 5315
 contributors:
   - corradio


### PR DESCRIPTION
An update seemed fit as 800 MW has come online the past 3 months, or in other words: a 10% increase! 🥳
[Same source. ](https://www.elia.be/en/grid-data/power-generation/solar-pv-power-generation-data)