### PR TITLE
Change Python caching strategy

### DIFF
--- a/.github/workflows/python_formatting.yml
+++ b/.github/workflows/python_formatting.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Get poetry version
         id: get-poetry-version
         run: |
-          echo "$(poetry --version | awk '{print $3}' | tr -d '()')" >> $GITHUB_OUTPUT
+          echo echo "$(poetry --version | awk '{print "poetry_"$3}' | tr -d '()')" >> $GITHUB_OUTPUT
       - name: Setup Python
         uses: actions/setup-python@v4
         with:
@@ -27,8 +27,8 @@ jobs:
         uses: actions/cache@v3
         with:
           path: .venv
-          key: ${{ runner.os }}-venv-poetry_${{steps.get-poetry-version.outputs.poetry-version}}-${{ hashFiles('poetry.lock') }}
-          restore-keys: ${{ runner.os }}-venv-poetry_${{steps.get-poetry-version.outputs.poetry-version}}
+          key: ${{ runner.os }}-venv-${{steps.get-poetry-version.outputs.poetry-version}}-${{ hashFiles('poetry.lock') }}
+          restore-keys: ${{ runner.os }}-venv-${{steps.get-poetry-version.outputs.poetry-version}}
       - name: Install Dependencies
         if: steps.cache.outputs.cache-hit != 'true'
         run: |

--- a/.github/workflows/python_formatting.yml
+++ b/.github/workflows/python_formatting.yml
@@ -14,24 +14,14 @@ jobs:
       - name: Install poetry
         run: |
           pipx install poetry
-      - name: Get poetry version
-        id: get-poetry-version
-        run: |
-          echo "{poetry-version}={$(poetry --version | grep -oP '(?<=Poetry ).*')}" >> $GITHUB_OUTPUT
       - name: Setup Python
+        id: setup-python
         uses: actions/setup-python@v4
         with:
           python-version-file: '.python-version'
           cache: 'poetry'
-      - name: Restore cache
-        id: cache
-        uses: actions/cache@v3
-        with:
-          path: .venv
-          key: ${{ runner.os }}-venv-${{steps.get-poetry-version.outputs.poetry-version}}-${{ hashFiles('poetry.lock') }}
-          restore-keys: ${{ runner.os }}-venv-${{steps.get-poetry-version.outputs.poetry-version}}
       - name: Install Dependencies
-        if: steps.cache.outputs.cache-hit != 'true'
+        if: steps.setup-python.outputs.cache-hit != 'true'
         run: |
           poetry install -E parsers --sync
       - name: Linting

--- a/.github/workflows/python_formatting.yml
+++ b/.github/workflows/python_formatting.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Get poetry version
         id: get-poetry-version
         run: |
-          echo "$(poetry --version | awk '{print "poetry_"$3}' | tr -d '()')" >> $GITHUB_OUTPUT
+          echo "$(poetry --version | awk '{print "poetry-version="$3}' | tr -d '()')" >> $GITHUB_OUTPUT
       - name: Setup Python
         uses: actions/setup-python@v4
         with:
@@ -27,8 +27,8 @@ jobs:
         uses: actions/cache@v3
         with:
           path: .venv
-          key: ${{ runner.os }}-venv-${{steps.get-poetry-version.outputs.poetry-version}}-${{ hashFiles('poetry.lock') }}
-          restore-keys: ${{ runner.os }}-venv-${{steps.get-poetry-version.outputs.poetry-version}}
+          key: ${{ runner.os }}-venv-poetry_${{steps.get-poetry-version.outputs.poetry-version}}-${{ hashFiles('poetry.lock') }}
+          restore-keys: ${{ runner.os }}-venv-poetry_${{steps.get-poetry-version.outputs.poetry-version}}
       - name: Install Dependencies
         if: steps.cache.outputs.cache-hit != 'true'
         run: |

--- a/.github/workflows/python_formatting.yml
+++ b/.github/workflows/python_formatting.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Get poetry version
         id: get-poetry-version
         run: |
-          echo echo "$(poetry --version | awk '{print "poetry_"$3}' | tr -d '()')" >> $GITHUB_OUTPUT
+          echo "$(poetry --version | awk '{print "poetry_"$3}' | tr -d '()')" >> $GITHUB_OUTPUT
       - name: Setup Python
         uses: actions/setup-python@v4
         with:

--- a/.github/workflows/python_formatting.yml
+++ b/.github/workflows/python_formatting.yml
@@ -15,13 +15,11 @@ jobs:
         run: |
           pipx install poetry
       - name: Setup Python
-        id: setup-python
         uses: actions/setup-python@v4
         with:
           python-version-file: '.python-version'
           cache: 'poetry'
       - name: Install Dependencies
-        if: steps.setup-python.outputs.cache-hit != 'true'
         run: |
           poetry install -E parsers --sync
       - name: Linting

--- a/.github/workflows/python_formatting.yml
+++ b/.github/workflows/python_formatting.yml
@@ -14,14 +14,25 @@ jobs:
       - name: Install poetry
         run: |
           pipx install poetry
+      - name: Get poetry version
+        id: get-poetry-version
+        run: |
+          echo "$(poetry --version | awk '{print $3}' | tr -d '()')" >> $GITHUB_OUTPUT
       - name: Setup Python
         uses: actions/setup-python@v4
         with:
           python-version-file: '.python-version'
-          cache: 'poetry'
+      - name: Restore cache
+        id: cache
+        uses: actions/cache@v3
+        with:
+          path: .venv
+          key: ${{ runner.os }}-venv-poetry_${{steps.get-poetry-version.outputs.poetry-version}}-${{ hashFiles('poetry.lock') }}
+          restore-keys: ${{ runner.os }}-venv-poetry_${{steps.get-poetry-version.outputs.poetry-version}}
       - name: Install Dependencies
+        if: steps.cache.outputs.cache-hit != 'true'
         run: |
-          poetry install -E parsers
+          poetry install -E parsers --sync
       - name: Linting
         run: |
           poetry run lint

--- a/.github/workflows/python_formatting.yml
+++ b/.github/workflows/python_formatting.yml
@@ -21,7 +21,7 @@ jobs:
           cache: 'poetry'
       - name: Install Dependencies
         run: |
-          poetry install -E parsers --sync
+          poetry install -E parsers
       - name: Linting
         run: |
           poetry run lint

--- a/.github/workflows/python_tests.yml
+++ b/.github/workflows/python_tests.yml
@@ -25,7 +25,7 @@ jobs:
           sudo apt-get install libxml2-dev tesseract-ocr tesseract-ocr-eng
       - name: Install Poetry dependencies
         run: |
-          poetry install -E parsers --sync
+          poetry install -E parsers
       - name: Run tests
         run: |
           poetry run test

--- a/.github/workflows/python_tests.yml
+++ b/.github/workflows/python_tests.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Get poetry version
         id: get-poetry-version
         run: |
-          echo "$(poetry --version | awk '{print "poetry_"$3}' | tr -d '()')" >> $GITHUB_OUTPUT
+          echo "$(poetry --version | awk '{print "poetry-version="$3}' | tr -d '()')" >> $GITHUB_OUTPUT
       - name: Setup Python
         uses: actions/setup-python@v4
         with:
@@ -27,8 +27,8 @@ jobs:
         uses: actions/cache@v3
         with:
           path: .venv
-          key: ${{ runner.os }}-venv-${{steps.get-poetry-version.outputs.poetry-version}}-${{ hashFiles('poetry.lock') }}
-          restore-keys: ${{ runner.os }}-venv-${{steps.get-poetry-version.outputs.poetry-version}}
+          key: ${{ runner.os }}-venv-poetry_${{steps.get-poetry-version.outputs.poetry-version}}-${{ hashFiles('poetry.lock') }}
+          restore-keys: ${{ runner.os }}-venv-poetry_${{steps.get-poetry-version.outputs.poetry-version}}
       - name: Install libxml2-dev and tesseract-ocr
         run: |
           sudo apt-get update

--- a/.github/workflows/python_tests.yml
+++ b/.github/workflows/python_tests.yml
@@ -14,28 +14,18 @@ jobs:
       - name: Install poetry
         run: |
           pipx install poetry
-      - name: Get poetry version
-        id: get-poetry-version
-        run: |
-          echo "{poetry-version}={$(poetry --version | grep -oP '(?<=Poetry ).*')}" >> $GITHUB_OUTPUT
       - name: Setup Python
+        id: setup-python
         uses: actions/setup-python@v4
         with:
           python-version-file: '.python-version'
           cache: 'poetry'
-      - name: Restore cache
-        id: cache
-        uses: actions/cache@v3
-        with:
-          path: .venv
-          key: ${{ runner.os }}-venv-${{steps.get-poetry-version.outputs.poetry-version}}-${{ hashFiles('poetry.lock') }}
-          restore-keys: ${{ runner.os }}-venv-${{steps.get-poetry-version.outputs.poetry-version}}
       - name: Install libxml2-dev and tesseract-ocr
         run: |
           sudo apt-get update
           sudo apt-get install libxml2-dev tesseract-ocr tesseract-ocr-eng
       - name: Install Poetry dependencies
-        if: steps.cache.outputs.cache-hit != 'true'
+        if: steps.setup-python.outputs.cache-hit != 'true'
         run: |
           poetry install -E parsers --sync
       - name: Run tests

--- a/.github/workflows/python_tests.yml
+++ b/.github/workflows/python_tests.yml
@@ -14,18 +14,29 @@ jobs:
       - name: Install poetry
         run: |
           pipx install poetry
+      - name: Get poetry version
+        id: get-poetry-version
+        run: |
+          echo "$(poetry --version | awk '{print $3}' | tr -d '()')" >> $GITHUB_OUTPUT
       - name: Setup Python
         uses: actions/setup-python@v4
         with:
           python-version-file: '.python-version'
-          cache: 'poetry'
+      - name: Restore cache
+        id: cache
+        uses: actions/cache@v3
+        with:
+          path: .venv
+          key: ${{ runner.os }}-venv-poetry_${{steps.get-poetry-version.outputs.poetry-version}}-${{ hashFiles('poetry.lock') }}
+          restore-keys: ${{ runner.os }}-venv-poetry_${{steps.get-poetry-version.outputs.poetry-version}}
       - name: Install libxml2-dev and tesseract-ocr
         run: |
           sudo apt-get update
           sudo apt-get install libxml2-dev tesseract-ocr tesseract-ocr-eng
       - name: Install Poetry dependencies
+        if: steps.cache.outputs.cache-hit != 'true'
         run: |
-          poetry install -E parsers
+          poetry install -E parsers --sync
       - name: Run tests
         run: |
           poetry run test

--- a/.github/workflows/python_tests.yml
+++ b/.github/workflows/python_tests.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Get poetry version
         id: get-poetry-version
         run: |
-          echo "$(poetry --version | awk '{print $3}' | tr -d '()')" >> $GITHUB_OUTPUT
+          echo "$(poetry --version | awk '{print "poetry_"$3}' | tr -d '()')" >> $GITHUB_OUTPUT
       - name: Setup Python
         uses: actions/setup-python@v4
         with:
@@ -27,8 +27,8 @@ jobs:
         uses: actions/cache@v3
         with:
           path: .venv
-          key: ${{ runner.os }}-venv-poetry_${{steps.get-poetry-version.outputs.poetry-version}}-${{ hashFiles('poetry.lock') }}
-          restore-keys: ${{ runner.os }}-venv-poetry_${{steps.get-poetry-version.outputs.poetry-version}}
+          key: ${{ runner.os }}-venv-${{steps.get-poetry-version.outputs.poetry-version}}-${{ hashFiles('poetry.lock') }}
+          restore-keys: ${{ runner.os }}-venv-${{steps.get-poetry-version.outputs.poetry-version}}
       - name: Install libxml2-dev and tesseract-ocr
         run: |
           sudo apt-get update

--- a/.github/workflows/python_tests.yml
+++ b/.github/workflows/python_tests.yml
@@ -15,7 +15,6 @@ jobs:
         run: |
           pipx install poetry
       - name: Setup Python
-        id: setup-python
         uses: actions/setup-python@v4
         with:
           python-version-file: '.python-version'
@@ -25,7 +24,6 @@ jobs:
           sudo apt-get update
           sudo apt-get install libxml2-dev tesseract-ocr tesseract-ocr-eng
       - name: Install Poetry dependencies
-        if: steps.setup-python.outputs.cache-hit != 'true'
         run: |
           poetry install -E parsers --sync
       - name: Run tests


### PR DESCRIPTION
This PR removes the built in caching in favour of our custom cache.

Before this we accidentally created duplicate caches (with the same data) as well as spending extra time restoring and saving both caches.

It won't cut down CI times that much (around 4 sec) but right now we are just wasting resources.

It also fixes the version printing for the poetry version to ensure the correct version is used for the venv.