### PR TITLE
[Capacity update] - Add disclaimer to ENTSO-e parser

### DIFF
--- a/electricitymap/contrib/capacity_parsers/ENTSOE.py
+++ b/electricitymap/contrib/capacity_parsers/ENTSOE.py
@@ -120,7 +120,7 @@ def fetch_production_capacity(
         )
         if zone_key in ZONES_WITH_BATTERY_STORAGE:
             logger.info(
-                f"\n Warning: {zone_key} has battery storage, storing capacity data source can be found on the contrib wiki"
+                f"\n\n Warning: {zone_key} has battery storage, data source can be found on the contrib wiki \n\n"
             )
         return capacity_dict
     else:

--- a/electricitymap/contrib/capacity_parsers/ENTSOE.py
+++ b/electricitymap/contrib/capacity_parsers/ENTSOE.py
@@ -67,6 +67,8 @@ ENTSOE_ZONES = [
     "UA",
 ]
 
+ZONES_WITH_BATTERY_STORAGE = ["FR"]
+
 
 def query_capacity(
     in_domain: str, session: Session, target_datetime: datetime
@@ -116,6 +118,10 @@ def fetch_production_capacity(
         logger.info(
             f"Capacity data for {zone_key} on {target_datetime.date()}: \n{capacity_dict}"
         )
+        if zone_key in ZONES_WITH_BATTERY_STORAGE:
+            logger.info(
+                f"\n Warning: {zone_key} has battery storage, storing capacity data source can be found on the contrib wiki"
+            )
         return capacity_dict
     else:
         logger.warning(
@@ -134,9 +140,6 @@ def fetch_production_capacity_for_all_zones(
         try:
             zone_capacity = fetch_production_capacity(zone, target_datetime, session)
             capacity_dict[zone] = zone_capacity
-            logger.info(
-                f"Fetched capacity for {zone} on {target_datetime.date()}: {zone_capacity}"
-            )
         except:
             logger.warning(
                 f"Failed to update capacity for {zone} on {target_datetime.date()}"


### PR DESCRIPTION
## Issue

ENTSOE doesn't have battery storage in their capacity data. The zones that have battery storage capacity are DE and FR. 
A new parser has been added for DE (see PR #6186) to get data from another source

## Description

added a list of zones with battery storage `ZONES_WITH_BATTERY_STORAGE`
for these zone, the parser logs a disclaimer informing the user that battery storage must be added manually from another source.

### Preview

![image](https://github.com/electricitymaps/electricitymaps-contrib/assets/107848894/b81ca8e0-0a52-411c-aff3-545d26effc45)

### Double check

- [ ] I have tested my parser changes locally with `poetry run test_parser "zone_key"`
- [ ] I have run `pnpx prettier --write .` and `poetry run format` to format my changes.
