### PR TITLE
refactor: remove arrow from CA-ON parser

### DIFF
--- a/parsers/CA_NB.py
+++ b/parsers/CA_NB.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python3
 
-# The arrow library is used to handle datetimes consistently with other parsers
 from datetime import datetime, timezone
 from logging import Logger, getLogger
 from typing import Any


### PR DESCRIPTION
## Issue
Refs: #6135 
<!-- If you want to close an issue automatically when your PR is merged, write "Closes X" where X is the PR number. For example: Closes #000 -->

## Description
Remove arrow from CA-ON parser. Retained same functionality
<!-- Explains the goal of this PR -->

### Preview

<!-- Please add screenshots and/or gif that shows visual changes (if applicable) -->

### Double check

- [x] I have tested my parser changes locally with `poetry run test_parser "zone_key"`
- [x] I have run `pnpx prettier --write .` and `poetry run format` to format my changes.
