### PR TITLE
[test-parser] raise error if data type is productionCapacity

### DIFF
--- a/test_parser.py
+++ b/test_parser.py
@@ -46,6 +46,10 @@ def test_parser(zone: ZoneKey, data_type: str, target_datetime: str | None):
     >>> poetry run test_parser GE production --target_datetime="2022-04-10 15:00"
 
     """
+    if data_type == "productionCapacity":
+        raise ValueError(
+            "productionCapacity is not supported by this script. Please use `poetry run update_capacity` instead."
+        )
     parsed_target_datetime = None
     if target_datetime is not None:
         parsed_target_datetime = datetime.fromisoformat(target_datetime)


### PR DESCRIPTION
## Issue
The poetry command test_parser does not run when data type is productionCapacity (this is done in update_capacity)

## Description

raise error in test_parser if  `data_type == productionCapacity`

### Preview

<img width="967" alt="image" src="https://github.com/electricitymaps/electricitymaps-contrib/assets/107848894/e283e23c-a0c0-42b2-8598-ca5bc931a622">


