### PR TITLE
Add VN unknown emission factor

### DIFF
--- a/config/zones/VN-C.yaml
+++ b/config/zones/VN-C.yaml
@@ -13,4 +13,41 @@ parsers:
   price: VN.fetch_price
   consumption: VN.fetch_consumption
 
+emissionFactors:
+  lifecycle:
+    unknown:
+      - datetime: '2022-01-01'
+        source: 'EMBER 2022; assumes 38.76% coal, 36.91% hydro, 10.68% gas, 10.14% solar, 3.09% wind, 0.14% biomass and 0.27% from other thermal'
+        value: 386
+  direct:
+    unknown:
+      - datetime: '2022-01-01'
+        source: 'EMBER 2022; assumes 38.76% coal, 36.91% hydro, 10.68% gas, 10.14% solar, 3.09% wind, 0.14% biomass and 0.27% from other thermal'
+        value: 336
+isLowCarbon:
+  unknown:
+    - datetime: '2022-01-01'
+      source: 'EMBER 2022; assumes 38.76% coal, 36.91% hydro, 10.68% gas, 10.14% solar, 3.09% wind, 0.14% biomass and 0.27% from other thermal'
+      value: 0.5028
+isRenewable:
+  unknown:
+    - datetime: '2022-01-01'
+      source: 'EMBER 2022; assumes 38.76% coal, 36.91% hydro, 10.68% gas, 10.14% solar, 3.09% wind, 0.14% biomass and 0.27% from other thermal'
+      value: 0.5028
+fallbackZoneMixes:
+  _source: EMBER 2022
+  powerOriginRatios:
+    value:
+      coal: 0.3876
+      gas: 0.1068
+      hydro: 0.3691
+      solar: 0.1014
+      wind: 0.0309
+      biomass: 0.0014
+      unknown: 0.0027
+
+sources:
+  EMBER 2022:
+    link: https://ember-climate.org/countries-and-regions/countries/viet-nam/
+
 timezone: Asia/Ho_Chi_Minh

--- a/config/zones/VN-N.yaml
+++ b/config/zones/VN-N.yaml
@@ -13,4 +13,41 @@ parsers:
   price: VN.fetch_price
   consumption: VN.fetch_consumption
 
+emissionFactors:
+  lifecycle:
+    unknown:
+      - datetime: '2022-01-01'
+        source: 'EMBER 2022; assumes 38.76% coal, 36.91% hydro, 10.68% gas, 10.14% solar, 3.09% wind, 0.14% biomass and 0.27% from other thermal'
+        value: 386
+  direct:
+    unknown:
+      - datetime: '2022-01-01'
+        source: 'EMBER 2022; assumes 38.76% coal, 36.91% hydro, 10.68% gas, 10.14% solar, 3.09% wind, 0.14% biomass and 0.27% from other thermal'
+        value: 336
+isLowCarbon:
+  unknown:
+    - datetime: '2022-01-01'
+      source: 'EMBER 2022; assumes 38.76% coal, 36.91% hydro, 10.68% gas, 10.14% solar, 3.09% wind, 0.14% biomass and 0.27% from other thermal'
+      value: 0.5028
+isRenewable:
+  unknown:
+    - datetime: '2022-01-01'
+      source: 'EMBER 2022; assumes 38.76% coal, 36.91% hydro, 10.68% gas, 10.14% solar, 3.09% wind, 0.14% biomass and 0.27% from other thermal'
+      value: 0.5028
+fallbackZoneMixes:
+  _source: EMBER 2022
+  powerOriginRatios:
+    value:
+      coal: 0.3876
+      gas: 0.1068
+      hydro: 0.3691
+      solar: 0.1014
+      wind: 0.0309
+      biomass: 0.0014
+      unknown: 0.0027
+
+sources:
+  EMBER 2022:
+    link: https://ember-climate.org/countries-and-regions/countries/viet-nam/
+
 timezone: Asia/Ho_Chi_Minh

--- a/config/zones/VN-S.yaml
+++ b/config/zones/VN-S.yaml
@@ -13,4 +13,41 @@ parsers:
   price: VN.fetch_price
   consumption: VN.fetch_consumption
 
+emissionFactors:
+  lifecycle:
+    unknown:
+      - datetime: '2022-01-01'
+        source: 'EMBER 2022; assumes 38.76% coal, 36.91% hydro, 10.68% gas, 10.14% solar, 3.09% wind, 0.14% biomass and 0.27% from other thermal'
+        value: 386
+  direct:
+    unknown:
+      - datetime: '2022-01-01'
+        source: 'EMBER 2022; assumes 38.76% coal, 36.91% hydro, 10.68% gas, 10.14% solar, 3.09% wind, 0.14% biomass and 0.27% from other thermal'
+        value: 336
+isLowCarbon:
+  unknown:
+    - datetime: '2022-01-01'
+      source: 'EMBER 2022; assumes 38.76% coal, 36.91% hydro, 10.68% gas, 10.14% solar, 3.09% wind, 0.14% biomass and 0.27% from other thermal'
+      value: 0.5028
+isRenewable:
+  unknown:
+    - datetime: '2022-01-01'
+      source: 'EMBER 2022; assumes 38.76% coal, 36.91% hydro, 10.68% gas, 10.14% solar, 3.09% wind, 0.14% biomass and 0.27% from other thermal'
+      value: 0.5028
+fallbackZoneMixes:
+  _source: EMBER 2022
+  powerOriginRatios:
+    value:
+      coal: 0.3876
+      gas: 0.1068
+      hydro: 0.3691
+      solar: 0.1014
+      wind: 0.0309
+      biomass: 0.0014
+      unknown: 0.0027
+
+sources:
+  EMBER 2022:
+    link: https://ember-climate.org/countries-and-regions/countries/viet-nam/
+
 timezone: Asia/Ho_Chi_Minh

--- a/config/zones/VN.yaml
+++ b/config/zones/VN.yaml
@@ -23,6 +23,40 @@ capacity:
   unknown: 619
   wind: 4667
 
+emissionFactors:
+  lifecycle:
+    unknown:
+      - datetime: '2022-01-01'
+        source: 'EMBER 2022; assumes 38.76% coal, 36.91% hydro, 10.68% gas, 10.14% solar, 3.09% wind, 0.14% biomass and 0.27% from other thermal'
+        value: 386
+  direct:
+    unknown:
+      - datetime: '2022-01-01'
+        source: 'EMBER 2022; assumes 38.76% coal, 36.91% hydro, 10.68% gas, 10.14% solar, 3.09% wind, 0.14% biomass and 0.27% from other thermal'
+        value: 336
+isLowCarbon:
+  unknown:
+    - datetime: '2022-01-01'
+      source: 'EMBER 2022; assumes 38.76% coal, 36.91% hydro, 10.68% gas, 10.14% solar, 3.09% wind, 0.14% biomass and 0.27% from other thermal'
+      value: 0.5028
+isRenewable:
+  unknown:
+    - datetime: '2022-01-01'
+      source: 'EMBER 2022; assumes 38.76% coal, 36.91% hydro, 10.68% gas, 10.14% solar, 3.09% wind, 0.14% biomass and 0.27% from other thermal'
+      value: 0.5028
+fallbackZoneMixes:
+  _source: EMBER 2022
+  datetime: '2022-01-01'
+  powerOriginRatios:
+    value:
+      coal: 0.3876
+      gas: 0.1068
+      hydro: 0.3691
+      solar: 0.1014
+      wind: 0.0309
+      biomass: 0.0014
+      unknown: 0.0027
+
 subZoneNames:
   - VN-N
   - VN-C

--- a/config/zones/VN.yaml
+++ b/config/zones/VN.yaml
@@ -46,7 +46,6 @@ isRenewable:
       value: 0.5028
 fallbackZoneMixes:
   _source: EMBER 2022
-  datetime: '2022-01-01'
   powerOriginRatios:
     value:
       coal: 0.3876
@@ -61,5 +60,9 @@ subZoneNames:
   - VN-N
   - VN-C
   - VN-S
+
+sources:
+  EMBER 2022:
+    link: https://ember-climate.org/countries-and-regions/countries/viet-nam/
 
 timezone: Asia/Ho_Chi_Minh


### PR DESCRIPTION
## Description

This adds the unknown emission factor for Vietnam, prerequisite to it showing on the map. I've used EMBER data and the default emission factors from the wiki.

### Double check

- [x] I have run `pnpx prettier --write .` and `poetry run format` to format my changes.
