### PR TITLE
Reduce AU-NT data lag

### DIFF
--- a/parsers/NTESMO.py
+++ b/parsers/NTESMO.py
@@ -24,6 +24,7 @@ AUSTRALIA_TZ = ZoneInfo("Australia/Darwin")
 INDEX_URL = "https://ntesmo.com.au/data/daily-trading/historical-daily-trading-data/{}-daily-trading-data"
 DEFAULT_URL = "https://ntesmo.com.au/data/daily-trading/historical-daily-trading-data"
 LATEST_URL = "https://ntesmo.com.au/data/daily-trading"
+DATA_DOC_PREFIX = "https://ntesmo.com.au/__data/assets/excel_doc/"
 # Data is being published after 5 days at the moment.
 DELAY = 24 * 5
 
@@ -70,6 +71,8 @@ retry_strategy = Retry(
     status_forcelist=[500, 502, 503, 504],
 )
 
+_DT_CLASS = "smp-tiles-article__title"
+
 
 def construct_latest_index(session: Session) -> dict[date, str]:
     """Browse all links from the latest daily reports page and index them."""
@@ -77,10 +80,8 @@ def construct_latest_index(session: Session) -> dict[date, str]:
     latest_index_page = session.get(LATEST_URL)
     soup = BeautifulSoup(latest_index_page.text, "html.parser")
     for a in soup.find_all("a", href=True):
-        if a["href"].startswith("https://ntesmo.com.au/__data/assets/excel_doc/"):
-            dt = pd.to_datetime(
-                a.find("div", {"class": "smp-tiles-article__title"}).text
-            )
+        if a["href"].startswith(DATA_DOC_PREFIX):
+            dt = pd.to_datetime(a.find("div", {"class": _DT_CLASS}).text)
             index[dt.date()] = a["href"]
     return index
 
@@ -95,10 +96,8 @@ def construct_year_index(year: int, session: Session) -> dict[date, str]:
     year_index_page = session.get(url)
     soup = BeautifulSoup(year_index_page.text, "html.parser")
     for a in soup.find_all("a", href=True):
-        if a["href"].startswith("https://ntesmo.com.au/__data/assets/excel_doc/"):
-            dt = pd.to_datetime(
-                a.find("div", {"class": "smp-tiles-article__title"}).text
-            )
+        if a["href"].startswith(DATA_DOC_PREFIX):
+            dt = pd.to_datetime(a.find("div", {"class": _DT_CLASS}).text)
             index[dt.date()] = a["href"]
     return index
 

--- a/parsers/NTESMO.py
+++ b/parsers/NTESMO.py
@@ -8,15 +8,16 @@ from collections.abc import Callable
 from datetime import date, datetime, time, timedelta
 from logging import Logger, getLogger
 from typing import TypedDict
+from zoneinfo import ZoneInfo
 
 import arrow
 import pandas as pd
 from bs4 import BeautifulSoup
-from parsers.lib.config import refetch_frequency, retry_policy
-from parsers.lib.exceptions import ParserException
 from requests import Session
 from requests.adapters import Retry
-from zoneinfo import ZoneInfo
+
+from parsers.lib.config import refetch_frequency, retry_policy
+from parsers.lib.exceptions import ParserException
 
 AUSTRALIA_TZ = ZoneInfo("Australia/Darwin")
 


### PR DESCRIPTION
## Issue

The AU-NT is quite delayed (5 days) even though much more recent data is available

## Description

* Allows parsing the links of the latest reports (1 day delay)
* Simplifies the data format for storing the links to the available reports

### Preview

Historical data:
<img width="775" alt="Screenshot 2023-12-11 at 14 02 24" src="https://github.com/electricitymaps/electricitymaps-contrib/assets/32778266/8bb4b356-bbfb-43a7-a212-b6b91710c3a7”>

Latest data:
<img width="757" alt="Screenshot 2023-12-11 at 14 02 44" src="https://github.com/electricitymaps/electricitymaps-contrib/assets/32778266/32d8d9d1-68db-4cce-bd62-254a4c618105">


### Double check

- [x] I have tested my parser changes locally with `poetry run test_parser "zone_key"`
- [x] I have run `pnpx prettier --write .` and `poetry run format` to format my changes.
