### PR TITLE
[REF] Update US emission factors

### DIFF
--- a/config/zones/US-AK.yaml
+++ b/config/zones/US-AK.yaml
@@ -6,34 +6,55 @@ bounding_box:
 emissionFactors:
   direct:
     coal:
-      datetime: '2020-01-01'
-      source: eGrid 2020
-      value: 1054.589992
+      - datetime: '2020-01-01'
+        source: eGrid 2020
+        value: 1054.589992
+      - datetime: '2021-01-01'
+        source: eGrid 2021
+        value: 1040.21
     gas:
-      datetime: '2020-01-01'
-      source: eGrid 2020
-      value: 470.7986093
+      - datetime: '2020-01-01'
+        source: eGrid 2020
+        value: 470.7986093
+      - datetime: '2021-01-01'
+        source: eGrid 2021
+        value: 442.92
     oil:
-      datetime: '2020-01-01'
-      source: eGrid 2020
-      value: 713.1828107
+      - datetime: '2020-01-01'
+        source: eGrid 2020
+        value: 713.1828107
+      - datetime: '2021-01-01'
+        source: eGrid 2021
+        value: 663.88
   lifecycle:
     coal:
-      datetime: '2020-01-01'
-      source: eGrid 2020; Oberschelp, Christopher, et al. "Global emission hotspots
-        of coal power generation."
-      value: 1061.619377
+      - datetime: '2020-01-01'
+        source: eGrid 2020; Oberschelp, Christopher, et al. "Global emission hotspots
+          of coal power generation."
+        value: 1061.619377
+      - datetime: '2021-01-01'
+        source: eGrid 2021; Oberschelp, Christopher, et al. "Global emission hotspots
+          of coal power generation."
+        value: 1047.239385
     gas:
-      datetime: '2020-01-01'
-      source: eGrid 2020; IPCC 2014
-      value: 590.7986093
+      - datetime: '2020-01-01'
+        source: eGrid 2020; IPCC 2014
+        value: 590.7986093
+      - datetime: '2021-01-01'
+        source: eGrid 2021; IPCC 2014
+        value: 562.9200000000001
     oil:
-      datetime: '2020-01-01'
-      source: eGrid 2020; IPCC 2014
-      value: 957.1828107
+      - datetime: '2020-01-01'
+        source: eGrid 2020; IPCC 2014
+        value: 957.1828107
+      - datetime: '2021-01-01'
+        source: eGrid 2021; IPCC 2014
+        value: 907.88
 sources:
   IPCC 2014:
     link: https://www.ipcc.ch/site/assets/uploads/2018/02/ipcc_wg3_ar5_annex-iii.pdf#page=7
   eGrid 2020:
     link: https://drive.google.com/file/d/1_FAAuTtIdMuORZKsqHnd9vMNHlQgYarh/view?usp=sharing
+  eGrid 2021:
+    link: ' https://drive.google.com/file/d/1_FAAuTtIdMuORZKsqHnd9vMNHlQgYarh/view?usp=sharing'
 timezone: America/Anchorage

--- a/config/zones/US-AK.yaml
+++ b/config/zones/US-AK.yaml
@@ -10,33 +10,30 @@ emissionFactors:
       source: eGrid 2020
       value: 1054.589992
     gas:
-      datetime: '2021-01-01'
+      datetime: '2020-01-01'
       source: eGrid 2020
       value: 470.7986093
     oil:
-      datetime: '2021-01-01'
+      datetime: '2020-01-01'
       source: eGrid 2020
       value: 713.1828107
   lifecycle:
     coal:
       datetime: '2020-01-01'
-      source: >-
-        eGrid 2020; Oberschelp, Christopher, et al. "Global emission hotspots of
-        coal power generation."
+      source: eGrid 2020; Oberschelp, Christopher, et al. "Global emission hotspots
+        of coal power generation."
       value: 1061.619377
     gas:
-      datetime: '2021-01-01'
+      datetime: '2020-01-01'
       source: eGrid 2020; IPCC 2014
       value: 590.7986093
     oil:
-      datetime: '2021-01-01'
+      datetime: '2020-01-01'
       source: eGrid 2020; IPCC 2014
       value: 957.1828107
 sources:
   IPCC 2014:
-    link: >-
-      https://www.ipcc.ch/site/assets/uploads/2018/02/ipcc_wg3_ar5_annex-iii.pdf#page=7
+    link: https://www.ipcc.ch/site/assets/uploads/2018/02/ipcc_wg3_ar5_annex-iii.pdf#page=7
   eGrid 2020:
-    link: >-
-      https://drive.google.com/file/d/1_FAAuTtIdMuORZKsqHnd9vMNHlQgYarh/view?usp=sharing
+    link: https://drive.google.com/file/d/1_FAAuTtIdMuORZKsqHnd9vMNHlQgYarh/view?usp=sharing
 timezone: America/Anchorage

--- a/config/zones/US-CAL-BANC.yaml
+++ b/config/zones/US-CAL-BANC.yaml
@@ -52,9 +52,12 @@ emissionFactors:
         source: Electricity Maps, 2021 average
         value: 205.95163168285458
     gas:
-      datetime: '2020-01-01'
-      source: eGrid 2020
-      value: 389.6341439
+      - datetime: '2020-01-01'
+        source: eGrid 2020
+        value: 389.6341439
+      - datetime: '2021-01-01'
+        source: eGrid 2021
+        value: 397.38
     hydro discharge:
       - datetime: '2015-01-01'
         source: Electricity Maps, 2015 average
@@ -105,9 +108,12 @@ emissionFactors:
       source: IPCC 2014
       value: 820.0
     gas:
-      datetime: '2020-01-01'
-      source: eGrid 2020; IPCC 2014
-      value: 509.6341439
+      - datetime: '2020-01-01'
+        source: eGrid 2020; IPCC 2014
+        value: 509.6341439
+      - datetime: '2021-01-01'
+        source: eGrid 2021; IPCC 2014
+        value: 517.38
     hydro discharge:
       - datetime: '2015-01-01'
         source: Electricity Maps, 2015 average
@@ -227,4 +233,6 @@ sources:
     link: https://www.ipcc.ch/site/assets/uploads/2018/02/ipcc_wg3_ar5_annex-iii.pdf#page=7
   eGrid 2020:
     link: https://drive.google.com/file/d/1_FAAuTtIdMuORZKsqHnd9vMNHlQgYarh/view?usp=sharing
+  eGrid 2021:
+    link: ' https://drive.google.com/file/d/1_FAAuTtIdMuORZKsqHnd9vMNHlQgYarh/view?usp=sharing'
 timezone: US/Pacific

--- a/config/zones/US-CAL-BANC.yaml
+++ b/config/zones/US-CAL-BANC.yaml
@@ -52,7 +52,7 @@ emissionFactors:
         source: Electricity Maps, 2021 average
         value: 205.95163168285458
     gas:
-      datetime: '2021-01-01'
+      datetime: '2020-01-01'
       source: eGrid 2020
       value: 389.6341439
     hydro discharge:
@@ -105,7 +105,7 @@ emissionFactors:
       source: IPCC 2014
       value: 820.0
     gas:
-      datetime: '2021-01-01'
+      datetime: '2020-01-01'
       source: eGrid 2020; IPCC 2014
       value: 509.6341439
     hydro discharge:

--- a/config/zones/US-CAL-CISO.yaml
+++ b/config/zones/US-CAL-CISO.yaml
@@ -54,11 +54,11 @@ emissionFactors:
       source: eGrid 2020
       value: 514.4743088
     gas:
-      datetime: '2021-01-01'
+      datetime: '2020-01-01'
       source: eGrid 2020
       value: 403.8432591
     geothermal:
-      datetime: '2021-01-01'
+      datetime: '2020-01-01'
       source: eGrid 2020
       value: 95.82104392
     hydro discharge:
@@ -84,7 +84,7 @@ emissionFactors:
         source: Electricity Maps, 2021 average
         value: 251.31712032739068
     oil:
-      datetime: '2021-01-01'
+      datetime: '2020-01-01'
       source: eGrid 2020
       value: 910.2232446
   lifecycle:
@@ -120,11 +120,11 @@ emissionFactors:
         of coal power generation."
       value: 587.8020898
     gas:
-      datetime: '2021-01-01'
+      datetime: '2020-01-01'
       source: eGrid 2020; IPCC 2014
       value: 523.8432591000001
     geothermal:
-      datetime: '2021-01-01'
+      datetime: '2020-01-01'
       source: eGrid 2020; IPCC 2014
       value: 133.82104392
     hydro discharge:
@@ -150,7 +150,7 @@ emissionFactors:
         source: Electricity Maps, 2021 average
         value: 251.31712032739068
     oil:
-      datetime: '2021-01-01'
+      datetime: '2020-01-01'
       source: eGrid 2020; IPCC 2014
       value: 1154.2232446
     solar:

--- a/config/zones/US-CAL-CISO.yaml
+++ b/config/zones/US-CAL-CISO.yaml
@@ -46,21 +46,33 @@ emissionFactors:
         source: Electricity Maps, 2021 average
         value: 251.31712032739068
     biomass:
-      datetime: '2020-01-01'
-      source: eGrid 2020
-      value: 0.0
+      - datetime: '2020-01-01'
+        source: eGrid 2020
+        value: 0.0
+      - datetime: '2021-01-01'
+        source: eGrid 2021
+        value: 0.0
     coal:
-      datetime: '2020-01-01'
-      source: eGrid 2020
-      value: 514.4743088
+      - datetime: '2020-01-01'
+        source: eGrid 2020
+        value: 514.4743088
+      - datetime: '2021-01-01'
+        source: eGrid 2021
+        value: 525.49
     gas:
-      datetime: '2020-01-01'
-      source: eGrid 2020
-      value: 403.8432591
+      - datetime: '2020-01-01'
+        source: eGrid 2020
+        value: 403.8432591
+      - datetime: '2021-01-01'
+        source: eGrid 2021
+        value: 388.81
     geothermal:
-      datetime: '2020-01-01'
-      source: eGrid 2020
-      value: 95.82104392
+      - datetime: '2020-01-01'
+        source: eGrid 2020
+        value: 95.82104392
+      - datetime: '2021-01-01'
+        source: eGrid 2021
+        value: 104.44
     hydro discharge:
       - datetime: '2015-01-01'
         source: Electricity Maps, 2015 average
@@ -84,9 +96,12 @@ emissionFactors:
         source: Electricity Maps, 2021 average
         value: 251.31712032739068
     oil:
-      datetime: '2020-01-01'
-      source: eGrid 2020
-      value: 910.2232446
+      - datetime: '2020-01-01'
+        source: eGrid 2020
+        value: 910.2232446
+      - datetime: '2021-01-01'
+        source: eGrid 2021
+        value: 1120.25
   lifecycle:
     battery discharge:
       - datetime: '2015-01-01'
@@ -111,22 +126,35 @@ emissionFactors:
         source: Electricity Maps, 2021 average
         value: 251.31712032739068
     biomass:
-      datetime: '2020-01-01'
-      source: eGrid 2020
-      value: 101.6370901
+      - datetime: '2020-01-01'
+        source: eGrid 2020
+        value: 101.6370901
+      - datetime: '2021-01-01'
+        source: eGrid 2021; eGrid 2021
+        value: 277.252
     coal:
-      datetime: '2020-01-01'
-      source: eGrid 2020; Oberschelp, Christopher, et al. "Global emission hotspots
-        of coal power generation."
-      value: 587.8020898
+      - datetime: '2020-01-01'
+        source: eGrid 2020; Oberschelp, Christopher, et al. "Global emission hotspots
+          of coal power generation."
+        value: 587.8020898
+      - datetime: '2021-01-01'
+        source: eGrid 2021; Oberschelp, Christopher, et al. "Global emission hotspots
+          of coal power generation."
+        value: 598.817781
     gas:
-      datetime: '2020-01-01'
-      source: eGrid 2020; IPCC 2014
-      value: 523.8432591000001
+      - datetime: '2020-01-01'
+        source: eGrid 2020; IPCC 2014
+        value: 523.8432591000001
+      - datetime: '2021-01-01'
+        source: eGrid 2021; IPCC 2014
+        value: 508.81
     geothermal:
-      datetime: '2020-01-01'
-      source: eGrid 2020; IPCC 2014
-      value: 133.82104392
+      - datetime: '2020-01-01'
+        source: eGrid 2020; IPCC 2014
+        value: 133.82104392
+      - datetime: '2021-01-01'
+        source: eGrid 2021; IPCC 2014
+        value: 142.44
     hydro discharge:
       - datetime: '2015-01-01'
         source: Electricity Maps, 2015 average
@@ -150,9 +178,12 @@ emissionFactors:
         source: Electricity Maps, 2021 average
         value: 251.31712032739068
     oil:
-      datetime: '2020-01-01'
-      source: eGrid 2020; IPCC 2014
-      value: 1154.2232446
+      - datetime: '2020-01-01'
+        source: eGrid 2020; IPCC 2014
+        value: 1154.2232446
+      - datetime: '2021-01-01'
+        source: eGrid 2021; IPCC 2014
+        value: 1364.25
     solar:
       datetime: '2021-01-01'
       source: INCER ACV
@@ -276,4 +307,6 @@ sources:
     link: https://www.ipcc.ch/site/assets/uploads/2018/02/ipcc_wg3_ar5_annex-iii.pdf#page=7
   eGrid 2020:
     link: https://drive.google.com/file/d/1_FAAuTtIdMuORZKsqHnd9vMNHlQgYarh/view?usp=sharing
+  eGrid 2021:
+    link: ' https://drive.google.com/file/d/1_FAAuTtIdMuORZKsqHnd9vMNHlQgYarh/view?usp=sharing'
 timezone: US/Pacific

--- a/config/zones/US-CAL-IID.yaml
+++ b/config/zones/US-CAL-IID.yaml
@@ -52,17 +52,26 @@ emissionFactors:
         source: Electricity Maps, 2021 average
         value: 493.0079136484788
     biomass:
-      datetime: '2020-01-01'
-      source: eGrid 2020
-      value: 0.0
+      - datetime: '2020-01-01'
+        source: eGrid 2020
+        value: 0.0
+      - datetime: '2021-01-01'
+        source: eGrid 2021
+        value: 0.0
     gas:
-      datetime: '2020-01-01'
-      source: eGrid 2020
-      value: 471.3724863
+      - datetime: '2020-01-01'
+        source: eGrid 2020
+        value: 471.3724863
+      - datetime: '2021-01-01'
+        source: eGrid 2021
+        value: 484.42
     geothermal:
-      datetime: '2020-01-01'
-      source: eGrid 2020
-      value: 56.8894463
+      - datetime: '2020-01-01'
+        source: eGrid 2020
+        value: 56.8894463
+      - datetime: '2021-01-01'
+        source: eGrid 2021
+        value: 88.15
     hydro discharge:
       - datetime: '2015-01-01'
         source: Electricity Maps, 2015 average
@@ -109,21 +118,30 @@ emissionFactors:
         source: Electricity Maps, 2021 average
         value: 605.7101776743226
     biomass:
-      datetime: '2020-01-01'
-      source: eGrid 2020
-      value: 39.38869109
+      - datetime: '2020-01-01'
+        source: eGrid 2020
+        value: 39.38869109
+      - datetime: '2021-01-01'
+        source: eGrid 2021; eGrid 2021
+        value: 277.252
     coal:
       datetime: '2014-01-01'
       source: IPCC 2014
       value: 820.0
     gas:
-      datetime: '2020-01-01'
-      source: eGrid 2020; IPCC 2014
-      value: 591.3724863
+      - datetime: '2020-01-01'
+        source: eGrid 2020; IPCC 2014
+        value: 591.3724863
+      - datetime: '2021-01-01'
+        source: eGrid 2021; IPCC 2014
+        value: 604.4200000000001
     geothermal:
-      datetime: '2020-01-01'
-      source: eGrid 2020; IPCC 2014
-      value: 94.8894463
+      - datetime: '2020-01-01'
+        source: eGrid 2020; IPCC 2014
+        value: 94.8894463
+      - datetime: '2021-01-01'
+        source: eGrid 2021; IPCC 2014
+        value: 126.15
     hydro discharge:
       - datetime: '2015-01-01'
         source: Electricity Maps, 2015 average
@@ -273,4 +291,6 @@ sources:
     link: https://www.ipcc.ch/site/assets/uploads/2018/02/ipcc_wg3_ar5_annex-iii.pdf#page=7
   eGrid 2020:
     link: https://drive.google.com/file/d/1_FAAuTtIdMuORZKsqHnd9vMNHlQgYarh/view?usp=sharing
+  eGrid 2021:
+    link: ' https://drive.google.com/file/d/1_FAAuTtIdMuORZKsqHnd9vMNHlQgYarh/view?usp=sharing'
 timezone: US/Pacific

--- a/config/zones/US-CAL-IID.yaml
+++ b/config/zones/US-CAL-IID.yaml
@@ -56,11 +56,11 @@ emissionFactors:
       source: eGrid 2020
       value: 0.0
     gas:
-      datetime: '2021-01-01'
+      datetime: '2020-01-01'
       source: eGrid 2020
       value: 471.3724863
     geothermal:
-      datetime: '2021-01-01'
+      datetime: '2020-01-01'
       source: eGrid 2020
       value: 56.8894463
     hydro discharge:
@@ -117,11 +117,11 @@ emissionFactors:
       source: IPCC 2014
       value: 820.0
     gas:
-      datetime: '2021-01-01'
+      datetime: '2020-01-01'
       source: eGrid 2020; IPCC 2014
       value: 591.3724863
     geothermal:
-      datetime: '2021-01-01'
+      datetime: '2020-01-01'
       source: eGrid 2020; IPCC 2014
       value: 94.8894463
     hydro discharge:

--- a/config/zones/US-CAL-LDWP.yaml
+++ b/config/zones/US-CAL-LDWP.yaml
@@ -52,17 +52,26 @@ emissionFactors:
         source: Electricity Maps, 2021 average
         value: 360.6966468753414
     biomass:
-      datetime: '2020-01-01'
-      source: eGrid 2020
-      value: 0.0
+      - datetime: '2020-01-01'
+        source: eGrid 2020
+        value: 0.0
+      - datetime: '2021-01-01'
+        source: eGrid 2021
+        value: 0.0
     coal:
-      datetime: '2020-01-01'
-      source: eGrid 2020
-      value: 932.7095009
+      - datetime: '2020-01-01'
+        source: eGrid 2020
+        value: 932.7095009
+      - datetime: '2021-01-01'
+        source: eGrid 2021
+        value: 917.69
     gas:
-      datetime: '2020-01-01'
-      source: eGrid 2020
-      value: 405.0754852
+      - datetime: '2020-01-01'
+        source: eGrid 2020
+        value: 405.0754852
+      - datetime: '2021-01-01'
+        source: eGrid 2021
+        value: 398.97
     hydro discharge:
       - datetime: '2015-01-01'
         source: Electricity Maps, 2015 average
@@ -109,17 +118,26 @@ emissionFactors:
         source: Electricity Maps, 2021 average
         value: 420.1968418441202
     biomass:
-      datetime: '2020-01-01'
-      source: eGrid 2020
-      value: 138.0968906
+      - datetime: '2020-01-01'
+        source: eGrid 2020
+        value: 138.0968906
+      - datetime: '2021-01-01'
+        source: eGrid 2021; eGrid 2021
+        value: 277.252
     coal:
-      datetime: '2020-01-01'
-      source: eGrid 2020; IPCC 2014
-      value: 992.7095009
+      - datetime: '2020-01-01'
+        source: eGrid 2020; IPCC 2014
+        value: 992.7095009
+      - datetime: '2021-01-01'
+        source: eGrid 2021; IPCC 2014
+        value: 977.69
     gas:
-      datetime: '2020-01-01'
-      source: eGrid 2020; IPCC 2014
-      value: 525.0754852
+      - datetime: '2020-01-01'
+        source: eGrid 2020; IPCC 2014
+        value: 525.0754852
+      - datetime: '2021-01-01'
+        source: eGrid 2021; IPCC 2014
+        value: 518.97
     hydro discharge:
       - datetime: '2015-01-01'
         source: Electricity Maps, 2015 average
@@ -209,4 +227,6 @@ sources:
     link: https://www.ipcc.ch/site/assets/uploads/2018/02/ipcc_wg3_ar5_annex-iii.pdf#page=7
   eGrid 2020:
     link: https://drive.google.com/file/d/1_FAAuTtIdMuORZKsqHnd9vMNHlQgYarh/view?usp=sharing
+  eGrid 2021:
+    link: ' https://drive.google.com/file/d/1_FAAuTtIdMuORZKsqHnd9vMNHlQgYarh/view?usp=sharing'
 timezone: US/Pacific

--- a/config/zones/US-CAL-LDWP.yaml
+++ b/config/zones/US-CAL-LDWP.yaml
@@ -60,7 +60,7 @@ emissionFactors:
       source: eGrid 2020
       value: 932.7095009
     gas:
-      datetime: '2021-01-01'
+      datetime: '2020-01-01'
       source: eGrid 2020
       value: 405.0754852
     hydro discharge:
@@ -117,7 +117,7 @@ emissionFactors:
       source: eGrid 2020; IPCC 2014
       value: 992.7095009
     gas:
-      datetime: '2021-01-01'
+      datetime: '2020-01-01'
       source: eGrid 2020; IPCC 2014
       value: 525.0754852
     hydro discharge:

--- a/config/zones/US-CAL-TIDC.yaml
+++ b/config/zones/US-CAL-TIDC.yaml
@@ -52,9 +52,12 @@ emissionFactors:
         source: Electricity Maps, 2021 average
         value: 295.12212439880415
     gas:
-      datetime: '2020-01-01'
-      source: eGrid 2020
-      value: 462.3610483
+      - datetime: '2020-01-01'
+        source: eGrid 2020
+        value: 462.3610483
+      - datetime: '2021-01-01'
+        source: eGrid 2021
+        value: 480.85
     hydro discharge:
       - datetime: '2015-01-01'
         source: Electricity Maps, 2015 average
@@ -105,9 +108,12 @@ emissionFactors:
       source: IPCC 2014
       value: 820.0
     gas:
-      datetime: '2020-01-01'
-      source: eGrid 2020; IPCC 2014
-      value: 582.3610483
+      - datetime: '2020-01-01'
+        source: eGrid 2020; IPCC 2014
+        value: 582.3610483
+      - datetime: '2021-01-01'
+        source: eGrid 2021; IPCC 2014
+        value: 600.85
     hydro discharge:
       - datetime: '2015-01-01'
         source: Electricity Maps, 2015 average
@@ -251,4 +257,6 @@ sources:
     link: https://www.ipcc.ch/site/assets/uploads/2018/02/ipcc_wg3_ar5_annex-iii.pdf#page=7
   eGrid 2020:
     link: https://drive.google.com/file/d/1_FAAuTtIdMuORZKsqHnd9vMNHlQgYarh/view?usp=sharing
+  eGrid 2021:
+    link: ' https://drive.google.com/file/d/1_FAAuTtIdMuORZKsqHnd9vMNHlQgYarh/view?usp=sharing'
 timezone: US/Pacific

--- a/config/zones/US-CAL-TIDC.yaml
+++ b/config/zones/US-CAL-TIDC.yaml
@@ -52,7 +52,7 @@ emissionFactors:
         source: Electricity Maps, 2021 average
         value: 295.12212439880415
     gas:
-      datetime: '2021-01-01'
+      datetime: '2020-01-01'
       source: eGrid 2020
       value: 462.3610483
     hydro discharge:
@@ -105,7 +105,7 @@ emissionFactors:
       source: IPCC 2014
       value: 820.0
     gas:
-      datetime: '2021-01-01'
+      datetime: '2020-01-01'
       source: eGrid 2020; IPCC 2014
       value: 582.3610483
     hydro discharge:

--- a/config/zones/US-CAR-CPLE.yaml
+++ b/config/zones/US-CAR-CPLE.yaml
@@ -52,17 +52,26 @@ emissionFactors:
         source: Electricity Maps, 2021 average
         value: 256.5720652928129
     biomass:
-      datetime: '2020-01-01'
-      source: eGrid 2020
-      value: 0.0
+      - datetime: '2020-01-01'
+        source: eGrid 2020
+        value: 0.0
+      - datetime: '2021-01-01'
+        source: eGrid 2021
+        value: 0.0
     coal:
-      datetime: '2020-01-01'
-      source: eGrid 2020
-      value: 937.9666611
+      - datetime: '2020-01-01'
+        source: eGrid 2020
+        value: 937.9666611
+      - datetime: '2021-01-01'
+        source: eGrid 2021
+        value: 1021.54
     gas:
-      datetime: '2020-01-01'
-      source: eGrid 2020
-      value: 394.223375
+      - datetime: '2020-01-01'
+        source: eGrid 2020
+        value: 394.223375
+      - datetime: '2021-01-01'
+        source: eGrid 2021
+        value: 401.12
     hydro discharge:
       - datetime: '2015-01-01'
         source: Electricity Maps, 2015 average
@@ -109,18 +118,28 @@ emissionFactors:
         source: Electricity Maps, 2021 average
         value: 316.56730941021874
     biomass:
-      datetime: '2020-01-01'
-      source: eGrid 2020
-      value: 216.6227355
+      - datetime: '2020-01-01'
+        source: eGrid 2020
+        value: 216.6227355
+      - datetime: '2021-01-01'
+        source: eGrid 2021; eGrid 2021
+        value: 277.252
     coal:
-      datetime: '2020-01-01'
-      source: eGrid 2020; Oberschelp, Christopher, et al. "Global emission hotspots
-        of coal power generation."
-      value: 1059.9982231
+      - datetime: '2020-01-01'
+        source: eGrid 2020; Oberschelp, Christopher, et al. "Global emission hotspots
+          of coal power generation."
+        value: 1059.9982231
+      - datetime: '2021-01-01'
+        source: eGrid 2021; Oberschelp, Christopher, et al. "Global emission hotspots
+          of coal power generation."
+        value: 1143.5715619999999
     gas:
-      datetime: '2020-01-01'
-      source: eGrid 2020; IPCC 2014
-      value: 514.223375
+      - datetime: '2020-01-01'
+        source: eGrid 2020; IPCC 2014
+        value: 514.223375
+      - datetime: '2021-01-01'
+        source: eGrid 2021; IPCC 2014
+        value: 521.12
     hydro discharge:
       - datetime: '2015-01-01'
         source: Electricity Maps, 2015 average
@@ -270,4 +289,6 @@ sources:
     link: https://www.ipcc.ch/site/assets/uploads/2018/02/ipcc_wg3_ar5_annex-iii.pdf#page=7
   eGrid 2020:
     link: https://drive.google.com/file/d/1_FAAuTtIdMuORZKsqHnd9vMNHlQgYarh/view?usp=sharing
+  eGrid 2021:
+    link: ' https://drive.google.com/file/d/1_FAAuTtIdMuORZKsqHnd9vMNHlQgYarh/view?usp=sharing'
 timezone: US/Eastern

--- a/config/zones/US-CAR-CPLE.yaml
+++ b/config/zones/US-CAR-CPLE.yaml
@@ -60,7 +60,7 @@ emissionFactors:
       source: eGrid 2020
       value: 937.9666611
     gas:
-      datetime: '2021-01-01'
+      datetime: '2020-01-01'
       source: eGrid 2020
       value: 394.223375
     hydro discharge:
@@ -118,7 +118,7 @@ emissionFactors:
         of coal power generation."
       value: 1059.9982231
     gas:
-      datetime: '2021-01-01'
+      datetime: '2020-01-01'
       source: eGrid 2020; IPCC 2014
       value: 514.223375
     hydro discharge:

--- a/config/zones/US-CAR-DUK.yaml
+++ b/config/zones/US-CAR-DUK.yaml
@@ -56,7 +56,7 @@ emissionFactors:
       source: eGrid 2020
       value: 856.3493858
     gas:
-      datetime: '2021-01-01'
+      datetime: '2020-01-01'
       source: eGrid 2020
       value: 396.0379906
     hydro discharge:
@@ -110,7 +110,7 @@ emissionFactors:
         of coal power generation."
       value: 941.3628778000001
     gas:
-      datetime: '2021-01-01'
+      datetime: '2020-01-01'
       source: eGrid 2020; IPCC 2014
       value: 516.0379906000001
     hydro discharge:

--- a/config/zones/US-CAR-DUK.yaml
+++ b/config/zones/US-CAR-DUK.yaml
@@ -52,13 +52,19 @@ emissionFactors:
         source: Electricity Maps, 2021 average
         value: 256.66970547913576
     coal:
-      datetime: '2020-01-01'
-      source: eGrid 2020
-      value: 856.3493858
+      - datetime: '2020-01-01'
+        source: eGrid 2020
+        value: 856.3493858
+      - datetime: '2021-01-01'
+        source: eGrid 2021
+        value: 778.05
     gas:
-      datetime: '2020-01-01'
-      source: eGrid 2020
-      value: 396.0379906
+      - datetime: '2020-01-01'
+        source: eGrid 2020
+        value: 396.0379906
+      - datetime: '2021-01-01'
+        source: eGrid 2021
+        value: 399.14
     hydro discharge:
       - datetime: '2015-01-01'
         source: Electricity Maps, 2015 average
@@ -105,14 +111,21 @@ emissionFactors:
         source: Electricity Maps, 2021 average
         value: 307.9074187530485
     coal:
-      datetime: '2020-01-01'
-      source: eGrid 2020; Oberschelp, Christopher, et al. "Global emission hotspots
-        of coal power generation."
-      value: 941.3628778000001
+      - datetime: '2020-01-01'
+        source: eGrid 2020; Oberschelp, Christopher, et al. "Global emission hotspots
+          of coal power generation."
+        value: 941.3628778000001
+      - datetime: '2021-01-01'
+        source: eGrid 2021; Oberschelp, Christopher, et al. "Global emission hotspots
+          of coal power generation."
+        value: 863.063492
     gas:
-      datetime: '2020-01-01'
-      source: eGrid 2020; IPCC 2014
-      value: 516.0379906000001
+      - datetime: '2020-01-01'
+        source: eGrid 2020; IPCC 2014
+        value: 516.0379906000001
+      - datetime: '2021-01-01'
+        source: eGrid 2021; IPCC 2014
+        value: 519.14
     hydro discharge:
       - datetime: '2015-01-01'
         source: Electricity Maps, 2015 average
@@ -262,4 +275,6 @@ sources:
     link: https://www.ipcc.ch/site/assets/uploads/2018/02/ipcc_wg3_ar5_annex-iii.pdf#page=7
   eGrid 2020:
     link: https://drive.google.com/file/d/1_FAAuTtIdMuORZKsqHnd9vMNHlQgYarh/view?usp=sharing
+  eGrid 2021:
+    link: ' https://drive.google.com/file/d/1_FAAuTtIdMuORZKsqHnd9vMNHlQgYarh/view?usp=sharing'
 timezone: US/Eastern

--- a/config/zones/US-CAR-SC.yaml
+++ b/config/zones/US-CAR-SC.yaml
@@ -54,17 +54,26 @@ emissionFactors:
         source: Electricity Maps, 2021 average
         value: 565.7753046389483
     biomass:
-      datetime: '2020-01-01'
-      source: eGrid 2020
-      value: 0.0
+      - datetime: '2020-01-01'
+        source: eGrid 2020
+        value: 0.0
+      - datetime: '2021-01-01'
+        source: eGrid 2021
+        value: 0.0
     coal:
-      datetime: '2020-01-01'
-      source: eGrid 2020
-      value: 1072.534134
+      - datetime: '2020-01-01'
+        source: eGrid 2020
+        value: 1072.534134
+      - datetime: '2021-01-01'
+        source: eGrid 2021
+        value: 1060.56
     gas:
-      datetime: '2020-01-01'
-      source: eGrid 2020
-      value: 442.9124649
+      - datetime: '2020-01-01'
+        source: eGrid 2020
+        value: 442.9124649
+      - datetime: '2021-01-01'
+        source: eGrid 2021
+        value: 445.8
     hydro discharge:
       - datetime: '2015-01-01'
         source: Electricity Maps, 2015 average
@@ -111,18 +120,28 @@ emissionFactors:
         source: Electricity Maps, 2021 average
         value: 648.4341212169911
     biomass:
-      datetime: '2020-01-01'
-      source: eGrid 2020
-      value: 53.68073353
+      - datetime: '2020-01-01'
+        source: eGrid 2020
+        value: 53.68073353
+      - datetime: '2021-01-01'
+        source: eGrid 2021; eGrid 2021
+        value: 277.252
     coal:
-      datetime: '2020-01-01'
-      source: eGrid 2020; Oberschelp, Christopher, et al. "Global emission hotspots
-        of coal power generation."
-      value: 1165.692392
+      - datetime: '2020-01-01'
+        source: eGrid 2020; Oberschelp, Christopher, et al. "Global emission hotspots
+          of coal power generation."
+        value: 1165.692392
+      - datetime: '2021-01-01'
+        source: eGrid 2021; Oberschelp, Christopher, et al. "Global emission hotspots
+          of coal power generation."
+        value: 1153.7182579999999
     gas:
-      datetime: '2020-01-01'
-      source: eGrid 2020; IPCC 2014
-      value: 562.9124649
+      - datetime: '2020-01-01'
+        source: eGrid 2020; IPCC 2014
+        value: 562.9124649
+      - datetime: '2021-01-01'
+        source: eGrid 2021; IPCC 2014
+        value: 565.8
     hydro discharge:
       - datetime: '2015-01-01'
         source: Electricity Maps, 2015 average
@@ -272,4 +291,6 @@ sources:
     link: https://www.ipcc.ch/site/assets/uploads/2018/02/ipcc_wg3_ar5_annex-iii.pdf#page=7
   eGrid 2020:
     link: https://drive.google.com/file/d/1_FAAuTtIdMuORZKsqHnd9vMNHlQgYarh/view?usp=sharing
+  eGrid 2021:
+    link: ' https://drive.google.com/file/d/1_FAAuTtIdMuORZKsqHnd9vMNHlQgYarh/view?usp=sharing'
 timezone: US/Eastern

--- a/config/zones/US-CAR-SC.yaml
+++ b/config/zones/US-CAR-SC.yaml
@@ -62,7 +62,7 @@ emissionFactors:
       source: eGrid 2020
       value: 1072.534134
     gas:
-      datetime: '2021-01-01'
+      datetime: '2020-01-01'
       source: eGrid 2020
       value: 442.9124649
     hydro discharge:
@@ -120,7 +120,7 @@ emissionFactors:
         of coal power generation."
       value: 1165.692392
     gas:
-      datetime: '2021-01-01'
+      datetime: '2020-01-01'
       source: eGrid 2020; IPCC 2014
       value: 562.9124649
     hydro discharge:

--- a/config/zones/US-CAR-SCEG.yaml
+++ b/config/zones/US-CAR-SCEG.yaml
@@ -63,7 +63,7 @@ emissionFactors:
       source: eGrid 2020
       value: 849.2213607
     gas:
-      datetime: '2021-01-01'
+      datetime: '2020-01-01'
       source: eGrid 2020
       value: 407.4177138
     hydro discharge:
@@ -121,7 +121,7 @@ emissionFactors:
         of coal power generation."
       value: 932.0702837
     gas:
-      datetime: '2021-01-01'
+      datetime: '2020-01-01'
       source: eGrid 2020; IPCC 2014
       value: 527.4177138
     hydro discharge:

--- a/config/zones/US-CAR-SCEG.yaml
+++ b/config/zones/US-CAR-SCEG.yaml
@@ -55,17 +55,26 @@ emissionFactors:
         source: Electricity Maps, 2021 average
         value: 359.73740517000465
     biomass:
-      datetime: '2020-01-01'
-      source: eGrid 2020
-      value: 0.0
+      - datetime: '2020-01-01'
+        source: eGrid 2020
+        value: 0.0
+      - datetime: '2021-01-01'
+        source: eGrid 2021
+        value: 0.0
     coal:
-      datetime: '2020-01-01'
-      source: eGrid 2020
-      value: 849.2213607
+      - datetime: '2020-01-01'
+        source: eGrid 2020
+        value: 849.2213607
+      - datetime: '2021-01-01'
+        source: eGrid 2021
+        value: 885.72
     gas:
-      datetime: '2020-01-01'
-      source: eGrid 2020
-      value: 407.4177138
+      - datetime: '2020-01-01'
+        source: eGrid 2020
+        value: 407.4177138
+      - datetime: '2021-01-01'
+        source: eGrid 2021
+        value: 462.31
     hydro discharge:
       - datetime: '2015-01-01'
         source: Electricity Maps, 2015 average
@@ -112,18 +121,28 @@ emissionFactors:
         source: Electricity Maps, 2021 average
         value: 441.1224874951236
     biomass:
-      datetime: '2020-01-01'
-      source: eGrid 2020
-      value: 90.54773858
+      - datetime: '2020-01-01'
+        source: eGrid 2020
+        value: 90.54773858
+      - datetime: '2021-01-01'
+        source: eGrid 2021; eGrid 2021
+        value: 277.252
     coal:
-      datetime: '2020-01-01'
-      source: eGrid 2020; Oberschelp, Christopher, et al. "Global emission hotspots
-        of coal power generation."
-      value: 932.0702837
+      - datetime: '2020-01-01'
+        source: eGrid 2020; Oberschelp, Christopher, et al. "Global emission hotspots
+          of coal power generation."
+        value: 932.0702837
+      - datetime: '2021-01-01'
+        source: eGrid 2021; Oberschelp, Christopher, et al. "Global emission hotspots
+          of coal power generation."
+        value: 968.568923
     gas:
-      datetime: '2020-01-01'
-      source: eGrid 2020; IPCC 2014
-      value: 527.4177138
+      - datetime: '2020-01-01'
+        source: eGrid 2020; IPCC 2014
+        value: 527.4177138
+      - datetime: '2021-01-01'
+        source: eGrid 2021; IPCC 2014
+        value: 582.31
     hydro discharge:
       - datetime: '2015-01-01'
         source: Electricity Maps, 2015 average
@@ -273,4 +292,6 @@ sources:
     link: https://www.ipcc.ch/site/assets/uploads/2018/02/ipcc_wg3_ar5_annex-iii.pdf#page=7
   eGrid 2020:
     link: https://drive.google.com/file/d/1_FAAuTtIdMuORZKsqHnd9vMNHlQgYarh/view?usp=sharing
+  eGrid 2021:
+    link: ' https://drive.google.com/file/d/1_FAAuTtIdMuORZKsqHnd9vMNHlQgYarh/view?usp=sharing'
 timezone: US/Eastern

--- a/config/zones/US-CENT-SPA.yaml
+++ b/config/zones/US-CENT-SPA.yaml
@@ -52,9 +52,12 @@ emissionFactors:
         source: Electricity Maps, 2021 average
         value: 164.00004434072346
     coal:
-      datetime: '2020-01-01'
-      source: eGrid 2020
-      value: 987.9224617
+      - datetime: '2020-01-01'
+        source: eGrid 2020
+        value: 987.9224617
+      - datetime: '2021-01-01'
+        source: eGrid 2021
+        value: 1062.02
     hydro discharge:
       - datetime: '2015-01-01'
         source: Electricity Maps, 2015 average
@@ -101,9 +104,12 @@ emissionFactors:
         source: Electricity Maps, 2021 average
         value: 214.8514952193525
     coal:
-      datetime: '2020-01-01'
-      source: eGrid 2020; IPCC 2014
-      value: 1047.9224617
+      - datetime: '2020-01-01'
+        source: eGrid 2020; IPCC 2014
+        value: 1047.9224617
+      - datetime: '2021-01-01'
+        source: eGrid 2021; IPCC 2014
+        value: 1122.02
     gas:
       datetime: '2014-01-01'
       source: IPCC 2014
@@ -236,4 +242,6 @@ sources:
     link: https://www.ipcc.ch/site/assets/uploads/2018/02/ipcc_wg3_ar5_annex-iii.pdf#page=7
   eGrid 2020:
     link: https://drive.google.com/file/d/1_FAAuTtIdMuORZKsqHnd9vMNHlQgYarh/view?usp=sharing
+  eGrid 2021:
+    link: ' https://drive.google.com/file/d/1_FAAuTtIdMuORZKsqHnd9vMNHlQgYarh/view?usp=sharing'
 timezone: US/Central

--- a/config/zones/US-CENT-SWPP.yaml
+++ b/config/zones/US-CENT-SWPP.yaml
@@ -46,17 +46,26 @@ emissionFactors:
         source: Electricity Maps, 2021 average
         value: 454.76337244396854
     biomass:
-      datetime: '2020-01-01'
-      source: eGrid 2020
-      value: 0
+      - datetime: '2020-01-01'
+        source: eGrid 2020
+        value: 0
+      - datetime: '2021-01-01'
+        source: eGrid 2021
+        value: 0.0
     coal:
-      datetime: '2020-01-01'
-      source: eGrid 2020
-      value: 1014.625275
+      - datetime: '2020-01-01'
+        source: eGrid 2020
+        value: 1014.625275
+      - datetime: '2021-01-01'
+        source: eGrid 2021
+        value: 1001.89
     gas:
-      datetime: '2020-01-01'
-      source: eGrid 2020
-      value: 459.1389525
+      - datetime: '2020-01-01'
+        source: eGrid 2020
+        value: 459.1389525
+      - datetime: '2021-01-01'
+        source: eGrid 2021
+        value: 459.68
     hydro discharge:
       - datetime: '2015-01-01'
         source: Electricity Maps, 2015 average
@@ -80,9 +89,12 @@ emissionFactors:
         source: Electricity Maps, 2021 average
         value: 454.76337244396854
     oil:
-      datetime: '2020-01-01'
-      source: eGrid 2020
-      value: 975.0111176
+      - datetime: '2020-01-01'
+        source: eGrid 2020
+        value: 975.0111176
+      - datetime: '2021-01-01'
+        source: eGrid 2021
+        value: 1315.85
   lifecycle:
     battery discharge:
       - datetime: '2015-01-01'
@@ -107,18 +119,28 @@ emissionFactors:
         source: Electricity Maps, 2021 average
         value: 495.53661158608855
     biomass:
-      datetime: '2020-01-01'
-      source: eGrid 2020
-      value: 66.69147532
+      - datetime: '2020-01-01'
+        source: eGrid 2020
+        value: 66.69147532
+      - datetime: '2021-01-01'
+        source: eGrid 2021; eGrid 2021
+        value: 277.252
     coal:
-      datetime: '2020-01-01'
-      source: eGrid 2020; Oberschelp, Christopher, et al. "Global emission hotspots
-        of coal power generation."
-      value: 1044.656633
+      - datetime: '2020-01-01'
+        source: eGrid 2020; Oberschelp, Christopher, et al. "Global emission hotspots
+          of coal power generation."
+        value: 1044.656633
+      - datetime: '2021-01-01'
+        source: eGrid 2021; Oberschelp, Christopher, et al. "Global emission hotspots
+          of coal power generation."
+        value: 1031.921358
     gas:
-      datetime: '2020-01-01'
-      source: eGrid 2020; IPCC 2014
-      value: 579.1389525
+      - datetime: '2020-01-01'
+        source: eGrid 2020; IPCC 2014
+        value: 579.1389525
+      - datetime: '2021-01-01'
+        source: eGrid 2021; IPCC 2014
+        value: 579.6800000000001
     hydro discharge:
       - datetime: '2015-01-01'
         source: Electricity Maps, 2015 average
@@ -142,9 +164,12 @@ emissionFactors:
         source: Electricity Maps, 2021 average
         value: 495.53661158608855
     oil:
-      datetime: '2020-01-01'
-      source: eGrid 2020; IPCC 2014
-      value: 1219.0111176
+      - datetime: '2020-01-01'
+        source: eGrid 2020; IPCC 2014
+        value: 1219.0111176
+      - datetime: '2021-01-01'
+        source: eGrid 2021; IPCC 2014
+        value: 1559.85
     solar:
       datetime: '2021-01-01'
       source: INCER ACV
@@ -269,4 +294,6 @@ sources:
     link: https://www.ipcc.ch/site/assets/uploads/2018/02/ipcc_wg3_ar5_annex-iii.pdf#page=7
   eGrid 2020:
     link: https://drive.google.com/file/d/1_FAAuTtIdMuORZKsqHnd9vMNHlQgYarh/view?usp=sharing
+  eGrid 2021:
+    link: ' https://drive.google.com/file/d/1_FAAuTtIdMuORZKsqHnd9vMNHlQgYarh/view?usp=sharing'
 timezone: US/Central

--- a/config/zones/US-CENT-SWPP.yaml
+++ b/config/zones/US-CENT-SWPP.yaml
@@ -54,7 +54,7 @@ emissionFactors:
       source: eGrid 2020
       value: 1014.625275
     gas:
-      datetime: '2021-01-01'
+      datetime: '2020-01-01'
       source: eGrid 2020
       value: 459.1389525
     hydro discharge:
@@ -80,7 +80,7 @@ emissionFactors:
         source: Electricity Maps, 2021 average
         value: 454.76337244396854
     oil:
-      datetime: '2021-01-01'
+      datetime: '2020-01-01'
       source: eGrid 2020
       value: 975.0111176
   lifecycle:
@@ -116,7 +116,7 @@ emissionFactors:
         of coal power generation."
       value: 1044.656633
     gas:
-      datetime: '2021-01-01'
+      datetime: '2020-01-01'
       source: eGrid 2020; IPCC 2014
       value: 579.1389525
     hydro discharge:
@@ -142,7 +142,7 @@ emissionFactors:
         source: Electricity Maps, 2021 average
         value: 495.53661158608855
     oil:
-      datetime: '2021-01-01'
+      datetime: '2020-01-01'
       source: eGrid 2020; IPCC 2014
       value: 1219.0111176
     solar:

--- a/config/zones/US-FLA-FMPP.yaml
+++ b/config/zones/US-FLA-FMPP.yaml
@@ -52,13 +52,19 @@ emissionFactors:
         source: Electricity Maps, 2021 average
         value: 490.1531912006671
     coal:
-      datetime: '2020-01-01'
-      source: eGrid 2020
-      value: 768.4856555
+      - datetime: '2020-01-01'
+        source: eGrid 2020
+        value: 768.4856555
+      - datetime: '2021-01-01'
+        source: eGrid 2021
+        value: 806.7
     gas:
-      datetime: '2020-01-01'
-      source: eGrid 2020
-      value: 446.015972
+      - datetime: '2020-01-01'
+        source: eGrid 2020
+        value: 446.015972
+      - datetime: '2021-01-01'
+        source: eGrid 2021
+        value: 439.9
     hydro discharge:
       - datetime: '2015-01-01'
         source: Electricity Maps, 2015 average
@@ -81,6 +87,10 @@ emissionFactors:
       - datetime: '2021-01-01'
         source: Electricity Maps, 2021 average
         value: 490.1531912006671
+    oil:
+      datetime: '2021-01-01'
+      source: eGrid 2021
+      value: 791.37
   lifecycle:
     battery discharge:
       - datetime: '2015-01-01'
@@ -105,13 +115,19 @@ emissionFactors:
         source: Electricity Maps, 2021 average
         value: 582.5695563225543
     coal:
-      datetime: '2020-01-01'
-      source: eGrid 2020; IPCC 2014
-      value: 828.4856555
+      - datetime: '2020-01-01'
+        source: eGrid 2020; IPCC 2014
+        value: 828.4856555
+      - datetime: '2021-01-01'
+        source: eGrid 2021; IPCC 2014
+        value: 866.7
     gas:
-      datetime: '2020-01-01'
-      source: eGrid 2020; IPCC 2014
-      value: 566.0159719999999
+      - datetime: '2020-01-01'
+        source: eGrid 2020; IPCC 2014
+        value: 566.0159719999999
+      - datetime: '2021-01-01'
+        source: eGrid 2021; IPCC 2014
+        value: 559.9
     hydro discharge:
       - datetime: '2015-01-01'
         source: Electricity Maps, 2015 average
@@ -135,9 +151,12 @@ emissionFactors:
         source: Electricity Maps, 2021 average
         value: 582.5695563225543
     oil:
-      datetime: '2014-01-01'
-      source: IPCC 2014; EIA 2020/BEIS 2021
-      value: 650.0
+      - datetime: '2014-01-01'
+        source: IPCC 2014; EIA 2020/BEIS 2021
+        value: 650.0
+      - datetime: '2021-01-01'
+        source: eGrid 2021; IPCC 2014
+        value: 1035.37
     solar:
       datetime: '2021-01-01'
       source: INCER ACV
@@ -261,4 +280,6 @@ sources:
     link: https://www.ipcc.ch/site/assets/uploads/2018/02/ipcc_wg3_ar5_annex-iii.pdf#page=7
   eGrid 2020:
     link: https://drive.google.com/file/d/1_FAAuTtIdMuORZKsqHnd9vMNHlQgYarh/view?usp=sharing
+  eGrid 2021:
+    link: ' https://drive.google.com/file/d/1_FAAuTtIdMuORZKsqHnd9vMNHlQgYarh/view?usp=sharing'
 timezone: US/Eastern

--- a/config/zones/US-FLA-FMPP.yaml
+++ b/config/zones/US-FLA-FMPP.yaml
@@ -56,7 +56,7 @@ emissionFactors:
       source: eGrid 2020
       value: 768.4856555
     gas:
-      datetime: '2021-01-01'
+      datetime: '2020-01-01'
       source: eGrid 2020
       value: 446.015972
     hydro discharge:
@@ -109,7 +109,7 @@ emissionFactors:
       source: eGrid 2020; IPCC 2014
       value: 828.4856555
     gas:
-      datetime: '2021-01-01'
+      datetime: '2020-01-01'
       source: eGrid 2020; IPCC 2014
       value: 566.0159719999999
     hydro discharge:

--- a/config/zones/US-FLA-FPC.yaml
+++ b/config/zones/US-FLA-FPC.yaml
@@ -52,17 +52,26 @@ emissionFactors:
         source: Electricity Maps, 2021 average
         value: 437.0786046556874
     biomass:
-      datetime: '2020-01-01'
-      source: eGrid 2020
-      value: 0.0
+      - datetime: '2020-01-01'
+        source: eGrid 2020
+        value: 0.0
+      - datetime: '2021-01-01'
+        source: eGrid 2021
+        value: 0.0
     coal:
-      datetime: '2020-01-01'
-      source: eGrid 2020
-      value: 521.6312947
+      - datetime: '2020-01-01'
+        source: eGrid 2020
+        value: 521.6312947
+      - datetime: '2021-01-01'
+        source: eGrid 2021
+        value: 569.16
     gas:
-      datetime: '2020-01-01'
-      source: eGrid 2020
-      value: 423.934686
+      - datetime: '2020-01-01'
+        source: eGrid 2020
+        value: 423.934686
+      - datetime: '2021-01-01'
+        source: eGrid 2021
+        value: 423.81
     hydro discharge:
       - datetime: '2015-01-01'
         source: Electricity Maps, 2015 average
@@ -86,9 +95,12 @@ emissionFactors:
         source: Electricity Maps, 2021 average
         value: 437.0786046556874
     oil:
-      datetime: '2020-01-01'
-      source: eGrid 2020
-      value: 1162.940076
+      - datetime: '2020-01-01'
+        source: eGrid 2020
+        value: 1162.940076
+      - datetime: '2021-01-01'
+        source: eGrid 2021
+        value: 654.9
   lifecycle:
     battery discharge:
       - datetime: '2015-01-01'
@@ -113,17 +125,26 @@ emissionFactors:
         source: Electricity Maps, 2021 average
         value: 543.5831773185287
     biomass:
-      datetime: '2020-01-01'
-      source: eGrid 2020
-      value: 572.1600047
+      - datetime: '2020-01-01'
+        source: eGrid 2020
+        value: 572.1600047
+      - datetime: '2021-01-01'
+        source: eGrid 2021; eGrid 2021
+        value: 277.252
     coal:
-      datetime: '2020-01-01'
-      source: eGrid 2020; IPCC 2014
-      value: 581.6312947
+      - datetime: '2020-01-01'
+        source: eGrid 2020; IPCC 2014
+        value: 581.6312947
+      - datetime: '2021-01-01'
+        source: eGrid 2021; IPCC 2014
+        value: 629.16
     gas:
-      datetime: '2020-01-01'
-      source: eGrid 2020; IPCC 2014
-      value: 543.934686
+      - datetime: '2020-01-01'
+        source: eGrid 2020; IPCC 2014
+        value: 543.934686
+      - datetime: '2021-01-01'
+        source: eGrid 2021; IPCC 2014
+        value: 543.81
     hydro discharge:
       - datetime: '2015-01-01'
         source: Electricity Maps, 2015 average
@@ -147,9 +168,12 @@ emissionFactors:
         source: Electricity Maps, 2021 average
         value: 543.5831773185287
     oil:
-      datetime: '2020-01-01'
-      source: eGrid 2020; IPCC 2014
-      value: 1406.940076
+      - datetime: '2020-01-01'
+        source: eGrid 2020; IPCC 2014
+        value: 1406.940076
+      - datetime: '2021-01-01'
+        source: eGrid 2021; IPCC 2014
+        value: 898.9
     solar:
       datetime: '2021-01-01'
       source: INCER ACV
@@ -273,4 +297,6 @@ sources:
     link: https://www.ipcc.ch/site/assets/uploads/2018/02/ipcc_wg3_ar5_annex-iii.pdf#page=7
   eGrid 2020:
     link: https://drive.google.com/file/d/1_FAAuTtIdMuORZKsqHnd9vMNHlQgYarh/view?usp=sharing
+  eGrid 2021:
+    link: ' https://drive.google.com/file/d/1_FAAuTtIdMuORZKsqHnd9vMNHlQgYarh/view?usp=sharing'
 timezone: US/Eastern

--- a/config/zones/US-FLA-FPC.yaml
+++ b/config/zones/US-FLA-FPC.yaml
@@ -60,7 +60,7 @@ emissionFactors:
       source: eGrid 2020
       value: 521.6312947
     gas:
-      datetime: '2021-01-01'
+      datetime: '2020-01-01'
       source: eGrid 2020
       value: 423.934686
     hydro discharge:
@@ -86,7 +86,7 @@ emissionFactors:
         source: Electricity Maps, 2021 average
         value: 437.0786046556874
     oil:
-      datetime: '2021-01-01'
+      datetime: '2020-01-01'
       source: eGrid 2020
       value: 1162.940076
   lifecycle:
@@ -121,7 +121,7 @@ emissionFactors:
       source: eGrid 2020; IPCC 2014
       value: 581.6312947
     gas:
-      datetime: '2021-01-01'
+      datetime: '2020-01-01'
       source: eGrid 2020; IPCC 2014
       value: 543.934686
     hydro discharge:
@@ -147,7 +147,7 @@ emissionFactors:
         source: Electricity Maps, 2021 average
         value: 543.5831773185287
     oil:
-      datetime: '2021-01-01'
+      datetime: '2020-01-01'
       source: eGrid 2020; IPCC 2014
       value: 1406.940076
     solar:

--- a/config/zones/US-FLA-FPL.yaml
+++ b/config/zones/US-FLA-FPL.yaml
@@ -52,13 +52,19 @@ emissionFactors:
         source: Electricity Maps, 2021 average
         value: 311.44269883203356
     biomass:
-      datetime: '2020-01-01'
-      source: eGrid 2020
-      value: 0.0
+      - datetime: '2020-01-01'
+        source: eGrid 2020
+        value: 0.0
+      - datetime: '2021-01-01'
+        source: eGrid 2021
+        value: 0.0
     gas:
-      datetime: '2020-01-01'
-      source: eGrid 2020
-      value: 367.4893706
+      - datetime: '2020-01-01'
+        source: eGrid 2020
+        value: 367.4893706
+      - datetime: '2021-01-01'
+        source: eGrid 2021
+        value: 365.66
     hydro discharge:
       - datetime: '2015-01-01'
         source: Electricity Maps, 2015 average
@@ -82,9 +88,12 @@ emissionFactors:
         source: Electricity Maps, 2021 average
         value: 311.44269883203356
     oil:
-      datetime: '2020-01-01'
-      source: eGrid 2020
-      value: 390.0504417
+      - datetime: '2020-01-01'
+        source: eGrid 2020
+        value: 390.0504417
+      - datetime: '2021-01-01'
+        source: eGrid 2021
+        value: 450.53
   lifecycle:
     battery discharge:
       - datetime: '2015-01-01'
@@ -109,17 +118,23 @@ emissionFactors:
         source: Electricity Maps, 2021 average
         value: 403.53304353083126
     biomass:
-      datetime: '2020-01-01'
-      source: eGrid 2020
-      value: 902.3445824
+      - datetime: '2020-01-01'
+        source: eGrid 2020
+        value: 902.3445824
+      - datetime: '2021-01-01'
+        source: eGrid 2021; eGrid 2021
+        value: 277.252
     coal:
       datetime: '2014-01-01'
       source: IPCC 2014
       value: 820.0
     gas:
-      datetime: '2020-01-01'
-      source: eGrid 2020; IPCC 2014
-      value: 487.4893706
+      - datetime: '2020-01-01'
+        source: eGrid 2020; IPCC 2014
+        value: 487.4893706
+      - datetime: '2021-01-01'
+        source: eGrid 2021; IPCC 2014
+        value: 485.66
     hydro discharge:
       - datetime: '2015-01-01'
         source: Electricity Maps, 2015 average
@@ -143,9 +158,12 @@ emissionFactors:
         source: Electricity Maps, 2021 average
         value: 403.53304353083126
     oil:
-      datetime: '2020-01-01'
-      source: eGrid 2020; IPCC 2014
-      value: 634.0504417
+      - datetime: '2020-01-01'
+        source: eGrid 2020; IPCC 2014
+        value: 634.0504417
+      - datetime: '2021-01-01'
+        source: eGrid 2021; IPCC 2014
+        value: 694.53
     solar:
       datetime: '2021-01-01'
       source: INCER ACV
@@ -269,4 +287,6 @@ sources:
     link: https://www.ipcc.ch/site/assets/uploads/2018/02/ipcc_wg3_ar5_annex-iii.pdf#page=7
   eGrid 2020:
     link: https://drive.google.com/file/d/1_FAAuTtIdMuORZKsqHnd9vMNHlQgYarh/view?usp=sharing
+  eGrid 2021:
+    link: ' https://drive.google.com/file/d/1_FAAuTtIdMuORZKsqHnd9vMNHlQgYarh/view?usp=sharing'
 timezone: US/Eastern

--- a/config/zones/US-FLA-FPL.yaml
+++ b/config/zones/US-FLA-FPL.yaml
@@ -56,7 +56,7 @@ emissionFactors:
       source: eGrid 2020
       value: 0.0
     gas:
-      datetime: '2021-01-01'
+      datetime: '2020-01-01'
       source: eGrid 2020
       value: 367.4893706
     hydro discharge:
@@ -82,7 +82,7 @@ emissionFactors:
         source: Electricity Maps, 2021 average
         value: 311.44269883203356
     oil:
-      datetime: '2021-01-01'
+      datetime: '2020-01-01'
       source: eGrid 2020
       value: 390.0504417
   lifecycle:
@@ -117,7 +117,7 @@ emissionFactors:
       source: IPCC 2014
       value: 820.0
     gas:
-      datetime: '2021-01-01'
+      datetime: '2020-01-01'
       source: eGrid 2020; IPCC 2014
       value: 487.4893706
     hydro discharge:
@@ -143,7 +143,7 @@ emissionFactors:
         source: Electricity Maps, 2021 average
         value: 403.53304353083126
     oil:
-      datetime: '2021-01-01'
+      datetime: '2020-01-01'
       source: eGrid 2020; IPCC 2014
       value: 634.0504417
     solar:

--- a/config/zones/US-FLA-GVL.yaml
+++ b/config/zones/US-FLA-GVL.yaml
@@ -60,7 +60,7 @@ emissionFactors:
       source: eGrid 2020
       value: 877.6982215
     gas:
-      datetime: '2021-01-01'
+      datetime: '2020-01-01'
       source: eGrid 2020
       value: 457.6172075
     hydro discharge:
@@ -118,7 +118,7 @@ emissionFactors:
         of coal power generation."
       value: 972.4589745000001
     gas:
-      datetime: '2021-01-01'
+      datetime: '2020-01-01'
       source: eGrid 2020; IPCC 2014
       value: 577.6172075
     hydro discharge:

--- a/config/zones/US-FLA-GVL.yaml
+++ b/config/zones/US-FLA-GVL.yaml
@@ -52,17 +52,26 @@ emissionFactors:
         source: Electricity Maps, 2021 average
         value: 600.8070125698916
     biomass:
-      datetime: '2020-01-01'
-      source: eGrid 2020
-      value: 0.0
+      - datetime: '2020-01-01'
+        source: eGrid 2020
+        value: 0.0
+      - datetime: '2021-01-01'
+        source: eGrid 2021
+        value: 0.0
     coal:
-      datetime: '2020-01-01'
-      source: eGrid 2020
-      value: 877.6982215
+      - datetime: '2020-01-01'
+        source: eGrid 2020
+        value: 877.6982215
+      - datetime: '2021-01-01'
+        source: eGrid 2021
+        value: 847.01
     gas:
-      datetime: '2020-01-01'
-      source: eGrid 2020
-      value: 457.6172075
+      - datetime: '2020-01-01'
+        source: eGrid 2020
+        value: 457.6172075
+      - datetime: '2021-01-01'
+        source: eGrid 2021
+        value: 474.34
     hydro discharge:
       - datetime: '2015-01-01'
         source: Electricity Maps, 2015 average
@@ -109,18 +118,28 @@ emissionFactors:
         source: Electricity Maps, 2021 average
         value: 712.0608932397764
     biomass:
-      datetime: '2020-01-01'
-      source: eGrid 2020
-      value: 424.0835095
+      - datetime: '2020-01-01'
+        source: eGrid 2020
+        value: 424.0835095
+      - datetime: '2021-01-01'
+        source: eGrid 2021; eGrid 2021
+        value: 277.252
     coal:
-      datetime: '2020-01-01'
-      source: eGrid 2020; Oberschelp, Christopher, et al. "Global emission hotspots
-        of coal power generation."
-      value: 972.4589745000001
+      - datetime: '2020-01-01'
+        source: eGrid 2020; Oberschelp, Christopher, et al. "Global emission hotspots
+          of coal power generation."
+        value: 972.4589745000001
+      - datetime: '2021-01-01'
+        source: eGrid 2021; Oberschelp, Christopher, et al. "Global emission hotspots
+          of coal power generation."
+        value: 941.770753
     gas:
-      datetime: '2020-01-01'
-      source: eGrid 2020; IPCC 2014
-      value: 577.6172075
+      - datetime: '2020-01-01'
+        source: eGrid 2020; IPCC 2014
+        value: 577.6172075
+      - datetime: '2021-01-01'
+        source: eGrid 2021; IPCC 2014
+        value: 594.3399999999999
     hydro discharge:
       - datetime: '2015-01-01'
         source: Electricity Maps, 2015 average
@@ -270,4 +289,6 @@ sources:
     link: https://www.ipcc.ch/site/assets/uploads/2018/02/ipcc_wg3_ar5_annex-iii.pdf#page=7
   eGrid 2020:
     link: https://drive.google.com/file/d/1_FAAuTtIdMuORZKsqHnd9vMNHlQgYarh/view?usp=sharing
+  eGrid 2021:
+    link: ' https://drive.google.com/file/d/1_FAAuTtIdMuORZKsqHnd9vMNHlQgYarh/view?usp=sharing'
 timezone: US/Eastern

--- a/config/zones/US-FLA-HST.yaml
+++ b/config/zones/US-FLA-HST.yaml
@@ -26,6 +26,7 @@ delays:
   consumptionForecast: 30
   production: 30
 emissionFactors:
+  direct: {}
   lifecycle:
     coal:
       datetime: '2014-01-01'

--- a/config/zones/US-FLA-JEA.yaml
+++ b/config/zones/US-FLA-JEA.yaml
@@ -56,7 +56,7 @@ emissionFactors:
       source: eGrid 2020
       value: 0.0
     gas:
-      datetime: '2021-01-01'
+      datetime: '2020-01-01'
       source: eGrid 2020
       value: 612.0220147
     hydro discharge:
@@ -114,7 +114,7 @@ emissionFactors:
         of coal power generation."
       value: 880.658933
     gas:
-      datetime: '2021-01-01'
+      datetime: '2020-01-01'
       source: eGrid 2020; IPCC 2014
       value: 732.0220147
     hydro discharge:

--- a/config/zones/US-FLA-JEA.yaml
+++ b/config/zones/US-FLA-JEA.yaml
@@ -52,13 +52,19 @@ emissionFactors:
         source: Electricity Maps, 2021 average
         value: 629.3057674336989
     biomass:
-      datetime: '2020-01-01'
-      source: eGrid 2020
-      value: 0.0
+      - datetime: '2020-01-01'
+        source: eGrid 2020
+        value: 0.0
+      - datetime: '2021-01-01'
+        source: eGrid 2021
+        value: 0.0
     gas:
-      datetime: '2020-01-01'
-      source: eGrid 2020
-      value: 612.0220147
+      - datetime: '2020-01-01'
+        source: eGrid 2020
+        value: 612.0220147
+      - datetime: '2021-01-01'
+        source: eGrid 2021
+        value: 524.92
     hydro discharge:
       - datetime: '2015-01-01'
         source: Electricity Maps, 2015 average
@@ -105,18 +111,24 @@ emissionFactors:
         source: Electricity Maps, 2021 average
         value: 680.8678239691804
     biomass:
-      datetime: '2020-01-01'
-      source: eGrid 2020
-      value: 82.16971627
+      - datetime: '2020-01-01'
+        source: eGrid 2020
+        value: 82.16971627
+      - datetime: '2021-01-01'
+        source: eGrid 2021; eGrid 2021
+        value: 277.252
     coal:
       datetime: '2012-01-01'
       source: IPCC 2014; Oberschelp, Christopher, et al. "Global emission hotspots
         of coal power generation."
       value: 880.658933
     gas:
-      datetime: '2020-01-01'
-      source: eGrid 2020; IPCC 2014
-      value: 732.0220147
+      - datetime: '2020-01-01'
+        source: eGrid 2020; IPCC 2014
+        value: 732.0220147
+      - datetime: '2021-01-01'
+        source: eGrid 2021; IPCC 2014
+        value: 644.92
     hydro discharge:
       - datetime: '2015-01-01'
         source: Electricity Maps, 2015 average
@@ -266,4 +278,6 @@ sources:
     link: https://www.ipcc.ch/site/assets/uploads/2018/02/ipcc_wg3_ar5_annex-iii.pdf#page=7
   eGrid 2020:
     link: https://drive.google.com/file/d/1_FAAuTtIdMuORZKsqHnd9vMNHlQgYarh/view?usp=sharing
+  eGrid 2021:
+    link: ' https://drive.google.com/file/d/1_FAAuTtIdMuORZKsqHnd9vMNHlQgYarh/view?usp=sharing'
 timezone: US/Eastern

--- a/config/zones/US-FLA-SEC.yaml
+++ b/config/zones/US-FLA-SEC.yaml
@@ -56,7 +56,7 @@ emissionFactors:
       source: eGrid 2020
       value: 964.3118179
     gas:
-      datetime: '2021-01-01'
+      datetime: '2020-01-01'
       source: eGrid 2020
       value: 386.3298038
     hydro discharge:
@@ -110,7 +110,7 @@ emissionFactors:
         of coal power generation."
       value: 1062.1123579
     gas:
-      datetime: '2021-01-01'
+      datetime: '2020-01-01'
       source: eGrid 2020; IPCC 2014
       value: 506.3298038
     hydro discharge:

--- a/config/zones/US-FLA-SEC.yaml
+++ b/config/zones/US-FLA-SEC.yaml
@@ -52,13 +52,19 @@ emissionFactors:
         source: Electricity Maps, 2021 average
         value: 699.4161197629264
     coal:
-      datetime: '2020-01-01'
-      source: eGrid 2020
-      value: 964.3118179
+      - datetime: '2020-01-01'
+        source: eGrid 2020
+        value: 964.3118179
+      - datetime: '2021-01-01'
+        source: eGrid 2021
+        value: 940.15
     gas:
-      datetime: '2020-01-01'
-      source: eGrid 2020
-      value: 386.3298038
+      - datetime: '2020-01-01'
+        source: eGrid 2020
+        value: 386.3298038
+      - datetime: '2021-01-01'
+        source: eGrid 2021
+        value: 387.4
     hydro discharge:
       - datetime: '2015-01-01'
         source: Electricity Maps, 2015 average
@@ -105,14 +111,21 @@ emissionFactors:
         source: Electricity Maps, 2021 average
         value: 803.9654161855685
     coal:
-      datetime: '2020-01-01'
-      source: eGrid 2020; Oberschelp, Christopher, et al. "Global emission hotspots
-        of coal power generation."
-      value: 1062.1123579
+      - datetime: '2020-01-01'
+        source: eGrid 2020; Oberschelp, Christopher, et al. "Global emission hotspots
+          of coal power generation."
+        value: 1062.1123579
+      - datetime: '2021-01-01'
+        source: eGrid 2021; Oberschelp, Christopher, et al. "Global emission hotspots
+          of coal power generation."
+        value: 1037.95054
     gas:
-      datetime: '2020-01-01'
-      source: eGrid 2020; IPCC 2014
-      value: 506.3298038
+      - datetime: '2020-01-01'
+        source: eGrid 2020; IPCC 2014
+        value: 506.3298038
+      - datetime: '2021-01-01'
+        source: eGrid 2021; IPCC 2014
+        value: 507.4
     hydro discharge:
       - datetime: '2015-01-01'
         source: Electricity Maps, 2015 average
@@ -247,4 +260,6 @@ sources:
     link: https://www.ipcc.ch/site/assets/uploads/2018/02/ipcc_wg3_ar5_annex-iii.pdf#page=7
   eGrid 2020:
     link: https://drive.google.com/file/d/1_FAAuTtIdMuORZKsqHnd9vMNHlQgYarh/view?usp=sharing
+  eGrid 2021:
+    link: ' https://drive.google.com/file/d/1_FAAuTtIdMuORZKsqHnd9vMNHlQgYarh/view?usp=sharing'
 timezone: US/Eastern

--- a/config/zones/US-FLA-TAL.yaml
+++ b/config/zones/US-FLA-TAL.yaml
@@ -52,9 +52,12 @@ emissionFactors:
         source: Electricity Maps, 2021 average
         value: 355.877712517318
     gas:
-      datetime: '2020-01-01'
-      source: eGrid 2020
-      value: 359.8683566
+      - datetime: '2020-01-01'
+        source: eGrid 2020
+        value: 359.8683566
+      - datetime: '2021-01-01'
+        source: eGrid 2021
+        value: 364.27
     hydro discharge:
       - datetime: '2015-01-01'
         source: Electricity Maps, 2015 average
@@ -105,9 +108,12 @@ emissionFactors:
       source: IPCC 2014
       value: 820.0
     gas:
-      datetime: '2020-01-01'
-      source: eGrid 2020; IPCC 2014
-      value: 479.8683566
+      - datetime: '2020-01-01'
+        source: eGrid 2020; IPCC 2014
+        value: 479.8683566
+      - datetime: '2021-01-01'
+        source: eGrid 2021; IPCC 2014
+        value: 484.27
     hydro discharge:
       - datetime: '2015-01-01'
         source: Electricity Maps, 2015 average
@@ -251,4 +257,6 @@ sources:
     link: https://www.ipcc.ch/site/assets/uploads/2018/02/ipcc_wg3_ar5_annex-iii.pdf#page=7
   eGrid 2020:
     link: https://drive.google.com/file/d/1_FAAuTtIdMuORZKsqHnd9vMNHlQgYarh/view?usp=sharing
+  eGrid 2021:
+    link: ' https://drive.google.com/file/d/1_FAAuTtIdMuORZKsqHnd9vMNHlQgYarh/view?usp=sharing'
 timezone: US/Eastern

--- a/config/zones/US-FLA-TAL.yaml
+++ b/config/zones/US-FLA-TAL.yaml
@@ -52,7 +52,7 @@ emissionFactors:
         source: Electricity Maps, 2021 average
         value: 355.877712517318
     gas:
-      datetime: '2021-01-01'
+      datetime: '2020-01-01'
       source: eGrid 2020
       value: 359.8683566
     hydro discharge:
@@ -105,7 +105,7 @@ emissionFactors:
       source: IPCC 2014
       value: 820.0
     gas:
-      datetime: '2021-01-01'
+      datetime: '2020-01-01'
       source: eGrid 2020; IPCC 2014
       value: 479.8683566
     hydro discharge:

--- a/config/zones/US-FLA-TEC.yaml
+++ b/config/zones/US-FLA-TEC.yaml
@@ -57,7 +57,7 @@ emissionFactors:
       source: eGrid 2020
       value: 0.0
     gas:
-      datetime: '2021-01-01'
+      datetime: '2020-01-01'
       source: eGrid 2020
       value: 432.8237021
     hydro discharge:
@@ -115,7 +115,7 @@ emissionFactors:
         of coal power generation."
       value: 866.085401
     gas:
-      datetime: '2021-01-01'
+      datetime: '2020-01-01'
       source: eGrid 2020; IPCC 2014
       value: 552.8237021
     hydro discharge:

--- a/config/zones/US-FLA-TEC.yaml
+++ b/config/zones/US-FLA-TEC.yaml
@@ -53,13 +53,23 @@ emissionFactors:
         source: Electricity Maps, 2021 average
         value: 510.62387145096113
     biomass:
-      datetime: '2020-01-01'
-      source: eGrid 2020
-      value: 0.0
+      - datetime: '2020-01-01'
+        source: eGrid 2020
+        value: 0.0
+      - datetime: '2021-01-01'
+        source: eGrid 2021
+        value: 0.0
+    coal:
+      datetime: '2021-01-01'
+      source: eGrid 2021
+      value: 863.2
     gas:
-      datetime: '2020-01-01'
-      source: eGrid 2020
-      value: 432.8237021
+      - datetime: '2020-01-01'
+        source: eGrid 2020
+        value: 432.8237021
+      - datetime: '2021-01-01'
+        source: eGrid 2021
+        value: 360.34
     hydro discharge:
       - datetime: '2015-01-01'
         source: Electricity Maps, 2015 average
@@ -106,18 +116,28 @@ emissionFactors:
         source: Electricity Maps, 2021 average
         value: 593.9242899009478
     biomass:
-      datetime: '2020-01-01'
-      source: eGrid 2020
-      value: 1248.927719
+      - datetime: '2020-01-01'
+        source: eGrid 2020
+        value: 1248.927719
+      - datetime: '2021-01-01'
+        source: eGrid 2021; eGrid 2021
+        value: 277.252
     coal:
-      datetime: '2012-01-01'
-      source: IPCC 2014; Oberschelp, Christopher, et al. "Global emission hotspots
-        of coal power generation."
-      value: 866.085401
+      - datetime: '2012-01-01'
+        source: IPCC 2014; Oberschelp, Christopher, et al. "Global emission hotspots
+          of coal power generation."
+        value: 866.085401
+      - datetime: '2021-01-01'
+        source: eGrid 2021; Oberschelp, Christopher, et al. "Global emission hotspots
+          of coal power generation."
+        value: 969.2854010000001
     gas:
-      datetime: '2020-01-01'
-      source: eGrid 2020; IPCC 2014
-      value: 552.8237021
+      - datetime: '2020-01-01'
+        source: eGrid 2020; IPCC 2014
+        value: 552.8237021
+      - datetime: '2021-01-01'
+        source: eGrid 2021; IPCC 2014
+        value: 480.34
     hydro discharge:
       - datetime: '2015-01-01'
         source: Electricity Maps, 2015 average
@@ -267,4 +287,6 @@ sources:
     link: https://www.ipcc.ch/site/assets/uploads/2018/02/ipcc_wg3_ar5_annex-iii.pdf#page=7
   eGrid 2020:
     link: https://drive.google.com/file/d/1_FAAuTtIdMuORZKsqHnd9vMNHlQgYarh/view?usp=sharing
+  eGrid 2021:
+    link: ' https://drive.google.com/file/d/1_FAAuTtIdMuORZKsqHnd9vMNHlQgYarh/view?usp=sharing'
 timezone: US/Eastern

--- a/config/zones/US-HI-HA.yaml
+++ b/config/zones/US-HI-HA.yaml
@@ -6,13 +6,19 @@ bounding_box:
 emissionFactors:
   direct:
     geothermal:
-      datetime: '2020-01-01'
-      source: eGrid 2020
-      value: 0.0
+      - datetime: '2020-01-01'
+        source: eGrid 2020
+        value: 0.0
+      - datetime: '2021-01-01'
+        source: eGrid 2021
+        value: 104.45
     oil:
-      datetime: '2020-01-01'
-      source: eGrid 2020
-      value: 785.7600688
+      - datetime: '2020-01-01'
+        source: eGrid 2020
+        value: 785.7600688
+      - datetime: '2021-01-01'
+        source: eGrid 2021
+        value: 776.65
   lifecycle:
     coal:
       datetime: '2014-01-01'
@@ -23,16 +29,24 @@ emissionFactors:
       source: IPCC 2014
       value: 490.0
     geothermal:
-      datetime: '2020-01-01'
-      source: eGrid 2020; IPCC 2014
-      value: 38.0
+      - datetime: '2020-01-01'
+        source: eGrid 2020; IPCC 2014
+        value: 38.0
+      - datetime: '2021-01-01'
+        source: eGrid 2021; IPCC 2014
+        value: 142.45
     oil:
-      datetime: '2020-01-01'
-      source: eGrid 2020; IPCC 2014
-      value: 1029.7600688
+      - datetime: '2020-01-01'
+        source: eGrid 2020; IPCC 2014
+        value: 1029.7600688
+      - datetime: '2021-01-01'
+        source: eGrid 2021; IPCC 2014
+        value: 1020.65
 sources:
   IPCC 2014:
     link: https://www.ipcc.ch/site/assets/uploads/2018/02/ipcc_wg3_ar5_annex-iii.pdf#page=7
   eGrid 2020:
     link: https://drive.google.com/file/d/1_FAAuTtIdMuORZKsqHnd9vMNHlQgYarh/view?usp=sharing
+  eGrid 2021:
+    link: ' https://drive.google.com/file/d/1_FAAuTtIdMuORZKsqHnd9vMNHlQgYarh/view?usp=sharing'
 timezone: Pacific/Honolulu

--- a/config/zones/US-HI-HA.yaml
+++ b/config/zones/US-HI-HA.yaml
@@ -6,11 +6,11 @@ bounding_box:
 emissionFactors:
   direct:
     geothermal:
-      datetime: '2021-01-01'
+      datetime: '2020-01-01'
       source: eGrid 2020
       value: 0.0
     oil:
-      datetime: '2021-01-01'
+      datetime: '2020-01-01'
       source: eGrid 2020
       value: 785.7600688
   lifecycle:
@@ -23,11 +23,11 @@ emissionFactors:
       source: IPCC 2014
       value: 490.0
     geothermal:
-      datetime: '2021-01-01'
+      datetime: '2020-01-01'
       source: eGrid 2020; IPCC 2014
       value: 38.0
     oil:
-      datetime: '2021-01-01'
+      datetime: '2020-01-01'
       source: eGrid 2020; IPCC 2014
       value: 1029.7600688
 sources:

--- a/config/zones/US-HI-KA.yaml
+++ b/config/zones/US-HI-KA.yaml
@@ -6,9 +6,12 @@ bounding_box:
 emissionFactors:
   direct:
     oil:
-      datetime: '2020-01-01'
-      source: eGrid 2020
-      value: 779.2439369
+      - datetime: '2020-01-01'
+        source: eGrid 2020
+        value: 779.2439369
+      - datetime: '2021-01-01'
+        source: eGrid 2021
+        value: 741.34
   lifecycle:
     coal:
       datetime: '2014-01-01'
@@ -19,12 +22,17 @@ emissionFactors:
       source: IPCC 2014
       value: 490.0
     oil:
-      datetime: '2020-01-01'
-      source: eGrid 2020; IPCC 2014
-      value: 1023.2439369
+      - datetime: '2020-01-01'
+        source: eGrid 2020; IPCC 2014
+        value: 1023.2439369
+      - datetime: '2021-01-01'
+        source: eGrid 2021; IPCC 2014
+        value: 985.34
 sources:
   IPCC 2014:
     link: https://www.ipcc.ch/site/assets/uploads/2018/02/ipcc_wg3_ar5_annex-iii.pdf#page=7
   eGrid 2020:
     link: https://drive.google.com/file/d/1_FAAuTtIdMuORZKsqHnd9vMNHlQgYarh/view?usp=sharing
+  eGrid 2021:
+    link: ' https://drive.google.com/file/d/1_FAAuTtIdMuORZKsqHnd9vMNHlQgYarh/view?usp=sharing'
 timezone: Pacific/Honolulu

--- a/config/zones/US-HI-KA.yaml
+++ b/config/zones/US-HI-KA.yaml
@@ -6,7 +6,7 @@ bounding_box:
 emissionFactors:
   direct:
     oil:
-      datetime: '2021-01-01'
+      datetime: '2020-01-01'
       source: eGrid 2020
       value: 779.2439369
   lifecycle:
@@ -19,7 +19,7 @@ emissionFactors:
       source: IPCC 2014
       value: 490.0
     oil:
-      datetime: '2021-01-01'
+      datetime: '2020-01-01'
       source: eGrid 2020; IPCC 2014
       value: 1023.2439369
 sources:

--- a/config/zones/US-HI-MA.yaml
+++ b/config/zones/US-HI-MA.yaml
@@ -6,7 +6,7 @@ bounding_box:
 emissionFactors:
   direct:
     oil:
-      datetime: '2021-01-01'
+      datetime: '2020-01-01'
       source: eGrid 2020
       value: 783.2844717
   lifecycle:
@@ -19,7 +19,7 @@ emissionFactors:
       source: IPCC 2014
       value: 490.0
     oil:
-      datetime: '2021-01-01'
+      datetime: '2020-01-01'
       source: eGrid 2020; IPCC 2014
       value: 1027.2844717
 sources:

--- a/config/zones/US-HI-MA.yaml
+++ b/config/zones/US-HI-MA.yaml
@@ -6,9 +6,12 @@ bounding_box:
 emissionFactors:
   direct:
     oil:
-      datetime: '2020-01-01'
-      source: eGrid 2020
-      value: 783.2844717
+      - datetime: '2020-01-01'
+        source: eGrid 2020
+        value: 783.2844717
+      - datetime: '2021-01-01'
+        source: eGrid 2021
+        value: 774.83
   lifecycle:
     coal:
       datetime: '2014-01-01'
@@ -19,12 +22,17 @@ emissionFactors:
       source: IPCC 2014
       value: 490.0
     oil:
-      datetime: '2020-01-01'
-      source: eGrid 2020; IPCC 2014
-      value: 1027.2844717
+      - datetime: '2020-01-01'
+        source: eGrid 2020; IPCC 2014
+        value: 1027.2844717
+      - datetime: '2021-01-01'
+        source: eGrid 2021; IPCC 2014
+        value: 1018.83
 sources:
   IPCC 2014:
     link: https://www.ipcc.ch/site/assets/uploads/2018/02/ipcc_wg3_ar5_annex-iii.pdf#page=7
   eGrid 2020:
     link: https://drive.google.com/file/d/1_FAAuTtIdMuORZKsqHnd9vMNHlQgYarh/view?usp=sharing
+  eGrid 2021:
+    link: ' https://drive.google.com/file/d/1_FAAuTtIdMuORZKsqHnd9vMNHlQgYarh/view?usp=sharing'
 timezone: Pacific/Honolulu

--- a/config/zones/US-HI-OA.yaml
+++ b/config/zones/US-HI-OA.yaml
@@ -77,7 +77,7 @@ emissionFactors:
         source: Electricity Maps, 2021 average
         value: 685.9001691120977
     oil:
-      datetime: '2021-01-01'
+      datetime: '2020-01-01'
       source: eGrid 2020
       value: 742.1719304
   lifecycle:
@@ -138,7 +138,7 @@ emissionFactors:
         source: Electricity Maps, 2021 average
         value: 923.678588772847
     oil:
-      datetime: '2021-01-01'
+      datetime: '2020-01-01'
       source: eGrid 2020; IPCC 2014
       value: 986.1719304
 fallbackZoneMixes:

--- a/config/zones/US-HI-OA.yaml
+++ b/config/zones/US-HI-OA.yaml
@@ -47,13 +47,19 @@ emissionFactors:
         source: Electricity Maps, 2021 average
         value: 685.9001691120977
     biomass:
-      datetime: '2020-01-01'
-      source: eGrid 2020
-      value: 0.0
+      - datetime: '2020-01-01'
+        source: eGrid 2020
+        value: 0.0
+      - datetime: '2021-01-01'
+        source: eGrid 2021
+        value: 0.0
     coal:
-      datetime: '2020-01-01'
-      source: eGrid 2020
-      value: 1088.282256
+      - datetime: '2020-01-01'
+        source: eGrid 2020
+        value: 1088.282256
+      - datetime: '2021-01-01'
+        source: eGrid 2021
+        value: 1095.15
     hydro discharge:
       - datetime: '2015-01-01'
         source: Electricity Maps, 2015 average
@@ -77,9 +83,12 @@ emissionFactors:
         source: Electricity Maps, 2021 average
         value: 685.9001691120977
     oil:
-      datetime: '2020-01-01'
-      source: eGrid 2020
-      value: 742.1719304
+      - datetime: '2020-01-01'
+        source: eGrid 2020
+        value: 742.1719304
+      - datetime: '2021-01-01'
+        source: eGrid 2021
+        value: 746.36
   lifecycle:
     battery discharge:
       - datetime: '2015-01-01'
@@ -104,13 +113,19 @@ emissionFactors:
         source: Electricity Maps, 2021 average
         value: 923.678588772847
     biomass:
-      datetime: '2020-01-01'
-      source: eGrid 2020
-      value: 980.1789569
+      - datetime: '2020-01-01'
+        source: eGrid 2020
+        value: 980.1789569
+      - datetime: '2021-01-01'
+        source: eGrid 2021; eGrid 2021
+        value: 277.252
     coal:
-      datetime: '2020-01-01'
-      source: eGrid 2020; IPCC 2014
-      value: 1148.282256
+      - datetime: '2020-01-01'
+        source: eGrid 2020; IPCC 2014
+        value: 1148.282256
+      - datetime: '2021-01-01'
+        source: eGrid 2021; IPCC 2014
+        value: 1155.15
     gas:
       datetime: '2014-01-01'
       source: IPCC 2014
@@ -138,9 +153,12 @@ emissionFactors:
         source: Electricity Maps, 2021 average
         value: 923.678588772847
     oil:
-      datetime: '2020-01-01'
-      source: eGrid 2020; IPCC 2014
-      value: 986.1719304
+      - datetime: '2020-01-01'
+        source: eGrid 2020; IPCC 2014
+        value: 986.1719304
+      - datetime: '2021-01-01'
+        source: eGrid 2021; IPCC 2014
+        value: 990.36
 fallbackZoneMixes:
   powerOriginRatios:
     - _source: Electricity Maps, 2015 average
@@ -253,4 +271,6 @@ sources:
     link: https://www.ipcc.ch/site/assets/uploads/2018/02/ipcc_wg3_ar5_annex-iii.pdf#page=7
   eGrid 2020:
     link: https://drive.google.com/file/d/1_FAAuTtIdMuORZKsqHnd9vMNHlQgYarh/view?usp=sharing
+  eGrid 2021:
+    link: ' https://drive.google.com/file/d/1_FAAuTtIdMuORZKsqHnd9vMNHlQgYarh/view?usp=sharing'
 timezone: Pacific/Honolulu

--- a/config/zones/US-MIDA-PJM.yaml
+++ b/config/zones/US-MIDA-PJM.yaml
@@ -46,17 +46,26 @@ emissionFactors:
         source: Electricity Maps, 2021 average
         value: 372.3153209954643
     biomass:
-      datetime: '2020-01-01'
-      source: eGrid 2020
-      value: 0.0
+      - datetime: '2020-01-01'
+        source: eGrid 2020
+        value: 0.0
+      - datetime: '2021-01-01'
+        source: eGrid 2021
+        value: 0.0
     coal:
-      datetime: '2020-01-01'
-      source: eGrid 2020
-      value: 970.4739304
+      - datetime: '2020-01-01'
+        source: eGrid 2020
+        value: 970.4739304
+      - datetime: '2021-01-01'
+        source: eGrid 2021
+        value: 977.91
     gas:
-      datetime: '2020-01-01'
-      source: eGrid 2020
-      value: 398.3043939
+      - datetime: '2020-01-01'
+        source: eGrid 2020
+        value: 398.3043939
+      - datetime: '2021-01-01'
+        source: eGrid 2021
+        value: 394.66
     hydro discharge:
       - datetime: '2015-01-01'
         source: Electricity Maps, 2015 average
@@ -80,9 +89,12 @@ emissionFactors:
         source: Electricity Maps, 2021 average
         value: 372.3153209954643
     oil:
-      datetime: '2020-01-01'
-      source: eGrid 2020
-      value: 751.5213327
+      - datetime: '2020-01-01'
+        source: eGrid 2020
+        value: 751.5213327
+      - datetime: '2021-01-01'
+        source: eGrid 2021
+        value: 970.02
   lifecycle:
     battery discharge:
       - datetime: '2015-01-01'
@@ -107,18 +119,28 @@ emissionFactors:
         source: Electricity Maps, 2021 average
         value: 441.8625978766893
     biomass:
-      datetime: '2020-01-01'
-      source: eGrid 2020
-      value: 515.9462429
+      - datetime: '2020-01-01'
+        source: eGrid 2020
+        value: 515.9462429
+      - datetime: '2021-01-01'
+        source: eGrid 2021; eGrid 2021
+        value: 277.252
     coal:
-      datetime: '2020-01-01'
-      source: eGrid 2020; Oberschelp, Christopher, et al. "Global emission hotspots
-        of coal power generation."
-      value: 1049.3545804
+      - datetime: '2020-01-01'
+        source: eGrid 2020; Oberschelp, Christopher, et al. "Global emission hotspots
+          of coal power generation."
+        value: 1049.3545804
+      - datetime: '2021-01-01'
+        source: eGrid 2021; Oberschelp, Christopher, et al. "Global emission hotspots
+          of coal power generation."
+        value: 1056.79065
     gas:
-      datetime: '2020-01-01'
-      source: eGrid 2020; IPCC 2014
-      value: 518.3043938999999
+      - datetime: '2020-01-01'
+        source: eGrid 2020; IPCC 2014
+        value: 518.3043938999999
+      - datetime: '2021-01-01'
+        source: eGrid 2021; IPCC 2014
+        value: 514.6600000000001
     hydro discharge:
       - datetime: '2015-01-01'
         source: Electricity Maps, 2015 average
@@ -142,9 +164,12 @@ emissionFactors:
         source: Electricity Maps, 2021 average
         value: 441.8625978766893
     oil:
-      datetime: '2020-01-01'
-      source: eGrid 2020; IPCC 2014
-      value: 995.5213327
+      - datetime: '2020-01-01'
+        source: eGrid 2020; IPCC 2014
+        value: 995.5213327
+      - datetime: '2021-01-01'
+        source: eGrid 2021; IPCC 2014
+        value: 1214.02
     solar:
       datetime: '2021-01-01'
       source: INCER ACV
@@ -269,4 +294,6 @@ sources:
     link: https://www.ipcc.ch/site/assets/uploads/2018/02/ipcc_wg3_ar5_annex-iii.pdf#page=7
   eGrid 2020:
     link: https://drive.google.com/file/d/1_FAAuTtIdMuORZKsqHnd9vMNHlQgYarh/view?usp=sharing
+  eGrid 2021:
+    link: ' https://drive.google.com/file/d/1_FAAuTtIdMuORZKsqHnd9vMNHlQgYarh/view?usp=sharing'
 timezone: US/Eastern

--- a/config/zones/US-MIDA-PJM.yaml
+++ b/config/zones/US-MIDA-PJM.yaml
@@ -54,7 +54,7 @@ emissionFactors:
       source: eGrid 2020
       value: 970.4739304
     gas:
-      datetime: '2021-01-01'
+      datetime: '2020-01-01'
       source: eGrid 2020
       value: 398.3043939
     hydro discharge:
@@ -80,7 +80,7 @@ emissionFactors:
         source: Electricity Maps, 2021 average
         value: 372.3153209954643
     oil:
-      datetime: '2021-01-01'
+      datetime: '2020-01-01'
       source: eGrid 2020
       value: 751.5213327
   lifecycle:
@@ -116,7 +116,7 @@ emissionFactors:
         of coal power generation."
       value: 1049.3545804
     gas:
-      datetime: '2021-01-01'
+      datetime: '2020-01-01'
       source: eGrid 2020; IPCC 2014
       value: 518.3043938999999
     hydro discharge:
@@ -142,7 +142,7 @@ emissionFactors:
         source: Electricity Maps, 2021 average
         value: 441.8625978766893
     oil:
-      datetime: '2021-01-01'
+      datetime: '2020-01-01'
       source: eGrid 2020; IPCC 2014
       value: 995.5213327
     solar:

--- a/config/zones/US-MIDW-AECI.yaml
+++ b/config/zones/US-MIDW-AECI.yaml
@@ -52,13 +52,19 @@ emissionFactors:
         source: Electricity Maps, 2021 average
         value: 617.5607015534879
     coal:
-      datetime: '2020-01-01'
-      source: eGrid 2020
-      value: 950.6306844
+      - datetime: '2020-01-01'
+        source: eGrid 2020
+        value: 950.6306844
+      - datetime: '2021-01-01'
+        source: eGrid 2021
+        value: 933.86
     gas:
-      datetime: '2020-01-01'
-      source: eGrid 2020
-      value: 400.7407839
+      - datetime: '2020-01-01'
+        source: eGrid 2020
+        value: 400.7407839
+      - datetime: '2021-01-01'
+        source: eGrid 2021
+        value: 408.74
     hydro discharge:
       - datetime: '2015-01-01'
         source: Electricity Maps, 2015 average
@@ -81,6 +87,10 @@ emissionFactors:
       - datetime: '2021-01-01'
         source: Electricity Maps, 2021 average
         value: 617.5607015534879
+    oil:
+      datetime: '2021-01-01'
+      source: eGrid 2021
+      value: 664.14
   lifecycle:
     battery discharge:
       - datetime: '2015-01-01'
@@ -105,14 +115,21 @@ emissionFactors:
         source: Electricity Maps, 2021 average
         value: 670.3401023258247
     coal:
-      datetime: '2020-01-01'
-      source: eGrid 2020; Oberschelp, Christopher, et al. "Global emission hotspots
-        of coal power generation."
-      value: 988.4513953999999
+      - datetime: '2020-01-01'
+        source: eGrid 2020; Oberschelp, Christopher, et al. "Global emission hotspots
+          of coal power generation."
+        value: 988.4513953999999
+      - datetime: '2021-01-01'
+        source: eGrid 2021; Oberschelp, Christopher, et al. "Global emission hotspots
+          of coal power generation."
+        value: 971.680711
     gas:
-      datetime: '2020-01-01'
-      source: eGrid 2020; IPCC 2014
-      value: 520.7407839
+      - datetime: '2020-01-01'
+        source: eGrid 2020; IPCC 2014
+        value: 520.7407839
+      - datetime: '2021-01-01'
+        source: eGrid 2021; IPCC 2014
+        value: 528.74
     hydro discharge:
       - datetime: '2015-01-01'
         source: Electricity Maps, 2015 average
@@ -136,9 +153,12 @@ emissionFactors:
         source: Electricity Maps, 2021 average
         value: 670.3401023258247
     oil:
-      datetime: '2014-01-01'
-      source: IPCC 2014; EIA 2020/BEIS 2021
-      value: 650.0
+      - datetime: '2014-01-01'
+        source: IPCC 2014; EIA 2020/BEIS 2021
+        value: 650.0
+      - datetime: '2021-01-01'
+        source: eGrid 2021; IPCC 2014
+        value: 908.14
     solar:
       datetime: '2021-01-01'
       source: INCER ACV
@@ -262,4 +282,6 @@ sources:
     link: https://www.ipcc.ch/site/assets/uploads/2018/02/ipcc_wg3_ar5_annex-iii.pdf#page=7
   eGrid 2020:
     link: https://drive.google.com/file/d/1_FAAuTtIdMuORZKsqHnd9vMNHlQgYarh/view?usp=sharing
+  eGrid 2021:
+    link: ' https://drive.google.com/file/d/1_FAAuTtIdMuORZKsqHnd9vMNHlQgYarh/view?usp=sharing'
 timezone: US/Central

--- a/config/zones/US-MIDW-AECI.yaml
+++ b/config/zones/US-MIDW-AECI.yaml
@@ -56,7 +56,7 @@ emissionFactors:
       source: eGrid 2020
       value: 950.6306844
     gas:
-      datetime: '2021-01-01'
+      datetime: '2020-01-01'
       source: eGrid 2020
       value: 400.7407839
     hydro discharge:
@@ -110,7 +110,7 @@ emissionFactors:
         of coal power generation."
       value: 988.4513953999999
     gas:
-      datetime: '2021-01-01'
+      datetime: '2020-01-01'
       source: eGrid 2020; IPCC 2014
       value: 520.7407839
     hydro discharge:

--- a/config/zones/US-MIDW-LGEE.yaml
+++ b/config/zones/US-MIDW-LGEE.yaml
@@ -56,7 +56,7 @@ emissionFactors:
       source: eGrid 2020
       value: 939.8190588
     gas:
-      datetime: '2021-01-01'
+      datetime: '2020-01-01'
       source: eGrid 2020
       value: 378.1877271
     hydro discharge:
@@ -110,7 +110,7 @@ emissionFactors:
         of coal power generation."
       value: 1040.9717968
     gas:
-      datetime: '2021-01-01'
+      datetime: '2020-01-01'
       source: eGrid 2020; IPCC 2014
       value: 498.1877271
     hydro discharge:

--- a/config/zones/US-MIDW-LGEE.yaml
+++ b/config/zones/US-MIDW-LGEE.yaml
@@ -52,13 +52,19 @@ emissionFactors:
         source: Electricity Maps, 2021 average
         value: 788.5967508417682
     coal:
-      datetime: '2020-01-01'
-      source: eGrid 2020
-      value: 939.8190588
+      - datetime: '2020-01-01'
+        source: eGrid 2020
+        value: 939.8190588
+      - datetime: '2021-01-01'
+        source: eGrid 2021
+        value: 942.23
     gas:
-      datetime: '2020-01-01'
-      source: eGrid 2020
-      value: 378.1877271
+      - datetime: '2020-01-01'
+        source: eGrid 2020
+        value: 378.1877271
+      - datetime: '2021-01-01'
+        source: eGrid 2021
+        value: 388.35
     hydro discharge:
       - datetime: '2015-01-01'
         source: Electricity Maps, 2015 average
@@ -105,14 +111,21 @@ emissionFactors:
         source: Electricity Maps, 2021 average
         value: 887.824855478869
     coal:
-      datetime: '2020-01-01'
-      source: eGrid 2020; Oberschelp, Christopher, et al. "Global emission hotspots
-        of coal power generation."
-      value: 1040.9717968
+      - datetime: '2020-01-01'
+        source: eGrid 2020; Oberschelp, Christopher, et al. "Global emission hotspots
+          of coal power generation."
+        value: 1040.9717968
+      - datetime: '2021-01-01'
+        source: eGrid 2021; Oberschelp, Christopher, et al. "Global emission hotspots
+          of coal power generation."
+        value: 1043.382738
     gas:
-      datetime: '2020-01-01'
-      source: eGrid 2020; IPCC 2014
-      value: 498.1877271
+      - datetime: '2020-01-01'
+        source: eGrid 2020; IPCC 2014
+        value: 498.1877271
+      - datetime: '2021-01-01'
+        source: eGrid 2021; IPCC 2014
+        value: 508.35
     hydro discharge:
       - datetime: '2015-01-01'
         source: Electricity Maps, 2015 average
@@ -256,4 +269,6 @@ sources:
     link: https://www.ipcc.ch/site/assets/uploads/2018/02/ipcc_wg3_ar5_annex-iii.pdf#page=7
   eGrid 2020:
     link: https://drive.google.com/file/d/1_FAAuTtIdMuORZKsqHnd9vMNHlQgYarh/view?usp=sharing
+  eGrid 2021:
+    link: ' https://drive.google.com/file/d/1_FAAuTtIdMuORZKsqHnd9vMNHlQgYarh/view?usp=sharing'
 timezone: US/Central

--- a/config/zones/US-MIDW-MISO.yaml
+++ b/config/zones/US-MIDW-MISO.yaml
@@ -52,17 +52,26 @@ emissionFactors:
         source: Electricity Maps, 2021 average
         value: 501.3722920933296
     biomass:
-      datetime: '2020-01-01'
-      source: eGrid 2020
-      value: 0.0
+      - datetime: '2020-01-01'
+        source: eGrid 2020
+        value: 0.0
+      - datetime: '2021-01-01'
+        source: eGrid 2021
+        value: 0.0
     coal:
-      datetime: '2020-01-01'
-      source: eGrid 2020
-      value: 1013.675084
+      - datetime: '2020-01-01'
+        source: eGrid 2020
+        value: 1013.675084
+      - datetime: '2021-01-01'
+        source: eGrid 2021
+        value: 1003.7
     gas:
-      datetime: '2020-01-01'
-      source: eGrid 2020
-      value: 409.253592
+      - datetime: '2020-01-01'
+        source: eGrid 2020
+        value: 409.253592
+      - datetime: '2021-01-01'
+        source: eGrid 2021
+        value: 409.43
     hydro discharge:
       - datetime: '2015-01-01'
         source: Electricity Maps, 2015 average
@@ -86,9 +95,12 @@ emissionFactors:
         source: Electricity Maps, 2021 average
         value: 501.3722920933296
     oil:
-      datetime: '2020-01-01'
-      source: eGrid 2020
-      value: 922.7890878
+      - datetime: '2020-01-01'
+        source: eGrid 2020
+        value: 922.7890878
+      - datetime: '2021-01-01'
+        source: eGrid 2021
+        value: 613.58
   lifecycle:
     battery discharge:
       - datetime: '2015-01-01'
@@ -113,18 +125,28 @@ emissionFactors:
         source: Electricity Maps, 2021 average
         value: 565.6209396789254
     biomass:
-      datetime: '2020-01-01'
-      source: eGrid 2020
-      value: 139.1151962
+      - datetime: '2020-01-01'
+        source: eGrid 2020
+        value: 139.1151962
+      - datetime: '2021-01-01'
+        source: eGrid 2021; eGrid 2021
+        value: 277.252
     coal:
-      datetime: '2020-01-01'
-      source: eGrid 2020; Oberschelp, Christopher, et al. "Global emission hotspots
-        of coal power generation."
-      value: 1076.354463
+      - datetime: '2020-01-01'
+        source: eGrid 2020; Oberschelp, Christopher, et al. "Global emission hotspots
+          of coal power generation."
+        value: 1076.354463
+      - datetime: '2021-01-01'
+        source: eGrid 2021; Oberschelp, Christopher, et al. "Global emission hotspots
+          of coal power generation."
+        value: 1066.379379
     gas:
-      datetime: '2020-01-01'
-      source: eGrid 2020; IPCC 2014
-      value: 529.253592
+      - datetime: '2020-01-01'
+        source: eGrid 2020; IPCC 2014
+        value: 529.253592
+      - datetime: '2021-01-01'
+        source: eGrid 2021; IPCC 2014
+        value: 529.4300000000001
     hydro discharge:
       - datetime: '2015-01-01'
         source: Electricity Maps, 2015 average
@@ -148,9 +170,12 @@ emissionFactors:
         source: Electricity Maps, 2021 average
         value: 565.6209396789254
     oil:
-      datetime: '2020-01-01'
-      source: eGrid 2020; IPCC 2014
-      value: 1166.7890877999998
+      - datetime: '2020-01-01'
+        source: eGrid 2020; IPCC 2014
+        value: 1166.7890877999998
+      - datetime: '2021-01-01'
+        source: eGrid 2021; IPCC 2014
+        value: 857.58
     solar:
       datetime: '2021-01-01'
       source: INCER ACV
@@ -200,4 +225,6 @@ sources:
     link: https://www.ipcc.ch/site/assets/uploads/2018/02/ipcc_wg3_ar5_annex-iii.pdf#page=7
   eGrid 2020:
     link: https://drive.google.com/file/d/1_FAAuTtIdMuORZKsqHnd9vMNHlQgYarh/view?usp=sharing
+  eGrid 2021:
+    link: ' https://drive.google.com/file/d/1_FAAuTtIdMuORZKsqHnd9vMNHlQgYarh/view?usp=sharing'
 timezone: US/Central

--- a/config/zones/US-MIDW-MISO.yaml
+++ b/config/zones/US-MIDW-MISO.yaml
@@ -60,7 +60,7 @@ emissionFactors:
       source: eGrid 2020
       value: 1013.675084
     gas:
-      datetime: '2021-01-01'
+      datetime: '2020-01-01'
       source: eGrid 2020
       value: 409.253592
     hydro discharge:
@@ -86,7 +86,7 @@ emissionFactors:
         source: Electricity Maps, 2021 average
         value: 501.3722920933296
     oil:
-      datetime: '2021-01-01'
+      datetime: '2020-01-01'
       source: eGrid 2020
       value: 922.7890878
   lifecycle:
@@ -122,7 +122,7 @@ emissionFactors:
         of coal power generation."
       value: 1076.354463
     gas:
-      datetime: '2021-01-01'
+      datetime: '2020-01-01'
       source: eGrid 2020; IPCC 2014
       value: 529.253592
     hydro discharge:
@@ -148,7 +148,7 @@ emissionFactors:
         source: Electricity Maps, 2021 average
         value: 565.6209396789254
     oil:
-      datetime: '2021-01-01'
+      datetime: '2020-01-01'
       source: eGrid 2020; IPCC 2014
       value: 1166.7890877999998
     solar:

--- a/config/zones/US-NE-ISNE.yaml
+++ b/config/zones/US-NE-ISNE.yaml
@@ -54,7 +54,7 @@ emissionFactors:
       source: eGrid 2020
       value: 1042.155724
     gas:
-      datetime: '2021-01-01'
+      datetime: '2020-01-01'
       source: eGrid 2020
       value: 389.0568749
     hydro discharge:
@@ -80,7 +80,7 @@ emissionFactors:
         source: Electricity Maps, 2021 average
         value: 196.32177755564254
     oil:
-      datetime: '2021-01-01'
+      datetime: '2020-01-01'
       source: eGrid 2020
       value: 1257.197843
   lifecycle:
@@ -116,7 +116,7 @@ emissionFactors:
         of coal power generation."
       value: 1133.712784
     gas:
-      datetime: '2021-01-01'
+      datetime: '2020-01-01'
       source: eGrid 2020; IPCC 2014
       value: 509.0568749
     hydro discharge:
@@ -142,7 +142,7 @@ emissionFactors:
         source: Electricity Maps, 2021 average
         value: 283.25905267667025
     oil:
-      datetime: '2021-01-01'
+      datetime: '2020-01-01'
       source: eGrid 2020; IPCC 2014
       value: 1501.197843
     solar:

--- a/config/zones/US-NE-ISNE.yaml
+++ b/config/zones/US-NE-ISNE.yaml
@@ -46,17 +46,26 @@ emissionFactors:
         source: Electricity Maps, 2021 average
         value: 196.32177755564254
     biomass:
-      datetime: '2020-01-01'
-      source: eGrid 2020
-      value: 0.0
+      - datetime: '2020-01-01'
+        source: eGrid 2020
+        value: 0.0
+      - datetime: '2021-01-01'
+        source: eGrid 2021
+        value: 0.0
     coal:
-      datetime: '2020-01-01'
-      source: eGrid 2020
-      value: 1042.155724
+      - datetime: '2020-01-01'
+        source: eGrid 2020
+        value: 1042.155724
+      - datetime: '2021-01-01'
+        source: eGrid 2021
+        value: 1049.54
     gas:
-      datetime: '2020-01-01'
-      source: eGrid 2020
-      value: 389.0568749
+      - datetime: '2020-01-01'
+        source: eGrid 2020
+        value: 389.0568749
+      - datetime: '2021-01-01'
+        source: eGrid 2021
+        value: 388.41
     hydro discharge:
       - datetime: '2015-01-01'
         source: Electricity Maps, 2015 average
@@ -80,9 +89,12 @@ emissionFactors:
         source: Electricity Maps, 2021 average
         value: 196.32177755564254
     oil:
-      datetime: '2020-01-01'
-      source: eGrid 2020
-      value: 1257.197843
+      - datetime: '2020-01-01'
+        source: eGrid 2020
+        value: 1257.197843
+      - datetime: '2021-01-01'
+        source: eGrid 2021
+        value: 781.56
   lifecycle:
     battery discharge:
       - datetime: '2015-01-01'
@@ -107,18 +119,28 @@ emissionFactors:
         source: Electricity Maps, 2021 average
         value: 283.25905267667025
     biomass:
-      datetime: '2020-01-01'
-      source: eGrid 2020
-      value: 429.7692167
+      - datetime: '2020-01-01'
+        source: eGrid 2020
+        value: 429.7692167
+      - datetime: '2021-01-01'
+        source: eGrid 2021; eGrid 2021
+        value: 277.252
     coal:
-      datetime: '2020-01-01'
-      source: eGrid 2020; Oberschelp, Christopher, et al. "Global emission hotspots
-        of coal power generation."
-      value: 1133.712784
+      - datetime: '2020-01-01'
+        source: eGrid 2020; Oberschelp, Christopher, et al. "Global emission hotspots
+          of coal power generation."
+        value: 1133.712784
+      - datetime: '2021-01-01'
+        source: eGrid 2021; Oberschelp, Christopher, et al. "Global emission hotspots
+          of coal power generation."
+        value: 1141.09706
     gas:
-      datetime: '2020-01-01'
-      source: eGrid 2020; IPCC 2014
-      value: 509.0568749
+      - datetime: '2020-01-01'
+        source: eGrid 2020; IPCC 2014
+        value: 509.0568749
+      - datetime: '2021-01-01'
+        source: eGrid 2021; IPCC 2014
+        value: 508.41
     hydro discharge:
       - datetime: '2015-01-01'
         source: Electricity Maps, 2015 average
@@ -142,9 +164,12 @@ emissionFactors:
         source: Electricity Maps, 2021 average
         value: 283.25905267667025
     oil:
-      datetime: '2020-01-01'
-      source: eGrid 2020; IPCC 2014
-      value: 1501.197843
+      - datetime: '2020-01-01'
+        source: eGrid 2020; IPCC 2014
+        value: 1501.197843
+      - datetime: '2021-01-01'
+        source: eGrid 2021; IPCC 2014
+        value: 1025.56
     solar:
       datetime: '2021-01-01'
       source: INCER ACV
@@ -223,4 +248,6 @@ sources:
     link: https://www.ipcc.ch/site/assets/uploads/2018/02/ipcc_wg3_ar5_annex-iii.pdf#page=7
   eGrid 2020:
     link: https://drive.google.com/file/d/1_FAAuTtIdMuORZKsqHnd9vMNHlQgYarh/view?usp=sharing
+  eGrid 2021:
+    link: ' https://drive.google.com/file/d/1_FAAuTtIdMuORZKsqHnd9vMNHlQgYarh/view?usp=sharing'
 timezone: US/Eastern

--- a/config/zones/US-NW-AVA.yaml
+++ b/config/zones/US-NW-AVA.yaml
@@ -56,7 +56,7 @@ emissionFactors:
       source: eGrid 2020
       value: 0.0
     gas:
-      datetime: '2021-01-01'
+      datetime: '2020-01-01'
       source: eGrid 2020
       value: 393.6395083
     hydro discharge:
@@ -113,7 +113,7 @@ emissionFactors:
       source: IPCC 2014
       value: 820.0
     gas:
-      datetime: '2021-01-01'
+      datetime: '2020-01-01'
       source: eGrid 2020; IPCC 2014
       value: 513.6395083
     hydro discharge:

--- a/config/zones/US-NW-AVA.yaml
+++ b/config/zones/US-NW-AVA.yaml
@@ -52,13 +52,19 @@ emissionFactors:
         source: Electricity Maps, 2021 average
         value: 150.30024090917905
     biomass:
-      datetime: '2020-01-01'
-      source: eGrid 2020
-      value: 0.0
+      - datetime: '2020-01-01'
+        source: eGrid 2020
+        value: 0.0
+      - datetime: '2021-01-01'
+        source: eGrid 2021
+        value: 0.0
     gas:
-      datetime: '2020-01-01'
-      source: eGrid 2020
-      value: 393.6395083
+      - datetime: '2020-01-01'
+        source: eGrid 2020
+        value: 393.6395083
+      - datetime: '2021-01-01'
+        source: eGrid 2021
+        value: 401.43
     hydro discharge:
       - datetime: '2015-01-01'
         source: Electricity Maps, 2015 average
@@ -105,17 +111,23 @@ emissionFactors:
         source: Electricity Maps, 2021 average
         value: 195.41846991631843
     biomass:
-      datetime: '2020-01-01'
-      source: eGrid 2020
-      value: 205.8471989
+      - datetime: '2020-01-01'
+        source: eGrid 2020
+        value: 205.8471989
+      - datetime: '2021-01-01'
+        source: eGrid 2021; eGrid 2021
+        value: 277.252
     coal:
       datetime: '2014-01-01'
       source: IPCC 2014
       value: 820.0
     gas:
-      datetime: '2020-01-01'
-      source: eGrid 2020; IPCC 2014
-      value: 513.6395083
+      - datetime: '2020-01-01'
+        source: eGrid 2020; IPCC 2014
+        value: 513.6395083
+      - datetime: '2021-01-01'
+        source: eGrid 2021; IPCC 2014
+        value: 521.4300000000001
     hydro discharge:
       - datetime: '2015-01-01'
         source: Electricity Maps, 2015 average
@@ -199,4 +211,6 @@ sources:
     link: https://www.ipcc.ch/site/assets/uploads/2018/02/ipcc_wg3_ar5_annex-iii.pdf#page=7
   eGrid 2020:
     link: https://drive.google.com/file/d/1_FAAuTtIdMuORZKsqHnd9vMNHlQgYarh/view?usp=sharing
+  eGrid 2021:
+    link: ' https://drive.google.com/file/d/1_FAAuTtIdMuORZKsqHnd9vMNHlQgYarh/view?usp=sharing'
 timezone: US/Pacific

--- a/config/zones/US-NW-BPAT.yaml
+++ b/config/zones/US-NW-BPAT.yaml
@@ -54,17 +54,26 @@ emissionFactors:
         source: Electricity Maps, 2021 average
         value: 64.16281498516693
     biomass:
-      datetime: '2020-01-01'
-      source: eGrid 2020
-      value: 0.0
+      - datetime: '2020-01-01'
+        source: eGrid 2020
+        value: 0.0
+      - datetime: '2021-01-01'
+        source: eGrid 2021
+        value: 0.0
     coal:
-      datetime: '2020-01-01'
-      source: eGrid 2020
-      value: 1134.898924
+      - datetime: '2020-01-01'
+        source: eGrid 2020
+        value: 1134.898924
+      - datetime: '2021-01-01'
+        source: eGrid 2021
+        value: 1118.44
     gas:
-      datetime: '2020-01-01'
-      source: eGrid 2020
-      value: 394.4247594
+      - datetime: '2020-01-01'
+        source: eGrid 2020
+        value: 394.4247594
+      - datetime: '2021-01-01'
+        source: eGrid 2021
+        value: 385.5
     geothermal:
       datetime: '2020-01-01'
       source: eGrid 2020
@@ -115,17 +124,26 @@ emissionFactors:
         source: Electricity Maps, 2021 average
         value: 94.64933322719386
     biomass:
-      datetime: '2020-01-01'
-      source: eGrid 2020
-      value: 85.91723542
+      - datetime: '2020-01-01'
+        source: eGrid 2020
+        value: 85.91723542
+      - datetime: '2021-01-01'
+        source: eGrid 2021; eGrid 2021
+        value: 277.252
     coal:
-      datetime: '2020-01-01'
-      source: eGrid 2020; IPCC 2014
-      value: 1194.898924
+      - datetime: '2020-01-01'
+        source: eGrid 2020; IPCC 2014
+        value: 1194.898924
+      - datetime: '2021-01-01'
+        source: eGrid 2021; IPCC 2014
+        value: 1178.44
     gas:
-      datetime: '2020-01-01'
-      source: eGrid 2020; IPCC 2014
-      value: 514.4247594000001
+      - datetime: '2020-01-01'
+        source: eGrid 2020; IPCC 2014
+        value: 514.4247594000001
+      - datetime: '2021-01-01'
+        source: eGrid 2021; IPCC 2014
+        value: 505.5
     geothermal:
       datetime: '2020-01-01'
       source: eGrid 2020; IPCC 2014
@@ -219,4 +237,6 @@ sources:
     link: https://www.ipcc.ch/site/assets/uploads/2018/02/ipcc_wg3_ar5_annex-iii.pdf#page=7
   eGrid 2020:
     link: https://drive.google.com/file/d/1_FAAuTtIdMuORZKsqHnd9vMNHlQgYarh/view?usp=sharing
+  eGrid 2021:
+    link: ' https://drive.google.com/file/d/1_FAAuTtIdMuORZKsqHnd9vMNHlQgYarh/view?usp=sharing'
 timezone: US/Pacific

--- a/config/zones/US-NW-BPAT.yaml
+++ b/config/zones/US-NW-BPAT.yaml
@@ -62,11 +62,11 @@ emissionFactors:
       source: eGrid 2020
       value: 1134.898924
     gas:
-      datetime: '2021-01-01'
+      datetime: '2020-01-01'
       source: eGrid 2020
       value: 394.4247594
     geothermal:
-      datetime: '2021-01-01'
+      datetime: '2020-01-01'
       source: eGrid 2020
       value: 0.0
     hydro discharge:
@@ -123,11 +123,11 @@ emissionFactors:
       source: eGrid 2020; IPCC 2014
       value: 1194.898924
     gas:
-      datetime: '2021-01-01'
+      datetime: '2020-01-01'
       source: eGrid 2020; IPCC 2014
       value: 514.4247594000001
     geothermal:
-      datetime: '2021-01-01'
+      datetime: '2020-01-01'
       source: eGrid 2020; IPCC 2014
       value: 38.0
     hydro discharge:

--- a/config/zones/US-NW-GRID.yaml
+++ b/config/zones/US-NW-GRID.yaml
@@ -49,7 +49,7 @@ emissionFactors:
         source: Electricity Maps, 2021 average
         value: 450.83303127459374
     gas:
-      datetime: '2021-01-01'
+      datetime: '2020-01-01'
       source: eGrid 2020
       value: 395.5270557
     hydro discharge:
@@ -102,7 +102,7 @@ emissionFactors:
       source: IPCC 2014
       value: 820.0
     gas:
-      datetime: '2021-01-01'
+      datetime: '2020-01-01'
       source: eGrid 2020; IPCC 2014
       value: 515.5270557
     hydro discharge:

--- a/config/zones/US-NW-GRID.yaml
+++ b/config/zones/US-NW-GRID.yaml
@@ -49,9 +49,12 @@ emissionFactors:
         source: Electricity Maps, 2021 average
         value: 450.83303127459374
     gas:
-      datetime: '2020-01-01'
-      source: eGrid 2020
-      value: 395.5270557
+      - datetime: '2020-01-01'
+        source: eGrid 2020
+        value: 395.5270557
+      - datetime: '2021-01-01'
+        source: eGrid 2021
+        value: 394.79
     hydro discharge:
       - datetime: '2015-01-01'
         source: Electricity Maps, 2015 average
@@ -102,9 +105,12 @@ emissionFactors:
       source: IPCC 2014
       value: 820.0
     gas:
-      datetime: '2020-01-01'
-      source: eGrid 2020; IPCC 2014
-      value: 515.5270557
+      - datetime: '2020-01-01'
+        source: eGrid 2020; IPCC 2014
+        value: 515.5270557
+      - datetime: '2021-01-01'
+        source: eGrid 2021; IPCC 2014
+        value: 514.79
     hydro discharge:
       - datetime: '2015-01-01'
         source: Electricity Maps, 2015 average
@@ -246,4 +252,6 @@ sources:
     link: https://www.ipcc.ch/site/assets/uploads/2018/02/ipcc_wg3_ar5_annex-iii.pdf#page=7
   eGrid 2020:
     link: https://drive.google.com/file/d/1_FAAuTtIdMuORZKsqHnd9vMNHlQgYarh/view?usp=sharing
+  eGrid 2021:
+    link: ' https://drive.google.com/file/d/1_FAAuTtIdMuORZKsqHnd9vMNHlQgYarh/view?usp=sharing'
 timezone: US/Pacific

--- a/config/zones/US-NW-IPCO.yaml
+++ b/config/zones/US-NW-IPCO.yaml
@@ -52,13 +52,19 @@ emissionFactors:
         source: Electricity Maps, 2021 average
         value: 318.13419884686334
     gas:
-      datetime: '2020-01-01'
-      source: eGrid 2020
-      value: 434.3409586
+      - datetime: '2020-01-01'
+        source: eGrid 2020
+        value: 434.3409586
+      - datetime: '2021-01-01'
+        source: eGrid 2021
+        value: 441.21
     geothermal:
-      datetime: '2020-01-01'
-      source: eGrid 2020
-      value: 0.0
+      - datetime: '2020-01-01'
+        source: eGrid 2020
+        value: 0.0
+      - datetime: '2021-01-01'
+        source: eGrid 2021
+        value: 0.0
     hydro discharge:
       - datetime: '2015-01-01'
         source: Electricity Maps, 2015 average
@@ -109,13 +115,19 @@ emissionFactors:
       source: IPCC 2014
       value: 820.0
     gas:
-      datetime: '2020-01-01'
-      source: eGrid 2020; IPCC 2014
-      value: 554.3409586
+      - datetime: '2020-01-01'
+        source: eGrid 2020; IPCC 2014
+        value: 554.3409586
+      - datetime: '2021-01-01'
+        source: eGrid 2021; IPCC 2014
+        value: 561.21
     geothermal:
-      datetime: '2020-01-01'
-      source: eGrid 2020; IPCC 2014
-      value: 38.0
+      - datetime: '2020-01-01'
+        source: eGrid 2020; IPCC 2014
+        value: 38.0
+      - datetime: '2021-01-01'
+        source: eGrid 2021; IPCC 2014
+        value: 38.0
     hydro discharge:
       - datetime: '2015-01-01'
         source: Electricity Maps, 2015 average
@@ -265,4 +277,6 @@ sources:
     link: https://www.ipcc.ch/site/assets/uploads/2018/02/ipcc_wg3_ar5_annex-iii.pdf#page=7
   eGrid 2020:
     link: https://drive.google.com/file/d/1_FAAuTtIdMuORZKsqHnd9vMNHlQgYarh/view?usp=sharing
+  eGrid 2021:
+    link: ' https://drive.google.com/file/d/1_FAAuTtIdMuORZKsqHnd9vMNHlQgYarh/view?usp=sharing'
 timezone: US/Mountain

--- a/config/zones/US-NW-IPCO.yaml
+++ b/config/zones/US-NW-IPCO.yaml
@@ -52,11 +52,11 @@ emissionFactors:
         source: Electricity Maps, 2021 average
         value: 318.13419884686334
     gas:
-      datetime: '2021-01-01'
+      datetime: '2020-01-01'
       source: eGrid 2020
       value: 434.3409586
     geothermal:
-      datetime: '2021-01-01'
+      datetime: '2020-01-01'
       source: eGrid 2020
       value: 0.0
     hydro discharge:
@@ -109,11 +109,11 @@ emissionFactors:
       source: IPCC 2014
       value: 820.0
     gas:
-      datetime: '2021-01-01'
+      datetime: '2020-01-01'
       source: eGrid 2020; IPCC 2014
       value: 554.3409586
     geothermal:
-      datetime: '2021-01-01'
+      datetime: '2020-01-01'
       source: eGrid 2020; IPCC 2014
       value: 38.0
     hydro discharge:

--- a/config/zones/US-NW-NEVP.yaml
+++ b/config/zones/US-NW-NEVP.yaml
@@ -56,11 +56,11 @@ emissionFactors:
       source: eGrid 2020
       value: 1092.399419
     gas:
-      datetime: '2021-01-01'
+      datetime: '2020-01-01'
       source: eGrid 2020
       value: 405.9274374
     geothermal:
-      datetime: '2021-01-01'
+      datetime: '2020-01-01'
       source: eGrid 2020
       value: 14.37975781
     hydro discharge:
@@ -114,11 +114,11 @@ emissionFactors:
         of coal power generation."
       value: 1179.761649
     gas:
-      datetime: '2021-01-01'
+      datetime: '2020-01-01'
       source: eGrid 2020; IPCC 2014
       value: 525.9274373999999
     geothermal:
-      datetime: '2021-01-01'
+      datetime: '2020-01-01'
       source: eGrid 2020; IPCC 2014
       value: 52.37975781
     hydro discharge:

--- a/config/zones/US-NW-NEVP.yaml
+++ b/config/zones/US-NW-NEVP.yaml
@@ -52,17 +52,26 @@ emissionFactors:
         source: Electricity Maps, 2021 average
         value: 419.24523870046954
     coal:
-      datetime: '2020-01-01'
-      source: eGrid 2020
-      value: 1092.399419
+      - datetime: '2020-01-01'
+        source: eGrid 2020
+        value: 1092.399419
+      - datetime: '2021-01-01'
+        source: eGrid 2021
+        value: 1092.63
     gas:
-      datetime: '2020-01-01'
-      source: eGrid 2020
-      value: 405.9274374
+      - datetime: '2020-01-01'
+        source: eGrid 2020
+        value: 405.9274374
+      - datetime: '2021-01-01'
+        source: eGrid 2021
+        value: 399.5
     geothermal:
-      datetime: '2020-01-01'
-      source: eGrid 2020
-      value: 14.37975781
+      - datetime: '2020-01-01'
+        source: eGrid 2020
+        value: 14.37975781
+      - datetime: '2021-01-01'
+        source: eGrid 2021
+        value: 3.43
     hydro discharge:
       - datetime: '2015-01-01'
         source: Electricity Maps, 2015 average
@@ -109,18 +118,28 @@ emissionFactors:
         source: Electricity Maps, 2021 average
         value: 508.9334157047475
     coal:
-      datetime: '2020-01-01'
-      source: eGrid 2020; Oberschelp, Christopher, et al. "Global emission hotspots
-        of coal power generation."
-      value: 1179.761649
+      - datetime: '2020-01-01'
+        source: eGrid 2020; Oberschelp, Christopher, et al. "Global emission hotspots
+          of coal power generation."
+        value: 1179.761649
+      - datetime: '2021-01-01'
+        source: eGrid 2021; Oberschelp, Christopher, et al. "Global emission hotspots
+          of coal power generation."
+        value: 1179.99223
     gas:
-      datetime: '2020-01-01'
-      source: eGrid 2020; IPCC 2014
-      value: 525.9274373999999
+      - datetime: '2020-01-01'
+        source: eGrid 2020; IPCC 2014
+        value: 525.9274373999999
+      - datetime: '2021-01-01'
+        source: eGrid 2021; IPCC 2014
+        value: 519.5
     geothermal:
-      datetime: '2020-01-01'
-      source: eGrid 2020; IPCC 2014
-      value: 52.37975781
+      - datetime: '2020-01-01'
+        source: eGrid 2020; IPCC 2014
+        value: 52.37975781
+      - datetime: '2021-01-01'
+        source: eGrid 2021; IPCC 2014
+        value: 41.43
     hydro discharge:
       - datetime: '2015-01-01'
         source: Electricity Maps, 2015 average
@@ -270,4 +289,6 @@ sources:
     link: https://www.ipcc.ch/site/assets/uploads/2018/02/ipcc_wg3_ar5_annex-iii.pdf#page=7
   eGrid 2020:
     link: https://drive.google.com/file/d/1_FAAuTtIdMuORZKsqHnd9vMNHlQgYarh/view?usp=sharing
+  eGrid 2021:
+    link: ' https://drive.google.com/file/d/1_FAAuTtIdMuORZKsqHnd9vMNHlQgYarh/view?usp=sharing'
 timezone: US/Pacific

--- a/config/zones/US-NW-NWMT.yaml
+++ b/config/zones/US-NW-NWMT.yaml
@@ -58,7 +58,7 @@ emissionFactors:
       source: eGrid 2020
       value: 1063.960044
     gas:
-      datetime: '2021-01-01'
+      datetime: '2020-01-01'
       source: eGrid 2020
       value: 655.0343565
     hydro discharge:
@@ -84,7 +84,7 @@ emissionFactors:
         source: Electricity Maps, 2021 average
         value: 669.0966947315127
     oil:
-      datetime: '2021-01-01'
+      datetime: '2020-01-01'
       source: eGrid 2020
       value: 825.7991359
   lifecycle:
@@ -116,7 +116,7 @@ emissionFactors:
         of coal power generation."
       value: 1070.1093959999998
     gas:
-      datetime: '2021-01-01'
+      datetime: '2020-01-01'
       source: eGrid 2020; IPCC 2014
       value: 775.0343565
     hydro discharge:
@@ -142,7 +142,7 @@ emissionFactors:
         source: Electricity Maps, 2021 average
         value: 690.0368231558688
     oil:
-      datetime: '2021-01-01'
+      datetime: '2020-01-01'
       source: eGrid 2020; IPCC 2014
       value: 1069.7991359
 fallbackZoneMixes:

--- a/config/zones/US-NW-NWMT.yaml
+++ b/config/zones/US-NW-NWMT.yaml
@@ -54,13 +54,19 @@ emissionFactors:
         source: Electricity Maps, 2021 average
         value: 669.0966947315127
     coal:
-      datetime: '2020-01-01'
-      source: eGrid 2020
-      value: 1063.960044
+      - datetime: '2020-01-01'
+        source: eGrid 2020
+        value: 1063.960044
+      - datetime: '2021-01-01'
+        source: eGrid 2021
+        value: 1031.11
     gas:
-      datetime: '2020-01-01'
-      source: eGrid 2020
-      value: 655.0343565
+      - datetime: '2020-01-01'
+        source: eGrid 2020
+        value: 655.0343565
+      - datetime: '2021-01-01'
+        source: eGrid 2021
+        value: 603.28
     hydro discharge:
       - datetime: '2015-01-01'
         source: Electricity Maps, 2015 average
@@ -84,9 +90,12 @@ emissionFactors:
         source: Electricity Maps, 2021 average
         value: 669.0966947315127
     oil:
-      datetime: '2020-01-01'
-      source: eGrid 2020
-      value: 825.7991359
+      - datetime: '2020-01-01'
+        source: eGrid 2020
+        value: 825.7991359
+      - datetime: '2021-01-01'
+        source: eGrid 2021
+        value: 830.05
   lifecycle:
     battery discharge:
       - datetime: '2015-01-01'
@@ -111,14 +120,21 @@ emissionFactors:
         source: Electricity Maps, 2021 average
         value: 690.0368231558688
     coal:
-      datetime: '2020-01-01'
-      source: eGrid 2020; Oberschelp, Christopher, et al. "Global emission hotspots
-        of coal power generation."
-      value: 1070.1093959999998
+      - datetime: '2020-01-01'
+        source: eGrid 2020; Oberschelp, Christopher, et al. "Global emission hotspots
+          of coal power generation."
+        value: 1070.1093959999998
+      - datetime: '2021-01-01'
+        source: eGrid 2021; Oberschelp, Christopher, et al. "Global emission hotspots
+          of coal power generation."
+        value: 1037.2593519999998
     gas:
-      datetime: '2020-01-01'
-      source: eGrid 2020; IPCC 2014
-      value: 775.0343565
+      - datetime: '2020-01-01'
+        source: eGrid 2020; IPCC 2014
+        value: 775.0343565
+      - datetime: '2021-01-01'
+        source: eGrid 2021; IPCC 2014
+        value: 723.28
     hydro discharge:
       - datetime: '2015-01-01'
         source: Electricity Maps, 2015 average
@@ -142,9 +158,12 @@ emissionFactors:
         source: Electricity Maps, 2021 average
         value: 690.0368231558688
     oil:
-      datetime: '2020-01-01'
-      source: eGrid 2020; IPCC 2014
-      value: 1069.7991359
+      - datetime: '2020-01-01'
+        source: eGrid 2020; IPCC 2014
+        value: 1069.7991359
+      - datetime: '2021-01-01'
+        source: eGrid 2021; IPCC 2014
+        value: 1074.05
 fallbackZoneMixes:
   powerOriginRatios:
     - _source: Electricity Maps, 2015 average
@@ -262,4 +281,6 @@ sources:
     link: https://www.ipcc.ch/site/assets/uploads/2018/02/ipcc_wg3_ar5_annex-iii.pdf#page=7
   eGrid 2020:
     link: https://drive.google.com/file/d/1_FAAuTtIdMuORZKsqHnd9vMNHlQgYarh/view?usp=sharing
+  eGrid 2021:
+    link: ' https://drive.google.com/file/d/1_FAAuTtIdMuORZKsqHnd9vMNHlQgYarh/view?usp=sharing'
 timezone: US/Mountain

--- a/config/zones/US-NW-PACE.yaml
+++ b/config/zones/US-NW-PACE.yaml
@@ -54,17 +54,26 @@ emissionFactors:
         source: Electricity Maps, 2021 average
         value: 592.4944239287973
     coal:
-      datetime: '2020-01-01'
-      source: eGrid 2020
-      value: 1048.49561
+      - datetime: '2020-01-01'
+        source: eGrid 2020
+        value: 1048.49561
+      - datetime: '2021-01-01'
+        source: eGrid 2021
+        value: 1038.3
     gas:
-      datetime: '2020-01-01'
-      source: eGrid 2020
-      value: 405.722707
+      - datetime: '2020-01-01'
+        source: eGrid 2020
+        value: 405.722707
+      - datetime: '2021-01-01'
+        source: eGrid 2021
+        value: 404.2
     geothermal:
-      datetime: '2020-01-01'
-      source: eGrid 2020
-      value: 32.63419569
+      - datetime: '2020-01-01'
+        source: eGrid 2020
+        value: 32.63419569
+      - datetime: '2021-01-01'
+        source: eGrid 2021
+        value: 61.08
     hydro discharge:
       - datetime: '2015-01-01'
         source: Electricity Maps, 2015 average
@@ -111,18 +120,28 @@ emissionFactors:
         source: Electricity Maps, 2021 average
         value: 639.8317920706698
     coal:
-      datetime: '2020-01-01'
-      source: eGrid 2020; Oberschelp, Christopher, et al. "Global emission hotspots
-        of coal power generation."
-      value: 1107.353715
+      - datetime: '2020-01-01'
+        source: eGrid 2020; Oberschelp, Christopher, et al. "Global emission hotspots
+          of coal power generation."
+        value: 1107.353715
+      - datetime: '2021-01-01'
+        source: eGrid 2021; Oberschelp, Christopher, et al. "Global emission hotspots
+          of coal power generation."
+        value: 1097.158105
     gas:
-      datetime: '2020-01-01'
-      source: eGrid 2020; IPCC 2014
-      value: 525.722707
+      - datetime: '2020-01-01'
+        source: eGrid 2020; IPCC 2014
+        value: 525.722707
+      - datetime: '2021-01-01'
+        source: eGrid 2021; IPCC 2014
+        value: 524.2
     geothermal:
-      datetime: '2020-01-01'
-      source: eGrid 2020; IPCC 2014
-      value: 70.63419569
+      - datetime: '2020-01-01'
+        source: eGrid 2020; IPCC 2014
+        value: 70.63419569
+      - datetime: '2021-01-01'
+        source: eGrid 2021; IPCC 2014
+        value: 99.08
     hydro discharge:
       - datetime: '2015-01-01'
         source: Electricity Maps, 2015 average
@@ -272,4 +291,6 @@ sources:
     link: https://www.ipcc.ch/site/assets/uploads/2018/02/ipcc_wg3_ar5_annex-iii.pdf#page=7
   eGrid 2020:
     link: https://drive.google.com/file/d/1_FAAuTtIdMuORZKsqHnd9vMNHlQgYarh/view?usp=sharing
+  eGrid 2021:
+    link: ' https://drive.google.com/file/d/1_FAAuTtIdMuORZKsqHnd9vMNHlQgYarh/view?usp=sharing'
 timezone: US/Mountain

--- a/config/zones/US-NW-PACE.yaml
+++ b/config/zones/US-NW-PACE.yaml
@@ -58,11 +58,11 @@ emissionFactors:
       source: eGrid 2020
       value: 1048.49561
     gas:
-      datetime: '2021-01-01'
+      datetime: '2020-01-01'
       source: eGrid 2020
       value: 405.722707
     geothermal:
-      datetime: '2021-01-01'
+      datetime: '2020-01-01'
       source: eGrid 2020
       value: 32.63419569
     hydro discharge:
@@ -116,11 +116,11 @@ emissionFactors:
         of coal power generation."
       value: 1107.353715
     gas:
-      datetime: '2021-01-01'
+      datetime: '2020-01-01'
       source: eGrid 2020; IPCC 2014
       value: 525.722707
     geothermal:
-      datetime: '2021-01-01'
+      datetime: '2020-01-01'
       source: eGrid 2020; IPCC 2014
       value: 70.63419569
     hydro discharge:

--- a/config/zones/US-NW-PACW.yaml
+++ b/config/zones/US-NW-PACW.yaml
@@ -56,7 +56,7 @@ emissionFactors:
       source: eGrid 2020
       value: 0.0
     gas:
-      datetime: '2021-01-01'
+      datetime: '2020-01-01'
       source: eGrid 2020
       value: 400.6744614
     hydro discharge:
@@ -114,7 +114,7 @@ emissionFactors:
         of coal power generation."
       value: 811.451201
     gas:
-      datetime: '2021-01-01'
+      datetime: '2020-01-01'
       source: eGrid 2020; IPCC 2014
       value: 520.6744613999999
     hydro discharge:

--- a/config/zones/US-NW-PACW.yaml
+++ b/config/zones/US-NW-PACW.yaml
@@ -52,13 +52,19 @@ emissionFactors:
         source: Electricity Maps, 2021 average
         value: 346.2845545248079
     biomass:
-      datetime: '2020-01-01'
-      source: eGrid 2020
-      value: 0.0
+      - datetime: '2020-01-01'
+        source: eGrid 2020
+        value: 0.0
+      - datetime: '2021-01-01'
+        source: eGrid 2021
+        value: 0.0
     gas:
-      datetime: '2020-01-01'
-      source: eGrid 2020
-      value: 400.6744614
+      - datetime: '2020-01-01'
+        source: eGrid 2020
+        value: 400.6744614
+      - datetime: '2021-01-01'
+        source: eGrid 2021
+        value: 404.13
     hydro discharge:
       - datetime: '2015-01-01'
         source: Electricity Maps, 2015 average
@@ -105,18 +111,24 @@ emissionFactors:
         source: Electricity Maps, 2021 average
         value: 319.9873165707287
     biomass:
-      datetime: '2020-01-01'
-      source: eGrid 2020
-      value: 29.16184216
+      - datetime: '2020-01-01'
+        source: eGrid 2020
+        value: 29.16184216
+      - datetime: '2021-01-01'
+        source: eGrid 2021; eGrid 2021
+        value: 277.252
     coal:
       datetime: '2012-01-01'
       source: IPCC 2014; Oberschelp, Christopher, et al. "Global emission hotspots
         of coal power generation."
       value: 811.451201
     gas:
-      datetime: '2020-01-01'
-      source: eGrid 2020; IPCC 2014
-      value: 520.6744613999999
+      - datetime: '2020-01-01'
+        source: eGrid 2020; IPCC 2014
+        value: 520.6744613999999
+      - datetime: '2021-01-01'
+        source: eGrid 2021; IPCC 2014
+        value: 524.13
     hydro discharge:
       - datetime: '2015-01-01'
         source: Electricity Maps, 2015 average
@@ -206,4 +218,6 @@ sources:
     link: https://www.ipcc.ch/site/assets/uploads/2018/02/ipcc_wg3_ar5_annex-iii.pdf#page=7
   eGrid 2020:
     link: https://drive.google.com/file/d/1_FAAuTtIdMuORZKsqHnd9vMNHlQgYarh/view?usp=sharing
+  eGrid 2021:
+    link: ' https://drive.google.com/file/d/1_FAAuTtIdMuORZKsqHnd9vMNHlQgYarh/view?usp=sharing'
 timezone: US/Pacific

--- a/config/zones/US-NW-PGE.yaml
+++ b/config/zones/US-NW-PGE.yaml
@@ -56,9 +56,12 @@ emissionFactors:
       source: eGrid 2020
       value: 1040.946037
     gas:
-      datetime: '2020-01-01'
-      source: eGrid 2020
-      value: 465.3652195
+      - datetime: '2020-01-01'
+        source: eGrid 2020
+        value: 465.3652195
+      - datetime: '2021-01-01'
+        source: eGrid 2021
+        value: 453.77
     hydro discharge:
       - datetime: '2015-01-01'
         source: Electricity Maps, 2015 average
@@ -109,9 +112,12 @@ emissionFactors:
       source: eGrid 2020; IPCC 2014
       value: 1100.946037
     gas:
-      datetime: '2020-01-01'
-      source: eGrid 2020; IPCC 2014
-      value: 585.3652195
+      - datetime: '2020-01-01'
+        source: eGrid 2020; IPCC 2014
+        value: 585.3652195
+      - datetime: '2021-01-01'
+        source: eGrid 2021; IPCC 2014
+        value: 573.77
     hydro discharge:
       - datetime: '2015-01-01'
         source: Electricity Maps, 2015 average
@@ -201,4 +207,6 @@ sources:
     link: https://www.ipcc.ch/site/assets/uploads/2018/02/ipcc_wg3_ar5_annex-iii.pdf#page=7
   eGrid 2020:
     link: https://drive.google.com/file/d/1_FAAuTtIdMuORZKsqHnd9vMNHlQgYarh/view?usp=sharing
+  eGrid 2021:
+    link: ' https://drive.google.com/file/d/1_FAAuTtIdMuORZKsqHnd9vMNHlQgYarh/view?usp=sharing'
 timezone: US/Pacific

--- a/config/zones/US-NW-PGE.yaml
+++ b/config/zones/US-NW-PGE.yaml
@@ -56,7 +56,7 @@ emissionFactors:
       source: eGrid 2020
       value: 1040.946037
     gas:
-      datetime: '2021-01-01'
+      datetime: '2020-01-01'
       source: eGrid 2020
       value: 465.3652195
     hydro discharge:
@@ -109,7 +109,7 @@ emissionFactors:
       source: eGrid 2020; IPCC 2014
       value: 1100.946037
     gas:
-      datetime: '2021-01-01'
+      datetime: '2020-01-01'
       source: eGrid 2020; IPCC 2014
       value: 585.3652195
     hydro discharge:

--- a/config/zones/US-NW-PSCO.yaml
+++ b/config/zones/US-NW-PSCO.yaml
@@ -56,7 +56,7 @@ emissionFactors:
       source: eGrid 2020
       value: 1078.74216
     gas:
-      datetime: '2021-01-01'
+      datetime: '2020-01-01'
       source: eGrid 2020
       value: 480.4971119
     hydro discharge:
@@ -110,7 +110,7 @@ emissionFactors:
         of coal power generation."
       value: 1117.644366
     gas:
-      datetime: '2021-01-01'
+      datetime: '2020-01-01'
       source: eGrid 2020; IPCC 2014
       value: 600.4971118999999
     hydro discharge:

--- a/config/zones/US-NW-PSCO.yaml
+++ b/config/zones/US-NW-PSCO.yaml
@@ -52,13 +52,19 @@ emissionFactors:
         source: Electricity Maps, 2021 average
         value: 563.0295272027809
     coal:
-      datetime: '2020-01-01'
-      source: eGrid 2020
-      value: 1078.74216
+      - datetime: '2020-01-01'
+        source: eGrid 2020
+        value: 1078.74216
+      - datetime: '2021-01-01'
+        source: eGrid 2021
+        value: 1052.62
     gas:
-      datetime: '2020-01-01'
-      source: eGrid 2020
-      value: 480.4971119
+      - datetime: '2020-01-01'
+        source: eGrid 2020
+        value: 480.4971119
+      - datetime: '2021-01-01'
+        source: eGrid 2021
+        value: 469.0
     hydro discharge:
       - datetime: '2015-01-01'
         source: Electricity Maps, 2015 average
@@ -105,14 +111,21 @@ emissionFactors:
         source: Electricity Maps, 2021 average
         value: 613.7060455510662
     coal:
-      datetime: '2020-01-01'
-      source: eGrid 2020; Oberschelp, Christopher, et al. "Global emission hotspots
-        of coal power generation."
-      value: 1117.644366
+      - datetime: '2020-01-01'
+        source: eGrid 2020; Oberschelp, Christopher, et al. "Global emission hotspots
+          of coal power generation."
+        value: 1117.644366
+      - datetime: '2021-01-01'
+        source: eGrid 2021; Oberschelp, Christopher, et al. "Global emission hotspots
+          of coal power generation."
+        value: 1091.5222059999999
     gas:
-      datetime: '2020-01-01'
-      source: eGrid 2020; IPCC 2014
-      value: 600.4971118999999
+      - datetime: '2020-01-01'
+        source: eGrid 2020; IPCC 2014
+        value: 600.4971118999999
+      - datetime: '2021-01-01'
+        source: eGrid 2021; IPCC 2014
+        value: 589.0
     hydro discharge:
       - datetime: '2015-01-01'
         source: Electricity Maps, 2015 average
@@ -262,4 +275,6 @@ sources:
     link: https://www.ipcc.ch/site/assets/uploads/2018/02/ipcc_wg3_ar5_annex-iii.pdf#page=7
   eGrid 2020:
     link: https://drive.google.com/file/d/1_FAAuTtIdMuORZKsqHnd9vMNHlQgYarh/view?usp=sharing
+  eGrid 2021:
+    link: ' https://drive.google.com/file/d/1_FAAuTtIdMuORZKsqHnd9vMNHlQgYarh/view?usp=sharing'
 timezone: US/Mountain

--- a/config/zones/US-NW-PSEI.yaml
+++ b/config/zones/US-NW-PSEI.yaml
@@ -56,7 +56,7 @@ emissionFactors:
       source: eGrid 2020
       value: 0.0
     gas:
-      datetime: '2021-01-01'
+      datetime: '2020-01-01'
       source: eGrid 2020
       value: 325.3877204
     hydro discharge:
@@ -113,7 +113,7 @@ emissionFactors:
       source: IPCC 2014
       value: 820.0
     gas:
-      datetime: '2021-01-01'
+      datetime: '2020-01-01'
       source: eGrid 2020; IPCC 2014
       value: 445.3877204
     hydro discharge:

--- a/config/zones/US-NW-PSEI.yaml
+++ b/config/zones/US-NW-PSEI.yaml
@@ -52,13 +52,19 @@ emissionFactors:
         source: Electricity Maps, 2021 average
         value: 99.29246149171
     biomass:
-      datetime: '2020-01-01'
-      source: eGrid 2020
-      value: 0.0
+      - datetime: '2020-01-01'
+        source: eGrid 2020
+        value: 0.0
+      - datetime: '2021-01-01'
+        source: eGrid 2021
+        value: 0.0
     gas:
-      datetime: '2020-01-01'
-      source: eGrid 2020
-      value: 325.3877204
+      - datetime: '2020-01-01'
+        source: eGrid 2020
+        value: 325.3877204
+      - datetime: '2021-01-01'
+        source: eGrid 2021
+        value: 388.9
     hydro discharge:
       - datetime: '2015-01-01'
         source: Electricity Maps, 2015 average
@@ -105,17 +111,23 @@ emissionFactors:
         source: Electricity Maps, 2021 average
         value: 142.05787012026707
     biomass:
-      datetime: '2020-01-01'
-      source: eGrid 2020
-      value: 11.13357253
+      - datetime: '2020-01-01'
+        source: eGrid 2020
+        value: 11.13357253
+      - datetime: '2021-01-01'
+        source: eGrid 2021; eGrid 2021
+        value: 277.252
     coal:
       datetime: '2014-01-01'
       source: IPCC 2014
       value: 820.0
     gas:
-      datetime: '2020-01-01'
-      source: eGrid 2020; IPCC 2014
-      value: 445.3877204
+      - datetime: '2020-01-01'
+        source: eGrid 2020; IPCC 2014
+        value: 445.3877204
+      - datetime: '2021-01-01'
+        source: eGrid 2021; IPCC 2014
+        value: 508.9
     hydro discharge:
       - datetime: '2015-01-01'
         source: Electricity Maps, 2015 average
@@ -199,4 +211,6 @@ sources:
     link: https://www.ipcc.ch/site/assets/uploads/2018/02/ipcc_wg3_ar5_annex-iii.pdf#page=7
   eGrid 2020:
     link: https://drive.google.com/file/d/1_FAAuTtIdMuORZKsqHnd9vMNHlQgYarh/view?usp=sharing
+  eGrid 2021:
+    link: ' https://drive.google.com/file/d/1_FAAuTtIdMuORZKsqHnd9vMNHlQgYarh/view?usp=sharing'
 timezone: US/Pacific

--- a/config/zones/US-NW-TPWR.yaml
+++ b/config/zones/US-NW-TPWR.yaml
@@ -52,9 +52,12 @@ emissionFactors:
         source: Electricity Maps, 2021 average
         value: 36.76361635161157
     biomass:
-      datetime: '2020-01-01'
-      source: eGrid 2020
-      value: 0.0
+      - datetime: '2020-01-01'
+        source: eGrid 2020
+        value: 0.0
+      - datetime: '2021-01-01'
+        source: eGrid 2021
+        value: 0.0
     hydro discharge:
       - datetime: '2015-01-01'
         source: Electricity Maps, 2015 average
@@ -101,9 +104,12 @@ emissionFactors:
         source: Electricity Maps, 2021 average
         value: 64.29134040496706
     biomass:
-      datetime: '2020-01-01'
-      source: eGrid 2020
-      value: 25.02597585
+      - datetime: '2020-01-01'
+        source: eGrid 2020
+        value: 25.02597585
+      - datetime: '2021-01-01'
+        source: eGrid 2021; eGrid 2021
+        value: 277.252
     coal:
       datetime: '2012-01-01'
       source: IPCC 2014; Oberschelp, Christopher, et al. "Global emission hotspots
@@ -196,4 +202,6 @@ sources:
     link: https://www.ipcc.ch/site/assets/uploads/2018/02/ipcc_wg3_ar5_annex-iii.pdf#page=7
   eGrid 2020:
     link: https://drive.google.com/file/d/1_FAAuTtIdMuORZKsqHnd9vMNHlQgYarh/view?usp=sharing
+  eGrid 2021:
+    link: ' https://drive.google.com/file/d/1_FAAuTtIdMuORZKsqHnd9vMNHlQgYarh/view?usp=sharing'
 timezone: US/Pacific

--- a/config/zones/US-NW-WACM.yaml
+++ b/config/zones/US-NW-WACM.yaml
@@ -52,13 +52,19 @@ emissionFactors:
         source: Electricity Maps, 2021 average
         value: 745.1015602237039
     coal:
-      datetime: '2020-01-01'
-      source: eGrid 2020
-      value: 1107.615308
+      - datetime: '2020-01-01'
+        source: eGrid 2020
+        value: 1107.615308
+      - datetime: '2021-01-01'
+        source: eGrid 2021
+        value: 1076.43
     gas:
-      datetime: '2020-01-01'
-      source: eGrid 2020
-      value: 451.7150314
+      - datetime: '2020-01-01'
+        source: eGrid 2020
+        value: 451.7150314
+      - datetime: '2021-01-01'
+        source: eGrid 2021
+        value: 521.13
     hydro discharge:
       - datetime: '2015-01-01'
         source: Electricity Maps, 2015 average
@@ -82,9 +88,12 @@ emissionFactors:
         source: Electricity Maps, 2021 average
         value: 745.1015602237039
     oil:
-      datetime: '2020-01-01'
-      source: eGrid 2020
-      value: 953.0188558
+      - datetime: '2020-01-01'
+        source: eGrid 2020
+        value: 953.0188558
+      - datetime: '2021-01-01'
+        source: eGrid 2021
+        value: 938.88
   lifecycle:
     battery discharge:
       - datetime: '2015-01-01'
@@ -109,14 +118,21 @@ emissionFactors:
         source: Electricity Maps, 2021 average
         value: 766.9391259296401
     coal:
-      datetime: '2020-01-01'
-      source: eGrid 2020; Oberschelp, Christopher, et al. "Global emission hotspots
-        of coal power generation."
-      value: 1125.725068
+      - datetime: '2020-01-01'
+        source: eGrid 2020; Oberschelp, Christopher, et al. "Global emission hotspots
+          of coal power generation."
+        value: 1125.725068
+      - datetime: '2021-01-01'
+        source: eGrid 2021; Oberschelp, Christopher, et al. "Global emission hotspots
+          of coal power generation."
+        value: 1094.5397600000001
     gas:
-      datetime: '2020-01-01'
-      source: eGrid 2020; IPCC 2014
-      value: 571.7150314
+      - datetime: '2020-01-01'
+        source: eGrid 2020; IPCC 2014
+        value: 571.7150314
+      - datetime: '2021-01-01'
+        source: eGrid 2021; IPCC 2014
+        value: 641.13
     hydro discharge:
       - datetime: '2015-01-01'
         source: Electricity Maps, 2015 average
@@ -140,9 +156,12 @@ emissionFactors:
         source: Electricity Maps, 2021 average
         value: 766.9391259296401
     oil:
-      datetime: '2020-01-01'
-      source: eGrid 2020; IPCC 2014
-      value: 1197.0188558
+      - datetime: '2020-01-01'
+        source: eGrid 2020; IPCC 2014
+        value: 1197.0188558
+      - datetime: '2021-01-01'
+        source: eGrid 2021; IPCC 2014
+        value: 1182.88
     solar:
       datetime: '2021-01-01'
       source: INCER ACV
@@ -266,4 +285,6 @@ sources:
     link: https://www.ipcc.ch/site/assets/uploads/2018/02/ipcc_wg3_ar5_annex-iii.pdf#page=7
   eGrid 2020:
     link: https://drive.google.com/file/d/1_FAAuTtIdMuORZKsqHnd9vMNHlQgYarh/view?usp=sharing
+  eGrid 2021:
+    link: ' https://drive.google.com/file/d/1_FAAuTtIdMuORZKsqHnd9vMNHlQgYarh/view?usp=sharing'
 timezone: US/Mountain

--- a/config/zones/US-NW-WACM.yaml
+++ b/config/zones/US-NW-WACM.yaml
@@ -56,7 +56,7 @@ emissionFactors:
       source: eGrid 2020
       value: 1107.615308
     gas:
-      datetime: '2021-01-01'
+      datetime: '2020-01-01'
       source: eGrid 2020
       value: 451.7150314
     hydro discharge:
@@ -82,7 +82,7 @@ emissionFactors:
         source: Electricity Maps, 2021 average
         value: 745.1015602237039
     oil:
-      datetime: '2021-01-01'
+      datetime: '2020-01-01'
       source: eGrid 2020
       value: 953.0188558
   lifecycle:
@@ -114,7 +114,7 @@ emissionFactors:
         of coal power generation."
       value: 1125.725068
     gas:
-      datetime: '2021-01-01'
+      datetime: '2020-01-01'
       source: eGrid 2020; IPCC 2014
       value: 571.7150314
     hydro discharge:
@@ -140,7 +140,7 @@ emissionFactors:
         source: Electricity Maps, 2021 average
         value: 766.9391259296401
     oil:
-      datetime: '2021-01-01'
+      datetime: '2020-01-01'
       source: eGrid 2020; IPCC 2014
       value: 1197.0188558
     solar:

--- a/config/zones/US-NY-NYIS.yaml
+++ b/config/zones/US-NY-NYIS.yaml
@@ -55,7 +55,7 @@ emissionFactors:
       source: eGrid 2020
       value: 1095.578562
     gas:
-      datetime: '2021-01-01'
+      datetime: '2020-01-01'
       source: eGrid 2020
       value: 412.8877102
     hydro discharge:
@@ -81,7 +81,7 @@ emissionFactors:
         source: Electricity Maps, 2021 average
         value: 201.96505688874868
     oil:
-      datetime: '2021-01-01'
+      datetime: '2020-01-01'
       source: eGrid 2020
       value: 662.0576145
   lifecycle:
@@ -117,7 +117,7 @@ emissionFactors:
         of coal power generation."
       value: 1179.0563129999998
     gas:
-      datetime: '2021-01-01'
+      datetime: '2020-01-01'
       source: eGrid 2020; IPCC 2014
       value: 532.8877102
     hydro discharge:
@@ -143,7 +143,7 @@ emissionFactors:
         source: Electricity Maps, 2021 average
         value: 266.28720998594736
     oil:
-      datetime: '2021-01-01'
+      datetime: '2020-01-01'
       source: eGrid 2020; IPCC 2014
       value: 906.0576145
     solar:

--- a/config/zones/US-NY-NYIS.yaml
+++ b/config/zones/US-NY-NYIS.yaml
@@ -47,17 +47,23 @@ emissionFactors:
         source: Electricity Maps, 2021 average
         value: 201.96505688874868
     biomass:
-      datetime: '2020-01-01'
-      source: eGrid 2020
-      value: 0.0
+      - datetime: '2020-01-01'
+        source: eGrid 2020
+        value: 0.0
+      - datetime: '2021-01-01'
+        source: eGrid 2021
+        value: 0.0
     coal:
       datetime: '2020-01-01'
       source: eGrid 2020
       value: 1095.578562
     gas:
-      datetime: '2020-01-01'
-      source: eGrid 2020
-      value: 412.8877102
+      - datetime: '2020-01-01'
+        source: eGrid 2020
+        value: 412.8877102
+      - datetime: '2021-01-01'
+        source: eGrid 2021
+        value: 412.81
     hydro discharge:
       - datetime: '2015-01-01'
         source: Electricity Maps, 2015 average
@@ -81,9 +87,12 @@ emissionFactors:
         source: Electricity Maps, 2021 average
         value: 201.96505688874868
     oil:
-      datetime: '2020-01-01'
-      source: eGrid 2020
-      value: 662.0576145
+      - datetime: '2020-01-01'
+        source: eGrid 2020
+        value: 662.0576145
+      - datetime: '2021-01-01'
+        source: eGrid 2021
+        value: 503.5
   lifecycle:
     battery discharge:
       - datetime: '2015-01-01'
@@ -108,18 +117,24 @@ emissionFactors:
         source: Electricity Maps, 2021 average
         value: 266.28720998594736
     biomass:
-      datetime: '2020-01-01'
-      source: eGrid 2020
-      value: 667.6942738
+      - datetime: '2020-01-01'
+        source: eGrid 2020
+        value: 667.6942738
+      - datetime: '2021-01-01'
+        source: eGrid 2021; eGrid 2021
+        value: 277.252
     coal:
       datetime: '2020-01-01'
       source: eGrid 2020; Oberschelp, Christopher, et al. "Global emission hotspots
         of coal power generation."
       value: 1179.0563129999998
     gas:
-      datetime: '2020-01-01'
-      source: eGrid 2020; IPCC 2014
-      value: 532.8877102
+      - datetime: '2020-01-01'
+        source: eGrid 2020; IPCC 2014
+        value: 532.8877102
+      - datetime: '2021-01-01'
+        source: eGrid 2021; IPCC 2014
+        value: 532.81
     hydro discharge:
       - datetime: '2015-01-01'
         source: Electricity Maps, 2015 average
@@ -143,9 +158,12 @@ emissionFactors:
         source: Electricity Maps, 2021 average
         value: 266.28720998594736
     oil:
-      datetime: '2020-01-01'
-      source: eGrid 2020; IPCC 2014
-      value: 906.0576145
+      - datetime: '2020-01-01'
+        source: eGrid 2020; IPCC 2014
+        value: 906.0576145
+      - datetime: '2021-01-01'
+        source: eGrid 2021; IPCC 2014
+        value: 747.5
     solar:
       datetime: '2021-01-01'
       source: INCER ACV
@@ -269,4 +287,6 @@ sources:
     link: https://www.ipcc.ch/site/assets/uploads/2018/02/ipcc_wg3_ar5_annex-iii.pdf#page=7
   eGrid 2020:
     link: https://drive.google.com/file/d/1_FAAuTtIdMuORZKsqHnd9vMNHlQgYarh/view?usp=sharing
+  eGrid 2021:
+    link: ' https://drive.google.com/file/d/1_FAAuTtIdMuORZKsqHnd9vMNHlQgYarh/view?usp=sharing'
 timezone: US/Eastern

--- a/config/zones/US-SE-SOCO.yaml
+++ b/config/zones/US-SE-SOCO.yaml
@@ -61,7 +61,7 @@ emissionFactors:
       source: eGrid 2020
       value: 865.2241498
     gas:
-      datetime: '2021-01-01'
+      datetime: '2020-01-01'
       source: eGrid 2020
       value: 403.2500634
     hydro discharge:
@@ -87,7 +87,7 @@ emissionFactors:
         source: Electricity Maps, 2021 average
         value: 385.44064889984975
     oil:
-      datetime: '2021-01-01'
+      datetime: '2020-01-01'
       source: eGrid 2020
       value: 569.2843708
   lifecycle:
@@ -123,7 +123,7 @@ emissionFactors:
         of coal power generation."
       value: 943.0750138
     gas:
-      datetime: '2021-01-01'
+      datetime: '2020-01-01'
       source: eGrid 2020; IPCC 2014
       value: 523.2500634
     hydro discharge:
@@ -149,7 +149,7 @@ emissionFactors:
         source: Electricity Maps, 2021 average
         value: 466.40479434576497
     oil:
-      datetime: '2021-01-01'
+      datetime: '2020-01-01'
       source: eGrid 2020; IPCC 2014
       value: 813.2843708
     solar:

--- a/config/zones/US-SE-SOCO.yaml
+++ b/config/zones/US-SE-SOCO.yaml
@@ -53,17 +53,26 @@ emissionFactors:
         source: Electricity Maps, 2021 average
         value: 385.44064889984975
     biomass:
-      datetime: '2020-01-01'
-      source: eGrid 2020
-      value: 0.0
+      - datetime: '2020-01-01'
+        source: eGrid 2020
+        value: 0.0
+      - datetime: '2021-01-01'
+        source: eGrid 2021
+        value: 0.0
     coal:
-      datetime: '2020-01-01'
-      source: eGrid 2020
-      value: 865.2241498
+      - datetime: '2020-01-01'
+        source: eGrid 2020
+        value: 865.2241498
+      - datetime: '2021-01-01'
+        source: eGrid 2021
+        value: 872.69
     gas:
-      datetime: '2020-01-01'
-      source: eGrid 2020
-      value: 403.2500634
+      - datetime: '2020-01-01'
+        source: eGrid 2020
+        value: 403.2500634
+      - datetime: '2021-01-01'
+        source: eGrid 2021
+        value: 391.97
     hydro discharge:
       - datetime: '2015-01-01'
         source: Electricity Maps, 2015 average
@@ -87,9 +96,12 @@ emissionFactors:
         source: Electricity Maps, 2021 average
         value: 385.44064889984975
     oil:
-      datetime: '2020-01-01'
-      source: eGrid 2020
-      value: 569.2843708
+      - datetime: '2020-01-01'
+        source: eGrid 2020
+        value: 569.2843708
+      - datetime: '2021-01-01'
+        source: eGrid 2021
+        value: 554.57
   lifecycle:
     battery discharge:
       - datetime: '2015-01-01'
@@ -114,18 +126,28 @@ emissionFactors:
         source: Electricity Maps, 2021 average
         value: 466.40479434576497
     biomass:
-      datetime: '2020-01-01'
-      source: eGrid 2020
-      value: 72.20359898
+      - datetime: '2020-01-01'
+        source: eGrid 2020
+        value: 72.20359898
+      - datetime: '2021-01-01'
+        source: eGrid 2021; eGrid 2021
+        value: 277.252
     coal:
-      datetime: '2020-01-01'
-      source: eGrid 2020; Oberschelp, Christopher, et al. "Global emission hotspots
-        of coal power generation."
-      value: 943.0750138
+      - datetime: '2020-01-01'
+        source: eGrid 2020; Oberschelp, Christopher, et al. "Global emission hotspots
+          of coal power generation."
+        value: 943.0750138
+      - datetime: '2021-01-01'
+        source: eGrid 2021; Oberschelp, Christopher, et al. "Global emission hotspots
+          of coal power generation."
+        value: 950.540864
     gas:
-      datetime: '2020-01-01'
-      source: eGrid 2020; IPCC 2014
-      value: 523.2500634
+      - datetime: '2020-01-01'
+        source: eGrid 2020; IPCC 2014
+        value: 523.2500634
+      - datetime: '2021-01-01'
+        source: eGrid 2021; IPCC 2014
+        value: 511.97
     hydro discharge:
       - datetime: '2015-01-01'
         source: Electricity Maps, 2015 average
@@ -149,9 +171,12 @@ emissionFactors:
         source: Electricity Maps, 2021 average
         value: 466.40479434576497
     oil:
-      datetime: '2020-01-01'
-      source: eGrid 2020; IPCC 2014
-      value: 813.2843708
+      - datetime: '2020-01-01'
+        source: eGrid 2020; IPCC 2014
+        value: 813.2843708
+      - datetime: '2021-01-01'
+        source: eGrid 2021; IPCC 2014
+        value: 798.57
     solar:
       datetime: '2021-01-01'
       source: INCER ACV
@@ -275,4 +300,6 @@ sources:
     link: https://www.ipcc.ch/site/assets/uploads/2018/02/ipcc_wg3_ar5_annex-iii.pdf#page=7
   eGrid 2020:
     link: https://drive.google.com/file/d/1_FAAuTtIdMuORZKsqHnd9vMNHlQgYarh/view?usp=sharing
+  eGrid 2021:
+    link: ' https://drive.google.com/file/d/1_FAAuTtIdMuORZKsqHnd9vMNHlQgYarh/view?usp=sharing'
 timezone: US/Eastern

--- a/config/zones/US-SW-AZPS.yaml
+++ b/config/zones/US-SW-AZPS.yaml
@@ -52,17 +52,26 @@ emissionFactors:
         source: Electricity Maps, 2021 average
         value: 394.89508781910087
     biomass:
-      datetime: '2020-01-01'
-      source: eGrid 2020
-      value: 0.0
+      - datetime: '2020-01-01'
+        source: eGrid 2020
+        value: 0.0
+      - datetime: '2021-01-01'
+        source: eGrid 2021
+        value: 0.0
     coal:
-      datetime: '2020-01-01'
-      source: eGrid 2020
-      value: 1055.103824
+      - datetime: '2020-01-01'
+        source: eGrid 2020
+        value: 1055.103824
+      - datetime: '2021-01-01'
+        source: eGrid 2021
+        value: 1030.78
     gas:
-      datetime: '2020-01-01'
-      source: eGrid 2020
-      value: 371.3656203
+      - datetime: '2020-01-01'
+        source: eGrid 2020
+        value: 371.3656203
+      - datetime: '2021-01-01'
+        source: eGrid 2021
+        value: 362.66
     hydro discharge:
       - datetime: '2015-01-01'
         source: Electricity Maps, 2015 average
@@ -109,18 +118,28 @@ emissionFactors:
         source: Electricity Maps, 2021 average
         value: 455.61015068419204
     biomass:
-      datetime: '2020-01-01'
-      source: eGrid 2020
-      value: 34.52335329
+      - datetime: '2020-01-01'
+        source: eGrid 2020
+        value: 34.52335329
+      - datetime: '2021-01-01'
+        source: eGrid 2021; eGrid 2021
+        value: 277.252
     coal:
-      datetime: '2020-01-01'
-      source: eGrid 2020; Oberschelp, Christopher, et al. "Global emission hotspots
-        of coal power generation."
-      value: 1072.158303
+      - datetime: '2020-01-01'
+        source: eGrid 2020; Oberschelp, Christopher, et al. "Global emission hotspots
+          of coal power generation."
+        value: 1072.158303
+      - datetime: '2021-01-01'
+        source: eGrid 2021; Oberschelp, Christopher, et al. "Global emission hotspots
+          of coal power generation."
+        value: 1047.8344789999999
     gas:
-      datetime: '2020-01-01'
-      source: eGrid 2020; IPCC 2014
-      value: 491.3656203
+      - datetime: '2020-01-01'
+        source: eGrid 2020; IPCC 2014
+        value: 491.3656203
+      - datetime: '2021-01-01'
+        source: eGrid 2021; IPCC 2014
+        value: 482.66
     hydro discharge:
       - datetime: '2015-01-01'
         source: Electricity Maps, 2015 average
@@ -270,4 +289,6 @@ sources:
     link: https://www.ipcc.ch/site/assets/uploads/2018/02/ipcc_wg3_ar5_annex-iii.pdf#page=7
   eGrid 2020:
     link: https://drive.google.com/file/d/1_FAAuTtIdMuORZKsqHnd9vMNHlQgYarh/view?usp=sharing
+  eGrid 2021:
+    link: ' https://drive.google.com/file/d/1_FAAuTtIdMuORZKsqHnd9vMNHlQgYarh/view?usp=sharing'
 timezone: US/Arizona

--- a/config/zones/US-SW-AZPS.yaml
+++ b/config/zones/US-SW-AZPS.yaml
@@ -60,7 +60,7 @@ emissionFactors:
       source: eGrid 2020
       value: 1055.103824
     gas:
-      datetime: '2021-01-01'
+      datetime: '2020-01-01'
       source: eGrid 2020
       value: 371.3656203
     hydro discharge:
@@ -118,7 +118,7 @@ emissionFactors:
         of coal power generation."
       value: 1072.158303
     gas:
-      datetime: '2021-01-01'
+      datetime: '2020-01-01'
       source: eGrid 2020; IPCC 2014
       value: 491.3656203
     hydro discharge:

--- a/config/zones/US-SW-EPE.yaml
+++ b/config/zones/US-SW-EPE.yaml
@@ -52,7 +52,7 @@ emissionFactors:
         source: Electricity Maps, 2021 average
         value: 552.3879131999372
     gas:
-      datetime: '2021-01-01'
+      datetime: '2020-01-01'
       source: eGrid 2020
       value: 545.8860298
     hydro discharge:
@@ -105,7 +105,7 @@ emissionFactors:
       source: IPCC 2014
       value: 820
     gas:
-      datetime: '2021-01-01'
+      datetime: '2020-01-01'
       source: eGrid 2020; IPCC 2014
       value: 665.8860298
     hydro discharge:

--- a/config/zones/US-SW-EPE.yaml
+++ b/config/zones/US-SW-EPE.yaml
@@ -52,9 +52,12 @@ emissionFactors:
         source: Electricity Maps, 2021 average
         value: 552.3879131999372
     gas:
-      datetime: '2020-01-01'
-      source: eGrid 2020
-      value: 545.8860298
+      - datetime: '2020-01-01'
+        source: eGrid 2020
+        value: 545.8860298
+      - datetime: '2021-01-01'
+        source: eGrid 2021
+        value: 564.57
     hydro discharge:
       - datetime: '2015-01-01'
         source: Electricity Maps, 2015 average
@@ -105,9 +108,12 @@ emissionFactors:
       source: IPCC 2014
       value: 820
     gas:
-      datetime: '2020-01-01'
-      source: eGrid 2020; IPCC 2014
-      value: 665.8860298
+      - datetime: '2020-01-01'
+        source: eGrid 2020; IPCC 2014
+        value: 665.8860298
+      - datetime: '2021-01-01'
+        source: eGrid 2021; IPCC 2014
+        value: 684.57
     hydro discharge:
       - datetime: '2015-01-01'
         source: Electricity Maps, 2015 average
@@ -257,4 +263,6 @@ sources:
     link: https://www.ipcc.ch/site/assets/uploads/2018/02/ipcc_wg3_ar5_annex-iii.pdf#page=7
   eGrid 2020:
     link: https://drive.google.com/file/d/1_FAAuTtIdMuORZKsqHnd9vMNHlQgYarh/view?usp=sharing
+  eGrid 2021:
+    link: ' https://drive.google.com/file/d/1_FAAuTtIdMuORZKsqHnd9vMNHlQgYarh/view?usp=sharing'
 timezone: US/Mountain

--- a/config/zones/US-SW-PNM.yaml
+++ b/config/zones/US-SW-PNM.yaml
@@ -57,7 +57,7 @@ emissionFactors:
       source: eGrid 2020
       value: 1202.427801
     gas:
-      datetime: '2021-01-01'
+      datetime: '2020-01-01'
       source: eGrid 2020
       value: 412.1499722
     hydro discharge:
@@ -111,7 +111,7 @@ emissionFactors:
         of coal power generation."
       value: 1246.197747
     gas:
-      datetime: '2021-01-01'
+      datetime: '2020-01-01'
       source: eGrid 2020; IPCC 2014
       value: 532.1499722
     hydro discharge:

--- a/config/zones/US-SW-PNM.yaml
+++ b/config/zones/US-SW-PNM.yaml
@@ -53,13 +53,19 @@ emissionFactors:
         source: Electricity Maps, 2021 average
         value: 620.554254535142
     coal:
-      datetime: '2020-01-01'
-      source: eGrid 2020
-      value: 1202.427801
+      - datetime: '2020-01-01'
+        source: eGrid 2020
+        value: 1202.427801
+      - datetime: '2021-01-01'
+        source: eGrid 2021
+        value: 1205.81
     gas:
-      datetime: '2020-01-01'
-      source: eGrid 2020
-      value: 412.1499722
+      - datetime: '2020-01-01'
+        source: eGrid 2020
+        value: 412.1499722
+      - datetime: '2021-01-01'
+        source: eGrid 2021
+        value: 415.96
     hydro discharge:
       - datetime: '2015-01-01'
         source: Electricity Maps, 2015 average
@@ -106,14 +112,21 @@ emissionFactors:
         source: Electricity Maps, 2021 average
         value: 677.0004108933182
     coal:
-      datetime: '2020-01-01'
-      source: eGrid 2020; Oberschelp, Christopher, et al. "Global emission hotspots
-        of coal power generation."
-      value: 1246.197747
+      - datetime: '2020-01-01'
+        source: eGrid 2020; Oberschelp, Christopher, et al. "Global emission hotspots
+          of coal power generation."
+        value: 1246.197747
+      - datetime: '2021-01-01'
+        source: eGrid 2021; Oberschelp, Christopher, et al. "Global emission hotspots
+          of coal power generation."
+        value: 1249.5799459999998
     gas:
-      datetime: '2020-01-01'
-      source: eGrid 2020; IPCC 2014
-      value: 532.1499722
+      - datetime: '2020-01-01'
+        source: eGrid 2020; IPCC 2014
+        value: 532.1499722
+      - datetime: '2021-01-01'
+        source: eGrid 2021; IPCC 2014
+        value: 535.96
     hydro discharge:
       - datetime: '2015-01-01'
         source: Electricity Maps, 2015 average
@@ -263,4 +276,6 @@ sources:
     link: https://www.ipcc.ch/site/assets/uploads/2018/02/ipcc_wg3_ar5_annex-iii.pdf#page=7
   eGrid 2020:
     link: https://drive.google.com/file/d/1_FAAuTtIdMuORZKsqHnd9vMNHlQgYarh/view?usp=sharing
+  eGrid 2021:
+    link: ' https://drive.google.com/file/d/1_FAAuTtIdMuORZKsqHnd9vMNHlQgYarh/view?usp=sharing'
 timezone: US/Mountain

--- a/config/zones/US-SW-SRP.yaml
+++ b/config/zones/US-SW-SRP.yaml
@@ -58,7 +58,7 @@ emissionFactors:
       source: eGrid 2020
       value: 1218.520193
     gas:
-      datetime: '2021-01-01'
+      datetime: '2020-01-01'
       source: eGrid 2020
       value: 376.0036772
     hydro discharge:
@@ -111,7 +111,7 @@ emissionFactors:
       source: eGrid 2020; IPCC 2014
       value: 1278.520193
     gas:
-      datetime: '2021-01-01'
+      datetime: '2020-01-01'
       source: eGrid 2020; IPCC 2014
       value: 496.0036772
     hydro discharge:

--- a/config/zones/US-SW-SRP.yaml
+++ b/config/zones/US-SW-SRP.yaml
@@ -54,13 +54,19 @@ emissionFactors:
         source: Electricity Maps, 2021 average
         value: 240.19057250496743
     coal:
-      datetime: '2020-01-01'
-      source: eGrid 2020
-      value: 1218.520193
+      - datetime: '2020-01-01'
+        source: eGrid 2020
+        value: 1218.520193
+      - datetime: '2021-01-01'
+        source: eGrid 2021
+        value: 1158.45
     gas:
-      datetime: '2020-01-01'
-      source: eGrid 2020
-      value: 376.0036772
+      - datetime: '2020-01-01'
+        source: eGrid 2020
+        value: 376.0036772
+      - datetime: '2021-01-01'
+        source: eGrid 2021
+        value: 385.41
     hydro discharge:
       - datetime: '2015-01-01'
         source: Electricity Maps, 2015 average
@@ -107,13 +113,19 @@ emissionFactors:
         source: Electricity Maps, 2021 average
         value: 301.1148243883558
     coal:
-      datetime: '2020-01-01'
-      source: eGrid 2020; IPCC 2014
-      value: 1278.520193
+      - datetime: '2020-01-01'
+        source: eGrid 2020; IPCC 2014
+        value: 1278.520193
+      - datetime: '2021-01-01'
+        source: eGrid 2021; IPCC 2014
+        value: 1218.45
     gas:
-      datetime: '2020-01-01'
-      source: eGrid 2020; IPCC 2014
-      value: 496.0036772
+      - datetime: '2020-01-01'
+        source: eGrid 2020; IPCC 2014
+        value: 496.0036772
+      - datetime: '2021-01-01'
+        source: eGrid 2021; IPCC 2014
+        value: 505.41
     hydro discharge:
       - datetime: '2015-01-01'
         source: Electricity Maps, 2015 average
@@ -263,4 +275,6 @@ sources:
     link: https://www.ipcc.ch/site/assets/uploads/2018/02/ipcc_wg3_ar5_annex-iii.pdf#page=7
   eGrid 2020:
     link: https://drive.google.com/file/d/1_FAAuTtIdMuORZKsqHnd9vMNHlQgYarh/view?usp=sharing
+  eGrid 2021:
+    link: ' https://drive.google.com/file/d/1_FAAuTtIdMuORZKsqHnd9vMNHlQgYarh/view?usp=sharing'
 timezone: US/Arizona

--- a/config/zones/US-SW-TEPC.yaml
+++ b/config/zones/US-SW-TEPC.yaml
@@ -52,13 +52,19 @@ emissionFactors:
         source: Electricity Maps, 2021 average
         value: 567.4448670565235
     coal:
-      datetime: '2020-01-01'
-      source: eGrid 2020
-      value: 1062.399036
+      - datetime: '2020-01-01'
+        source: eGrid 2020
+        value: 1062.399036
+      - datetime: '2021-01-01'
+        source: eGrid 2021
+        value: 1044.04
     gas:
-      datetime: '2020-01-01'
-      source: eGrid 2020
-      value: 505.3167692
+      - datetime: '2020-01-01'
+        source: eGrid 2020
+        value: 505.3167692
+      - datetime: '2021-01-01'
+        source: eGrid 2021
+        value: 551.22
     hydro discharge:
       - datetime: '2015-01-01'
         source: Electricity Maps, 2015 average
@@ -105,13 +111,19 @@ emissionFactors:
         source: Electricity Maps, 2021 average
         value: 639.620389531979
     coal:
-      datetime: '2020-01-01'
-      source: eGrid 2020; IPCC 2014
-      value: 1122.399036
+      - datetime: '2020-01-01'
+        source: eGrid 2020; IPCC 2014
+        value: 1122.399036
+      - datetime: '2021-01-01'
+        source: eGrid 2021; IPCC 2014
+        value: 1104.04
     gas:
-      datetime: '2020-01-01'
-      source: eGrid 2020; IPCC 2014
-      value: 625.3167692
+      - datetime: '2020-01-01'
+        source: eGrid 2020; IPCC 2014
+        value: 625.3167692
+      - datetime: '2021-01-01'
+        source: eGrid 2021; IPCC 2014
+        value: 671.22
     hydro discharge:
       - datetime: '2015-01-01'
         source: Electricity Maps, 2015 average
@@ -261,4 +273,6 @@ sources:
     link: https://www.ipcc.ch/site/assets/uploads/2018/02/ipcc_wg3_ar5_annex-iii.pdf#page=7
   eGrid 2020:
     link: https://drive.google.com/file/d/1_FAAuTtIdMuORZKsqHnd9vMNHlQgYarh/view?usp=sharing
+  eGrid 2021:
+    link: ' https://drive.google.com/file/d/1_FAAuTtIdMuORZKsqHnd9vMNHlQgYarh/view?usp=sharing'
 timezone: US/Arizona

--- a/config/zones/US-SW-TEPC.yaml
+++ b/config/zones/US-SW-TEPC.yaml
@@ -56,7 +56,7 @@ emissionFactors:
       source: eGrid 2020
       value: 1062.399036
     gas:
-      datetime: '2021-01-01'
+      datetime: '2020-01-01'
       source: eGrid 2020
       value: 505.3167692
     hydro discharge:
@@ -109,7 +109,7 @@ emissionFactors:
       source: eGrid 2020; IPCC 2014
       value: 1122.399036
     gas:
-      datetime: '2021-01-01'
+      datetime: '2020-01-01'
       source: eGrid 2020; IPCC 2014
       value: 625.3167692
     hydro discharge:

--- a/config/zones/US-SW-WALC.yaml
+++ b/config/zones/US-SW-WALC.yaml
@@ -54,7 +54,7 @@ emissionFactors:
         source: Electricity Maps, 2021 average
         value: 331.91605662559556
     gas:
-      datetime: '2021-01-01'
+      datetime: '2020-01-01'
       source: eGrid 2020
       value: 517.3221021
     hydro discharge:
@@ -108,7 +108,7 @@ emissionFactors:
         of coal power generation."
       value: 817.120985
     gas:
-      datetime: '2021-01-01'
+      datetime: '2020-01-01'
       source: eGrid 2020; IPCC 2014
       value: 637.3221021
     hydro discharge:

--- a/config/zones/US-SW-WALC.yaml
+++ b/config/zones/US-SW-WALC.yaml
@@ -53,10 +53,17 @@ emissionFactors:
       - datetime: '2021-01-01'
         source: Electricity Maps, 2021 average
         value: 331.91605662559556
+    coal:
+      datetime: '2021-01-01'
+      source: eGrid 2021
+      value: 837.49
     gas:
-      datetime: '2020-01-01'
-      source: eGrid 2020
-      value: 517.3221021
+      - datetime: '2020-01-01'
+        source: eGrid 2020
+        value: 517.3221021
+      - datetime: '2021-01-01'
+        source: eGrid 2021
+        value: 405.17
     hydro discharge:
       - datetime: '2015-01-01'
         source: Electricity Maps, 2015 average
@@ -103,14 +110,21 @@ emissionFactors:
         source: Electricity Maps, 2021 average
         value: 387.9264386600192
     coal:
-      datetime: '2012-01-01'
-      source: IPCC 2014; Oberschelp, Christopher, et al. "Global emission hotspots
-        of coal power generation."
-      value: 817.120985
+      - datetime: '2012-01-01'
+        source: IPCC 2014; Oberschelp, Christopher, et al. "Global emission hotspots
+          of coal power generation."
+        value: 817.120985
+      - datetime: '2021-01-01'
+        source: eGrid 2021; Oberschelp, Christopher, et al. "Global emission hotspots
+          of coal power generation."
+        value: 894.610985
     gas:
-      datetime: '2020-01-01'
-      source: eGrid 2020; IPCC 2014
-      value: 637.3221021
+      - datetime: '2020-01-01'
+        source: eGrid 2020; IPCC 2014
+        value: 637.3221021
+      - datetime: '2021-01-01'
+        source: eGrid 2021; IPCC 2014
+        value: 525.1700000000001
     hydro discharge:
       - datetime: '2015-01-01'
         source: Electricity Maps, 2015 average
@@ -254,4 +268,6 @@ sources:
     link: https://www.ipcc.ch/site/assets/uploads/2018/02/ipcc_wg3_ar5_annex-iii.pdf#page=7
   eGrid 2020:
     link: https://drive.google.com/file/d/1_FAAuTtIdMuORZKsqHnd9vMNHlQgYarh/view?usp=sharing
+  eGrid 2021:
+    link: ' https://drive.google.com/file/d/1_FAAuTtIdMuORZKsqHnd9vMNHlQgYarh/view?usp=sharing'
 timezone: US/Arizona

--- a/config/zones/US-TEN-TVA.yaml
+++ b/config/zones/US-TEN-TVA.yaml
@@ -60,7 +60,7 @@ emissionFactors:
       source: eGrid 2020
       value: 1070.741206
     gas:
-      datetime: '2021-01-01'
+      datetime: '2020-01-01'
       source: eGrid 2020
       value: 391.2963051
     hydro discharge:
@@ -86,7 +86,7 @@ emissionFactors:
         source: Electricity Maps, 2021 average
         value: 309.10263292981676
     oil:
-      datetime: '2021-01-01'
+      datetime: '2020-01-01'
       source: eGrid 2020
       value: 472.7975672
   lifecycle:
@@ -122,7 +122,7 @@ emissionFactors:
         of coal power generation."
       value: 1152.251617
     gas:
-      datetime: '2021-01-01'
+      datetime: '2020-01-01'
       source: eGrid 2020; IPCC 2014
       value: 511.2963051
     hydro discharge:
@@ -148,7 +148,7 @@ emissionFactors:
         source: Electricity Maps, 2021 average
         value: 364.57502733192445
     oil:
-      datetime: '2021-01-01'
+      datetime: '2020-01-01'
       source: eGrid 2020; IPCC 2014
       value: 716.7975672
     solar:

--- a/config/zones/US-TEN-TVA.yaml
+++ b/config/zones/US-TEN-TVA.yaml
@@ -52,17 +52,26 @@ emissionFactors:
         source: Electricity Maps, 2021 average
         value: 309.10263292981676
     biomass:
-      datetime: '2020-01-01'
-      source: eGrid 2020
-      value: 0.0
+      - datetime: '2020-01-01'
+        source: eGrid 2020
+        value: 0.0
+      - datetime: '2021-01-01'
+        source: eGrid 2021
+        value: 0.0
     coal:
-      datetime: '2020-01-01'
-      source: eGrid 2020
-      value: 1070.741206
+      - datetime: '2020-01-01'
+        source: eGrid 2020
+        value: 1070.741206
+      - datetime: '2021-01-01'
+        source: eGrid 2021
+        value: 1089.66
     gas:
-      datetime: '2020-01-01'
-      source: eGrid 2020
-      value: 391.2963051
+      - datetime: '2020-01-01'
+        source: eGrid 2020
+        value: 391.2963051
+      - datetime: '2021-01-01'
+        source: eGrid 2021
+        value: 397.1
     hydro discharge:
       - datetime: '2015-01-01'
         source: Electricity Maps, 2015 average
@@ -113,18 +122,28 @@ emissionFactors:
         source: Electricity Maps, 2021 average
         value: 364.57502733192445
     biomass:
-      datetime: '2020-01-01'
-      source: eGrid 2020
-      value: 14.46015011
+      - datetime: '2020-01-01'
+        source: eGrid 2020
+        value: 14.46015011
+      - datetime: '2021-01-01'
+        source: eGrid 2021; eGrid 2021
+        value: 277.252
     coal:
-      datetime: '2020-01-01'
-      source: eGrid 2020; Oberschelp, Christopher, et al. "Global emission hotspots
-        of coal power generation."
-      value: 1152.251617
+      - datetime: '2020-01-01'
+        source: eGrid 2020; Oberschelp, Christopher, et al. "Global emission hotspots
+          of coal power generation."
+        value: 1152.251617
+      - datetime: '2021-01-01'
+        source: eGrid 2021; Oberschelp, Christopher, et al. "Global emission hotspots
+          of coal power generation."
+        value: 1171.170411
     gas:
-      datetime: '2020-01-01'
-      source: eGrid 2020; IPCC 2014
-      value: 511.2963051
+      - datetime: '2020-01-01'
+        source: eGrid 2020; IPCC 2014
+        value: 511.2963051
+      - datetime: '2021-01-01'
+        source: eGrid 2021; IPCC 2014
+        value: 517.1
     hydro discharge:
       - datetime: '2015-01-01'
         source: Electricity Maps, 2015 average
@@ -274,4 +293,6 @@ sources:
     link: https://www.ipcc.ch/site/assets/uploads/2018/02/ipcc_wg3_ar5_annex-iii.pdf#page=7
   eGrid 2020:
     link: https://drive.google.com/file/d/1_FAAuTtIdMuORZKsqHnd9vMNHlQgYarh/view?usp=sharing
+  eGrid 2021:
+    link: ' https://drive.google.com/file/d/1_FAAuTtIdMuORZKsqHnd9vMNHlQgYarh/view?usp=sharing'
 timezone: US/Central

--- a/config/zones/US-TEX-ERCO.yaml
+++ b/config/zones/US-TEX-ERCO.yaml
@@ -60,7 +60,7 @@ emissionFactors:
       source: eGrid 2020
       value: 1043.400889
     gas:
-      datetime: '2021-01-01'
+      datetime: '2020-01-01'
       source: eGrid 2020
       value: 393.100066
     hydro discharge:
@@ -86,7 +86,7 @@ emissionFactors:
         source: Electricity Maps, 2021 average
         value: 366.1763011584388
     oil:
-      datetime: '2021-01-01'
+      datetime: '2020-01-01'
       source: eGrid 2020
       value: 1070.811109
   lifecycle:
@@ -122,7 +122,7 @@ emissionFactors:
         of coal power generation."
       value: 1081.455715
     gas:
-      datetime: '2021-01-01'
+      datetime: '2020-01-01'
       source: eGrid 2020; IPCC 2014
       value: 513.100066
     hydro discharge:
@@ -148,7 +148,7 @@ emissionFactors:
         source: Electricity Maps, 2021 average
         value: 428.8286615039803
     oil:
-      datetime: '2021-01-01'
+      datetime: '2020-01-01'
       source: eGrid 2020; IPCC 2014
       value: 1314.811109
     solar:

--- a/config/zones/US-TEX-ERCO.yaml
+++ b/config/zones/US-TEX-ERCO.yaml
@@ -52,17 +52,26 @@ emissionFactors:
         source: Electricity Maps, 2021 average
         value: 366.1763011584388
     biomass:
-      datetime: '2020-01-01'
-      source: eGrid 2020
-      value: 0
+      - datetime: '2020-01-01'
+        source: eGrid 2020
+        value: 0
+      - datetime: '2021-01-01'
+        source: eGrid 2021
+        value: 0.0
     coal:
-      datetime: '2020-01-01'
-      source: eGrid 2020
-      value: 1043.400889
+      - datetime: '2020-01-01'
+        source: eGrid 2020
+        value: 1043.400889
+      - datetime: '2021-01-01'
+        source: eGrid 2021
+        value: 1032.02
     gas:
-      datetime: '2020-01-01'
-      source: eGrid 2020
-      value: 393.100066
+      - datetime: '2020-01-01'
+        source: eGrid 2020
+        value: 393.100066
+      - datetime: '2021-01-01'
+        source: eGrid 2021
+        value: 392.27
     hydro discharge:
       - datetime: '2015-01-01'
         source: Electricity Maps, 2015 average
@@ -86,9 +95,12 @@ emissionFactors:
         source: Electricity Maps, 2021 average
         value: 366.1763011584388
     oil:
-      datetime: '2020-01-01'
-      source: eGrid 2020
-      value: 1070.811109
+      - datetime: '2020-01-01'
+        source: eGrid 2020
+        value: 1070.811109
+      - datetime: '2021-01-01'
+        source: eGrid 2021
+        value: 1068.73
   lifecycle:
     battery discharge:
       - datetime: '2015-01-01'
@@ -113,18 +125,28 @@ emissionFactors:
         source: Electricity Maps, 2021 average
         value: 428.8286615039803
     biomass:
-      datetime: '2020-01-01'
-      source: eGrid 2020
-      value: 0.4539605655
+      - datetime: '2020-01-01'
+        source: eGrid 2020
+        value: 0.4539605655
+      - datetime: '2021-01-01'
+        source: eGrid 2021; eGrid 2021
+        value: 277.252
     coal:
-      datetime: '2020-01-01'
-      source: eGrid 2020; Oberschelp, Christopher, et al. "Global emission hotspots
-        of coal power generation."
-      value: 1081.455715
+      - datetime: '2020-01-01'
+        source: eGrid 2020; Oberschelp, Christopher, et al. "Global emission hotspots
+          of coal power generation."
+        value: 1081.455715
+      - datetime: '2021-01-01'
+        source: eGrid 2021; Oberschelp, Christopher, et al. "Global emission hotspots
+          of coal power generation."
+        value: 1070.074826
     gas:
-      datetime: '2020-01-01'
-      source: eGrid 2020; IPCC 2014
-      value: 513.100066
+      - datetime: '2020-01-01'
+        source: eGrid 2020; IPCC 2014
+        value: 513.100066
+      - datetime: '2021-01-01'
+        source: eGrid 2021; IPCC 2014
+        value: 512.27
     hydro discharge:
       - datetime: '2015-01-01'
         source: Electricity Maps, 2015 average
@@ -148,9 +170,12 @@ emissionFactors:
         source: Electricity Maps, 2021 average
         value: 428.8286615039803
     oil:
-      datetime: '2020-01-01'
-      source: eGrid 2020; IPCC 2014
-      value: 1314.811109
+      - datetime: '2020-01-01'
+        source: eGrid 2020; IPCC 2014
+        value: 1314.811109
+      - datetime: '2021-01-01'
+        source: eGrid 2021; IPCC 2014
+        value: 1312.73
     solar:
       datetime: '2021-01-01'
       source: INCER ACV
@@ -274,4 +299,6 @@ sources:
     link: https://www.ipcc.ch/site/assets/uploads/2018/02/ipcc_wg3_ar5_annex-iii.pdf#page=7
   eGrid 2020:
     link: https://drive.google.com/file/d/1_FAAuTtIdMuORZKsqHnd9vMNHlQgYarh/view?usp=sharing
+  eGrid 2021:
+    link: ' https://drive.google.com/file/d/1_FAAuTtIdMuORZKsqHnd9vMNHlQgYarh/view?usp=sharing'
 timezone: US/Central

--- a/tests/test_co2eq_parameters.py
+++ b/tests/test_co2eq_parameters.py
@@ -394,9 +394,12 @@ class CO2eqParametersDirect(BaseClasses.CO2eqParametersDirectAndLifecycleBase):
         # Fossil fuels: usually above 500 gCO2eq/kWh.
         "coal": (500, 1600),
         "gas": (200, 700),
-        "oil": (300, 1300),
+        "oil": (300, 1400),
         # Low-carbon: direct emissions are usually zero, with some possible exceptions.
-        "geothermal": (0, 100),
+        "geothermal": (
+            0,
+            199,
+        ),  # 80% of geothermal plants emit less than 200 gCO2eq/kWhs
         "hydro": (0, 0),
         "nuclear": (0, 0),
         "solar": (0, 0),
@@ -425,7 +428,7 @@ class CO2eqParametersLifecycle(BaseClasses.CO2eqParametersDirectAndLifecycleBase
         "gas": (400, 900),
         # Low-carbon: generally below 50 gCO2eq/kWh with some exceptions.
         # For lifecycle emissions, this should not be zero.
-        "geothermal": (30, 140),
+        "geothermal": (30, 199),
         "hydro": (10, 25),
         "nuclear": (4, 12),
         "biomass": (0.4, 1300),


### PR DESCRIPTION
NOTE: I haven't had time to review all the new EFs and will try to go through them tomorrow

## Issue

Update US emission factors with eGRID 2021 values. The process is the same as last year, see [wiki](https://github.com/electricitymaps/electricitymaps-contrib/wiki/US-emission-factors) for documentation 

Computation notebook: [US_emission_factors.ipynb](https://colab.research.google.com/drive/1_FAAuTtIdMuORZKsqHnd9vMNHlQgYarh#scrollTo=IjloJbBZzub3)

## Description
Updated yaml files for all US zones that have REF

### Preview

NA

### Double check

- [ ] I have tested my parser changes locally with `poetry run test_parser "zone_key"`
- [ ] I have run `pnpx prettier --write .` and `poetry run format` to format my changes.
