### PR TITLE
[Labeler]: Switch sync labels to a bool

### DIFF
--- a/.github/workflows/label.yml
+++ b/.github/workflows/label.yml
@@ -16,4 +16,4 @@ jobs:
       - uses: actions/labeler@v5
         with:
           repo-token: '${{ secrets.GITHUB_TOKEN }}'
-          sync-labels: ''
+          sync-labels: true


### PR DESCRIPTION
The first pr fixed the schema but a new error poped up.

We used a empty string for the config of the sync labels option which is no longer supported, this PR sets it to a bool instead.
