### PR TITLE
Switch RUFF to use SARIF output format for code analytics

### DIFF
--- a/.github/workflows/label.yml
+++ b/.github/workflows/label.yml
@@ -16,4 +16,4 @@ jobs:
       - uses: actions/labeler@v5
         with:
           repo-token: '${{ secrets.GITHUB_TOKEN }}'
-          sync-labels: true
+          sync-labels: false

--- a/.github/workflows/python_formatting.yml
+++ b/.github/workflows/python_formatting.yml
@@ -36,6 +36,13 @@ jobs:
       - name: Check formatting
         run: |
           poetry run ruff format . --check
+        continue-on-error: true
       - name: Check linting
         run: |
-          poetry run ruff check . --output-format=github
+          poetry run ruff check . --output-format=sarif >> ruff-results.sarif
+        continue-on-error: true
+      - name: Upload SARIF results to GitHub
+        uses: github/codeql-action/upload-sarif@v2
+        with:
+          sarif_file: ruff-results.sarif
+          wait-for-processing: true

--- a/parsers/ajenti.py
+++ b/parsers/ajenti.py
@@ -10,7 +10,7 @@ To get the very exact data, we would need to have a parser running constanty to 
 """
 
 import json
-from datetime import datetime
+from datetime import datetime,      timedelta
 from logging import Logger, getLogger
 from zoneinfo import ZoneInfo
 


### PR DESCRIPTION
## Description
Switching to SARIF format should give us more contextual and better code annotations in GitHub. This format is also cross platform so it will be easier to integrate with other systems if we ever decide to do that.

SARIF as an output format was added to RUFF in version 0.1.8 which is why it wasn't used from the start.

