### PR TITLE
update REE capacity mode mapping

### DIFF
--- a/electricitymap/contrib/capacity_parsers/REE.py
+++ b/electricitymap/contrib/capacity_parsers/REE.py
@@ -19,7 +19,7 @@ MODE_MAPPING = {
     "Eólica": "wind",
     "Solar fotovoltaica": "solar",
     "Solar térmica": "solar",
-    "Otras renovables": "unknown",
+    "Otras renovables": "biomass",  # Cross-checked against ENTSOE installed capacity + production data
     "Cogeneración": "gas",
     "Residuos no renovables": "unknown",
     "Residuos renovables": "biomass",


### PR DESCRIPTION
## Issue

current biomass capacity is too low 

## Description

Update the mode mapping. If we considered biomass to be only "residuos renovables" then the capacity is too low compared to the production
<img width="630" alt="image" src="https://github.com/electricitymaps/electricitymaps-contrib/assets/107848894/8f6f6662-16fb-4330-b407-2ee3b52de223">


### Preview
![image](https://github.com/electricitymaps/electricitymaps-contrib/assets/107848894/0a7cf1d5-e0ed-4006-9221-78805e048c2e)


vs 
![image](https://github.com/electricitymaps/electricitymaps-contrib/assets/107848894/b8ff5ed2-a65b-41c9-a725-4dae579ffc7c)


### Double check

- [ ] I have tested my parser changes locally with `poetry run test_parser "zone_key"`
- [ ] I have run `pnpx prettier --write .` and `poetry run format` to format my changes.
