### PR TITLE
fix(event structure): round values in settratr

### DIFF
--- a/electricitymap/contrib/lib/models/events.py
+++ b/electricitymap/contrib/lib/models/events.py
@@ -54,7 +54,7 @@ class Mix(BaseModel, ABC):
         Overriding the setattr method to raise an error if the mode is unknown.
         """
         # 6 decimal places gives us a precision of 1 W.
-        return super().__setattr__(name, _none_safe_round(value))
+        super().__setattr__(name, _none_safe_round(value))
 
 
 class ProductionMix(Mix):

--- a/electricitymap/contrib/lib/models/events.py
+++ b/electricitymap/contrib/lib/models/events.py
@@ -41,9 +41,7 @@ class Mix(BaseModel, ABC):
         existing_value: float | None = getattr(self, mode)
         if existing_value is not None:
             value = 0 if value is None else value
-            self.__setattr__(
-                mode, existing_value + value
-            )
+            self.__setattr__(mode, existing_value + value)
         else:
             self.__setattr__(mode, value)
 
@@ -57,7 +55,6 @@ class Mix(BaseModel, ABC):
         """
         # 6 decimal places gives us a precision of 1 W.
         return super().__setattr__(name, _none_safe_round(value))
-
 
 
 class ProductionMix(Mix):

--- a/electricitymap/contrib/lib/models/events.py
+++ b/electricitymap/contrib/lib/models/events.py
@@ -42,14 +42,22 @@ class Mix(BaseModel, ABC):
         if existing_value is not None:
             value = 0 if value is None else value
             self.__setattr__(
-                mode, _none_safe_round(existing_value + value)
-            )  # 6 decimal places gives us a precision of 1 W.
+                mode, existing_value + value
+            )
         else:
-            self.__setattr__(mode, _none_safe_round(value))
+            self.__setattr__(mode, value)
 
     @classmethod
     def merge(cls, mixes: list["Mix"]) -> "Mix":
         raise NotImplementedError()
+
+    def __setattr__(self, name: str, value: float | None) -> None:
+        """
+        Overriding the setattr method to raise an error if the mode is unknown.
+        """
+        # 6 decimal places gives us a precision of 1 W.
+        return super().__setattr__(name, _none_safe_round(value))
+
 
 
 class ProductionMix(Mix):


### PR DESCRIPTION
## Issue

We currently don't have a consistent way of initializing attributes. They are rounded when using the `add_value` method and not rounded if using `__setattr__` directly.

## Description

Use the same proceding for both add_value and settatr so they are now consistent.

### Double check

- [ ] I have tested my parser changes locally with `poetry run test_parser "zone_key"`
- [ ] I have run `pnpx prettier --write .` and `poetry run format` to format my changes.
