### PR TITLE
fix(Taipower parser down): update number of expected columns in the TW parser

### DIFF
--- a/parsers/TAIPOWER.py
+++ b/parsers/TAIPOWER.py
@@ -52,16 +52,15 @@ def fetch_production(
         "output",
         "percentage",
         "additional_2",
+        "additional_3",
     ]
     assert len(objData.iloc[0]) == len(columns), "number of input columns changed"
     objData.columns = columns
-
     objData["fueltype"] = objData.fueltype.str.split("<b>").str[1]
     objData["fueltype"] = objData.fueltype.str.split("</b>").str[0]
     objData.loc[:, ["capacity", "output"]] = objData[["capacity", "output"]].apply(
         pd.to_numeric, errors="coerce"
     )
-
     if objData["fueltype"].str.contains("OTHERRENEWABLEENERGY").any():
         if objData["name"].str.contains("Geothermal").any():
             objData.loc[
@@ -78,7 +77,7 @@ def fetch_production(
     ), "output data is entirely NaN - input column order may have changed"
 
     objData.drop(
-        columns=["additional_1", "name", "additional_2", "percentage"],
+        columns=["additional_1", "name", "additional_2", "percentage", "additional_3"],
         axis=1,
         inplace=True,
     )

--- a/parsers/test/mocks/TAIPOWER/genary.json
+++ b/parsers/test/mocks/TAIPOWER/genary.json
@@ -1,1 +1,2036 @@
-{"":"2023-09-24 01:30","dataset":[["<A NAME='nuclear'></A><b>NUCLEAR</b>","","NPP3#1","951.0","940.4","98.885%"," "],["<A NAME='nuclear'></A><b>NUCLEAR</b>","","NPP3#2","951.0","937.0","98.528%"," "],["<A NAME='nuclear'></A><b>NUCLEAR</b>","","Subtotal","1902.0(3.561%)","1877.4(6.679%)","",""],["<A NAME='coal'></A><b>COAL</b>","","Linkou#1","800.0","761.5","95.188%"," "],["<A NAME='coal'></A><b>COAL</b>","","Linkou#2","800.0","759.4","94.925%"," "],["<A NAME='coal'></A><b>COAL</b>","","Linkou#3","800.0","759.7","94.963%"," "],["<A NAME='coal'></A><b>COAL</b>","","Taichung#1","550.0","510.7","92.855%"," "],["<A NAME='coal'></A><b>COAL</b>","","Taichung#2","550.0","510.7","92.855%"," "],["<A NAME='coal'></A><b>COAL</b>","","Taichung#3","550.0","473.2","86.036%","23"],["<A NAME='coal'></A><b>COAL</b>","","Taichung#4","550.0","513.0","93.273%"," "],["<A NAME='coal'></A><b>COAL</b>","","Taichung#5","550.0","0.0","0.000%","1"],["<A NAME='coal'></A><b>COAL</b>","","Taichung#6","550.0","522.5","95.000%"," "],["<A NAME='coal'></A><b>COAL</b>","","Taichung#7","550.0","528.0","96.000%"," "],["<A NAME='coal'></A><b>COAL</b>","","Taichung#8","550.0","531.1","96.564%","26"],["<A NAME='coal'></A><b>COAL</b>","","Taichung#9","550.0","482.8","87.782%","23"],["<A NAME='coal'></A><b>COAL</b>","","Taichung#10","550.0","492.1","89.473%","23"],["<A NAME='coal'></A><b>COAL</b>","","Xingda#1(Remark XII)","500.0","375.2","75.040%"," "],["<A NAME='coal'></A><b>COAL</b>","","Xingda#2(Remark XII)","500.0","389.1","77.820%"," "],["<A NAME='coal'></A><b>COAL</b>","","Xingda#3(Remark XII)","550.0","452.1","82.200%"," "],["<A NAME='coal'></A><b>COAL</b>","","Xingda#4(Remark XII)","550.0","403.9","73.436%"," "],["<A NAME='coal'></A><b>COAL</b>","","Dalin#1","800.0","758.6","94.825%"," "],["<A NAME='coal'></A><b>COAL</b>","","Dalin#2","800.0","761.0","95.125%"," "],["<A NAME='coal'></A><b>COAL</b>","","Subtotal","11600.0(21.719%)","9984.6(35.521%)","",""],["<A NAME='cogen'></A><b>COGEN</b>","","Co-Generation","626.9","617.4","-"," "],["<A NAME='cogen'></A><b>COGEN</b>","","Subtotal","626.9(1.174%)","617.4(2.196%)","",""],["<A NAME='ippcoal'></A><b>IPPCOAL</b>","","Hoping#1","648.6","446.3","68.815%","23"],["<A NAME='ippcoal'></A><b>IPPCOAL</b>","","Hoping#2","648.6","566.2","87.302%"," "],["<A NAME='ippcoal'></A><b>IPPCOAL</b>","","Mailiao#1","600.0","569.7","94.950%"," "],["<A NAME='ippcoal'></A><b>IPPCOAL</b>","","Mailiao#2","600.0","571.6","95.267%"," "],["<A NAME='ippcoal'></A><b>IPPCOAL</b>","","Mailiao#3","600.0","571.9","95.317%"," "],["<A NAME='ippcoal'></A><b>IPPCOAL</b>","","Subtotal","3097.1(5.799%)","2725.7(9.697%)","",""],["<A NAME='lng'></A><b>LNG</b>","","Datan#1","742.7","583.9","78.619%","23"],["<A NAME='lng'></A><b>LNG</b>","","Datan#2","742.7","701.0","94.385%"," "],["<A NAME='lng'></A><b>LNG</b>","","Datan#3","724.7","315.2","43.494%","16"],["<A NAME='lng'></A><b>LNG</b>","","Datan#4","724.7","650.8","89.803%"," "],["<A NAME='lng'></A><b>LNG</b>","","Datan#5","724.7","337.1","46.516%","17"],["<A NAME='lng'></A><b>LNG</b>","","Datan#6","724.7","654.0","90.244%"," "],["<A NAME='lng'></A><b>LNG</b>","","Datan#7","600.0","0.0","0.000%","21"],["<A NAME='lng'></A><b>LNG</b>","","Datan#8(Remark X)","-","0.0","-"," "],["<A NAME='lng'></A><b>LNG</b>","","Tongxiao#1","892.6","850.6","95.295%"," "],["<A NAME='lng'></A><b>LNG</b>","","Tongxiao#2","892.6","857.6","96.079%"," "],["<A NAME='lng'></A><b>LNG</b>","","Tongxiao#3","892.6","872.3","97.726%"," "],["<A NAME='lng'></A><b>LNG</b>","","Tongxiao#4","386.0","371.4","96.218%"," "],["<A NAME='lng'></A><b>LNG</b>","","Tongxiao#5","386.0","222.1","57.539%","23"],["<A NAME='lng'></A><b>LNG</b>","","Tongxiao#6","321.2","277.6","86.426%"," "],["<A NAME='lng'></A><b>LNG</b>","","TongxiaoGT#9","180.9","0.0","0.000%"," "],["<A NAME='lng'></A><b>LNG</b>","","Xingda#1","445.2","331.3","74.418%"," "],["<A NAME='lng'></A><b>LNG</b>","","Xingda#2","445.2","405.6","91.107%"," "],["<A NAME='lng'></A><b>LNG</b>","","Xingda#3","445.2","389.0","87.378%"," "],["<A NAME='lng'></A><b>LNG</b>","","Xingda#4","445.2","345.1","77.517%"," "],["<A NAME='lng'></A><b>LNG</b>","","Xingda#5","445.2","341.6","76.731%"," "],["<A NAME='lng'></A><b>LNG</b>","","Nanbu#1","288.8","238.8","82.687%"," "],["<A NAME='lng'></A><b>LNG</b>","","Nanbu#2","288.8","218.6","75.693%"," "],["<A NAME='lng'></A><b>LNG</b>","","Nanbu#3","288.8","201.8","69.875%"," "],["<A NAME='lng'></A><b>LNG</b>","","Nanbu#4","251.4","218.3","86.834%"," "],["<A NAME='lng'></A><b>LNG</b>","","Dalin#5","-","0.0","-","21"],["<A NAME='lng'></A><b>LNG</b>","","Dalin#6","550.0","390.5","71.000%"," "],["<A NAME='lng'></A><b>LNG</b>","","Subtotal","12829.8(24.022%)","9774.2(34.773%)","",""],["<A NAME='ipplng'></A><b>IPPLNG</b>","","Haihu#1","450.0","448.5","99.667%"," "],["<A NAME='ipplng'></A><b>IPPLNG</b>","","Haihu#2","450.0","0.0","0.000%","2"],["<A NAME='ipplng'></A><b>IPPLNG</b>","","Hsintao#1","630.0","0.0","0.000%","18"],["<A NAME='ipplng'></A><b>IPPLNG</b>","","Guoguang#1","480.0","0.0","0.000%","1"],["<A NAME='ipplng'></A><b>IPPLNG</b>","","Xingzhang#1","506.9","0.0","0.000%","1"],["<A NAME='ipplng'></A><b>IPPLNG</b>","","Xingyuan#1","490.0","511.3","104.347%"," "],["<A NAME='ipplng'></A><b>IPPLNG</b>","","Jiahui#1","700.0","0.0","0.000%","2"],["<A NAME='ipplng'></A><b>IPPLNG</b>","","Jiahui#2","510.0","503.9","98.804%"," "],["<A NAME='ipplng'></A><b>IPPLNG</b>","","Fongde#1","506.9","493.8","97.424%"," "],["<A NAME='ipplng'></A><b>IPPLNG</b>","","Fongde#2","506.9","494.3","97.523%"," "],["<A NAME='ipplng'></A><b>IPPLNG</b>","","Subtotal","5230.6(9.793%)","2451.8(8.723%)","",""],["<A NAME='oil'></A><b>OIL</b>","","Xiehe#3","500.0","138.3","27.660%","22"],["<A NAME='oil'></A><b>OIL</b>","","Xiehe#4","500.0","138.2","27.640%","22"],["<A NAME='oil'></A><b>OIL</b>","","Penghu-Jianshan(Remark IV)","129.8","36.0","27.735%","17"],["<A NAME='oil'></A><b>OIL</b>","","Subtotal","1129.8(2.115%)","312.5(1.112%)","",""],["<A NAME='diesel'></A><b>DIESEL</b>","","NPP2 Gas1","-","0.0","-"," "],["<A NAME='diesel'></A><b>DIESEL</b>","","NPP2 Gas2","-","0.0","-"," "],["<A NAME='diesel'></A><b>DIESEL</b>","","NPP3 Gas1","-","0.0","-"," "],["<A NAME='diesel'></A><b>DIESEL</b>","","NPP3 Gas2","-","0.0","-"," "],["<A NAME='diesel'></A><b>DIESEL</b>","","Taichung Gas1&amp;2","140.0","0.0","0.000%"," "],["<A NAME='diesel'></A><b>DIESEL</b>","","Taichung Gas3&amp;4","140.0","0.0","0.000%"," "],["<A NAME='diesel'></A><b>DIESEL</b>","","Kinmen-Tashan(Remark IV)","113.3","43.4","38.308%"," "],["<A NAME='diesel'></A><b>DIESEL</b>","","Masu-Zhushan(Remark IV)","28.6","8.7","30.377%"," "],["<A NAME='diesel'></A><b>DIESEL</b>","","Other outlying Islands(Remark IV)","40.8","N/A","N/A"," "],["<A NAME='diesel'></A><b>DIESEL</b>","","Subtotal(Remark V)","462.7(0.866%)","52.1(0.185%)","",""],["<A NAME='hydro'></A><b>HYDRO</b>","","Deji#1","78.0","0.0","0.000%"," "],["<A NAME='hydro'></A><b>HYDRO</b>","","Deji#2","78.0","0.0","0.000%"," "],["<A NAME='hydro'></A><b>HYDRO</b>","","Deji#3","78.0","0.0","0.000%"," "],["<A NAME='hydro'></A><b>HYDRO</b>","","Qingshan#1","92.0","6.4","6.957%"," "],["<A NAME='hydro'></A><b>HYDRO</b>","","Qingshan#2","92.0","0.0","0.000%"," "],["<A NAME='hydro'></A><b>HYDRO</b>","","Qingshan#3","92.0","0.0","0.000%"," "],["<A NAME='hydro'></A><b>HYDRO</b>","","Qingshan#4","92.0","6.4","6.957%"," "],["<A NAME='hydro'></A><b>HYDRO</b>","","Guguan#1","54.4","23.2","42.608%"," "],["<A NAME='hydro'></A><b>HYDRO</b>","","Guguan#2","54.4","0.0","0.000%"," "],["<A NAME='hydro'></A><b>HYDRO</b>","","Guguan#3","54.4","0.0","0.000%"," "],["<A NAME='hydro'></A><b>HYDRO</b>","","Guguan#4","54.4","0.0","0.000%"," "],["<A NAME='hydro'></A><b>HYDRO</b>","","Tienlun#1","22.5","0.0","0.000%"," "],["<A NAME='hydro'></A><b>HYDRO</b>","","Tienlun#2","22.5","13.1","58.222%"," "],["<A NAME='hydro'></A><b>HYDRO</b>","","Tienlun#3","22.5","0.0","0.000%"," "],["<A NAME='hydro'></A><b>HYDRO</b>","","Tienlun#4","22.5","13.3","59.111%"," "],["<A NAME='hydro'></A><b>HYDRO</b>","","Tienlun#5","105.0","0.0","0.000%"," "],["<A NAME='hydro'></A><b>HYDRO</b>","","Ma-an#1","66.7","0.0","0.000%"," "],["<A NAME='hydro'></A><b>HYDRO</b>","","Ma-an#2","66.7","19.6","29.368%"," "],["<A NAME='hydro'></A><b>HYDRO</b>","","Zhuolan#1","40.0","18.4","46.000%"," "],["<A NAME='hydro'></A><b>HYDRO</b>","","Zhuolan#2","40.0","0.0","0.000%"," "],["<A NAME='hydro'></A><b>HYDRO</b>","","Wanda#1","10.4","10.0","96.618%"," "],["<A NAME='hydro'></A><b>HYDRO</b>","","Wanda#2","10.4","0.0","0.000%"," "],["<A NAME='hydro'></A><b>HYDRO</b>","","Wanda#3","15.3","0.0","0.000%","8"],["<A NAME='hydro'></A><b>HYDRO</b>","","Wanda#4","19.7","0.0","0.000%"," "],["<A NAME='hydro'></A><b>HYDRO</b>","","Songlin#1&amp;2","20.9","0.0","0.000%","41"],["<A NAME='hydro'></A><b>HYDRO</b>","","Daguan1#1","22.0","9.8","44.545%"," "],["<A NAME='hydro'></A><b>HYDRO</b>","","Daguan1#2","22.0","10.1","45.909%"," "],["<A NAME='hydro'></A><b>HYDRO</b>","","Daguan1#3","22.0","9.7","44.091%"," "],["<A NAME='hydro'></A><b>HYDRO</b>","","Daguan1#4","22.0","9.9","45.000%"," "],["<A NAME='hydro'></A><b>HYDRO</b>","","Daguan1#5","22.0","9.9","45.000%"," "],["<A NAME='hydro'></A><b>HYDRO</b>","","Jugong#1","21.8","12.2","56.092%"," "],["<A NAME='hydro'></A><b>HYDRO</b>","","Jugong#2","21.8","14.0","64.368%"," "],["<A NAME='hydro'></A><b>HYDRO</b>","","Shuili#1","12.8","8.6","67.451%"," "],["<A NAME='hydro'></A><b>HYDRO</b>","","Liwu#1&amp;#2","32.0","32.0","100.000%"," "],["<A NAME='hydro'></A><b>HYDRO</b>","","Longjian#1","48.6","0.0","0.000%"," "],["<A NAME='hydro'></A><b>HYDRO</b>","","Longjian#2","48.6","30.6","62.963%"," "],["<A NAME='hydro'></A><b>HYDRO</b>","","Bihai","61.2","55.6","90.850%"," "],["<A NAME='hydro'></A><b>HYDRO</b>","","Wulai&amp;Gueishan&amp;Cukeng","40.5","20.7","51.111%"," "],["<A NAME='hydro'></A><b>HYDRO</b>","","Small hydro in the northern region(Remark VI)","26.6","N/A","N/A"," "],["<A NAME='hydro'></A><b>HYDRO</b>","","Small hydro in the central region(Remark VI)","19.2","N/A","N/A"," "],["<A NAME='hydro'></A><b>HYDRO</b>","","Small hydro in the southern region(Remark VI)","7.2","N/A","N/A"," "],["<A NAME='hydro'></A><b>HYDRO</b>","","Small hydro in the eastern region(Remark VI)","54.6","49.6","90.842%"," "],["<A NAME='hydro'></A><b>HYDRO</b>","","Feicuei#1","70.0","0.0","0.000%"," "],["<A NAME='hydro'></A><b>HYDRO</b>","","Shihmen#1","45.0","0.0","0.000%"," "],["<A NAME='hydro'></A><b>HYDRO</b>","","Shihmen#2","45.0","24.6","54.667%"," "],["<A NAME='hydro'></A><b>HYDRO</b>","","Zengwun#1","50.0","0.0","0.000%"," "],["<A NAME='hydro'></A><b>HYDRO</b>","","Yising#1","40.0","37.3","93.250%"," "],["<A NAME='hydro'></A><b>HYDRO</b>","","Mingjian","16.7","14.0","83.832%"," "],["<A NAME='hydro'></A><b>HYDRO</b>","","Jiananxikou&amp;Wushantou&amp;Batian","22.5","0.0","0.000%"," "],["<A NAME='hydro'></A><b>HYDRO</b>","","HouliDemo","0.1","N/A","N/A"," "],["<A NAME='hydro'></A><b>HYDRO</b>","","Beinan","2.0","0.0","0.000%"," "],["<A NAME='hydro'></A><b>HYDRO</b>","","HYDROTRON,Heng Shuei Chuang Dian","0.1","N/A","N/A"," "],["<A NAME='hydro'></A><b>HYDRO</b>","","GuanShan","1.0","0.6","61.300%"," "],["<A NAME='hydro'></A><b>HYDRO</b>","","Subtotal(Remark V)","2102.0(3.936%)","501.4(1.784%)","",""],["<A NAME='wind'></A><b>WIND</b>","Onshore Wind TPC(Remark XIII)","Guanyuan","30.0","0.9","3.000%"," "],["<A NAME='wind'></A><b>WIND</b>","Onshore Wind TPC(Remark XIII)","Taichung Harbor","35.0","0.0","0.000%"," "],["<A NAME='wind'></A><b>WIND</b>","Onshore Wind TPC(Remark XIII)","Wanggong","23.0","0.8","3.478%"," "],["<A NAME='wind'></A><b>WIND</b>","Onshore Wind TPC(Remark XIII)","Zhanggong","86.2","0.9","1.044%"," "],["<A NAME='wind'></A><b>WIND</b>","Onshore Wind TPC(Remark XIII)","Yunmai","46.0","0.1","0.217%"," "],["<A NAME='wind'></A><b>WIND</b>","Onshore Wind TPC(Remark XIII)","Sihhu","28.0","0.4","1.429%"," "],["<A NAME='wind'></A><b>WIND</b>","Onshore Wind TPC(Remark XIII)","Remaining Wind TPC","72.8","6.7","9.198%"," "],["<A NAME='wind'></A><b>WIND</b>","Onshore Wind Purchases(Remark XIII)","Miaoli-Dapong","42.0","0.0","0.000%"," "],["<A NAME='wind'></A><b>WIND</b>","Onshore Wind Purchases(Remark XIII)","Luwei-Zhangbin","55.2","0.8","1.522%"," "],["<A NAME='wind'></A><b>WIND</b>","Onshore Wind Purchases(Remark XIII)","Guanwei-Guanyin&amp;Taowei-Xinwu","48.3","0.9","1.863%"," "],["<A NAME='wind'></A><b>WIND</b>","Onshore Wind Purchases(Remark XIII)","Zhongwei Da-an","75.9","0.0","0.000%"," "],["<A NAME='wind'></A><b>WIND</b>","Onshore Wind Purchases(Remark XIII)","ChuangWei Wind(Remark X)","-","0.0","-"," "],["<A NAME='wind'></A><b>WIND</b>","Onshore Wind Purchases(Remark XIII)","Remaining Wind Purchases","178.4","1.4","0.785%"," "],["<A NAME='wind'></A><b>WIND</b>","Offshore Wind TPC(Remark XIII)","Offshore Wind Generation Project Phase I","109.2","5.0","4.579%"," "],["<A NAME='wind'></A><b>WIND</b>","Offshore Wind Purchases(Remark XIII)","Formosa 1 Offshore Wind Farm,HaiYang Zhunan","128.0","0.0","0.000%"," "],["<A NAME='wind'></A><b>WIND</b>","Offshore Wind Purchases(Remark XIII)","OWF Yunlin,YunHu(Remark X)","-","7.3","-"," "],["<A NAME='wind'></A><b>WIND</b>","Offshore Wind Purchases(Remark XIII)","OWF Yunlin,YunSi(Remark X)","-","0.8","-"," "],["<A NAME='wind'></A><b>WIND</b>","Offshore Wind Purchases(Remark XIII)","Orsted Greater Changhua-southeast,WoYi Wind(Remark X)","-","0.0","-"," "],["<A NAME='wind'></A><b>WIND</b>","Offshore Wind Purchases(Remark XIII)","Orsted Greater Changhua-southwest,WoEr Wind(Remark X)","-","2.0","-"," "],["<A NAME='wind'></A><b>WIND</b>","Offshore Wind Purchases(Remark XIII)","CHANGFANG-XIDAO OFFSHORE WIND FARMS I,FangYi Wind(Remark X)","-","1.4","-"," "],["<A NAME='wind'></A><b>WIND</b>","Offshore Wind Purchases(Remark XIII)","Changfang - phase 2 Offshore Wind Farm,FangEr Wind(Remark X)","-","0.0","-"," "],["<A NAME='wind'></A><b>WIND</b>","Offshore Wind Purchases(Remark XIII)","Formosa 2 Offshore Wind Farm,HaiNeng Wind(Remark X)","-","0.0","-"," "],["<A NAME='wind'></A><b>WIND</b>","","Subtotal(Remark V)","958.0(1.794%)","29.5(0.105%)","",""],["<A NAME='solar'></A><b>SOLAR</b>","SOLAR TPC(Remark XIII)","Jhangbin Solar Power","100.0","0.000","0.000%"," "],["<A NAME='solar'></A><b>SOLAR</b>","SOLAR TPC(Remark XIII)","Tainan Salt Field Solar","150.0","0.000","0.000%"," "],["<A NAME='solar'></A><b>SOLAR</b>","SOLAR TPC(Remark XIII)","Remaining Solar TPC","24.3","0.000","0.000%"," "],["<A NAME='solar'></A><b>SOLAR</b>","SOLAR Purchases(Remark XIII)","Lunwei Solar Power","-","0.000","-","43"],["<A NAME='solar'></A><b>SOLAR</b>","SOLAR Purchases(Remark XIII)","TianChon PV","-","0.000","-","43"],["<A NAME='solar'></A><b>SOLAR</b>","SOLAR Purchases(Remark XIII)","TianPeng PV","80.0","0.000","0.000%"," "],["<A NAME='solar'></A><b>SOLAR</b>","SOLAR Purchases(Remark XIII)","Pau Shing PV(Remark X)","-","0.000","-"," "],["<A NAME='solar'></A><b>SOLAR</b>","SOLAR Purchases(Remark XIII)","SunnyRichPower,SianYang PV(Remark X)","-","0.000","-"," "],["<A NAME='solar'></A><b>SOLAR</b>","SOLAR Purchases(Remark XIII)","SingWeiPV(Remark X)","-","0.000","-"," "],["<A NAME='solar'></A><b>SOLAR</b>","SOLAR Purchases(Remark XIII)","Shuo Li PV(Remark X)","-","0.000","-"," "],["<A NAME='solar'></A><b>SOLAR</b>","SOLAR Purchases(Remark XIII)","TianYing Solar(Remark X)","-","0.000","-"," "],["<A NAME='solar'></A><b>SOLAR</b>","SOLAR Purchases(Remark XIII)","JhihGuang Solar(Remark X)","-","0.000","-"," "],["<A NAME='solar'></A><b>SOLAR</b>","SOLAR Purchases(Remark XIII)","Remaining Solar Purchases","10468.1","0.000","0.000%"," "],["<A NAME='solar'></A><b>SOLAR</b>","","Subtotal(Remark V)","10822.4(20.263%)","0.0(0.000%)","",""],["<A NAME='pumpinggen'></A><b>PUMPINGGEN</b>","","DaGuan2#1","250.0","0.0","0.000%"," "],["<A NAME='pumpinggen'></A><b>PUMPINGGEN</b>","","DaGuan2#2","250.0","0.0","0.000%"," "],["<A NAME='pumpinggen'></A><b>PUMPINGGEN</b>","","DaGuan2#3","250.0","0.0","0.000%"," "],["<A NAME='pumpinggen'></A><b>PUMPINGGEN</b>","","DaGuan2#4","250.0","0.0","0.000%"," "],["<A NAME='pumpinggen'></A><b>PUMPINGGEN</b>","","Mingtan#1","267.0","0.0","0.000%"," "],["<A NAME='pumpinggen'></A><b>PUMPINGGEN</b>","","Mingtan#2","267.0","0.0","0.000%"," "],["<A NAME='pumpinggen'></A><b>PUMPINGGEN</b>","","Mingtan#3","267.0","0.0","0.000%"," "],["<A NAME='pumpinggen'></A><b>PUMPINGGEN</b>","","Mingtan#4","267.0","0.0","0.000%"," "],["<A NAME='pumpinggen'></A><b>PUMPINGGEN</b>","","Mingtan#5","267.0","0.0","0.000%"," "],["<A NAME='pumpinggen'></A><b>PUMPINGGEN</b>","","Mingtan#6","267.0","0.0","0.000%"," "],["<A NAME='pumpinggen'></A><b>PUMPINGGEN</b>","","Subtotal(Remark V)","2602.0(4.872%)","0.0(0.000%)","",""],["<A NAME='pumpingload'></A><b>PUMPINGLOAD</b>","","DaGuan2#1","-","0.0","-"," "],["<A NAME='pumpingload'></A><b>PUMPINGLOAD</b>","","DaGuan2#2","-","0.0","-"," "],["<A NAME='pumpingload'></A><b>PUMPINGLOAD</b>","","DaGuan2#3","-","-245.8","-"," "],["<A NAME='pumpingload'></A><b>PUMPINGLOAD</b>","","DaGuan2#4","-","0.0","-"," "],["<A NAME='pumpingload'></A><b>PUMPINGLOAD</b>","","Mingtan#1","-","0.0","-"," "],["<A NAME='pumpingload'></A><b>PUMPINGLOAD</b>","","Mingtan#2","-","0.0","-"," "],["<A NAME='pumpingload'></A><b>PUMPINGLOAD</b>","","Mingtan#3","-","0.0","-"," "],["<A NAME='pumpingload'></A><b>PUMPINGLOAD</b>","","Mingtan#4","-","0.0","-"," "],["<A NAME='pumpingload'></A><b>PUMPINGLOAD</b>","","Mingtan#5","-","0.0","-"," "],["<A NAME='pumpingload'></A><b>PUMPINGLOAD</b>","","Mingtan#6","-","0.0","-"," "],["<A NAME='OtherRenewableEnergy'></A><b>OTHERRENEWABLEENERGY</b>","","TPC Geothermal","0.8","0.5","59.524%"," "],["<A NAME='OtherRenewableEnergy'></A><b>OTHERRENEWABLEENERGY</b>","","Geothermal Purchases","6.4","2.2","34.114%"," "],["<A NAME='OtherRenewableEnergy'></A><b>OTHERRENEWABLEENERGY</b>","","Biofuel","38.2","25.3","66.230%"," "],["<A NAME='OtherRenewableEnergy'></A><b>OTHERRENEWABLEENERGY</b>","","Subtotal(Remark V)","45.5(0.085%)","28.0(0.100%)","",""]]}
+{
+    "": "2023-12-29 19:10",
+    "dataset": [
+        [
+            "<A NAME='nuclear'></A><b>NUCLEAR</b>",
+            "",
+            "NPP3#1",
+            "951.0",
+            "949.5",
+            "99.842%",
+            " ",
+            ""
+        ],
+        [
+            "<A NAME='nuclear'></A><b>NUCLEAR</b>",
+            "",
+            "NPP3#2",
+            "951.0",
+            "944.9",
+            "99.359%",
+            " ",
+            ""
+        ],
+        [
+            "<A NAME='nuclear'></A><b>NUCLEAR</b>",
+            "",
+            "Subtotal",
+            "1902.0(3.557%)",
+            "1894.4(6.938%)",
+            "",
+            "",
+            ""
+        ],
+        [
+            "<A NAME='coal'></A><b>COAL</b>",
+            "",
+            "Linkou#1",
+            "800.0",
+            "759.3",
+            "94.912%",
+            " ",
+            ""
+        ],
+        [
+            "<A NAME='coal'></A><b>COAL</b>",
+            "",
+            "Linkou#2",
+            "800.0",
+            "0.0",
+            "0.000%",
+            "1",
+            ""
+        ],
+        [
+            "<A NAME='coal'></A><b>COAL</b>",
+            "",
+            "Linkou#3",
+            "800.0",
+            "761.3",
+            "95.162%",
+            " ",
+            ""
+        ],
+        [
+            "<A NAME='coal'></A><b>COAL</b>",
+            "",
+            "Taichung#1",
+            "550.0",
+            "361.8",
+            "65.782%",
+            "22",
+            ""
+        ],
+        [
+            "<A NAME='coal'></A><b>COAL</b>",
+            "",
+            "Taichung#2",
+            "550.0",
+            "362.9",
+            "65.982%",
+            "22",
+            ""
+        ],
+        [
+            "<A NAME='coal'></A><b>COAL</b>",
+            "",
+            "Taichung#3",
+            "550.0",
+            "380.4",
+            "69.164%",
+            "22",
+            ""
+        ],
+        [
+            "<A NAME='coal'></A><b>COAL</b>",
+            "",
+            "Taichung#4",
+            "550.0",
+            "0.0",
+            "0.000%",
+            "1",
+            ""
+        ],
+        [
+            "<A NAME='coal'></A><b>COAL</b>",
+            "",
+            "Taichung#5",
+            "550.0",
+            "0.0",
+            "0.000%",
+            "1",
+            ""
+        ],
+        [
+            "<A NAME='coal'></A><b>COAL</b>",
+            "",
+            "Taichung#6",
+            "550.0",
+            "0.0",
+            "0.000%",
+            "1",
+            ""
+        ],
+        [
+            "<A NAME='coal'></A><b>COAL</b>",
+            "",
+            "Taichung#7",
+            "550.0",
+            "373.9",
+            "67.982%",
+            "22",
+            ""
+        ],
+        [
+            "<A NAME='coal'></A><b>COAL</b>",
+            "",
+            "Taichung#8",
+            "550.0",
+            "438.8",
+            "79.782%",
+            "22",
+            ""
+        ],
+        [
+            "<A NAME='coal'></A><b>COAL</b>",
+            "",
+            "Taichung#9",
+            "550.0",
+            "384.4",
+            "69.891%",
+            "22",
+            ""
+        ],
+        [
+            "<A NAME='coal'></A><b>COAL</b>",
+            "",
+            "Taichung#10",
+            "550.0",
+            "382.3",
+            "69.509%",
+            "22",
+            ""
+        ],
+        [
+            "<A NAME='coal'></A><b>COAL</b>",
+            "",
+            "Xinda#1(Remark XV)",
+            "-",
+            "0.0",
+            "-",
+            " ",
+            ""
+        ],
+        [
+            "<A NAME='coal'></A><b>COAL</b>",
+            "",
+            "Xingda#2",
+            "500.0",
+            "0.0",
+            "0.000%",
+            "28",
+            ""
+        ],
+        [
+            "<A NAME='coal'></A><b>COAL</b>",
+            "",
+            "Xingda#3(Remark XII)",
+            "550.0",
+            "259.6",
+            "47.200%",
+            "22",
+            ""
+        ],
+        [
+            "<A NAME='coal'></A><b>COAL</b>",
+            "",
+            "Xingda#4(Remark XII)",
+            "550.0",
+            "0.0",
+            "0.000%",
+            "28",
+            ""
+        ],
+        [
+            "<A NAME='coal'></A><b>COAL</b>",
+            "",
+            "Dalin#1",
+            "800.0",
+            "0.0",
+            "0.000%",
+            "1",
+            ""
+        ],
+        [
+            "<A NAME='coal'></A><b>COAL</b>",
+            "",
+            "Dalin#2",
+            "800.0",
+            "759.4",
+            "94.925%",
+            " ",
+            ""
+        ],
+        [
+            "<A NAME='coal'></A><b>COAL</b>",
+            "",
+            "Subtotal",
+            "11100.0(20.761%)",
+            "5224.1(19.132%)",
+            "",
+            "",
+            ""
+        ],
+        [
+            "<A NAME='cogen'></A><b>COGEN</b>",
+            "",
+            "Co-Generation",
+            "626.9",
+            "1494.6",
+            "-",
+            " ",
+            ""
+        ],
+        [
+            "<A NAME='cogen'></A><b>COGEN</b>",
+            "",
+            "Subtotal",
+            "626.9(1.173%)",
+            "1494.6(5.473%)",
+            "",
+            "",
+            ""
+        ],
+        [
+            "<A NAME='ippcoal'></A><b>IPPCOAL</b>",
+            "",
+            "Hoping#1",
+            "648.6",
+            "0.0",
+            "0.000%",
+            "1",
+            ""
+        ],
+        [
+            "<A NAME='ippcoal'></A><b>IPPCOAL</b>",
+            "",
+            "Hoping#2",
+            "648.6",
+            "580.4",
+            "89.492%",
+            " ",
+            ""
+        ],
+        [
+            "<A NAME='ippcoal'></A><b>IPPCOAL</b>",
+            "",
+            "Mailiao#1",
+            "600.0",
+            "280.4",
+            "46.733%",
+            "22",
+            ""
+        ],
+        [
+            "<A NAME='ippcoal'></A><b>IPPCOAL</b>",
+            "",
+            "Mailiao#2",
+            "600.0",
+            "282.7",
+            "47.117%",
+            "22",
+            ""
+        ],
+        [
+            "<A NAME='ippcoal'></A><b>IPPCOAL</b>",
+            "",
+            "Mailiao#3",
+            "600.0",
+            "0.0",
+            "0.000%",
+            "1",
+            ""
+        ],
+        [
+            "<A NAME='ippcoal'></A><b>IPPCOAL</b>",
+            "",
+            "Subtotal",
+            "3097.1(5.793%)",
+            "1143.5(4.188%)",
+            "",
+            "",
+            ""
+        ],
+        [
+            "<A NAME='lng'></A><b>LNG</b>",
+            "",
+            "Datan#1",
+            "742.7",
+            "576.0",
+            "77.555%",
+            "23",
+            ""
+        ],
+        [
+            "<A NAME='lng'></A><b>LNG</b>",
+            "",
+            "Datan#2",
+            "742.7",
+            "36.1",
+            "4.861%",
+            "26",
+            ""
+        ],
+        [
+            "<A NAME='lng'></A><b>LNG</b>",
+            "",
+            "Datan#3",
+            "724.7",
+            "742.5",
+            "102.456%",
+            " ",
+            ""
+        ],
+        [
+            "<A NAME='lng'></A><b>LNG</b>",
+            "",
+            "Datan#4",
+            "724.7",
+            "683.2",
+            "94.273%",
+            " ",
+            ""
+        ],
+        [
+            "<A NAME='lng'></A><b>LNG</b>",
+            "",
+            "Datan#5",
+            "724.7",
+            "695.2",
+            "95.929%",
+            " ",
+            ""
+        ],
+        [
+            "<A NAME='lng'></A><b>LNG</b>",
+            "",
+            "Datan#6",
+            "724.7",
+            "319.9",
+            "44.142%",
+            "17",
+            ""
+        ],
+        [
+            "<A NAME='lng'></A><b>LNG</b>",
+            "",
+            "Datan#7",
+            "600.0",
+            "0.0",
+            "0.000%",
+            "21",
+            ""
+        ],
+        [
+            "<A NAME='lng'></A><b>LNG</b>",
+            "",
+            "Datan#8(Remark X)",
+            "-",
+            "544.9",
+            "-",
+            "19",
+            ""
+        ],
+        [
+            "<A NAME='lng'></A><b>LNG</b>",
+            "",
+            "Tongxiao#1",
+            "892.6",
+            "912.2",
+            "102.196%",
+            " ",
+            ""
+        ],
+        [
+            "<A NAME='lng'></A><b>LNG</b>",
+            "",
+            "Tongxiao#2",
+            "892.6",
+            "921.1",
+            "103.193%",
+            " ",
+            ""
+        ],
+        [
+            "<A NAME='lng'></A><b>LNG</b>",
+            "",
+            "Tongxiao#3",
+            "892.6",
+            "441.9",
+            "49.507%",
+            "15",
+            ""
+        ],
+        [
+            "<A NAME='lng'></A><b>LNG</b>",
+            "",
+            "Tongxiao#4",
+            "386.0",
+            "372.5",
+            "96.503%",
+            " ",
+            ""
+        ],
+        [
+            "<A NAME='lng'></A><b>LNG</b>",
+            "",
+            "Tongxiao#5",
+            "386.0",
+            "374.3",
+            "96.969%",
+            " ",
+            ""
+        ],
+        [
+            "<A NAME='lng'></A><b>LNG</b>",
+            "",
+            "Tongxiao#6",
+            "321.2",
+            "309.9",
+            "96.482%",
+            " ",
+            ""
+        ],
+        [
+            "<A NAME='lng'></A><b>LNG</b>",
+            "",
+            "TongxiaoGT#9",
+            "180.9",
+            "0.0",
+            "0.000%",
+            " ",
+            ""
+        ],
+        [
+            "<A NAME='lng'></A><b>LNG</b>",
+            "",
+            "Xingda#1",
+            "445.2",
+            "463.6",
+            "104.135%",
+            " ",
+            ""
+        ],
+        [
+            "<A NAME='lng'></A><b>LNG</b>",
+            "",
+            "Xingda#2",
+            "445.2",
+            "0.0",
+            "0.000%",
+            "2",
+            ""
+        ],
+        [
+            "<A NAME='lng'></A><b>LNG</b>",
+            "",
+            "Xingda#3",
+            "445.2",
+            "443.2",
+            "99.553%",
+            " ",
+            ""
+        ],
+        [
+            "<A NAME='lng'></A><b>LNG</b>",
+            "",
+            "Xingda#4",
+            "445.2",
+            "465.3",
+            "104.517%",
+            " ",
+            ""
+        ],
+        [
+            "<A NAME='lng'></A><b>LNG</b>",
+            "",
+            "Xingda#5",
+            "445.2",
+            "449.2",
+            "100.901%",
+            " ",
+            ""
+        ],
+        [
+            "<A NAME='lng'></A><b>LNG</b>",
+            "",
+            "Nanbu#1",
+            "288.8",
+            "298.5",
+            "103.359%",
+            " ",
+            ""
+        ],
+        [
+            "<A NAME='lng'></A><b>LNG</b>",
+            "",
+            "Nanbu#2",
+            "288.8",
+            "267.6",
+            "92.659%",
+            " ",
+            ""
+        ],
+        [
+            "<A NAME='lng'></A><b>LNG</b>",
+            "",
+            "Nanbu#3",
+            "288.8",
+            "245.0",
+            "84.834%",
+            "17",
+            ""
+        ],
+        [
+            "<A NAME='lng'></A><b>LNG</b>",
+            "",
+            "Nanbu#4",
+            "251.4",
+            "246.0",
+            "97.852%",
+            " ",
+            ""
+        ],
+        [
+            "<A NAME='lng'></A><b>LNG</b>",
+            "",
+            "Dalin#5",
+            "-",
+            "0.0",
+            "-",
+            "21",
+            ""
+        ],
+        [
+            "<A NAME='lng'></A><b>LNG</b>",
+            "",
+            "Dalin#6",
+            "550.0",
+            "221.7",
+            "40.309%",
+            " ",
+            ""
+        ],
+        [
+            "<A NAME='lng'></A><b>LNG</b>",
+            "",
+            "Subtotal",
+            "12829.8(23.997%)",
+            "10029.8(36.731%)",
+            "",
+            "",
+            ""
+        ],
+        [
+            "<A NAME='ipplng'></A><b>IPPLNG</b>",
+            "",
+            "Haihu#1",
+            "450.0",
+            "0.0",
+            "0.000%",
+            "2",
+            ""
+        ],
+        [
+            "<A NAME='ipplng'></A><b>IPPLNG</b>",
+            "",
+            "Haihu#2",
+            "450.0",
+            "404.3",
+            "89.844%",
+            " ",
+            ""
+        ],
+        [
+            "<A NAME='ipplng'></A><b>IPPLNG</b>",
+            "",
+            "Hsintao#1",
+            "630.0",
+            "469.3",
+            "74.492%",
+            "18",
+            ""
+        ],
+        [
+            "<A NAME='ipplng'></A><b>IPPLNG</b>",
+            "",
+            "Guoguang#1",
+            "480.0",
+            "488.2",
+            "101.708%",
+            " ",
+            ""
+        ],
+        [
+            "<A NAME='ipplng'></A><b>IPPLNG</b>",
+            "",
+            "Xingzhang#1",
+            "506.9",
+            "464.2",
+            "91.584%",
+            " ",
+            ""
+        ],
+        [
+            "<A NAME='ipplng'></A><b>IPPLNG</b>",
+            "",
+            "Xingyuan#1",
+            "490.0",
+            "471.9",
+            "96.306%",
+            " ",
+            ""
+        ],
+        [
+            "<A NAME='ipplng'></A><b>IPPLNG</b>",
+            "",
+            "Jiahui#1",
+            "700.0",
+            "689.0",
+            "98.429%",
+            " ",
+            ""
+        ],
+        [
+            "<A NAME='ipplng'></A><b>IPPLNG</b>",
+            "",
+            "Jiahui#2",
+            "510.0",
+            "0.0",
+            "0.000%",
+            "6",
+            ""
+        ],
+        [
+            "<A NAME='ipplng'></A><b>IPPLNG</b>",
+            "",
+            "Fongde#1",
+            "506.9",
+            "497.9",
+            "98.233%",
+            " ",
+            ""
+        ],
+        [
+            "<A NAME='ipplng'></A><b>IPPLNG</b>",
+            "",
+            "Fongde#2",
+            "506.9",
+            "496.0",
+            "97.858%",
+            " ",
+            ""
+        ],
+        [
+            "<A NAME='ipplng'></A><b>IPPLNG</b>",
+            "",
+            "Subtotal",
+            "5230.6(9.783%)",
+            "3980.8(14.578%)",
+            "",
+            "",
+            ""
+        ],
+        [
+            "<A NAME='oil'></A><b>OIL</b>",
+            "",
+            "Xiehe#3",
+            "500.0",
+            "141.5",
+            "28.300%",
+            "22",
+            ""
+        ],
+        [
+            "<A NAME='oil'></A><b>OIL</b>",
+            "",
+            "Xiehe#4",
+            "500.0",
+            "137.4",
+            "27.480%",
+            "22",
+            ""
+        ],
+        [
+            "<A NAME='oil'></A><b>OIL</b>",
+            "",
+            "Penghu-Jianshan(Remark IV)",
+            "129.8",
+            "27.2",
+            "20.955%",
+            "16",
+            ""
+        ],
+        [
+            "<A NAME='oil'></A><b>OIL</b>",
+            "",
+            "Subtotal",
+            "1129.8(2.113%)",
+            "306.1(1.121%)",
+            "",
+            "",
+            ""
+        ],
+        [
+            "<A NAME='diesel'></A><b>DIESEL</b>",
+            "",
+            "NPP2 Gas1",
+            "-",
+            "0.0",
+            "-",
+            " ",
+            ""
+        ],
+        [
+            "<A NAME='diesel'></A><b>DIESEL</b>",
+            "",
+            "NPP2 Gas2",
+            "-",
+            "0.0",
+            "-",
+            " ",
+            ""
+        ],
+        [
+            "<A NAME='diesel'></A><b>DIESEL</b>",
+            "",
+            "NPP3 Gas1",
+            "-",
+            "0.0",
+            "-",
+            " ",
+            ""
+        ],
+        [
+            "<A NAME='diesel'></A><b>DIESEL</b>",
+            "",
+            "NPP3 Gas2",
+            "-",
+            "0.0",
+            "-",
+            " ",
+            ""
+        ],
+        [
+            "<A NAME='diesel'></A><b>DIESEL</b>",
+            "",
+            "Taichung Gas1&amp;2",
+            "140.0",
+            "0.0",
+            "0.000%",
+            " ",
+            ""
+        ],
+        [
+            "<A NAME='diesel'></A><b>DIESEL</b>",
+            "",
+            "Taichung Gas3&amp;4",
+            "140.0",
+            "0.0",
+            "0.000%",
+            " ",
+            ""
+        ],
+        [
+            "<A NAME='diesel'></A><b>DIESEL</b>",
+            "",
+            "Kinmen-Tashan(Remark IV)",
+            "113.3",
+            "1.0",
+            "0.883%",
+            " ",
+            ""
+        ],
+        [
+            "<A NAME='diesel'></A><b>DIESEL</b>",
+            "",
+            "Masu-Zhushan(Remark IV)",
+            "28.6",
+            "7.4",
+            "25.838%",
+            " ",
+            ""
+        ],
+        [
+            "<A NAME='diesel'></A><b>DIESEL</b>",
+            "",
+            "Other outlying Islands(Remark IV)",
+            "40.8",
+            "N/A",
+            "N/A",
+            " ",
+            ""
+        ],
+        [
+            "<A NAME='diesel'></A><b>DIESEL</b>",
+            "",
+            "Subtotal(Remark V)",
+            "462.7(0.865%)",
+            "8.4(0.031%)",
+            "",
+            "",
+            ""
+        ],
+        [
+            "<A NAME='hydro'></A><b>HYDRO</b>",
+            "",
+            "Deji#1",
+            "78.0",
+            "0.0",
+            "0.000%",
+            " ",
+            ""
+        ],
+        [
+            "<A NAME='hydro'></A><b>HYDRO</b>",
+            "",
+            "Deji#2",
+            "78.0",
+            "30.0",
+            "38.462%",
+            " ",
+            ""
+        ],
+        [
+            "<A NAME='hydro'></A><b>HYDRO</b>",
+            "",
+            "Deji#3",
+            "78.0",
+            "0.0",
+            "0.000%",
+            "1",
+            ""
+        ],
+        [
+            "<A NAME='hydro'></A><b>HYDRO</b>",
+            "",
+            "Qingshan#1",
+            "92.0",
+            "12.4",
+            "13.478%",
+            " ",
+            ""
+        ],
+        [
+            "<A NAME='hydro'></A><b>HYDRO</b>",
+            "",
+            "Qingshan#2",
+            "92.0",
+            "5.7",
+            "6.196%",
+            " ",
+            ""
+        ],
+        [
+            "<A NAME='hydro'></A><b>HYDRO</b>",
+            "",
+            "Qingshan#3",
+            "92.0",
+            "5.1",
+            "5.543%",
+            " ",
+            ""
+        ],
+        [
+            "<A NAME='hydro'></A><b>HYDRO</b>",
+            "",
+            "Qingshan#4",
+            "92.0",
+            "5.2",
+            "5.652%",
+            " ",
+            ""
+        ],
+        [
+            "<A NAME='hydro'></A><b>HYDRO</b>",
+            "",
+            "Guguan#1",
+            "54.4",
+            "0.0",
+            "0.000%",
+            " ",
+            ""
+        ],
+        [
+            "<A NAME='hydro'></A><b>HYDRO</b>",
+            "",
+            "Guguan#2",
+            "54.4",
+            "0.0",
+            "0.000%",
+            " ",
+            ""
+        ],
+        [
+            "<A NAME='hydro'></A><b>HYDRO</b>",
+            "",
+            "Guguan#3",
+            "54.4",
+            "0.0",
+            "0.000%",
+            " ",
+            ""
+        ],
+        [
+            "<A NAME='hydro'></A><b>HYDRO</b>",
+            "",
+            "Guguan#4",
+            "54.4",
+            "20.9",
+            "38.384%",
+            " ",
+            ""
+        ],
+        [
+            "<A NAME='hydro'></A><b>HYDRO</b>",
+            "",
+            "Tienlun#1",
+            "22.5",
+            "9.9",
+            "44.000%",
+            " ",
+            ""
+        ],
+        [
+            "<A NAME='hydro'></A><b>HYDRO</b>",
+            "",
+            "Tienlun#2",
+            "22.5",
+            "0.0",
+            "0.000%",
+            " ",
+            ""
+        ],
+        [
+            "<A NAME='hydro'></A><b>HYDRO</b>",
+            "",
+            "Tienlun#3",
+            "22.5",
+            "10.2",
+            "45.333%",
+            " ",
+            ""
+        ],
+        [
+            "<A NAME='hydro'></A><b>HYDRO</b>",
+            "",
+            "Tienlun#4",
+            "22.5",
+            "0.0",
+            "0.000%",
+            " ",
+            ""
+        ],
+        [
+            "<A NAME='hydro'></A><b>HYDRO</b>",
+            "",
+            "Tienlun#5",
+            "105.0",
+            "0.0",
+            "0.000%",
+            " ",
+            ""
+        ],
+        [
+            "<A NAME='hydro'></A><b>HYDRO</b>",
+            "",
+            "Ma-an#1",
+            "66.7",
+            "9.4",
+            "14.085%",
+            " ",
+            ""
+        ],
+        [
+            "<A NAME='hydro'></A><b>HYDRO</b>",
+            "",
+            "Ma-an#2",
+            "66.7",
+            "0.0",
+            "0.000%",
+            "1",
+            ""
+        ],
+        [
+            "<A NAME='hydro'></A><b>HYDRO</b>",
+            "",
+            "Zhuolan#1",
+            "40.0",
+            "0.0",
+            "0.000%",
+            "1",
+            ""
+        ],
+        [
+            "<A NAME='hydro'></A><b>HYDRO</b>",
+            "",
+            "Zhuolan#2",
+            "40.0",
+            "39.0",
+            "97.500%",
+            " ",
+            ""
+        ],
+        [
+            "<A NAME='hydro'></A><b>HYDRO</b>",
+            "",
+            "Wanda#1",
+            "10.4",
+            "10.0",
+            "96.618%",
+            " ",
+            ""
+        ],
+        [
+            "<A NAME='hydro'></A><b>HYDRO</b>",
+            "",
+            "Wanda#2",
+            "10.4",
+            "10.0",
+            "96.618%",
+            " ",
+            ""
+        ],
+        [
+            "<A NAME='hydro'></A><b>HYDRO</b>",
+            "",
+            "Wanda#3",
+            "15.3",
+            "0.0",
+            "0.000%",
+            "8",
+            ""
+        ],
+        [
+            "<A NAME='hydro'></A><b>HYDRO</b>",
+            "",
+            "Wanda#4",
+            "19.7",
+            "19.2",
+            "97.462%",
+            " ",
+            ""
+        ],
+        [
+            "<A NAME='hydro'></A><b>HYDRO</b>",
+            "",
+            "Songlin#1&amp;2",
+            "20.9",
+            "0.0",
+            "0.000%",
+            " ",
+            ""
+        ],
+        [
+            "<A NAME='hydro'></A><b>HYDRO</b>",
+            "",
+            "Daguan1#1",
+            "22.0",
+            "2.0",
+            "9.091%",
+            " ",
+            ""
+        ],
+        [
+            "<A NAME='hydro'></A><b>HYDRO</b>",
+            "",
+            "Daguan1#2",
+            "22.0",
+            "2.0",
+            "9.091%",
+            " ",
+            ""
+        ],
+        [
+            "<A NAME='hydro'></A><b>HYDRO</b>",
+            "",
+            "Daguan1#3",
+            "22.0",
+            "2.6",
+            "11.818%",
+            " ",
+            ""
+        ],
+        [
+            "<A NAME='hydro'></A><b>HYDRO</b>",
+            "",
+            "Daguan1#4",
+            "22.0",
+            "0.0",
+            "0.000%",
+            "1",
+            ""
+        ],
+        [
+            "<A NAME='hydro'></A><b>HYDRO</b>",
+            "",
+            "Daguan1#5",
+            "22.0",
+            "0.0",
+            "0.000%",
+            "2",
+            ""
+        ],
+        [
+            "<A NAME='hydro'></A><b>HYDRO</b>",
+            "",
+            "Jugong#1",
+            "21.8",
+            "0.0",
+            "0.000%",
+            " ",
+            ""
+        ],
+        [
+            "<A NAME='hydro'></A><b>HYDRO</b>",
+            "",
+            "Jugong#2",
+            "21.8",
+            "0.0",
+            "0.000%",
+            " ",
+            ""
+        ],
+        [
+            "<A NAME='hydro'></A><b>HYDRO</b>",
+            "",
+            "Shuili#1",
+            "12.8",
+            "3.1",
+            "24.314%",
+            "2",
+            ""
+        ],
+        [
+            "<A NAME='hydro'></A><b>HYDRO</b>",
+            "",
+            "Liwu#1&amp;#2",
+            "32.0",
+            "16.0",
+            "50.000%",
+            "16",
+            ""
+        ],
+        [
+            "<A NAME='hydro'></A><b>HYDRO</b>",
+            "",
+            "Longjian#1",
+            "48.6",
+            "30.4",
+            "62.551%",
+            " ",
+            ""
+        ],
+        [
+            "<A NAME='hydro'></A><b>HYDRO</b>",
+            "",
+            "Longjian#2",
+            "48.6",
+            "0.0",
+            "0.000%",
+            " ",
+            ""
+        ],
+        [
+            "<A NAME='hydro'></A><b>HYDRO</b>",
+            "",
+            "Bihai",
+            "61.2",
+            "29.4",
+            "48.039%",
+            " ",
+            ""
+        ],
+        [
+            "<A NAME='hydro'></A><b>HYDRO</b>",
+            "",
+            "Wulai&amp;Gueishan&amp;Cukeng",
+            "40.5",
+            "19.8",
+            "48.889%",
+            " ",
+            ""
+        ],
+        [
+            "<A NAME='hydro'></A><b>HYDRO</b>",
+            "",
+            "Small hydro in the northern region(Remark VI)",
+            "26.6",
+            "N/A",
+            "N/A",
+            " ",
+            ""
+        ],
+        [
+            "<A NAME='hydro'></A><b>HYDRO</b>",
+            "",
+            "Small hydro in the central region(Remark VI)",
+            "19.2",
+            "N/A",
+            "N/A",
+            " ",
+            ""
+        ],
+        [
+            "<A NAME='hydro'></A><b>HYDRO</b>",
+            "",
+            "Small hydro in the southern region(Remark VI)",
+            "7.2",
+            "N/A",
+            "N/A",
+            " ",
+            ""
+        ],
+        [
+            "<A NAME='hydro'></A><b>HYDRO</b>",
+            "",
+            "Small hydro in the eastern region(Remark VI)",
+            "54.6",
+            "32.5",
+            "59.524%",
+            " ",
+            ""
+        ],
+        [
+            "<A NAME='hydro'></A><b>HYDRO</b>",
+            "",
+            "Feicuei#1",
+            "70.0",
+            "75.6",
+            "108.000%",
+            " ",
+            ""
+        ],
+        [
+            "<A NAME='hydro'></A><b>HYDRO</b>",
+            "",
+            "Shihmen#1",
+            "45.0",
+            "0.0",
+            "0.000%",
+            " ",
+            ""
+        ],
+        [
+            "<A NAME='hydro'></A><b>HYDRO</b>",
+            "",
+            "Shihmen#2",
+            "45.0",
+            "45.1",
+            "100.222%",
+            " ",
+            ""
+        ],
+        [
+            "<A NAME='hydro'></A><b>HYDRO</b>",
+            "",
+            "Zengwun#1",
+            "50.0",
+            "0.0",
+            "0.000%",
+            "2",
+            ""
+        ],
+        [
+            "<A NAME='hydro'></A><b>HYDRO</b>",
+            "",
+            "Yising#1",
+            "40.0",
+            "12.2",
+            "30.500%",
+            " ",
+            ""
+        ],
+        [
+            "<A NAME='hydro'></A><b>HYDRO</b>",
+            "",
+            "Mingjian",
+            "16.7",
+            "0.0",
+            "0.000%",
+            " ",
+            ""
+        ],
+        [
+            "<A NAME='hydro'></A><b>HYDRO</b>",
+            "",
+            "Jiananxikou&amp;Wushantou&amp;Batian",
+            "22.5",
+            "0.0",
+            "0.000%",
+            " ",
+            ""
+        ],
+        [
+            "<A NAME='hydro'></A><b>HYDRO</b>",
+            "",
+            "HouliDemo",
+            "0.1",
+            "N/A",
+            "N/A",
+            " ",
+            ""
+        ],
+        [
+            "<A NAME='hydro'></A><b>HYDRO</b>",
+            "",
+            "Beinan",
+            "2.0",
+            "1.0",
+            "50.505%",
+            " ",
+            ""
+        ],
+        [
+            "<A NAME='hydro'></A><b>HYDRO</b>",
+            "",
+            "HYDROTRON,Heng Shuei Chuang Dian",
+            "0.1",
+            "N/A",
+            "N/A",
+            " ",
+            ""
+        ],
+        [
+            "<A NAME='hydro'></A><b>HYDRO</b>",
+            "",
+            "GuanShan",
+            "1.0",
+            "0.0",
+            "0.000%",
+            " ",
+            ""
+        ],
+        [
+            "<A NAME='hydro'></A><b>HYDRO</b>",
+            "",
+            "Subtotal",
+            "2102.0(3.931%)",
+            "486.8(1.783%)",
+            "",
+            "",
+            ""
+        ],
+        [
+            "<A NAME='wind'></A><b>WIND</b>",
+            "Onshore Wind TPC(Remark XIII)",
+            "Guanyuan",
+            "30.0",
+            "29.8",
+            "99.333%",
+            " ",
+            ""
+        ],
+        [
+            "<A NAME='wind'></A><b>WIND</b>",
+            "Onshore Wind TPC(Remark XIII)",
+            "Taichung Harbor",
+            "35.0",
+            "26.1",
+            "74.571%",
+            " ",
+            ""
+        ],
+        [
+            "<A NAME='wind'></A><b>WIND</b>",
+            "Onshore Wind TPC(Remark XIII)",
+            "Wanggong",
+            "23.0",
+            "14.9",
+            "64.783%",
+            " ",
+            ""
+        ],
+        [
+            "<A NAME='wind'></A><b>WIND</b>",
+            "Onshore Wind TPC(Remark XIII)",
+            "Zhanggong",
+            "86.2",
+            "42.1",
+            "48.840%",
+            " ",
+            ""
+        ],
+        [
+            "<A NAME='wind'></A><b>WIND</b>",
+            "Onshore Wind TPC(Remark XIII)",
+            "Yunmai",
+            "46.0",
+            "14.9",
+            "32.391%",
+            " ",
+            ""
+        ],
+        [
+            "<A NAME='wind'></A><b>WIND</b>",
+            "Onshore Wind TPC(Remark XIII)",
+            "Sihhu",
+            "28.0",
+            "11.1",
+            "39.643%",
+            " ",
+            ""
+        ],
+        [
+            "<A NAME='wind'></A><b>WIND</b>",
+            "Onshore Wind TPC(Remark XIII)",
+            "Remaining Wind TPC",
+            "72.8",
+            "34.1",
+            "46.815%",
+            " ",
+            ""
+        ],
+        [
+            "<A NAME='wind'></A><b>WIND</b>",
+            "Onshore Wind Purchases(Remark XIII)",
+            "Miaoli-Dapong",
+            "42.0",
+            "19.0",
+            "45.238%",
+            " ",
+            ""
+        ],
+        [
+            "<A NAME='wind'></A><b>WIND</b>",
+            "Onshore Wind Purchases(Remark XIII)",
+            "Luwei-Zhangbin",
+            "55.2",
+            "26.3",
+            "47.645%",
+            " ",
+            ""
+        ],
+        [
+            "<A NAME='wind'></A><b>WIND</b>",
+            "Onshore Wind Purchases(Remark XIII)",
+            "Guanwei-Guanyin&amp;Taowei-Xinwu",
+            "48.3",
+            "23.7",
+            "49.068%",
+            " ",
+            ""
+        ],
+        [
+            "<A NAME='wind'></A><b>WIND</b>",
+            "Onshore Wind Purchases(Remark XIII)",
+            "Zhongwei Da-an",
+            "75.9",
+            "0.0",
+            "0.000%",
+            " ",
+            ""
+        ],
+        [
+            "<A NAME='wind'></A><b>WIND</b>",
+            "Onshore Wind Purchases(Remark XIII)",
+            "ChuangWei Wind",
+            "49.2",
+            "34.8",
+            "70.732%",
+            " ",
+            ""
+        ],
+        [
+            "<A NAME='wind'></A><b>WIND</b>",
+            "Onshore Wind Purchases(Remark XIII)",
+            "wpd,SinYuan-Lunbei",
+            "25.2",
+            "9.2",
+            "36.508%",
+            " ",
+            ""
+        ],
+        [
+            "<A NAME='wind'></A><b>WIND</b>",
+            "Onshore Wind Purchases(Remark XIII)",
+            "Remaining Wind Purchases",
+            "178.4",
+            "54.3",
+            "30.437%",
+            " ",
+            ""
+        ],
+        [
+            "<A NAME='wind'></A><b>WIND</b>",
+            "Offshore Wind TPC(Remark XIII)",
+            "Offshore Wind Generation Project Phase I",
+            "109.2",
+            "72.8",
+            "66.667%",
+            " ",
+            ""
+        ],
+        [
+            "<A NAME='wind'></A><b>WIND</b>",
+            "Offshore Wind Purchases(Remark XIII)",
+            "Formosa 1 Offshore Wind Farm,HaiYang Zhunan",
+            "128.0",
+            "116.3",
+            "90.859%",
+            " ",
+            ""
+        ],
+        [
+            "<A NAME='wind'></A><b>WIND</b>",
+            "Offshore Wind Purchases(Remark XIII)",
+            "OWF Yunlin,YunHu(Remark X)",
+            "-",
+            "237.2",
+            "-",
+            " ",
+            ""
+        ],
+        [
+            "<A NAME='wind'></A><b>WIND</b>",
+            "Offshore Wind Purchases(Remark XIII)",
+            "OWF Yunlin,YunSi(Remark X)",
+            "-",
+            "0.0",
+            "-",
+            " ",
+            ""
+        ],
+        [
+            "<A NAME='wind'></A><b>WIND</b>",
+            "Offshore Wind Purchases(Remark XIII)",
+            "Orsted Greater Changhua-southeast,WoYi Wind(Remark X)",
+            "-",
+            "292.0",
+            "-",
+            " ",
+            ""
+        ],
+        [
+            "<A NAME='wind'></A><b>WIND</b>",
+            "Offshore Wind Purchases(Remark XIII)",
+            "Orsted Greater Changhua-southwest,WoEr Wind(Remark X)",
+            "-",
+            "201.0",
+            "-",
+            " ",
+            ""
+        ],
+        [
+            "<A NAME='wind'></A><b>WIND</b>",
+            "Offshore Wind Purchases(Remark XIII)",
+            "CHANGFANG-XIDAO OFFSHORE WIND FARMS I,FangYi Wind(Remark X)",
+            "-",
+            "79.8",
+            "-",
+            " ",
+            ""
+        ],
+        [
+            "<A NAME='wind'></A><b>WIND</b>",
+            "Offshore Wind Purchases(Remark XIII)",
+            "Changfang - phase 2 Offshore Wind Farm,FangEr Wind(Remark X)",
+            "-",
+            "9.2",
+            "-",
+            " ",
+            ""
+        ],
+        [
+            "<A NAME='wind'></A><b>WIND</b>",
+            "Offshore Wind Purchases(Remark XIII)",
+            "Formosa 2 Offshore Wind Farm,HaiNeng Wind(Remark X)",
+            "-",
+            "364.1",
+            "-",
+            " ",
+            ""
+        ],
+        [
+            "<A NAME='wind'></A><b>WIND</b>",
+            "",
+            "Subtotal",
+            "1032.4(1.931%)",
+            "1712.7(6.272%)",
+            "",
+            "",
+            ""
+        ],
+        [
+            "<A NAME='solar'></A><b>SOLAR</b>",
+            "SOLAR TPC(Remark XIII)",
+            "Jhangbin Solar Power",
+            "100.0",
+            "0.000",
+            "0.000%",
+            " ",
+            ""
+        ],
+        [
+            "<A NAME='solar'></A><b>SOLAR</b>",
+            "SOLAR TPC(Remark XIII)",
+            "Tainan Salt Field Solar",
+            "150.0",
+            "0.000",
+            "0.000%",
+            " ",
+            ""
+        ],
+        [
+            "<A NAME='solar'></A><b>SOLAR</b>",
+            "SOLAR TPC(Remark XIII)",
+            "Remaining Solar TPC",
+            "24.3",
+            "0.000",
+            "0.000%",
+            " ",
+            ""
+        ],
+        [
+            "<A NAME='solar'></A><b>SOLAR</b>",
+            "SOLAR Purchases(Remark XIII)",
+            "Lunwei Solar Power",
+            "-",
+            "0.000",
+            "-",
+            "43",
+            ""
+        ],
+        [
+            "<A NAME='solar'></A><b>SOLAR</b>",
+            "SOLAR Purchases(Remark XIII)",
+            "TianChon PV",
+            "-",
+            "0.000",
+            "-",
+            "43",
+            ""
+        ],
+        [
+            "<A NAME='solar'></A><b>SOLAR</b>",
+            "SOLAR Purchases(Remark XIII)",
+            "TianPeng PV",
+            "80.0",
+            "0.000",
+            "0.000%",
+            " ",
+            ""
+        ],
+        [
+            "<A NAME='solar'></A><b>SOLAR</b>",
+            "SOLAR Purchases(Remark XIII)",
+            "Pau Shing PV(Remark X)",
+            "-",
+            "0.000",
+            "-",
+            " ",
+            ""
+        ],
+        [
+            "<A NAME='solar'></A><b>SOLAR</b>",
+            "SOLAR Purchases(Remark XIII)",
+            "URECO/HuahSuan Green Energy/HEXA Renewables Taiwan,LianHua Solar",
+            "-",
+            "0.000",
+            "-",
+            " ",
+            ""
+        ],
+        [
+            "<A NAME='solar'></A><b>SOLAR</b>",
+            "SOLAR Purchases(Remark XIII)",
+            "SunnyRichPower,SianYang PV(Remark X)",
+            "-",
+            "0.000",
+            "-",
+            " ",
+            ""
+        ],
+        [
+            "<A NAME='solar'></A><b>SOLAR</b>",
+            "SOLAR Purchases(Remark XIII)",
+            "SingWeiPV(Remark X)",
+            "-",
+            "0.000",
+            "-",
+            " ",
+            ""
+        ],
+        [
+            "<A NAME='solar'></A><b>SOLAR</b>",
+            "SOLAR Purchases(Remark XIII)",
+            "Shuo Li PV(Remark X)",
+            "-",
+            "0.000",
+            "-",
+            " ",
+            ""
+        ],
+        [
+            "<A NAME='solar'></A><b>SOLAR</b>",
+            "SOLAR Purchases(Remark XIII)",
+            "TianYing Solar(Remark X)",
+            "-",
+            "0.000",
+            "-",
+            " ",
+            ""
+        ],
+        [
+            "<A NAME='solar'></A><b>SOLAR</b>",
+            "SOLAR Purchases(Remark XIII)",
+            "JhihGuang Solar(Remark X)",
+            "-",
+            "0.000",
+            "-",
+            " ",
+            ""
+        ],
+        [
+            "<A NAME='solar'></A><b>SOLAR</b>",
+            "SOLAR Purchases(Remark XIII)",
+            "Remaining Solar Purchases",
+            "10949.8",
+            "0.000",
+            "0.000%",
+            " ",
+            ""
+        ],
+        [
+            "<A NAME='solar'></A><b>SOLAR</b>",
+            "",
+            "Subtotal",
+            "11304.1(21.143%)",
+            "0.0(0.000%)",
+            "",
+            "",
+            ""
+        ],
+        [
+            "<A NAME='pumpinggen'></A><b>PUMPINGGEN</b>",
+            "",
+            "DaGuan2#1",
+            "250.0",
+            "145.9",
+            "58.360%",
+            " ",
+            ""
+        ],
+        [
+            "<A NAME='pumpinggen'></A><b>PUMPINGGEN</b>",
+            "",
+            "DaGuan2#2",
+            "250.0",
+            "0.0",
+            "0.000%",
+            " ",
+            ""
+        ],
+        [
+            "<A NAME='pumpinggen'></A><b>PUMPINGGEN</b>",
+            "",
+            "DaGuan2#3",
+            "250.0",
+            "0.0",
+            "0.000%",
+            " ",
+            ""
+        ],
+        [
+            "<A NAME='pumpinggen'></A><b>PUMPINGGEN</b>",
+            "",
+            "DaGuan2#4",
+            "250.0",
+            "150.1",
+            "60.040%",
+            " ",
+            ""
+        ],
+        [
+            "<A NAME='pumpinggen'></A><b>PUMPINGGEN</b>",
+            "",
+            "Mingtan#1",
+            "267.0",
+            "179.3",
+            "67.154%",
+            " ",
+            ""
+        ],
+        [
+            "<A NAME='pumpinggen'></A><b>PUMPINGGEN</b>",
+            "",
+            "Mingtan#2",
+            "267.0",
+            "153.0",
+            "57.303%",
+            " ",
+            ""
+        ],
+        [
+            "<A NAME='pumpinggen'></A><b>PUMPINGGEN</b>",
+            "",
+            "Mingtan#3",
+            "267.0",
+            "0.0",
+            "0.000%",
+            " ",
+            ""
+        ],
+        [
+            "<A NAME='pumpinggen'></A><b>PUMPINGGEN</b>",
+            "",
+            "Mingtan#4",
+            "267.0",
+            "152.7",
+            "57.191%",
+            " ",
+            ""
+        ],
+        [
+            "<A NAME='pumpinggen'></A><b>PUMPINGGEN</b>",
+            "",
+            "Mingtan#5",
+            "267.0",
+            "0.0",
+            "0.000%",
+            " ",
+            ""
+        ],
+        [
+            "<A NAME='pumpinggen'></A><b>PUMPINGGEN</b>",
+            "",
+            "Mingtan#6",
+            "267.0",
+            "154.7",
+            "57.940%",
+            " ",
+            ""
+        ],
+        [
+            "<A NAME='pumpinggen'></A><b>PUMPINGGEN</b>",
+            "",
+            "Subtotal",
+            "2602.0(4.867%)",
+            "935.7(3.427%)",
+            "",
+            "",
+            ""
+        ],
+        [
+            "<A NAME='pumpingload'></A><b>PUMPINGLOAD</b>",
+            "",
+            "DaGuan2#1",
+            "-",
+            "0.0",
+            "-",
+            " ",
+            ""
+        ],
+        [
+            "<A NAME='pumpingload'></A><b>PUMPINGLOAD</b>",
+            "",
+            "DaGuan2#2",
+            "-",
+            "0.0",
+            "-",
+            " ",
+            ""
+        ],
+        [
+            "<A NAME='pumpingload'></A><b>PUMPINGLOAD</b>",
+            "",
+            "DaGuan2#3",
+            "-",
+            "0.0",
+            "-",
+            " ",
+            ""
+        ],
+        [
+            "<A NAME='pumpingload'></A><b>PUMPINGLOAD</b>",
+            "",
+            "DaGuan2#4",
+            "-",
+            "0.0",
+            "-",
+            " ",
+            ""
+        ],
+        [
+            "<A NAME='pumpingload'></A><b>PUMPINGLOAD</b>",
+            "",
+            "Mingtan#1",
+            "-",
+            "0.0",
+            "-",
+            " ",
+            ""
+        ],
+        [
+            "<A NAME='pumpingload'></A><b>PUMPINGLOAD</b>",
+            "",
+            "Mingtan#2",
+            "-",
+            "0.0",
+            "-",
+            " ",
+            ""
+        ],
+        [
+            "<A NAME='pumpingload'></A><b>PUMPINGLOAD</b>",
+            "",
+            "Mingtan#3",
+            "-",
+            "0.0",
+            "-",
+            " ",
+            ""
+        ],
+        [
+            "<A NAME='pumpingload'></A><b>PUMPINGLOAD</b>",
+            "",
+            "Mingtan#4",
+            "-",
+            "0.0",
+            "-",
+            " ",
+            ""
+        ],
+        [
+            "<A NAME='pumpingload'></A><b>PUMPINGLOAD</b>",
+            "",
+            "Mingtan#5",
+            "-",
+            "0.0",
+            "-",
+            " ",
+            ""
+        ],
+        [
+            "<A NAME='pumpingload'></A><b>PUMPINGLOAD</b>",
+            "",
+            "Mingtan#6",
+            "-",
+            "0.0",
+            "-",
+            " ",
+            ""
+        ],
+        [
+            "<A NAME='EnergyStorageDischarge'></A><b>ENERGYSTORAGEDISCHARGE</b>",
+            "",
+            "Energy Storage Discharge",
+            "-",
+            "60.9",
+            "-",
+            " ",
+            ""
+        ],
+        [
+            "<A NAME='EnergyStorageDischarge'></A><b>ENERGYSTORAGEDISCHARGE</b>",
+            "",
+            "Subtotal",
+            "0.0(0.000%)",
+            "60.9(0.223%)",
+            "",
+            "",
+            ""
+        ],
+        [
+            "<A NAME='OtherRenewableEnergy'></A><b>OTHERRENEWABLEENERGY</b>",
+            "",
+            "TPC Geothermal",
+            "0.8",
+            "0.5",
+            "59.524%",
+            " ",
+            ""
+        ],
+        [
+            "<A NAME='OtherRenewableEnergy'></A><b>OTHERRENEWABLEENERGY</b>",
+            "",
+            "Geothermal Purchases",
+            "6.4",
+            "2.1",
+            "32.563%",
+            " ",
+            ""
+        ],
+        [
+            "<A NAME='OtherRenewableEnergy'></A><b>OTHERRENEWABLEENERGY</b>",
+            "",
+            "Biofuel",
+            "38.2",
+            "25.8",
+            "67.539%",
+            " ",
+            ""
+        ],
+        [
+            "<A NAME='OtherRenewableEnergy'></A><b>OTHERRENEWABLEENERGY</b>",
+            "",
+            "Subtotal",
+            "45.5(0.085%)",
+            "28.4(0.104%)",
+            "",
+            "",
+            ""
+        ]
+    ],
+    "SubUnitSet": []
+}

--- a/parsers/test/snapshots/snap_test_TAIPOWER.py
+++ b/parsers/test/snapshots/snap_test_TAIPOWER.py
@@ -1,39 +1,44 @@
+# -*- coding: utf-8 -*-
 # snapshottest: v1 - https://goo.gl/zC4yUc
+from __future__ import unicode_literals
 
 from snapshottest import Snapshot
 
+
 snapshots = Snapshot()
 
-snapshots["test_production 1"] = [
+snapshots['test_production 1'] = [
     {
-        "capacity": {
-            "biomass": 38.2,
-            "coal": 14697.2,
-            "gas": 18060.6,
-            "geothermal": 7.2,
-            "hydro": 2101.9999999999995,
-            "nuclear": 1902.0,
-            "oil": 1592.5,
-            "solar": 10822.4,
-            "unknown": 626.9,
-            "wind": 958.0,
+        'capacity': {
+            'biomass': 38.2,
+            'coal': 14197.2,
+            'gas': 18060.6,
+            'geothermal': 7.2,
+            'hydro': 2101.9999999999995,
+            'nuclear': 1902.0,
+            'oil': 1592.5,
+            'solar': 11304.099999999999,
+            'unknown': 626.9,
+            'wind': 1032.4
         },
-        "datetime": "2023-09-24T01:30:00+08:00",
-        "production": {
-            "biomass": 25.3,
-            "coal": 12710.3,
-            "gas": 12226.0,
-            "geothermal": 2.7,
-            "hydro": 459.6,
-            "nuclear": 1877.4,
-            "oil": 364.6,
-            "solar": 0.0,
-            "unknown": 617.4,
-            "wind": 29.4,
+        'datetime': '2023-12-29T19:10:00+08:00',
+        'production': {
+            'biomass': 25.8,
+            'coal': 6367.6,
+            'gas': 14010.6,
+            'geothermal': 2.6,
+            'hydro': 458.7,
+            'nuclear': 1894.4,
+            'oil': 314.5,
+            'solar': 0.0,
+            'unknown': 1494.6,
+            'wind': 1712.7
         },
-        "source": "taipower.com.tw",
-        "sourceType": "measured",
-        "storage": {"hydro": 245.8},
-        "zoneKey": "TW",
+        'source': 'taipower.com.tw',
+        'sourceType': 'measured',
+        'storage': {
+            'hydro': -935.7
+        },
+        'zoneKey': 'TW'
     }
 ]


### PR DESCRIPTION
## Issue

The Taipower parser is currently down because the source returns an additional column now. Seems that it is an empty column but it's preventing the parser from parsing the data.
<img width="1493" alt="image" src="https://github.com/electricitymaps/electricitymaps-contrib/assets/38283096/70ff5b5c-faaa-4c49-a9dc-57a376653d0b">


## Description

- Update the parser to handle this extra column. We don't use this column.
- Update the mock data with the updated source data.
- Update the snapshot.

### Double check

- [ ] I have tested my parser changes locally with `poetry run test_parser "zone_key"`
- [ ] I have run `pnpx prettier --write .` and `poetry run format` to format my changes.
