### PR TITLE
Add reload button to overlay after a while

### DIFF
--- a/web/public/locales/en.json
+++ b/web/public/locales/en.json
@@ -202,7 +202,8 @@
     "privacyPolicy": "Privacy Policy",
     "legalNotice": "Legal Notice",
     "dismiss": "Dismiss",
-    "reload": "Reload"
+    "reload": "Reload",
+    "slow-loading-text": "Still loading, if this continues try reloading..."
   },
   "wind": "wind",
   "windDataError": "Wind data is currently unavailable",

--- a/web/src/components/LoadingOverlay.tsx
+++ b/web/src/components/LoadingOverlay.tsx
@@ -2,25 +2,62 @@ import { animated, useTransition } from '@react-spring/web';
 import useGetState from 'api/getState';
 import { loadingMapAtom } from 'features/map/mapAtoms';
 import { useAtom } from 'jotai';
+import { useEffect, useState } from 'react';
+import { useTranslation } from 'translation/translation';
+
+import { Button } from './Button';
+
+const TIME_BEFORE_SHOWING_RELOAD_BUTTON = 8000;
 
 // TODO: Consider splitting up the icon and the overlay into two different components.
 // That way we can maybe reuse it in panels for a loading indicator there.
 // TODO: Consider loading svg directly or via img tag instead of the background-image
 // approach used here.
 function FadingOverlay({ isVisible }: { isVisible: boolean }) {
+  const { __ } = useTranslation();
+
+  const [showButton, setShowButton] = useState(false);
   const transitions = useTransition(isVisible, {
     from: { opacity: 1 },
     leave: { opacity: 0 },
   });
 
+  // Show the reload button after some time
+  useEffect(() => {
+    setTimeout(() => {
+      if (showButton === false && isVisible) {
+        setShowButton(true);
+      }
+    }, TIME_BEFORE_SHOWING_RELOAD_BUTTON);
+    return () => {
+      setShowButton(false);
+    };
+  }, [isVisible]);
+
   return transitions(
     (styles, isVisible) =>
       isVisible && (
         <animated.div
-          className="fixed z-50 h-full w-full bg-gray-100 bg-[url('/images/loading-icon.svg')] bg-[length:100px] bg-center bg-no-repeat dark:bg-gray-900 dark:bg-[url('/images/loading-icon-darkmode.svg')]"
+          className="fixed z-50 h-full w-full bg-gray-100 dark:bg-gray-900"
           style={styles}
           data-test-id="loading-overlay"
-        />
+        >
+          <div className="flex h-full flex-col items-center justify-center">
+            <div className="h-40 w-40 bg-[url('/images/loading-icon.svg')] bg-[length:100px] bg-center bg-no-repeat dark:bg-gray-900 dark:bg-[url('/images/loading-icon-darkmode.svg')]" />
+            {showButton && (
+              <>
+                <p>{__('misc.slow-loading-text')}</p>
+                <Button
+                  className="w-20 min-w-min dark:bg-gray-800/80"
+                  aria-label="Reload page"
+                  onClick={() => window.location.reload()}
+                >
+                  {__('misc.reload')}
+                </Button>
+              </>
+            )}
+          </div>
+        </animated.div>
       )
   );
 }


### PR DESCRIPTION
## Description

The app-backend sometimes get stuck on too much load. This is not ideally and it is something we're looking into fixing.
In the mean time, this quick fix would let users know that things are taking too long and suggest that they reload the page to force a new request.

### Preview

![Screenshot 2024-01-04 at 14 10 10](https://github.com/electricitymaps/electricitymaps-contrib/assets/3296643/ac5e54ba-76f3-48de-a6ef-5d3116fffe9e)

### Double check

- [x] I have run `pnpx prettier --write .` and `poetry run format` to format my changes.
