### PR TITLE
Add link to Methodology page to the header

### DIFF
--- a/web/src/features/header/Header.tsx
+++ b/web/src/features/header/Header.tsx
@@ -28,7 +28,7 @@ function MenuLink({
     onClick && onClick();
   };
   return (
-    <div className="relative flex py-2 ">
+    <div className="relative flex py-2">
       <NavigationMenu.Item
         asChild
         className="cursor-pointer rounded-md transition-colors hover:bg-zinc-100 dark:hover:bg-black/50"
@@ -36,7 +36,7 @@ function MenuLink({
         <NavigationMenu.Link
           onClick={handleClick}
           href={href}
-          className="group px-2 py-2"
+          className="group px-1 py-2 text-base lg:px-2 lg:text-[1rem]"
         >
           {children}
           {isExternal && (
@@ -59,13 +59,13 @@ export default function Header(): JSX.Element {
   return (
     <header
       className={twMerge(
-        'z-30 hidden w-full items-center justify-between bg-white pl-4 pr-8 shadow-[0_4px_6px_-2px_rgba(0,0,0,0.1)] dark:bg-gray-800 dark:shadow-[0_4px_6px_-2px_rgba(0,0,0,0.25)]',
-        !isMobileApp && 'sm:flex'
+        'z-30 hidden w-full items-center justify-between bg-white px-4 shadow-[0_4px_6px_-2px_rgba(0,0,0,0.1)] dark:bg-gray-800 dark:shadow-[0_4px_6px_-2px_rgba(0,0,0,0.25)] md:pr-8',
+        !isMobileApp && 'sm:block md:flex'
       )}
     >
       <Logo className="h-12 w-56 fill-black dark:fill-white" />
-      <NavigationMenu.Root className="hidden md:block">
-        <NavigationMenu.List className="flex space-x-2">
+      <NavigationMenu.Root className="hidden sm:block">
+        <NavigationMenu.List className="flex w-full justify-around md:space-x-2">
           <MenuLink id="faq" onClick={onFAQClick}>
             FAQ
           </MenuLink>

--- a/web/src/features/header/Header.tsx
+++ b/web/src/features/header/Header.tsx
@@ -70,6 +70,13 @@ export default function Header(): JSX.Element {
             FAQ
           </MenuLink>
           <MenuLink
+            href="https://www.electricitymaps.com/methodology/?utm_source=app.electricitymaps.com&utm_medium=referral"
+            id="methodology"
+            isExternal
+          >
+            Methodology
+          </MenuLink>
+          <MenuLink
             href="https://www.electricitymaps.com/jobs/?utm_source=app.electricitymaps.com&utm_medium=referral"
             id="jobs"
             isExternal

--- a/web/src/features/header/Header.tsx
+++ b/web/src/features/header/Header.tsx
@@ -59,7 +59,7 @@ export default function Header(): JSX.Element {
   return (
     <header
       className={twMerge(
-        'z-30 hidden w-full items-center justify-between bg-white px-4 shadow-[0_4px_6px_-2px_rgba(0,0,0,0.1)] dark:bg-gray-800 dark:shadow-[0_4px_6px_-2px_rgba(0,0,0,0.25)] md:pr-8',
+        'z-30 hidden w-full items-center justify-between bg-white px-4 shadow-[0_4px_6px_-2px_rgba(0,0,0,0.1)] md:pr-8 dark:bg-gray-800 dark:shadow-[0_4px_6px_-2px_rgba(0,0,0,0.25)]',
         !isMobileApp && 'sm:block md:flex'
       )}
     >


### PR DESCRIPTION
## Issue

We are frequently seeing discussions using the map as source, but with people questioning how data is calculated. The FAQ covers part of it, but maybe we can educate more people by also adding a link to the header menu for the Methodology page :)

## Description

Adds a link to https://www.electricitymaps.com/methodology, and updates styling to handle the wider menu on smaller devices.

### Preview

Three different styling schemes are now in use depending on breakpoint:

- On mobile, there is still no header

- On devices between mobile and 768px, we now show the menu beneath the logo. Previously we would show the logo, but no menu at all 🤔 
![Screenshot 2024-01-11 at 09 44 48](https://github.com/electricitymaps/electricitymaps-contrib/assets/3296643/76a16716-5582-4efa-942e-2d832e0b6c41)

- On devices between tablet and desktop, the text size is slightly smaller:
![Screenshot 2024-01-11 at 09 43 58](https://github.com/electricitymaps/electricitymaps-contrib/assets/3296643/4923a89b-e31d-4cdd-be04-e41b2bdb0cbe)

- And on desktops styling is as before:
![Screenshot 2024-01-11 at 09 44 35](https://github.com/electricitymaps/electricitymaps-contrib/assets/3296643/69a10f52-8c77-459a-aa6c-5ef6365e3bc7)



### Double check

- [x] I have run `pnpx prettier --write .` and `poetry run format` to format my changes.
