### PR TITLE
Enable ruff for the test files

### DIFF
--- a/parsers/test/mocks/quality_check.py
+++ b/parsers/test/mocks/quality_check.py
@@ -5,9 +5,9 @@ Test datapoints for quality.py
 Each one is designed to test some part of the validation functions.
 """
 
-import datetime
+from datetime import datetime, timedelta, timezone
 
-dt = datetime.datetime.utcnow()
+dt = datetime.now(timezone.utc)
 
 prod = {
     "biomass": 15.0,
@@ -71,7 +71,7 @@ e3 = {
     "source": "mysource.com",
 }
 
-future = datetime.datetime.utcnow() + datetime.timedelta(minutes=55)
+future = datetime.now(timezone.utc) + timedelta(minutes=55)
 
 e4 = {
     "sortedZoneKeys": "DK->NO",

--- a/parsers/test/snapshots/snap_test_CNDC.py
+++ b/parsers/test/snapshots/snap_test_CNDC.py
@@ -1,312 +1,298 @@
-# -*- coding: utf-8 -*-
 # snapshottest: v1 - https://goo.gl/zC4yUc
-from __future__ import unicode_literals
 
 from snapshottest import Snapshot
 
-
 snapshots = Snapshot()
 
-snapshots['TestCNDC::test_fetch_generation_forecast 1'] = [
+snapshots["TestCNDC::test_fetch_generation_forecast 1"] = [
     {
-        'datetime': '2023-12-20T00:00:00-04:00',
-        'generation': 1199.23,
-        'source': 'cndc.bo',
-        'zoneKey': 'BO'
+        "datetime": "2023-12-20T00:00:00-04:00",
+        "generation": 1199.23,
+        "source": "cndc.bo",
+        "zoneKey": "BO",
     },
     {
-        'datetime': '2023-12-20T01:00:00-04:00',
-        'generation': 1141.49,
-        'source': 'cndc.bo',
-        'zoneKey': 'BO'
+        "datetime": "2023-12-20T01:00:00-04:00",
+        "generation": 1141.49,
+        "source": "cndc.bo",
+        "zoneKey": "BO",
     },
     {
-        'datetime': '2023-12-20T02:00:00-04:00',
-        'generation': 1108.31,
-        'source': 'cndc.bo',
-        'zoneKey': 'BO'
+        "datetime": "2023-12-20T02:00:00-04:00",
+        "generation": 1108.31,
+        "source": "cndc.bo",
+        "zoneKey": "BO",
     },
     {
-        'datetime': '2023-12-20T03:00:00-04:00',
-        'generation': 1088.02,
-        'source': 'cndc.bo',
-        'zoneKey': 'BO'
+        "datetime": "2023-12-20T03:00:00-04:00",
+        "generation": 1088.02,
+        "source": "cndc.bo",
+        "zoneKey": "BO",
     },
     {
-        'datetime': '2023-12-20T04:00:00-04:00',
-        'generation': 1118.32,
-        'source': 'cndc.bo',
-        'zoneKey': 'BO'
+        "datetime": "2023-12-20T04:00:00-04:00",
+        "generation": 1118.32,
+        "source": "cndc.bo",
+        "zoneKey": "BO",
     },
     {
-        'datetime': '2023-12-20T05:00:00-04:00',
-        'generation': 1080.45,
-        'source': 'cndc.bo',
-        'zoneKey': 'BO'
+        "datetime": "2023-12-20T05:00:00-04:00",
+        "generation": 1080.45,
+        "source": "cndc.bo",
+        "zoneKey": "BO",
     },
     {
-        'datetime': '2023-12-20T06:00:00-04:00',
-        'generation': 1228.59,
-        'source': 'cndc.bo',
-        'zoneKey': 'BO'
+        "datetime": "2023-12-20T06:00:00-04:00",
+        "generation": 1228.59,
+        "source": "cndc.bo",
+        "zoneKey": "BO",
     },
     {
-        'datetime': '2023-12-20T07:00:00-04:00',
-        'generation': 1292.94,
-        'source': 'cndc.bo',
-        'zoneKey': 'BO'
+        "datetime": "2023-12-20T07:00:00-04:00",
+        "generation": 1292.94,
+        "source": "cndc.bo",
+        "zoneKey": "BO",
     },
     {
-        'datetime': '2023-12-20T08:00:00-04:00',
-        'generation': 1399.9,
-        'source': 'cndc.bo',
-        'zoneKey': 'BO'
+        "datetime": "2023-12-20T08:00:00-04:00",
+        "generation": 1399.9,
+        "source": "cndc.bo",
+        "zoneKey": "BO",
     },
     {
-        'datetime': '2023-12-20T09:00:00-04:00',
-        'generation': 1454.64,
-        'source': 'cndc.bo',
-        'zoneKey': 'BO'
+        "datetime": "2023-12-20T09:00:00-04:00",
+        "generation": 1454.64,
+        "source": "cndc.bo",
+        "zoneKey": "BO",
     },
     {
-        'datetime': '2023-12-20T10:00:00-04:00',
-        'generation': 1485.06,
-        'source': 'cndc.bo',
-        'zoneKey': 'BO'
+        "datetime": "2023-12-20T10:00:00-04:00",
+        "generation": 1485.06,
+        "source": "cndc.bo",
+        "zoneKey": "BO",
     },
     {
-        'datetime': '2023-12-20T11:00:00-04:00',
-        'generation': 1499.31,
-        'source': 'cndc.bo',
-        'zoneKey': 'BO'
+        "datetime": "2023-12-20T11:00:00-04:00",
+        "generation": 1499.31,
+        "source": "cndc.bo",
+        "zoneKey": "BO",
     },
     {
-        'datetime': '2023-12-20T12:00:00-04:00',
-        'generation': 1488.93,
-        'source': 'cndc.bo',
-        'zoneKey': 'BO'
+        "datetime": "2023-12-20T12:00:00-04:00",
+        "generation": 1488.93,
+        "source": "cndc.bo",
+        "zoneKey": "BO",
     },
     {
-        'datetime': '2023-12-20T13:00:00-04:00',
-        'generation': 1547.23,
-        'source': 'cndc.bo',
-        'zoneKey': 'BO'
+        "datetime": "2023-12-20T13:00:00-04:00",
+        "generation": 1547.23,
+        "source": "cndc.bo",
+        "zoneKey": "BO",
     },
     {
-        'datetime': '2023-12-20T14:00:00-04:00',
-        'generation': 1590.45,
-        'source': 'cndc.bo',
-        'zoneKey': 'BO'
+        "datetime": "2023-12-20T14:00:00-04:00",
+        "generation": 1590.45,
+        "source": "cndc.bo",
+        "zoneKey": "BO",
     },
     {
-        'datetime': '2023-12-20T15:00:00-04:00',
-        'generation': 1572.62,
-        'source': 'cndc.bo',
-        'zoneKey': 'BO'
+        "datetime": "2023-12-20T15:00:00-04:00",
+        "generation": 1572.62,
+        "source": "cndc.bo",
+        "zoneKey": "BO",
     },
     {
-        'datetime': '2023-12-20T16:00:00-04:00',
-        'generation': 1516.26,
-        'source': 'cndc.bo',
-        'zoneKey': 'BO'
+        "datetime": "2023-12-20T16:00:00-04:00",
+        "generation": 1516.26,
+        "source": "cndc.bo",
+        "zoneKey": "BO",
     },
     {
-        'datetime': '2023-12-20T17:00:00-04:00',
-        'generation': 1442.56,
-        'source': 'cndc.bo',
-        'zoneKey': 'BO'
+        "datetime": "2023-12-20T17:00:00-04:00",
+        "generation": 1442.56,
+        "source": "cndc.bo",
+        "zoneKey": "BO",
     },
     {
-        'datetime': '2023-12-20T18:00:00-04:00',
-        'generation': 1571.34,
-        'source': 'cndc.bo',
-        'zoneKey': 'BO'
+        "datetime": "2023-12-20T18:00:00-04:00",
+        "generation": 1571.34,
+        "source": "cndc.bo",
+        "zoneKey": "BO",
     },
     {
-        'datetime': '2023-12-20T19:00:00-04:00',
-        'generation': 1627.02,
-        'source': 'cndc.bo',
-        'zoneKey': 'BO'
+        "datetime": "2023-12-20T19:00:00-04:00",
+        "generation": 1627.02,
+        "source": "cndc.bo",
+        "zoneKey": "BO",
     },
     {
-        'datetime': '2023-12-20T20:00:00-04:00',
-        'generation': 1599.87,
-        'source': 'cndc.bo',
-        'zoneKey': 'BO'
+        "datetime": "2023-12-20T20:00:00-04:00",
+        "generation": 1599.87,
+        "source": "cndc.bo",
+        "zoneKey": "BO",
     },
     {
-        'datetime': '2023-12-20T21:00:00-04:00',
-        'generation': 1525.8,
-        'source': 'cndc.bo',
-        'zoneKey': 'BO'
+        "datetime": "2023-12-20T21:00:00-04:00",
+        "generation": 1525.8,
+        "source": "cndc.bo",
+        "zoneKey": "BO",
     },
     {
-        'datetime': '2023-12-20T22:00:00-04:00',
-        'generation': 1411.17,
-        'source': 'cndc.bo',
-        'zoneKey': 'BO'
+        "datetime": "2023-12-20T22:00:00-04:00",
+        "generation": 1411.17,
+        "source": "cndc.bo",
+        "zoneKey": "BO",
     },
     {
-        'datetime': '2023-12-20T23:00:00-04:00',
-        'generation': 1294.64,
-        'source': 'cndc.bo',
-        'zoneKey': 'BO'
-    }
+        "datetime": "2023-12-20T23:00:00-04:00",
+        "generation": 1294.64,
+        "source": "cndc.bo",
+        "zoneKey": "BO",
+    },
 ]
 
-snapshots['TestCNDC::test_fetch_production 1'] = [
+snapshots["TestCNDC::test_fetch_production 1"] = [
     {
-        'datetime': '2023-12-20T00:00:00-04:00',
-        'production': {
-            'biomass': 0.0,
-            'hydro': 384.86,
-            'solar': 0.0,
-            'unknown': 744.75,
-            'wind': 45.39
+        "datetime": "2023-12-20T00:00:00-04:00",
+        "production": {
+            "biomass": 0.0,
+            "hydro": 384.86,
+            "solar": 0.0,
+            "unknown": 744.75,
+            "wind": 45.39,
         },
-        'source': 'cndc.bo',
-        'storage': {
-        },
-        'zoneKey': 'BO'
+        "source": "cndc.bo",
+        "storage": {},
+        "zoneKey": "BO",
     },
     {
-        'datetime': '2023-12-20T01:00:00-04:00',
-        'production': {
-            'biomass': 0.0,
-            'hydro': 402.78,
-            'solar': 0.0,
-            'unknown': 696.4,
-            'wind': 47.16
+        "datetime": "2023-12-20T01:00:00-04:00",
+        "production": {
+            "biomass": 0.0,
+            "hydro": 402.78,
+            "solar": 0.0,
+            "unknown": 696.4,
+            "wind": 47.16,
         },
-        'source': 'cndc.bo',
-        'storage': {
-        },
-        'zoneKey': 'BO'
+        "source": "cndc.bo",
+        "storage": {},
+        "zoneKey": "BO",
     },
     {
-        'datetime': '2023-12-20T02:00:00-04:00',
-        'production': {
-            'biomass': 0.0,
-            'hydro': 406.37,
-            'solar': 0.0,
-            'unknown': 661.4,
-            'wind': 48.76
+        "datetime": "2023-12-20T02:00:00-04:00",
+        "production": {
+            "biomass": 0.0,
+            "hydro": 406.37,
+            "solar": 0.0,
+            "unknown": 661.4,
+            "wind": 48.76,
         },
-        'source': 'cndc.bo',
-        'storage': {
-        },
-        'zoneKey': 'BO'
+        "source": "cndc.bo",
+        "storage": {},
+        "zoneKey": "BO",
     },
     {
-        'datetime': '2023-12-20T03:00:00-04:00',
-        'production': {
-            'biomass': 0.0,
-            'hydro': 380.18,
-            'solar': 0.0,
-            'unknown': 662.76,
-            'wind': 47.33
+        "datetime": "2023-12-20T03:00:00-04:00",
+        "production": {
+            "biomass": 0.0,
+            "hydro": 380.18,
+            "solar": 0.0,
+            "unknown": 662.76,
+            "wind": 47.33,
         },
-        'source': 'cndc.bo',
-        'storage': {
-        },
-        'zoneKey': 'BO'
+        "source": "cndc.bo",
+        "storage": {},
+        "zoneKey": "BO",
     },
     {
-        'datetime': '2023-12-20T04:00:00-04:00',
-        'production': {
-            'biomass': 0.0,
-            'hydro': 379.26,
-            'solar': 0.0,
-            'unknown': 661.1500000000001,
-            'wind': 51.32
+        "datetime": "2023-12-20T04:00:00-04:00",
+        "production": {
+            "biomass": 0.0,
+            "hydro": 379.26,
+            "solar": 0.0,
+            "unknown": 661.1500000000001,
+            "wind": 51.32,
         },
-        'source': 'cndc.bo',
-        'storage': {
-        },
-        'zoneKey': 'BO'
+        "source": "cndc.bo",
+        "storage": {},
+        "zoneKey": "BO",
     },
     {
-        'datetime': '2023-12-20T05:00:00-04:00',
-        'production': {
-            'biomass': 0.0,
-            'hydro': 350.42,
-            'solar': 0.39,
-            'unknown': 647.5,
-            'wind': 50.26
+        "datetime": "2023-12-20T05:00:00-04:00",
+        "production": {
+            "biomass": 0.0,
+            "hydro": 350.42,
+            "solar": 0.39,
+            "unknown": 647.5,
+            "wind": 50.26,
         },
-        'source': 'cndc.bo',
-        'storage': {
-        },
-        'zoneKey': 'BO'
+        "source": "cndc.bo",
+        "storage": {},
+        "zoneKey": "BO",
     },
     {
-        'datetime': '2023-12-20T06:00:00-04:00',
-        'production': {
-            'biomass': 0.0,
-            'hydro': 422.66,
-            'solar': 13.45,
-            'unknown': 670.38,
-            'wind': 41.49
+        "datetime": "2023-12-20T06:00:00-04:00",
+        "production": {
+            "biomass": 0.0,
+            "hydro": 422.66,
+            "solar": 13.45,
+            "unknown": 670.38,
+            "wind": 41.49,
         },
-        'source': 'cndc.bo',
-        'storage': {
-        },
-        'zoneKey': 'BO'
+        "source": "cndc.bo",
+        "storage": {},
+        "zoneKey": "BO",
     },
     {
-        'datetime': '2023-12-20T07:00:00-04:00',
-        'production': {
-            'biomass': 0.0,
-            'hydro': 500.35,
-            'solar': 47.85,
-            'unknown': 717.29,
-            'wind': 45.95
+        "datetime": "2023-12-20T07:00:00-04:00",
+        "production": {
+            "biomass": 0.0,
+            "hydro": 500.35,
+            "solar": 47.85,
+            "unknown": 717.29,
+            "wind": 45.95,
         },
-        'source': 'cndc.bo',
-        'storage': {
-        },
-        'zoneKey': 'BO'
+        "source": "cndc.bo",
+        "storage": {},
+        "zoneKey": "BO",
     },
     {
-        'datetime': '2023-12-20T08:00:00-04:00',
-        'production': {
-            'biomass': 0.0,
-            'hydro': 505.62,
-            'solar': 90.01,
-            'unknown': 769.71,
-            'wind': 46.62
+        "datetime": "2023-12-20T08:00:00-04:00",
+        "production": {
+            "biomass": 0.0,
+            "hydro": 505.62,
+            "solar": 90.01,
+            "unknown": 769.71,
+            "wind": 46.62,
         },
-        'source': 'cndc.bo',
-        'storage': {
-        },
-        'zoneKey': 'BO'
+        "source": "cndc.bo",
+        "storage": {},
+        "zoneKey": "BO",
     },
     {
-        'datetime': '2023-12-20T09:00:00-04:00',
-        'production': {
-            'biomass': 0.0,
-            'hydro': 523.88,
-            'solar': 113.07,
-            'unknown': 845.1199999999999,
-            'wind': 32.52
+        "datetime": "2023-12-20T09:00:00-04:00",
+        "production": {
+            "biomass": 0.0,
+            "hydro": 523.88,
+            "solar": 113.07,
+            "unknown": 845.1199999999999,
+            "wind": 32.52,
         },
-        'source': 'cndc.bo',
-        'storage': {
-        },
-        'zoneKey': 'BO'
+        "source": "cndc.bo",
+        "storage": {},
+        "zoneKey": "BO",
     },
     {
-        'datetime': '2023-12-20T10:00:00-04:00',
-        'production': {
-            'biomass': 0.0,
-            'hydro': 511.72,
-            'solar': 124.97,
-            'unknown': 920.99,
-            'wind': 24.76
+        "datetime": "2023-12-20T10:00:00-04:00",
+        "production": {
+            "biomass": 0.0,
+            "hydro": 511.72,
+            "solar": 124.97,
+            "unknown": 920.99,
+            "wind": 24.76,
         },
-        'source': 'cndc.bo',
-        'storage': {
-        },
-        'zoneKey': 'BO'
-    }
+        "source": "cndc.bo",
+        "storage": {},
+        "zoneKey": "BO",
+    },
 ]

--- a/parsers/test/snapshots/snap_test_ERP_PGCB.py
+++ b/parsers/test/snapshots/snap_test_ERP_PGCB.py
@@ -1,1292 +1,1289 @@
-# -*- coding: utf-8 -*-
 # snapshottest: v1 - https://goo.gl/zC4yUc
-from __future__ import unicode_literals
 
 from snapshottest import Snapshot
 
-
 snapshots = Snapshot()
 
-snapshots['TestERP_PGCB::test_exchanges 1'] = [
+snapshots["TestERP_PGCB::test_exchanges 1"] = [
     {
-        'datetime': '2023-12-19T21:00:00+06:00',
-        'netFlow': -94.0,
-        'sortedZoneKeys': 'BD->IN-NE',
-        'source': 'erp.pgcb.gov.bd'
+        "datetime": "2023-12-19T21:00:00+06:00",
+        "netFlow": -94.0,
+        "sortedZoneKeys": "BD->IN-NE",
+        "source": "erp.pgcb.gov.bd",
     },
     {
-        'datetime': '2023-12-19T20:00:00+06:00',
-        'netFlow': -106.0,
-        'sortedZoneKeys': 'BD->IN-NE',
-        'source': 'erp.pgcb.gov.bd'
+        "datetime": "2023-12-19T20:00:00+06:00",
+        "netFlow": -106.0,
+        "sortedZoneKeys": "BD->IN-NE",
+        "source": "erp.pgcb.gov.bd",
     },
     {
-        'datetime': '2023-12-19T19:30:00+06:00',
-        'netFlow': -106.0,
-        'sortedZoneKeys': 'BD->IN-NE',
-        'source': 'erp.pgcb.gov.bd'
+        "datetime": "2023-12-19T19:30:00+06:00",
+        "netFlow": -106.0,
+        "sortedZoneKeys": "BD->IN-NE",
+        "source": "erp.pgcb.gov.bd",
     },
     {
-        'datetime': '2023-12-19T19:00:00+06:00',
-        'netFlow': -102.0,
-        'sortedZoneKeys': 'BD->IN-NE',
-        'source': 'erp.pgcb.gov.bd'
+        "datetime": "2023-12-19T19:00:00+06:00",
+        "netFlow": -102.0,
+        "sortedZoneKeys": "BD->IN-NE",
+        "source": "erp.pgcb.gov.bd",
     },
     {
-        'datetime': '2023-12-19T18:00:00+06:00',
-        'netFlow': -106.0,
-        'sortedZoneKeys': 'BD->IN-NE',
-        'source': 'erp.pgcb.gov.bd'
+        "datetime": "2023-12-19T18:00:00+06:00",
+        "netFlow": -106.0,
+        "sortedZoneKeys": "BD->IN-NE",
+        "source": "erp.pgcb.gov.bd",
     },
     {
-        'datetime': '2023-12-19T17:00:00+06:00',
-        'netFlow': -92.0,
-        'sortedZoneKeys': 'BD->IN-NE',
-        'source': 'erp.pgcb.gov.bd'
+        "datetime": "2023-12-19T17:00:00+06:00",
+        "netFlow": -92.0,
+        "sortedZoneKeys": "BD->IN-NE",
+        "source": "erp.pgcb.gov.bd",
     },
     {
-        'datetime': '2023-12-19T16:00:00+06:00',
-        'netFlow': -96.0,
-        'sortedZoneKeys': 'BD->IN-NE',
-        'source': 'erp.pgcb.gov.bd'
+        "datetime": "2023-12-19T16:00:00+06:00",
+        "netFlow": -96.0,
+        "sortedZoneKeys": "BD->IN-NE",
+        "source": "erp.pgcb.gov.bd",
     },
     {
-        'datetime': '2023-12-19T15:00:00+06:00',
-        'netFlow': -100.0,
-        'sortedZoneKeys': 'BD->IN-NE',
-        'source': 'erp.pgcb.gov.bd'
+        "datetime": "2023-12-19T15:00:00+06:00",
+        "netFlow": -100.0,
+        "sortedZoneKeys": "BD->IN-NE",
+        "source": "erp.pgcb.gov.bd",
     },
     {
-        'datetime': '2023-12-19T14:00:00+06:00',
-        'netFlow': -102.0,
-        'sortedZoneKeys': 'BD->IN-NE',
-        'source': 'erp.pgcb.gov.bd'
+        "datetime": "2023-12-19T14:00:00+06:00",
+        "netFlow": -102.0,
+        "sortedZoneKeys": "BD->IN-NE",
+        "source": "erp.pgcb.gov.bd",
     },
     {
-        'datetime': '2023-12-19T13:00:00+06:00',
-        'netFlow': -104.0,
-        'sortedZoneKeys': 'BD->IN-NE',
-        'source': 'erp.pgcb.gov.bd'
+        "datetime": "2023-12-19T13:00:00+06:00",
+        "netFlow": -104.0,
+        "sortedZoneKeys": "BD->IN-NE",
+        "source": "erp.pgcb.gov.bd",
     },
     {
-        'datetime': '2023-12-19T12:00:00+06:00',
-        'netFlow': -102.0,
-        'sortedZoneKeys': 'BD->IN-NE',
-        'source': 'erp.pgcb.gov.bd'
+        "datetime": "2023-12-19T12:00:00+06:00",
+        "netFlow": -102.0,
+        "sortedZoneKeys": "BD->IN-NE",
+        "source": "erp.pgcb.gov.bd",
     },
     {
-        'datetime': '2023-12-19T11:00:00+06:00',
-        'netFlow': -98.0,
-        'sortedZoneKeys': 'BD->IN-NE',
-        'source': 'erp.pgcb.gov.bd'
+        "datetime": "2023-12-19T11:00:00+06:00",
+        "netFlow": -98.0,
+        "sortedZoneKeys": "BD->IN-NE",
+        "source": "erp.pgcb.gov.bd",
     },
     {
-        'datetime': '2023-12-19T10:00:00+06:00',
-        'netFlow': -90.0,
-        'sortedZoneKeys': 'BD->IN-NE',
-        'source': 'erp.pgcb.gov.bd'
+        "datetime": "2023-12-19T10:00:00+06:00",
+        "netFlow": -90.0,
+        "sortedZoneKeys": "BD->IN-NE",
+        "source": "erp.pgcb.gov.bd",
     },
     {
-        'datetime': '2023-12-19T09:00:00+06:00',
-        'netFlow': -88.0,
-        'sortedZoneKeys': 'BD->IN-NE',
-        'source': 'erp.pgcb.gov.bd'
+        "datetime": "2023-12-19T09:00:00+06:00",
+        "netFlow": -88.0,
+        "sortedZoneKeys": "BD->IN-NE",
+        "source": "erp.pgcb.gov.bd",
     },
     {
-        'datetime': '2023-12-19T08:00:00+06:00',
-        'netFlow': -84.0,
-        'sortedZoneKeys': 'BD->IN-NE',
-        'source': 'erp.pgcb.gov.bd'
+        "datetime": "2023-12-19T08:00:00+06:00",
+        "netFlow": -84.0,
+        "sortedZoneKeys": "BD->IN-NE",
+        "source": "erp.pgcb.gov.bd",
     },
     {
-        'datetime': '2023-12-19T07:00:00+06:00',
-        'netFlow': -82.0,
-        'sortedZoneKeys': 'BD->IN-NE',
-        'source': 'erp.pgcb.gov.bd'
+        "datetime": "2023-12-19T07:00:00+06:00",
+        "netFlow": -82.0,
+        "sortedZoneKeys": "BD->IN-NE",
+        "source": "erp.pgcb.gov.bd",
     },
     {
-        'datetime': '2023-12-19T06:00:00+06:00',
-        'netFlow': -76.0,
-        'sortedZoneKeys': 'BD->IN-NE',
-        'source': 'erp.pgcb.gov.bd'
+        "datetime": "2023-12-19T06:00:00+06:00",
+        "netFlow": -76.0,
+        "sortedZoneKeys": "BD->IN-NE",
+        "source": "erp.pgcb.gov.bd",
     },
     {
-        'datetime': '2023-12-19T05:00:00+06:00',
-        'netFlow': -76.0,
-        'sortedZoneKeys': 'BD->IN-NE',
-        'source': 'erp.pgcb.gov.bd'
+        "datetime": "2023-12-19T05:00:00+06:00",
+        "netFlow": -76.0,
+        "sortedZoneKeys": "BD->IN-NE",
+        "source": "erp.pgcb.gov.bd",
     },
     {
-        'datetime': '2023-12-19T04:00:00+06:00',
-        'netFlow': -78.0,
-        'sortedZoneKeys': 'BD->IN-NE',
-        'source': 'erp.pgcb.gov.bd'
+        "datetime": "2023-12-19T04:00:00+06:00",
+        "netFlow": -78.0,
+        "sortedZoneKeys": "BD->IN-NE",
+        "source": "erp.pgcb.gov.bd",
     },
     {
-        'datetime': '2023-12-19T03:00:00+06:00',
-        'netFlow': -78.0,
-        'sortedZoneKeys': 'BD->IN-NE',
-        'source': 'erp.pgcb.gov.bd'
+        "datetime": "2023-12-19T03:00:00+06:00",
+        "netFlow": -78.0,
+        "sortedZoneKeys": "BD->IN-NE",
+        "source": "erp.pgcb.gov.bd",
     },
     {
-        'datetime': '2023-12-19T02:00:00+06:00',
-        'netFlow': -76.0,
-        'sortedZoneKeys': 'BD->IN-NE',
-        'source': 'erp.pgcb.gov.bd'
+        "datetime": "2023-12-19T02:00:00+06:00",
+        "netFlow": -76.0,
+        "sortedZoneKeys": "BD->IN-NE",
+        "source": "erp.pgcb.gov.bd",
     },
     {
-        'datetime': '2023-12-19T01:00:00+06:00',
-        'netFlow': -80.0,
-        'sortedZoneKeys': 'BD->IN-NE',
-        'source': 'erp.pgcb.gov.bd'
+        "datetime": "2023-12-19T01:00:00+06:00",
+        "netFlow": -80.0,
+        "sortedZoneKeys": "BD->IN-NE",
+        "source": "erp.pgcb.gov.bd",
     },
     {
-        'datetime': '2023-12-19T00:00:00+06:00',
-        'netFlow': -92.0,
-        'sortedZoneKeys': 'BD->IN-NE',
-        'source': 'erp.pgcb.gov.bd'
+        "datetime": "2023-12-19T00:00:00+06:00",
+        "netFlow": -92.0,
+        "sortedZoneKeys": "BD->IN-NE",
+        "source": "erp.pgcb.gov.bd",
     },
     {
-        'datetime': '2023-12-18T23:00:00+06:00',
-        'netFlow': -96.0,
-        'sortedZoneKeys': 'BD->IN-NE',
-        'source': 'erp.pgcb.gov.bd'
+        "datetime": "2023-12-18T23:00:00+06:00",
+        "netFlow": -96.0,
+        "sortedZoneKeys": "BD->IN-NE",
+        "source": "erp.pgcb.gov.bd",
     },
     {
-        'datetime': '2023-12-18T22:00:00+06:00',
-        'netFlow': -104.0,
-        'sortedZoneKeys': 'BD->IN-NE',
-        'source': 'erp.pgcb.gov.bd'
+        "datetime": "2023-12-18T22:00:00+06:00",
+        "netFlow": -104.0,
+        "sortedZoneKeys": "BD->IN-NE",
+        "source": "erp.pgcb.gov.bd",
     },
     {
-        'datetime': '2023-12-18T21:00:00+06:00',
-        'netFlow': -100.0,
-        'sortedZoneKeys': 'BD->IN-NE',
-        'source': 'erp.pgcb.gov.bd'
+        "datetime": "2023-12-18T21:00:00+06:00",
+        "netFlow": -100.0,
+        "sortedZoneKeys": "BD->IN-NE",
+        "source": "erp.pgcb.gov.bd",
     },
     {
-        'datetime': '2023-12-18T20:00:00+06:00',
-        'netFlow': -102.0,
-        'sortedZoneKeys': 'BD->IN-NE',
-        'source': 'erp.pgcb.gov.bd'
+        "datetime": "2023-12-18T20:00:00+06:00",
+        "netFlow": -102.0,
+        "sortedZoneKeys": "BD->IN-NE",
+        "source": "erp.pgcb.gov.bd",
     },
     {
-        'datetime': '2023-12-18T19:30:00+06:00',
-        'netFlow': -100.0,
-        'sortedZoneKeys': 'BD->IN-NE',
-        'source': 'erp.pgcb.gov.bd'
+        "datetime": "2023-12-18T19:30:00+06:00",
+        "netFlow": -100.0,
+        "sortedZoneKeys": "BD->IN-NE",
+        "source": "erp.pgcb.gov.bd",
     },
     {
-        'datetime': '2023-12-18T19:00:00+06:00',
-        'netFlow': -90.0,
-        'sortedZoneKeys': 'BD->IN-NE',
-        'source': 'erp.pgcb.gov.bd'
+        "datetime": "2023-12-18T19:00:00+06:00",
+        "netFlow": -90.0,
+        "sortedZoneKeys": "BD->IN-NE",
+        "source": "erp.pgcb.gov.bd",
     },
     {
-        'datetime': '2023-12-18T18:00:00+06:00',
-        'netFlow': -92.0,
-        'sortedZoneKeys': 'BD->IN-NE',
-        'source': 'erp.pgcb.gov.bd'
+        "datetime": "2023-12-18T18:00:00+06:00",
+        "netFlow": -92.0,
+        "sortedZoneKeys": "BD->IN-NE",
+        "source": "erp.pgcb.gov.bd",
     },
     {
-        'datetime': '2023-12-18T17:00:00+06:00',
-        'netFlow': -96.0,
-        'sortedZoneKeys': 'BD->IN-NE',
-        'source': 'erp.pgcb.gov.bd'
+        "datetime": "2023-12-18T17:00:00+06:00",
+        "netFlow": -96.0,
+        "sortedZoneKeys": "BD->IN-NE",
+        "source": "erp.pgcb.gov.bd",
     },
     {
-        'datetime': '2023-12-18T16:00:00+06:00',
-        'netFlow': -98.0,
-        'sortedZoneKeys': 'BD->IN-NE',
-        'source': 'erp.pgcb.gov.bd'
+        "datetime": "2023-12-18T16:00:00+06:00",
+        "netFlow": -98.0,
+        "sortedZoneKeys": "BD->IN-NE",
+        "source": "erp.pgcb.gov.bd",
     },
     {
-        'datetime': '2023-12-18T15:00:00+06:00',
-        'netFlow': -90.0,
-        'sortedZoneKeys': 'BD->IN-NE',
-        'source': 'erp.pgcb.gov.bd'
+        "datetime": "2023-12-18T15:00:00+06:00",
+        "netFlow": -90.0,
+        "sortedZoneKeys": "BD->IN-NE",
+        "source": "erp.pgcb.gov.bd",
     },
     {
-        'datetime': '2023-12-18T14:00:00+06:00',
-        'netFlow': -92.0,
-        'sortedZoneKeys': 'BD->IN-NE',
-        'source': 'erp.pgcb.gov.bd'
+        "datetime": "2023-12-18T14:00:00+06:00",
+        "netFlow": -92.0,
+        "sortedZoneKeys": "BD->IN-NE",
+        "source": "erp.pgcb.gov.bd",
     },
     {
-        'datetime': '2023-12-18T13:00:00+06:00',
-        'netFlow': -96.0,
-        'sortedZoneKeys': 'BD->IN-NE',
-        'source': 'erp.pgcb.gov.bd'
+        "datetime": "2023-12-18T13:00:00+06:00",
+        "netFlow": -96.0,
+        "sortedZoneKeys": "BD->IN-NE",
+        "source": "erp.pgcb.gov.bd",
     },
     {
-        'datetime': '2023-12-18T12:00:00+06:00',
-        'netFlow': -102.0,
-        'sortedZoneKeys': 'BD->IN-NE',
-        'source': 'erp.pgcb.gov.bd'
+        "datetime": "2023-12-18T12:00:00+06:00",
+        "netFlow": -102.0,
+        "sortedZoneKeys": "BD->IN-NE",
+        "source": "erp.pgcb.gov.bd",
     },
     {
-        'datetime': '2023-12-18T11:00:00+06:00',
-        'netFlow': -96.0,
-        'sortedZoneKeys': 'BD->IN-NE',
-        'source': 'erp.pgcb.gov.bd'
+        "datetime": "2023-12-18T11:00:00+06:00",
+        "netFlow": -96.0,
+        "sortedZoneKeys": "BD->IN-NE",
+        "source": "erp.pgcb.gov.bd",
     },
     {
-        'datetime': '2023-12-18T10:00:00+06:00',
-        'netFlow': -94.0,
-        'sortedZoneKeys': 'BD->IN-NE',
-        'source': 'erp.pgcb.gov.bd'
+        "datetime": "2023-12-18T10:00:00+06:00",
+        "netFlow": -94.0,
+        "sortedZoneKeys": "BD->IN-NE",
+        "source": "erp.pgcb.gov.bd",
     },
     {
-        'datetime': '2023-12-18T09:00:00+06:00',
-        'netFlow': -90.0,
-        'sortedZoneKeys': 'BD->IN-NE',
-        'source': 'erp.pgcb.gov.bd'
+        "datetime": "2023-12-18T09:00:00+06:00",
+        "netFlow": -90.0,
+        "sortedZoneKeys": "BD->IN-NE",
+        "source": "erp.pgcb.gov.bd",
     },
     {
-        'datetime': '2023-12-18T08:00:00+06:00',
-        'netFlow': -80.0,
-        'sortedZoneKeys': 'BD->IN-NE',
-        'source': 'erp.pgcb.gov.bd'
+        "datetime": "2023-12-18T08:00:00+06:00",
+        "netFlow": -80.0,
+        "sortedZoneKeys": "BD->IN-NE",
+        "source": "erp.pgcb.gov.bd",
     },
     {
-        'datetime': '2023-12-18T07:00:00+06:00',
-        'netFlow': -68.0,
-        'sortedZoneKeys': 'BD->IN-NE',
-        'source': 'erp.pgcb.gov.bd'
+        "datetime": "2023-12-18T07:00:00+06:00",
+        "netFlow": -68.0,
+        "sortedZoneKeys": "BD->IN-NE",
+        "source": "erp.pgcb.gov.bd",
     },
     {
-        'datetime': '2023-12-18T06:00:00+06:00',
-        'netFlow': -70.0,
-        'sortedZoneKeys': 'BD->IN-NE',
-        'source': 'erp.pgcb.gov.bd'
+        "datetime": "2023-12-18T06:00:00+06:00",
+        "netFlow": -70.0,
+        "sortedZoneKeys": "BD->IN-NE",
+        "source": "erp.pgcb.gov.bd",
     },
     {
-        'datetime': '2023-12-18T05:00:00+06:00',
-        'netFlow': -74.0,
-        'sortedZoneKeys': 'BD->IN-NE',
-        'source': 'erp.pgcb.gov.bd'
+        "datetime": "2023-12-18T05:00:00+06:00",
+        "netFlow": -74.0,
+        "sortedZoneKeys": "BD->IN-NE",
+        "source": "erp.pgcb.gov.bd",
     },
     {
-        'datetime': '2023-12-18T04:00:00+06:00',
-        'netFlow': -76.0,
-        'sortedZoneKeys': 'BD->IN-NE',
-        'source': 'erp.pgcb.gov.bd'
+        "datetime": "2023-12-18T04:00:00+06:00",
+        "netFlow": -76.0,
+        "sortedZoneKeys": "BD->IN-NE",
+        "source": "erp.pgcb.gov.bd",
     },
     {
-        'datetime': '2023-12-18T03:00:00+06:00',
-        'netFlow': -72.0,
-        'sortedZoneKeys': 'BD->IN-NE',
-        'source': 'erp.pgcb.gov.bd'
+        "datetime": "2023-12-18T03:00:00+06:00",
+        "netFlow": -72.0,
+        "sortedZoneKeys": "BD->IN-NE",
+        "source": "erp.pgcb.gov.bd",
     },
     {
-        'datetime': '2023-12-18T02:00:00+06:00',
-        'netFlow': -76.0,
-        'sortedZoneKeys': 'BD->IN-NE',
-        'source': 'erp.pgcb.gov.bd'
+        "datetime": "2023-12-18T02:00:00+06:00",
+        "netFlow": -76.0,
+        "sortedZoneKeys": "BD->IN-NE",
+        "source": "erp.pgcb.gov.bd",
     },
     {
-        'datetime': '2023-12-18T01:00:00+06:00',
-        'netFlow': -78.0,
-        'sortedZoneKeys': 'BD->IN-NE',
-        'source': 'erp.pgcb.gov.bd'
+        "datetime": "2023-12-18T01:00:00+06:00",
+        "netFlow": -78.0,
+        "sortedZoneKeys": "BD->IN-NE",
+        "source": "erp.pgcb.gov.bd",
     },
     {
-        'datetime': '2023-12-18T00:00:00+06:00',
-        'netFlow': -82.0,
-        'sortedZoneKeys': 'BD->IN-NE',
-        'source': 'erp.pgcb.gov.bd'
+        "datetime": "2023-12-18T00:00:00+06:00",
+        "netFlow": -82.0,
+        "sortedZoneKeys": "BD->IN-NE",
+        "source": "erp.pgcb.gov.bd",
     },
     {
-        'datetime': '2023-12-17T23:00:00+06:00',
-        'netFlow': -90.0,
-        'sortedZoneKeys': 'BD->IN-NE',
-        'source': 'erp.pgcb.gov.bd'
+        "datetime": "2023-12-17T23:00:00+06:00",
+        "netFlow": -90.0,
+        "sortedZoneKeys": "BD->IN-NE",
+        "source": "erp.pgcb.gov.bd",
     },
     {
-        'datetime': '2023-12-17T22:00:00+06:00',
-        'netFlow': -90.0,
-        'sortedZoneKeys': 'BD->IN-NE',
-        'source': 'erp.pgcb.gov.bd'
+        "datetime": "2023-12-17T22:00:00+06:00",
+        "netFlow": -90.0,
+        "sortedZoneKeys": "BD->IN-NE",
+        "source": "erp.pgcb.gov.bd",
     },
     {
-        'datetime': '2023-12-17T21:00:00+06:00',
-        'netFlow': -96.0,
-        'sortedZoneKeys': 'BD->IN-NE',
-        'source': 'erp.pgcb.gov.bd'
-    }
+        "datetime": "2023-12-17T21:00:00+06:00",
+        "netFlow": -96.0,
+        "sortedZoneKeys": "BD->IN-NE",
+        "source": "erp.pgcb.gov.bd",
+    },
 ]
 
-snapshots['TestERP_PGCB::test_fetch_consumption 1'] = [
+snapshots["TestERP_PGCB::test_fetch_consumption 1"] = [
     {
-        'consumption': 9116.0,
-        'datetime': '2023-12-17T21:00:00+06:00',
-        'source': 'erp.pgcb.gov.bd'
+        "consumption": 9116.0,
+        "datetime": "2023-12-17T21:00:00+06:00",
+        "source": "erp.pgcb.gov.bd",
     },
     {
-        'consumption': 8736.0,
-        'datetime': '2023-12-17T22:00:00+06:00',
-        'source': 'erp.pgcb.gov.bd'
+        "consumption": 8736.0,
+        "datetime": "2023-12-17T22:00:00+06:00",
+        "source": "erp.pgcb.gov.bd",
     },
     {
-        'consumption': 8190.0,
-        'datetime': '2023-12-17T23:00:00+06:00',
-        'source': 'erp.pgcb.gov.bd'
+        "consumption": 8190.0,
+        "datetime": "2023-12-17T23:00:00+06:00",
+        "source": "erp.pgcb.gov.bd",
     },
     {
-        'consumption': 7683.0,
-        'datetime': '2023-12-18T00:00:00+06:00',
-        'source': 'erp.pgcb.gov.bd'
+        "consumption": 7683.0,
+        "datetime": "2023-12-18T00:00:00+06:00",
+        "source": "erp.pgcb.gov.bd",
     },
     {
-        'consumption': 7159.0,
-        'datetime': '2023-12-18T01:00:00+06:00',
-        'source': 'erp.pgcb.gov.bd'
+        "consumption": 7159.0,
+        "datetime": "2023-12-18T01:00:00+06:00",
+        "source": "erp.pgcb.gov.bd",
     },
     {
-        'consumption': 6752.0,
-        'datetime': '2023-12-18T02:00:00+06:00',
-        'source': 'erp.pgcb.gov.bd'
+        "consumption": 6752.0,
+        "datetime": "2023-12-18T02:00:00+06:00",
+        "source": "erp.pgcb.gov.bd",
     },
     {
-        'consumption': 6490.0,
-        'datetime': '2023-12-18T03:00:00+06:00',
-        'source': 'erp.pgcb.gov.bd'
+        "consumption": 6490.0,
+        "datetime": "2023-12-18T03:00:00+06:00",
+        "source": "erp.pgcb.gov.bd",
     },
     {
-        'consumption': 6339.0,
-        'datetime': '2023-12-18T04:00:00+06:00',
-        'source': 'erp.pgcb.gov.bd'
+        "consumption": 6339.0,
+        "datetime": "2023-12-18T04:00:00+06:00",
+        "source": "erp.pgcb.gov.bd",
     },
     {
-        'consumption': 6274.0,
-        'datetime': '2023-12-18T05:00:00+06:00',
-        'source': 'erp.pgcb.gov.bd'
+        "consumption": 6274.0,
+        "datetime": "2023-12-18T05:00:00+06:00",
+        "source": "erp.pgcb.gov.bd",
     },
     {
-        'consumption': 6509.0,
-        'datetime': '2023-12-18T06:00:00+06:00',
-        'source': 'erp.pgcb.gov.bd'
+        "consumption": 6509.0,
+        "datetime": "2023-12-18T06:00:00+06:00",
+        "source": "erp.pgcb.gov.bd",
     },
     {
-        'consumption': 7092.0,
-        'datetime': '2023-12-18T07:00:00+06:00',
-        'source': 'erp.pgcb.gov.bd'
+        "consumption": 7092.0,
+        "datetime": "2023-12-18T07:00:00+06:00",
+        "source": "erp.pgcb.gov.bd",
     },
     {
-        'consumption': 8756.0,
-        'datetime': '2023-12-18T08:00:00+06:00',
-        'source': 'erp.pgcb.gov.bd'
+        "consumption": 8756.0,
+        "datetime": "2023-12-18T08:00:00+06:00",
+        "source": "erp.pgcb.gov.bd",
     },
     {
-        'consumption': 8176.0,
-        'datetime': '2023-12-18T09:00:00+06:00',
-        'source': 'erp.pgcb.gov.bd'
+        "consumption": 8176.0,
+        "datetime": "2023-12-18T09:00:00+06:00",
+        "source": "erp.pgcb.gov.bd",
     },
     {
-        'consumption': 8059.0,
-        'datetime': '2023-12-18T10:00:00+06:00',
-        'source': 'erp.pgcb.gov.bd'
+        "consumption": 8059.0,
+        "datetime": "2023-12-18T10:00:00+06:00",
+        "source": "erp.pgcb.gov.bd",
     },
     {
-        'consumption': 8550.0,
-        'datetime': '2023-12-18T11:00:00+06:00',
-        'source': 'erp.pgcb.gov.bd'
+        "consumption": 8550.0,
+        "datetime": "2023-12-18T11:00:00+06:00",
+        "source": "erp.pgcb.gov.bd",
     },
     {
-        'consumption': 8756.0,
-        'datetime': '2023-12-18T12:00:00+06:00',
-        'source': 'erp.pgcb.gov.bd'
+        "consumption": 8756.0,
+        "datetime": "2023-12-18T12:00:00+06:00",
+        "source": "erp.pgcb.gov.bd",
     },
     {
-        'consumption': 9200.0,
-        'datetime': '2023-12-18T13:00:00+06:00',
-        'source': 'erp.pgcb.gov.bd'
+        "consumption": 9200.0,
+        "datetime": "2023-12-18T13:00:00+06:00",
+        "source": "erp.pgcb.gov.bd",
     },
     {
-        'consumption': 8895.0,
-        'datetime': '2023-12-18T14:00:00+06:00',
-        'source': 'erp.pgcb.gov.bd'
+        "consumption": 8895.0,
+        "datetime": "2023-12-18T14:00:00+06:00",
+        "source": "erp.pgcb.gov.bd",
     },
     {
-        'consumption': 8432.0,
-        'datetime': '2023-12-18T15:00:00+06:00',
-        'source': 'erp.pgcb.gov.bd'
+        "consumption": 8432.0,
+        "datetime": "2023-12-18T15:00:00+06:00",
+        "source": "erp.pgcb.gov.bd",
     },
     {
-        'consumption': 8318.0,
-        'datetime': '2023-12-18T16:00:00+06:00',
-        'source': 'erp.pgcb.gov.bd'
+        "consumption": 8318.0,
+        "datetime": "2023-12-18T16:00:00+06:00",
+        "source": "erp.pgcb.gov.bd",
     },
     {
-        'consumption': 8570.0,
-        'datetime': '2023-12-18T17:00:00+06:00',
-        'source': 'erp.pgcb.gov.bd'
+        "consumption": 8570.0,
+        "datetime": "2023-12-18T17:00:00+06:00",
+        "source": "erp.pgcb.gov.bd",
     },
     {
-        'consumption': 10111.0,
-        'datetime': '2023-12-18T18:00:00+06:00',
-        'source': 'erp.pgcb.gov.bd'
+        "consumption": 10111.0,
+        "datetime": "2023-12-18T18:00:00+06:00",
+        "source": "erp.pgcb.gov.bd",
     },
     {
-        'consumption': 9874.0,
-        'datetime': '2023-12-18T19:00:00+06:00',
-        'source': 'erp.pgcb.gov.bd'
+        "consumption": 9874.0,
+        "datetime": "2023-12-18T19:00:00+06:00",
+        "source": "erp.pgcb.gov.bd",
     },
     {
-        'consumption': 9639.0,
-        'datetime': '2023-12-18T19:30:00+06:00',
-        'source': 'erp.pgcb.gov.bd'
+        "consumption": 9639.0,
+        "datetime": "2023-12-18T19:30:00+06:00",
+        "source": "erp.pgcb.gov.bd",
     },
     {
-        'consumption': 9616.0,
-        'datetime': '2023-12-18T20:00:00+06:00',
-        'source': 'erp.pgcb.gov.bd'
+        "consumption": 9616.0,
+        "datetime": "2023-12-18T20:00:00+06:00",
+        "source": "erp.pgcb.gov.bd",
     },
     {
-        'consumption': 9346.0,
-        'datetime': '2023-12-18T21:00:00+06:00',
-        'source': 'erp.pgcb.gov.bd'
+        "consumption": 9346.0,
+        "datetime": "2023-12-18T21:00:00+06:00",
+        "source": "erp.pgcb.gov.bd",
     },
     {
-        'consumption': 8825.0,
-        'datetime': '2023-12-18T22:00:00+06:00',
-        'source': 'erp.pgcb.gov.bd'
+        "consumption": 8825.0,
+        "datetime": "2023-12-18T22:00:00+06:00",
+        "source": "erp.pgcb.gov.bd",
     },
     {
-        'consumption': 8232.0,
-        'datetime': '2023-12-18T23:00:00+06:00',
-        'source': 'erp.pgcb.gov.bd'
+        "consumption": 8232.0,
+        "datetime": "2023-12-18T23:00:00+06:00",
+        "source": "erp.pgcb.gov.bd",
     },
     {
-        'consumption': 7755.0,
-        'datetime': '2023-12-19T00:00:00+06:00',
-        'source': 'erp.pgcb.gov.bd'
+        "consumption": 7755.0,
+        "datetime": "2023-12-19T00:00:00+06:00",
+        "source": "erp.pgcb.gov.bd",
     },
     {
-        'consumption': 7267.0,
-        'datetime': '2023-12-19T01:00:00+06:00',
-        'source': 'erp.pgcb.gov.bd'
+        "consumption": 7267.0,
+        "datetime": "2023-12-19T01:00:00+06:00",
+        "source": "erp.pgcb.gov.bd",
     },
     {
-        'consumption': 6887.0,
-        'datetime': '2023-12-19T02:00:00+06:00',
-        'source': 'erp.pgcb.gov.bd'
+        "consumption": 6887.0,
+        "datetime": "2023-12-19T02:00:00+06:00",
+        "source": "erp.pgcb.gov.bd",
     },
     {
-        'consumption': 6624.0,
-        'datetime': '2023-12-19T03:00:00+06:00',
-        'source': 'erp.pgcb.gov.bd'
+        "consumption": 6624.0,
+        "datetime": "2023-12-19T03:00:00+06:00",
+        "source": "erp.pgcb.gov.bd",
     },
     {
-        'consumption': 6367.0,
-        'datetime': '2023-12-19T04:00:00+06:00',
-        'source': 'erp.pgcb.gov.bd'
+        "consumption": 6367.0,
+        "datetime": "2023-12-19T04:00:00+06:00",
+        "source": "erp.pgcb.gov.bd",
     },
     {
-        'consumption': 6353.0,
-        'datetime': '2023-12-19T05:00:00+06:00',
-        'source': 'erp.pgcb.gov.bd'
+        "consumption": 6353.0,
+        "datetime": "2023-12-19T05:00:00+06:00",
+        "source": "erp.pgcb.gov.bd",
     },
     {
-        'consumption': 6765.0,
-        'datetime': '2023-12-19T06:00:00+06:00',
-        'source': 'erp.pgcb.gov.bd'
+        "consumption": 6765.0,
+        "datetime": "2023-12-19T06:00:00+06:00",
+        "source": "erp.pgcb.gov.bd",
     },
     {
-        'consumption': 7267.0,
-        'datetime': '2023-12-19T07:00:00+06:00',
-        'source': 'erp.pgcb.gov.bd'
+        "consumption": 7267.0,
+        "datetime": "2023-12-19T07:00:00+06:00",
+        "source": "erp.pgcb.gov.bd",
     },
     {
-        'consumption': 8013.0,
-        'datetime': '2023-12-19T08:00:00+06:00',
-        'source': 'erp.pgcb.gov.bd'
+        "consumption": 8013.0,
+        "datetime": "2023-12-19T08:00:00+06:00",
+        "source": "erp.pgcb.gov.bd",
     },
     {
-        'consumption': 8347.0,
-        'datetime': '2023-12-19T09:00:00+06:00',
-        'source': 'erp.pgcb.gov.bd'
+        "consumption": 8347.0,
+        "datetime": "2023-12-19T09:00:00+06:00",
+        "source": "erp.pgcb.gov.bd",
     },
     {
-        'consumption': 8272.0,
-        'datetime': '2023-12-19T10:00:00+06:00',
-        'source': 'erp.pgcb.gov.bd'
+        "consumption": 8272.0,
+        "datetime": "2023-12-19T10:00:00+06:00",
+        "source": "erp.pgcb.gov.bd",
     },
     {
-        'consumption': 8459.0,
-        'datetime': '2023-12-19T11:00:00+06:00',
-        'source': 'erp.pgcb.gov.bd'
+        "consumption": 8459.0,
+        "datetime": "2023-12-19T11:00:00+06:00",
+        "source": "erp.pgcb.gov.bd",
     },
     {
-        'consumption': 8790.0,
-        'datetime': '2023-12-19T12:00:00+06:00',
-        'source': 'erp.pgcb.gov.bd'
+        "consumption": 8790.0,
+        "datetime": "2023-12-19T12:00:00+06:00",
+        "source": "erp.pgcb.gov.bd",
     },
     {
-        'consumption': 9165.0,
-        'datetime': '2023-12-19T13:00:00+06:00',
-        'source': 'erp.pgcb.gov.bd'
+        "consumption": 9165.0,
+        "datetime": "2023-12-19T13:00:00+06:00",
+        "source": "erp.pgcb.gov.bd",
     },
     {
-        'consumption': 8812.0,
-        'datetime': '2023-12-19T14:00:00+06:00',
-        'source': 'erp.pgcb.gov.bd'
+        "consumption": 8812.0,
+        "datetime": "2023-12-19T14:00:00+06:00",
+        "source": "erp.pgcb.gov.bd",
     },
     {
-        'consumption': 8498.0,
-        'datetime': '2023-12-19T15:00:00+06:00',
-        'source': 'erp.pgcb.gov.bd'
+        "consumption": 8498.0,
+        "datetime": "2023-12-19T15:00:00+06:00",
+        "source": "erp.pgcb.gov.bd",
     },
     {
-        'consumption': 8346.0,
-        'datetime': '2023-12-19T16:00:00+06:00',
-        'source': 'erp.pgcb.gov.bd'
+        "consumption": 8346.0,
+        "datetime": "2023-12-19T16:00:00+06:00",
+        "source": "erp.pgcb.gov.bd",
     },
     {
-        'consumption': 8769.0,
-        'datetime': '2023-12-19T17:00:00+06:00',
-        'source': 'erp.pgcb.gov.bd'
+        "consumption": 8769.0,
+        "datetime": "2023-12-19T17:00:00+06:00",
+        "source": "erp.pgcb.gov.bd",
     },
     {
-        'consumption': 10180.0,
-        'datetime': '2023-12-19T18:00:00+06:00',
-        'source': 'erp.pgcb.gov.bd'
+        "consumption": 10180.0,
+        "datetime": "2023-12-19T18:00:00+06:00",
+        "source": "erp.pgcb.gov.bd",
     },
     {
-        'consumption': 10016.0,
-        'datetime': '2023-12-19T19:00:00+06:00',
-        'source': 'erp.pgcb.gov.bd'
+        "consumption": 10016.0,
+        "datetime": "2023-12-19T19:00:00+06:00",
+        "source": "erp.pgcb.gov.bd",
     },
     {
-        'consumption': 9936.0,
-        'datetime': '2023-12-19T19:30:00+06:00',
-        'source': 'erp.pgcb.gov.bd'
+        "consumption": 9936.0,
+        "datetime": "2023-12-19T19:30:00+06:00",
+        "source": "erp.pgcb.gov.bd",
     },
     {
-        'consumption': 9758.0,
-        'datetime': '2023-12-19T20:00:00+06:00',
-        'source': 'erp.pgcb.gov.bd'
+        "consumption": 9758.0,
+        "datetime": "2023-12-19T20:00:00+06:00",
+        "source": "erp.pgcb.gov.bd",
     },
     {
-        'consumption': 9373.0,
-        'datetime': '2023-12-19T21:00:00+06:00',
-        'source': 'erp.pgcb.gov.bd'
-    }
+        "consumption": 9373.0,
+        "datetime": "2023-12-19T21:00:00+06:00",
+        "source": "erp.pgcb.gov.bd",
+    },
 ]
 
-snapshots['TestERP_PGCB::test_fetch_production 1'] = [
+snapshots["TestERP_PGCB::test_fetch_production 1"] = [
     {
-        'datetime': '2023-12-19T21:00:00+06:00',
-        'production': {
-            'coal': 2871.0,
-            'gas': 4670.0,
-            'hydro': 107.0,
-            'oil': 715.0,
-            'solar': 0.0,
-            'unknown': 1006.0,
-            'wind': 4.0
+        "datetime": "2023-12-19T21:00:00+06:00",
+        "production": {
+            "coal": 2871.0,
+            "gas": 4670.0,
+            "hydro": 107.0,
+            "oil": 715.0,
+            "solar": 0.0,
+            "unknown": 1006.0,
+            "wind": 4.0,
         },
-        'source': 'erp.pgcb.gov.bd',
-        'zoneKey': 'BD'
+        "source": "erp.pgcb.gov.bd",
+        "zoneKey": "BD",
     },
     {
-        'datetime': '2023-12-19T20:00:00+06:00',
-        'production': {
-            'coal': 2899.0,
-            'gas': 4538.0,
-            'hydro': 107.0,
-            'oil': 1289.0,
-            'solar': 0.0,
-            'unknown': 922.0,
-            'wind': 3.0
+        "datetime": "2023-12-19T20:00:00+06:00",
+        "production": {
+            "coal": 2899.0,
+            "gas": 4538.0,
+            "hydro": 107.0,
+            "oil": 1289.0,
+            "solar": 0.0,
+            "unknown": 922.0,
+            "wind": 3.0,
         },
-        'source': 'erp.pgcb.gov.bd',
-        'zoneKey': 'BD'
+        "source": "erp.pgcb.gov.bd",
+        "zoneKey": "BD",
     },
     {
-        'datetime': '2023-12-19T19:30:00+06:00',
-        'production': {
-            'coal': 2910.0,
-            'gas': 4572.0,
-            'hydro': 107.0,
-            'oil': 1610.0,
-            'solar': 0.0,
-            'unknown': 735.0,
-            'wind': 2.0
+        "datetime": "2023-12-19T19:30:00+06:00",
+        "production": {
+            "coal": 2910.0,
+            "gas": 4572.0,
+            "hydro": 107.0,
+            "oil": 1610.0,
+            "solar": 0.0,
+            "unknown": 735.0,
+            "wind": 2.0,
         },
-        'source': 'erp.pgcb.gov.bd',
-        'zoneKey': 'BD'
+        "source": "erp.pgcb.gov.bd",
+        "zoneKey": "BD",
     },
     {
-        'datetime': '2023-12-19T19:00:00+06:00',
-        'production': {
-            'coal': 2976.0,
-            'gas': 4534.0,
-            'hydro': 92.0,
-            'oil': 1682.0,
-            'solar': 0.0,
-            'unknown': 731.0,
-            'wind': 1.0
+        "datetime": "2023-12-19T19:00:00+06:00",
+        "production": {
+            "coal": 2976.0,
+            "gas": 4534.0,
+            "hydro": 92.0,
+            "oil": 1682.0,
+            "solar": 0.0,
+            "unknown": 731.0,
+            "wind": 1.0,
         },
-        'source': 'erp.pgcb.gov.bd',
-        'zoneKey': 'BD'
+        "source": "erp.pgcb.gov.bd",
+        "zoneKey": "BD",
     },
     {
-        'datetime': '2023-12-19T18:00:00+06:00',
-        'production': {
-            'coal': 2906.0,
-            'gas': 4502.0,
-            'hydro': 92.0,
-            'oil': 1916.0,
-            'solar': 0.0,
-            'unknown': 761.0,
-            'wind': 3.0
+        "datetime": "2023-12-19T18:00:00+06:00",
+        "production": {
+            "coal": 2906.0,
+            "gas": 4502.0,
+            "hydro": 92.0,
+            "oil": 1916.0,
+            "solar": 0.0,
+            "unknown": 761.0,
+            "wind": 3.0,
         },
-        'source': 'erp.pgcb.gov.bd',
-        'zoneKey': 'BD'
+        "source": "erp.pgcb.gov.bd",
+        "zoneKey": "BD",
     },
     {
-        'datetime': '2023-12-19T17:00:00+06:00',
-        'production': {
-            'coal': 2639.0,
-            'gas': 3780.0,
-            'hydro': 92.0,
-            'oil': 1290.0,
-            'solar': 8.0,
-            'unknown': 960.0,
-            'wind': 0.0
+        "datetime": "2023-12-19T17:00:00+06:00",
+        "production": {
+            "coal": 2639.0,
+            "gas": 3780.0,
+            "hydro": 92.0,
+            "oil": 1290.0,
+            "solar": 8.0,
+            "unknown": 960.0,
+            "wind": 0.0,
         },
-        'source': 'erp.pgcb.gov.bd',
-        'zoneKey': 'BD'
+        "source": "erp.pgcb.gov.bd",
+        "zoneKey": "BD",
     },
     {
-        'datetime': '2023-12-19T16:00:00+06:00',
-        'production': {
-            'coal': 2551.0,
-            'gas': 4076.0,
-            'hydro': 92.0,
-            'oil': 587.0,
-            'solar': 79.0,
-            'unknown': 958.0,
-            'wind': 3.0
+        "datetime": "2023-12-19T16:00:00+06:00",
+        "production": {
+            "coal": 2551.0,
+            "gas": 4076.0,
+            "hydro": 92.0,
+            "oil": 587.0,
+            "solar": 79.0,
+            "unknown": 958.0,
+            "wind": 3.0,
         },
-        'source': 'erp.pgcb.gov.bd',
-        'zoneKey': 'BD'
+        "source": "erp.pgcb.gov.bd",
+        "zoneKey": "BD",
     },
     {
-        'datetime': '2023-12-19T15:00:00+06:00',
-        'production': {
-            'coal': 2692.0,
-            'gas': 4083.0,
-            'hydro': 70.0,
-            'oil': 482.0,
-            'solar': 209.0,
-            'unknown': 962.0,
-            'wind': 0.0
+        "datetime": "2023-12-19T15:00:00+06:00",
+        "production": {
+            "coal": 2692.0,
+            "gas": 4083.0,
+            "hydro": 70.0,
+            "oil": 482.0,
+            "solar": 209.0,
+            "unknown": 962.0,
+            "wind": 0.0,
         },
-        'source': 'erp.pgcb.gov.bd',
-        'zoneKey': 'BD'
+        "source": "erp.pgcb.gov.bd",
+        "zoneKey": "BD",
     },
     {
-        'datetime': '2023-12-19T14:00:00+06:00',
-        'production': {
-            'coal': 2673.0,
-            'gas': 4192.0,
-            'hydro': 92.0,
-            'oil': 588.0,
-            'solar': 302.0,
-            'unknown': 965.0,
-            'wind': 0.0
+        "datetime": "2023-12-19T14:00:00+06:00",
+        "production": {
+            "coal": 2673.0,
+            "gas": 4192.0,
+            "hydro": 92.0,
+            "oil": 588.0,
+            "solar": 302.0,
+            "unknown": 965.0,
+            "wind": 0.0,
         },
-        'source': 'erp.pgcb.gov.bd',
-        'zoneKey': 'BD'
+        "source": "erp.pgcb.gov.bd",
+        "zoneKey": "BD",
     },
     {
-        'datetime': '2023-12-19T13:00:00+06:00',
-        'production': {
-            'coal': 2666.0,
-            'gas': 4625.0,
-            'hydro': 92.0,
-            'oil': 466.0,
-            'solar': 349.0,
-            'unknown': 967.0,
-            'wind': 0.0
+        "datetime": "2023-12-19T13:00:00+06:00",
+        "production": {
+            "coal": 2666.0,
+            "gas": 4625.0,
+            "hydro": 92.0,
+            "oil": 466.0,
+            "solar": 349.0,
+            "unknown": 967.0,
+            "wind": 0.0,
         },
-        'source': 'erp.pgcb.gov.bd',
-        'zoneKey': 'BD'
+        "source": "erp.pgcb.gov.bd",
+        "zoneKey": "BD",
     },
     {
-        'datetime': '2023-12-19T12:00:00+06:00',
-        'production': {
-            'coal': 2567.0,
-            'gas': 4459.0,
-            'hydro': 92.0,
-            'oil': 336.0,
-            'solar': 366.0,
-            'unknown': 968.0,
-            'wind': 2.0
+        "datetime": "2023-12-19T12:00:00+06:00",
+        "production": {
+            "coal": 2567.0,
+            "gas": 4459.0,
+            "hydro": 92.0,
+            "oil": 336.0,
+            "solar": 366.0,
+            "unknown": 968.0,
+            "wind": 2.0,
         },
-        'source': 'erp.pgcb.gov.bd',
-        'zoneKey': 'BD'
+        "source": "erp.pgcb.gov.bd",
+        "zoneKey": "BD",
     },
     {
-        'datetime': '2023-12-19T11:00:00+06:00',
-        'production': {
-            'coal': 2654.0,
-            'gas': 4118.0,
-            'hydro': 92.0,
-            'oil': 291.0,
-            'solar': 335.0,
-            'unknown': 963.0,
-            'wind': 6.0
+        "datetime": "2023-12-19T11:00:00+06:00",
+        "production": {
+            "coal": 2654.0,
+            "gas": 4118.0,
+            "hydro": 92.0,
+            "oil": 291.0,
+            "solar": 335.0,
+            "unknown": 963.0,
+            "wind": 6.0,
         },
-        'source': 'erp.pgcb.gov.bd',
-        'zoneKey': 'BD'
+        "source": "erp.pgcb.gov.bd",
+        "zoneKey": "BD",
     },
     {
-        'datetime': '2023-12-19T10:00:00+06:00',
-        'production': {
-            'coal': 2679.0,
-            'gas': 4224.0,
-            'hydro': 92.0,
-            'oil': 279.0,
-            'solar': 277.0,
-            'unknown': 720.0,
-            'wind': 1.0
+        "datetime": "2023-12-19T10:00:00+06:00",
+        "production": {
+            "coal": 2679.0,
+            "gas": 4224.0,
+            "hydro": 92.0,
+            "oil": 279.0,
+            "solar": 277.0,
+            "unknown": 720.0,
+            "wind": 1.0,
         },
-        'source': 'erp.pgcb.gov.bd',
-        'zoneKey': 'BD'
+        "source": "erp.pgcb.gov.bd",
+        "zoneKey": "BD",
     },
     {
-        'datetime': '2023-12-19T09:00:00+06:00',
-        'production': {
-            'coal': 2667.0,
-            'gas': 4445.0,
-            'hydro': 92.0,
-            'oil': 236.0,
-            'solar': 190.0,
-            'unknown': 717.0,
-            'wind': 0.0
+        "datetime": "2023-12-19T09:00:00+06:00",
+        "production": {
+            "coal": 2667.0,
+            "gas": 4445.0,
+            "hydro": 92.0,
+            "oil": 236.0,
+            "solar": 190.0,
+            "unknown": 717.0,
+            "wind": 0.0,
         },
-        'source': 'erp.pgcb.gov.bd',
-        'zoneKey': 'BD'
+        "source": "erp.pgcb.gov.bd",
+        "zoneKey": "BD",
     },
     {
-        'datetime': '2023-12-19T08:00:00+06:00',
-        'production': {
-            'coal': 2623.0,
-            'gas': 4400.0,
-            'hydro': 92.0,
-            'oil': 83.0,
-            'solar': 85.0,
-            'unknown': 726.0,
-            'wind': 4.0
+        "datetime": "2023-12-19T08:00:00+06:00",
+        "production": {
+            "coal": 2623.0,
+            "gas": 4400.0,
+            "hydro": 92.0,
+            "oil": 83.0,
+            "solar": 85.0,
+            "unknown": 726.0,
+            "wind": 4.0,
         },
-        'source': 'erp.pgcb.gov.bd',
-        'zoneKey': 'BD'
+        "source": "erp.pgcb.gov.bd",
+        "zoneKey": "BD",
     },
     {
-        'datetime': '2023-12-19T07:00:00+06:00',
-        'production': {
-            'coal': 2348.0,
-            'gas': 4149.0,
-            'hydro': 92.0,
-            'oil': 0.0,
-            'solar': 9.0,
-            'unknown': 665.0,
-            'wind': 4.0
+        "datetime": "2023-12-19T07:00:00+06:00",
+        "production": {
+            "coal": 2348.0,
+            "gas": 4149.0,
+            "hydro": 92.0,
+            "oil": 0.0,
+            "solar": 9.0,
+            "unknown": 665.0,
+            "wind": 4.0,
         },
-        'source': 'erp.pgcb.gov.bd',
-        'zoneKey': 'BD'
+        "source": "erp.pgcb.gov.bd",
+        "zoneKey": "BD",
     },
     {
-        'datetime': '2023-12-19T06:00:00+06:00',
-        'production': {
-            'coal': 2256.0,
-            'gas': 3750.0,
-            'hydro': 92.0,
-            'oil': 0.0,
-            'solar': 0.0,
-            'unknown': 659.0,
-            'wind': 8.0
+        "datetime": "2023-12-19T06:00:00+06:00",
+        "production": {
+            "coal": 2256.0,
+            "gas": 3750.0,
+            "hydro": 92.0,
+            "oil": 0.0,
+            "solar": 0.0,
+            "unknown": 659.0,
+            "wind": 8.0,
         },
-        'source': 'erp.pgcb.gov.bd',
-        'zoneKey': 'BD'
+        "source": "erp.pgcb.gov.bd",
+        "zoneKey": "BD",
     },
     {
-        'datetime': '2023-12-19T05:00:00+06:00',
-        'production': {
-            'coal': 2257.0,
-            'gas': 3359.0,
-            'hydro': 70.0,
-            'oil': 0.0,
-            'solar': 0.0,
-            'unknown': 659.0,
-            'wind': 8.0
+        "datetime": "2023-12-19T05:00:00+06:00",
+        "production": {
+            "coal": 2257.0,
+            "gas": 3359.0,
+            "hydro": 70.0,
+            "oil": 0.0,
+            "solar": 0.0,
+            "unknown": 659.0,
+            "wind": 8.0,
         },
-        'source': 'erp.pgcb.gov.bd',
-        'zoneKey': 'BD'
+        "source": "erp.pgcb.gov.bd",
+        "zoneKey": "BD",
     },
     {
-        'datetime': '2023-12-19T04:00:00+06:00',
-        'production': {
-            'coal': 2254.0,
-            'gas': 3378.0,
-            'hydro': 70.0,
-            'oil': 0.0,
-            'solar': 0.0,
-            'unknown': 661.0,
-            'wind': 4.0
+        "datetime": "2023-12-19T04:00:00+06:00",
+        "production": {
+            "coal": 2254.0,
+            "gas": 3378.0,
+            "hydro": 70.0,
+            "oil": 0.0,
+            "solar": 0.0,
+            "unknown": 661.0,
+            "wind": 4.0,
         },
-        'source': 'erp.pgcb.gov.bd',
-        'zoneKey': 'BD'
+        "source": "erp.pgcb.gov.bd",
+        "zoneKey": "BD",
     },
     {
-        'datetime': '2023-12-19T03:00:00+06:00',
-        'production': {
-            'coal': 2269.0,
-            'gas': 3617.0,
-            'hydro': 70.0,
-            'oil': 0.0,
-            'solar': 0.0,
-            'unknown': 661.0,
-            'wind': 7.0
+        "datetime": "2023-12-19T03:00:00+06:00",
+        "production": {
+            "coal": 2269.0,
+            "gas": 3617.0,
+            "hydro": 70.0,
+            "oil": 0.0,
+            "solar": 0.0,
+            "unknown": 661.0,
+            "wind": 7.0,
         },
-        'source': 'erp.pgcb.gov.bd',
-        'zoneKey': 'BD'
+        "source": "erp.pgcb.gov.bd",
+        "zoneKey": "BD",
     },
     {
-        'datetime': '2023-12-19T02:00:00+06:00',
-        'production': {
-            'coal': 2255.0,
-            'gas': 3870.0,
-            'hydro': 92.0,
-            'oil': 0.0,
-            'solar': 0.0,
-            'unknown': 659.0,
-            'wind': 11.0
+        "datetime": "2023-12-19T02:00:00+06:00",
+        "production": {
+            "coal": 2255.0,
+            "gas": 3870.0,
+            "hydro": 92.0,
+            "oil": 0.0,
+            "solar": 0.0,
+            "unknown": 659.0,
+            "wind": 11.0,
         },
-        'source': 'erp.pgcb.gov.bd',
-        'zoneKey': 'BD'
+        "source": "erp.pgcb.gov.bd",
+        "zoneKey": "BD",
     },
     {
-        'datetime': '2023-12-19T01:00:00+06:00',
-        'production': {
-            'coal': 2327.0,
-            'gas': 4157.0,
-            'hydro': 92.0,
-            'oil': 0.0,
-            'solar': 0.0,
-            'unknown': 685.0,
-            'wind': 6.0
+        "datetime": "2023-12-19T01:00:00+06:00",
+        "production": {
+            "coal": 2327.0,
+            "gas": 4157.0,
+            "hydro": 92.0,
+            "oil": 0.0,
+            "solar": 0.0,
+            "unknown": 685.0,
+            "wind": 6.0,
         },
-        'source': 'erp.pgcb.gov.bd',
-        'zoneKey': 'BD'
+        "source": "erp.pgcb.gov.bd",
+        "zoneKey": "BD",
     },
     {
-        'datetime': '2023-12-19T00:00:00+06:00',
-        'production': {
-            'coal': 2432.0,
-            'gas': 4307.0,
-            'hydro': 92.0,
-            'oil': 0.0,
-            'solar': 0.0,
-            'unknown': 919.0,
-            'wind': 5.0
+        "datetime": "2023-12-19T00:00:00+06:00",
+        "production": {
+            "coal": 2432.0,
+            "gas": 4307.0,
+            "hydro": 92.0,
+            "oil": 0.0,
+            "solar": 0.0,
+            "unknown": 919.0,
+            "wind": 5.0,
         },
-        'source': 'erp.pgcb.gov.bd',
-        'zoneKey': 'BD'
+        "source": "erp.pgcb.gov.bd",
+        "zoneKey": "BD",
     },
     {
-        'datetime': '2023-12-18T23:00:00+06:00',
-        'production': {
-            'coal': 2663.0,
-            'gas': 4398.0,
-            'hydro': 92.0,
-            'oil': 68.0,
-            'solar': 0.0,
-            'unknown': 1008.0,
-            'wind': 3.0
+        "datetime": "2023-12-18T23:00:00+06:00",
+        "production": {
+            "coal": 2663.0,
+            "gas": 4398.0,
+            "hydro": 92.0,
+            "oil": 68.0,
+            "solar": 0.0,
+            "unknown": 1008.0,
+            "wind": 3.0,
         },
-        'source': 'erp.pgcb.gov.bd',
-        'zoneKey': 'BD'
+        "source": "erp.pgcb.gov.bd",
+        "zoneKey": "BD",
     },
     {
-        'datetime': '2023-12-18T22:00:00+06:00',
-        'production': {
-            'coal': 2783.0,
-            'gas': 4544.0,
-            'hydro': 92.0,
-            'oil': 388.0,
-            'solar': 0.0,
-            'unknown': 1015.0,
-            'wind': 3.0
+        "datetime": "2023-12-18T22:00:00+06:00",
+        "production": {
+            "coal": 2783.0,
+            "gas": 4544.0,
+            "hydro": 92.0,
+            "oil": 388.0,
+            "solar": 0.0,
+            "unknown": 1015.0,
+            "wind": 3.0,
         },
-        'source': 'erp.pgcb.gov.bd',
-        'zoneKey': 'BD'
+        "source": "erp.pgcb.gov.bd",
+        "zoneKey": "BD",
     },
     {
-        'datetime': '2023-12-18T21:00:00+06:00',
-        'production': {
-            'coal': 2792.0,
-            'gas': 4636.0,
-            'hydro': 92.0,
-            'oil': 814.0,
-            'solar': 0.0,
-            'unknown': 1012.0,
-            'wind': 0.0
+        "datetime": "2023-12-18T21:00:00+06:00",
+        "production": {
+            "coal": 2792.0,
+            "gas": 4636.0,
+            "hydro": 92.0,
+            "oil": 814.0,
+            "solar": 0.0,
+            "unknown": 1012.0,
+            "wind": 0.0,
         },
-        'source': 'erp.pgcb.gov.bd',
-        'zoneKey': 'BD'
+        "source": "erp.pgcb.gov.bd",
+        "zoneKey": "BD",
     },
     {
-        'datetime': '2023-12-18T20:00:00+06:00',
-        'production': {
-            'coal': 2812.0,
-            'gas': 4653.0,
-            'hydro': 92.0,
-            'oil': 1139.0,
-            'solar': 0.0,
-            'unknown': 920.0,
-            'wind': 0.0
+        "datetime": "2023-12-18T20:00:00+06:00",
+        "production": {
+            "coal": 2812.0,
+            "gas": 4653.0,
+            "hydro": 92.0,
+            "oil": 1139.0,
+            "solar": 0.0,
+            "unknown": 920.0,
+            "wind": 0.0,
         },
-        'source': 'erp.pgcb.gov.bd',
-        'zoneKey': 'BD'
+        "source": "erp.pgcb.gov.bd",
+        "zoneKey": "BD",
     },
     {
-        'datetime': '2023-12-18T19:30:00+06:00',
-        'production': {
-            'coal': 2847.0,
-            'gas': 4715.0,
-            'hydro': 92.0,
-            'oil': 1257.0,
-            'solar': 0.0,
-            'unknown': 728.0,
-            'wind': 0.0
+        "datetime": "2023-12-18T19:30:00+06:00",
+        "production": {
+            "coal": 2847.0,
+            "gas": 4715.0,
+            "hydro": 92.0,
+            "oil": 1257.0,
+            "solar": 0.0,
+            "unknown": 728.0,
+            "wind": 0.0,
         },
-        'source': 'erp.pgcb.gov.bd',
-        'zoneKey': 'BD'
+        "source": "erp.pgcb.gov.bd",
+        "zoneKey": "BD",
     },
     {
-        'datetime': '2023-12-18T19:00:00+06:00',
-        'production': {
-            'coal': 2916.0,
-            'gas': 4581.0,
-            'hydro': 92.0,
-            'oil': 1567.0,
-            'solar': 0.0,
-            'unknown': 718.0,
-            'wind': 0.0
+        "datetime": "2023-12-18T19:00:00+06:00",
+        "production": {
+            "coal": 2916.0,
+            "gas": 4581.0,
+            "hydro": 92.0,
+            "oil": 1567.0,
+            "solar": 0.0,
+            "unknown": 718.0,
+            "wind": 0.0,
         },
-        'source': 'erp.pgcb.gov.bd',
-        'zoneKey': 'BD'
+        "source": "erp.pgcb.gov.bd",
+        "zoneKey": "BD",
     },
     {
-        'datetime': '2023-12-18T18:00:00+06:00',
-        'production': {
-            'coal': 3009.0,
-            'gas': 4583.0,
-            'hydro': 92.0,
-            'oil': 1559.0,
-            'solar': 0.0,
-            'unknown': 868.0,
-            'wind': 0.0
+        "datetime": "2023-12-18T18:00:00+06:00",
+        "production": {
+            "coal": 3009.0,
+            "gas": 4583.0,
+            "hydro": 92.0,
+            "oil": 1559.0,
+            "solar": 0.0,
+            "unknown": 868.0,
+            "wind": 0.0,
         },
-        'source': 'erp.pgcb.gov.bd',
-        'zoneKey': 'BD'
+        "source": "erp.pgcb.gov.bd",
+        "zoneKey": "BD",
     },
     {
-        'datetime': '2023-12-18T17:00:00+06:00',
-        'production': {
-            'coal': 2574.0,
-            'gas': 3858.0,
-            'hydro': 92.0,
-            'oil': 1079.0,
-            'solar': 7.0,
-            'unknown': 960.0,
-            'wind': 0.0
+        "datetime": "2023-12-18T17:00:00+06:00",
+        "production": {
+            "coal": 2574.0,
+            "gas": 3858.0,
+            "hydro": 92.0,
+            "oil": 1079.0,
+            "solar": 7.0,
+            "unknown": 960.0,
+            "wind": 0.0,
         },
-        'source': 'erp.pgcb.gov.bd',
-        'zoneKey': 'BD'
+        "source": "erp.pgcb.gov.bd",
+        "zoneKey": "BD",
     },
     {
-        'datetime': '2023-12-18T16:00:00+06:00',
-        'production': {
-            'coal': 2255.0,
-            'gas': 4081.0,
-            'hydro': 92.0,
-            'oil': 867.0,
-            'solar': 60.0,
-            'unknown': 963.0,
-            'wind': 0.0
+        "datetime": "2023-12-18T16:00:00+06:00",
+        "production": {
+            "coal": 2255.0,
+            "gas": 4081.0,
+            "hydro": 92.0,
+            "oil": 867.0,
+            "solar": 60.0,
+            "unknown": 963.0,
+            "wind": 0.0,
         },
-        'source': 'erp.pgcb.gov.bd',
-        'zoneKey': 'BD'
+        "source": "erp.pgcb.gov.bd",
+        "zoneKey": "BD",
     },
     {
-        'datetime': '2023-12-18T15:00:00+06:00',
-        'production': {
-            'coal': 2390.0,
-            'gas': 3866.0,
-            'hydro': 92.0,
-            'oil': 945.0,
-            'solar': 184.0,
-            'unknown': 955.0,
-            'wind': 0.0
+        "datetime": "2023-12-18T15:00:00+06:00",
+        "production": {
+            "coal": 2390.0,
+            "gas": 3866.0,
+            "hydro": 92.0,
+            "oil": 945.0,
+            "solar": 184.0,
+            "unknown": 955.0,
+            "wind": 0.0,
         },
-        'source': 'erp.pgcb.gov.bd',
-        'zoneKey': 'BD'
+        "source": "erp.pgcb.gov.bd",
+        "zoneKey": "BD",
     },
     {
-        'datetime': '2023-12-18T14:00:00+06:00',
-        'production': {
-            'coal': 2175.0,
-            'gas': 4297.0,
-            'hydro': 92.0,
-            'oil': 1144.0,
-            'solar': 230.0,
-            'unknown': 957.0,
-            'wind': 0.0
+        "datetime": "2023-12-18T14:00:00+06:00",
+        "production": {
+            "coal": 2175.0,
+            "gas": 4297.0,
+            "hydro": 92.0,
+            "oil": 1144.0,
+            "solar": 230.0,
+            "unknown": 957.0,
+            "wind": 0.0,
         },
-        'source': 'erp.pgcb.gov.bd',
-        'zoneKey': 'BD'
+        "source": "erp.pgcb.gov.bd",
+        "zoneKey": "BD",
     },
     {
-        'datetime': '2023-12-18T13:00:00+06:00',
-        'production': {
-            'coal': 2414.0,
-            'gas': 4348.0,
-            'hydro': 92.0,
-            'oil': 1077.0,
-            'solar': 309.0,
-            'unknown': 960.0,
-            'wind': 0.0
+        "datetime": "2023-12-18T13:00:00+06:00",
+        "production": {
+            "coal": 2414.0,
+            "gas": 4348.0,
+            "hydro": 92.0,
+            "oil": 1077.0,
+            "solar": 309.0,
+            "unknown": 960.0,
+            "wind": 0.0,
         },
-        'source': 'erp.pgcb.gov.bd',
-        'zoneKey': 'BD'
+        "source": "erp.pgcb.gov.bd",
+        "zoneKey": "BD",
     },
     {
-        'datetime': '2023-12-18T12:00:00+06:00',
-        'production': {
-            'coal': 2261.0,
-            'gas': 4328.0,
-            'hydro': 92.0,
-            'oil': 744.0,
-            'solar': 364.0,
-            'unknown': 967.0,
-            'wind': 0.0
+        "datetime": "2023-12-18T12:00:00+06:00",
+        "production": {
+            "coal": 2261.0,
+            "gas": 4328.0,
+            "hydro": 92.0,
+            "oil": 744.0,
+            "solar": 364.0,
+            "unknown": 967.0,
+            "wind": 0.0,
         },
-        'source': 'erp.pgcb.gov.bd',
-        'zoneKey': 'BD'
+        "source": "erp.pgcb.gov.bd",
+        "zoneKey": "BD",
     },
     {
-        'datetime': '2023-12-18T11:00:00+06:00',
-        'production': {
-            'coal': 2512.0,
-            'gas': 4270.0,
-            'hydro': 92.0,
-            'oil': 374.0,
-            'solar': 341.0,
-            'unknown': 961.0,
-            'wind': 0.0
+        "datetime": "2023-12-18T11:00:00+06:00",
+        "production": {
+            "coal": 2512.0,
+            "gas": 4270.0,
+            "hydro": 92.0,
+            "oil": 374.0,
+            "solar": 341.0,
+            "unknown": 961.0,
+            "wind": 0.0,
         },
-        'source': 'erp.pgcb.gov.bd',
-        'zoneKey': 'BD'
+        "source": "erp.pgcb.gov.bd",
+        "zoneKey": "BD",
     },
     {
-        'datetime': '2023-12-18T10:00:00+06:00',
-        'production': {
-            'coal': 2420.0,
-            'gas': 4046.0,
-            'hydro': 92.0,
-            'oil': 292.0,
-            'solar': 286.0,
-            'unknown': 923.0,
-            'wind': 0.0
+        "datetime": "2023-12-18T10:00:00+06:00",
+        "production": {
+            "coal": 2420.0,
+            "gas": 4046.0,
+            "hydro": 92.0,
+            "oil": 292.0,
+            "solar": 286.0,
+            "unknown": 923.0,
+            "wind": 0.0,
         },
-        'source': 'erp.pgcb.gov.bd',
-        'zoneKey': 'BD'
+        "source": "erp.pgcb.gov.bd",
+        "zoneKey": "BD",
     },
     {
-        'datetime': '2023-12-18T09:00:00+06:00',
-        'production': {
-            'coal': 2561.0,
-            'gas': 4476.0,
-            'hydro': 92.0,
-            'oil': 137.0,
-            'solar': 191.0,
-            'unknown': 719.0,
-            'wind': 0.0
+        "datetime": "2023-12-18T09:00:00+06:00",
+        "production": {
+            "coal": 2561.0,
+            "gas": 4476.0,
+            "hydro": 92.0,
+            "oil": 137.0,
+            "solar": 191.0,
+            "unknown": 719.0,
+            "wind": 0.0,
         },
-        'source': 'erp.pgcb.gov.bd',
-        'zoneKey': 'BD'
+        "source": "erp.pgcb.gov.bd",
+        "zoneKey": "BD",
     },
     {
-        'datetime': '2023-12-18T08:00:00+06:00',
-        'production': {
-            'coal': 2330.0,
-            'gas': 4495.0,
-            'hydro': 92.0,
-            'oil': 61.0,
-            'solar': 80.0,
-            'unknown': 1697.0,
-            'wind': 1.0
+        "datetime": "2023-12-18T08:00:00+06:00",
+        "production": {
+            "coal": 2330.0,
+            "gas": 4495.0,
+            "hydro": 92.0,
+            "oil": 61.0,
+            "solar": 80.0,
+            "unknown": 1697.0,
+            "wind": 1.0,
         },
-        'source': 'erp.pgcb.gov.bd',
-        'zoneKey': 'BD'
+        "source": "erp.pgcb.gov.bd",
+        "zoneKey": "BD",
     },
     {
-        'datetime': '2023-12-18T07:00:00+06:00',
-        'production': {
-            'coal': 2083.0,
-            'gas': 4345.0,
-            'hydro': 92.0,
-            'oil': 3.0,
-            'solar': 9.0,
-            'unknown': 556.0,
-            'wind': 4.0
+        "datetime": "2023-12-18T07:00:00+06:00",
+        "production": {
+            "coal": 2083.0,
+            "gas": 4345.0,
+            "hydro": 92.0,
+            "oil": 3.0,
+            "solar": 9.0,
+            "unknown": 556.0,
+            "wind": 4.0,
         },
-        'source': 'erp.pgcb.gov.bd',
-        'zoneKey': 'BD'
+        "source": "erp.pgcb.gov.bd",
+        "zoneKey": "BD",
     },
     {
-        'datetime': '2023-12-18T06:00:00+06:00',
-        'production': {
-            'coal': 1881.0,
-            'gas': 3887.0,
-            'hydro': 92.0,
-            'oil': 0.0,
-            'solar': 0.0,
-            'unknown': 643.0,
-            'wind': 6.0
+        "datetime": "2023-12-18T06:00:00+06:00",
+        "production": {
+            "coal": 1881.0,
+            "gas": 3887.0,
+            "hydro": 92.0,
+            "oil": 0.0,
+            "solar": 0.0,
+            "unknown": 643.0,
+            "wind": 6.0,
         },
-        'source': 'erp.pgcb.gov.bd',
-        'zoneKey': 'BD'
+        "source": "erp.pgcb.gov.bd",
+        "zoneKey": "BD",
     },
     {
-        'datetime': '2023-12-18T05:00:00+06:00',
-        'production': {
-            'coal': 1875.0,
-            'gas': 3654.0,
-            'hydro': 92.0,
-            'oil': 0.0,
-            'solar': 0.0,
-            'unknown': 647.0,
-            'wind': 6.0
+        "datetime": "2023-12-18T05:00:00+06:00",
+        "production": {
+            "coal": 1875.0,
+            "gas": 3654.0,
+            "hydro": 92.0,
+            "oil": 0.0,
+            "solar": 0.0,
+            "unknown": 647.0,
+            "wind": 6.0,
         },
-        'source': 'erp.pgcb.gov.bd',
-        'zoneKey': 'BD'
+        "source": "erp.pgcb.gov.bd",
+        "zoneKey": "BD",
     },
     {
-        'datetime': '2023-12-18T04:00:00+06:00',
-        'production': {
-            'coal': 1932.0,
-            'gas': 3656.0,
-            'hydro': 92.0,
-            'oil': 0.0,
-            'solar': 0.0,
-            'unknown': 649.0,
-            'wind': 10.0
+        "datetime": "2023-12-18T04:00:00+06:00",
+        "production": {
+            "coal": 1932.0,
+            "gas": 3656.0,
+            "hydro": 92.0,
+            "oil": 0.0,
+            "solar": 0.0,
+            "unknown": 649.0,
+            "wind": 10.0,
         },
-        'source': 'erp.pgcb.gov.bd',
-        'zoneKey': 'BD'
+        "source": "erp.pgcb.gov.bd",
+        "zoneKey": "BD",
     },
     {
-        'datetime': '2023-12-18T03:00:00+06:00',
-        'production': {
-            'coal': 2001.0,
-            'gas': 3729.0,
-            'hydro': 92.0,
-            'oil': 0.0,
-            'solar': 0.0,
-            'unknown': 654.0,
-            'wind': 14.0
+        "datetime": "2023-12-18T03:00:00+06:00",
+        "production": {
+            "coal": 2001.0,
+            "gas": 3729.0,
+            "hydro": 92.0,
+            "oil": 0.0,
+            "solar": 0.0,
+            "unknown": 654.0,
+            "wind": 14.0,
         },
-        'source': 'erp.pgcb.gov.bd',
-        'zoneKey': 'BD'
+        "source": "erp.pgcb.gov.bd",
+        "zoneKey": "BD",
     },
     {
-        'datetime': '2023-12-18T02:00:00+06:00',
-        'production': {
-            'coal': 1971.0,
-            'gas': 4018.0,
-            'hydro': 92.0,
-            'oil': 0.0,
-            'solar': 0.0,
-            'unknown': 658.0,
-            'wind': 13.0
+        "datetime": "2023-12-18T02:00:00+06:00",
+        "production": {
+            "coal": 1971.0,
+            "gas": 4018.0,
+            "hydro": 92.0,
+            "oil": 0.0,
+            "solar": 0.0,
+            "unknown": 658.0,
+            "wind": 13.0,
         },
-        'source': 'erp.pgcb.gov.bd',
-        'zoneKey': 'BD'
+        "source": "erp.pgcb.gov.bd",
+        "zoneKey": "BD",
     },
     {
-        'datetime': '2023-12-18T01:00:00+06:00',
-        'production': {
-            'coal': 2073.0,
-            'gas': 4319.0,
-            'hydro': 92.0,
-            'oil': 0.0,
-            'solar': 0.0,
-            'unknown': 660.0,
-            'wind': 15.0
+        "datetime": "2023-12-18T01:00:00+06:00",
+        "production": {
+            "coal": 2073.0,
+            "gas": 4319.0,
+            "hydro": 92.0,
+            "oil": 0.0,
+            "solar": 0.0,
+            "unknown": 660.0,
+            "wind": 15.0,
         },
-        'source': 'erp.pgcb.gov.bd',
-        'zoneKey': 'BD'
+        "source": "erp.pgcb.gov.bd",
+        "zoneKey": "BD",
     },
     {
-        'datetime': '2023-12-18T00:00:00+06:00',
-        'production': {
-            'coal': 2139.0,
-            'gas': 4640.0,
-            'hydro': 92.0,
-            'oil': 0.0,
-            'solar': 0.0,
-            'unknown': 807.0,
-            'wind': 5.0
+        "datetime": "2023-12-18T00:00:00+06:00",
+        "production": {
+            "coal": 2139.0,
+            "gas": 4640.0,
+            "hydro": 92.0,
+            "oil": 0.0,
+            "solar": 0.0,
+            "unknown": 807.0,
+            "wind": 5.0,
         },
-        'source': 'erp.pgcb.gov.bd',
-        'zoneKey': 'BD'
+        "source": "erp.pgcb.gov.bd",
+        "zoneKey": "BD",
     },
     {
-        'datetime': '2023-12-17T23:00:00+06:00',
-        'production': {
-            'coal': 2219.0,
-            'gas': 4777.0,
-            'hydro': 92.0,
-            'oil': 98.0,
-            'solar': 0.0,
-            'unknown': 1001.0,
-            'wind': 3.0
+        "datetime": "2023-12-17T23:00:00+06:00",
+        "production": {
+            "coal": 2219.0,
+            "gas": 4777.0,
+            "hydro": 92.0,
+            "oil": 98.0,
+            "solar": 0.0,
+            "unknown": 1001.0,
+            "wind": 3.0,
         },
-        'source': 'erp.pgcb.gov.bd',
-        'zoneKey': 'BD'
+        "source": "erp.pgcb.gov.bd",
+        "zoneKey": "BD",
     },
     {
-        'datetime': '2023-12-17T22:00:00+06:00',
-        'production': {
-            'coal': 2508.0,
-            'gas': 4681.0,
-            'hydro': 92.0,
-            'oil': 448.0,
-            'solar': 0.0,
-            'unknown': 1001.0,
-            'wind': 6.0
+        "datetime": "2023-12-17T22:00:00+06:00",
+        "production": {
+            "coal": 2508.0,
+            "gas": 4681.0,
+            "hydro": 92.0,
+            "oil": 448.0,
+            "solar": 0.0,
+            "unknown": 1001.0,
+            "wind": 6.0,
         },
-        'source': 'erp.pgcb.gov.bd',
-        'zoneKey': 'BD'
+        "source": "erp.pgcb.gov.bd",
+        "zoneKey": "BD",
     },
     {
-        'datetime': '2023-12-17T21:00:00+06:00',
-        'production': {
-            'coal': 2464.0,
-            'gas': 4757.0,
-            'hydro': 92.0,
-            'oil': 696.0,
-            'solar': 0.0,
-            'unknown': 1106.0,
-            'wind': 1.0
+        "datetime": "2023-12-17T21:00:00+06:00",
+        "production": {
+            "coal": 2464.0,
+            "gas": 4757.0,
+            "hydro": 92.0,
+            "oil": 696.0,
+            "solar": 0.0,
+            "unknown": 1106.0,
+            "wind": 1.0,
         },
-        'source': 'erp.pgcb.gov.bd',
-        'zoneKey': 'BD'
-    }
+        "source": "erp.pgcb.gov.bd",
+        "zoneKey": "BD",
+    },
 ]

--- a/parsers/test/snapshots/snap_test_TAIPOWER.py
+++ b/parsers/test/snapshots/snap_test_TAIPOWER.py
@@ -1,44 +1,39 @@
-# -*- coding: utf-8 -*-
 # snapshottest: v1 - https://goo.gl/zC4yUc
-from __future__ import unicode_literals
 
 from snapshottest import Snapshot
 
-
 snapshots = Snapshot()
 
-snapshots['test_production 1'] = [
+snapshots["test_production 1"] = [
     {
-        'capacity': {
-            'biomass': 38.2,
-            'coal': 14197.2,
-            'gas': 18060.6,
-            'geothermal': 7.2,
-            'hydro': 2101.9999999999995,
-            'nuclear': 1902.0,
-            'oil': 1592.5,
-            'solar': 11304.099999999999,
-            'unknown': 626.9,
-            'wind': 1032.4
+        "capacity": {
+            "biomass": 38.2,
+            "coal": 14197.2,
+            "gas": 18060.6,
+            "geothermal": 7.2,
+            "hydro": 2101.9999999999995,
+            "nuclear": 1902.0,
+            "oil": 1592.5,
+            "solar": 11304.099999999999,
+            "unknown": 626.9,
+            "wind": 1032.4,
         },
-        'datetime': '2023-12-29T19:10:00+08:00',
-        'production': {
-            'biomass': 25.8,
-            'coal': 6367.6,
-            'gas': 14010.6,
-            'geothermal': 2.6,
-            'hydro': 458.7,
-            'nuclear': 1894.4,
-            'oil': 314.5,
-            'solar': 0.0,
-            'unknown': 1494.6,
-            'wind': 1712.7
+        "datetime": "2023-12-29T19:10:00+08:00",
+        "production": {
+            "biomass": 25.8,
+            "coal": 6367.6,
+            "gas": 14010.6,
+            "geothermal": 2.6,
+            "hydro": 458.7,
+            "nuclear": 1894.4,
+            "oil": 314.5,
+            "solar": 0.0,
+            "unknown": 1494.6,
+            "wind": 1712.7,
         },
-        'source': 'taipower.com.tw',
-        'sourceType': 'measured',
-        'storage': {
-            'hydro': -935.7
-        },
-        'zoneKey': 'TW'
+        "source": "taipower.com.tw",
+        "sourceType": "measured",
+        "storage": {"hydro": -935.7},
+        "zoneKey": "TW",
     }
 ]

--- a/parsers/test/snapshots/snap_test_amper_landsnet.py
+++ b/parsers/test/snapshots/snap_test_amper_landsnet.py
@@ -1,24 +1,16 @@
-# -*- coding: utf-8 -*-
 # snapshottest: v1 - https://goo.gl/zC4yUc
-from __future__ import unicode_literals
 
 from snapshottest import Snapshot
 
-
 snapshots = Snapshot()
 
-snapshots['TestLandsnet::test_fetch_production 1'] = [
+snapshots["TestLandsnet::test_fetch_production 1"] = [
     {
-        'datetime': '2023-12-19T15:53:23.729935+00:00',
-        'production': {
-            'geothermal': 653.1291,
-            'hydro': 1588.2567,
-            'oil': 0.0
-        },
-        'source': 'amper.landsnet.is',
-        'sourceType': 'measured',
-        'storage': {
-        },
-        'zoneKey': 'IS'
+        "datetime": "2023-12-19T15:53:23.729935+00:00",
+        "production": {"geothermal": 653.1291, "hydro": 1588.2567, "oil": 0.0},
+        "source": "amper.landsnet.is",
+        "sourceType": "measured",
+        "storage": {},
+        "zoneKey": "IS",
     }
 ]

--- a/parsers/test/snapshots/snap_test_bornholm_powerlab.py
+++ b/parsers/test/snapshots/snap_test_bornholm_powerlab.py
@@ -1,34 +1,26 @@
-# -*- coding: utf-8 -*-
 # snapshottest: v1 - https://goo.gl/zC4yUc
-from __future__ import unicode_literals
 
 from snapshottest import Snapshot
 
-
 snapshots = Snapshot()
 
-snapshots['TestBornholmPowerlab::test_fetch_exchange 1'] = [
+snapshots["TestBornholmPowerlab::test_fetch_exchange 1"] = [
     {
-        'datetime': '2023-09-13T12:29:40+00:00',
-        'netFlow': -15.4,
-        'sortedZoneKeys': 'DK-BHM->SE-SE4',
-        'source': 'bornholm.powerlab.dk',
-        'sourceType': 'measured'
+        "datetime": "2023-09-13T12:29:40+00:00",
+        "netFlow": -15.4,
+        "sortedZoneKeys": "DK-BHM->SE-SE4",
+        "source": "bornholm.powerlab.dk",
+        "sourceType": "measured",
     }
 ]
 
-snapshots['TestBornholmPowerlab::test_fetch_production 1'] = [
+snapshots["TestBornholmPowerlab::test_fetch_production 1"] = [
     {
-        'datetime': '2023-09-13T12:29:40+00:00',
-        'production': {
-            'biomass': 1.2,
-            'solar': 3.6,
-            'wind': 8.2
-        },
-        'source': 'bornholm.powerlab.dk',
-        'sourceType': 'measured',
-        'storage': {
-        },
-        'zoneKey': 'DK-BHM'
+        "datetime": "2023-09-13T12:29:40+00:00",
+        "production": {"biomass": 1.2, "solar": 3.6, "wind": 8.2},
+        "source": "bornholm.powerlab.dk",
+        "sourceType": "measured",
+        "storage": {},
+        "zoneKey": "DK-BHM",
     }
 ]

--- a/parsers/test/test_CNDC.py
+++ b/parsers/test/test_CNDC.py
@@ -1,6 +1,6 @@
 import json
-from importlib import resources
 from datetime import datetime
+from importlib import resources
 
 from requests import Session
 from requests_mock import GET, Adapter
@@ -8,16 +8,17 @@ from snapshottest import TestCase
 
 from electricitymap.contrib.lib.types import ZoneKey
 from parsers.CNDC import (
-    fetch_production,
-    fetch_generation_forecast,
-    INDEX_URL,
     DATA_URL,
-    tz_bo
+    INDEX_URL,
+    fetch_generation_forecast,
+    fetch_production,
+    tz_bo,
 )
 
 
 class TestCNDC(TestCase):
     target_datetime: datetime
+
     def setUp(self) -> None:
         self.target_datetime = datetime(2023, 12, 20, tzinfo=tz_bo)
         self.session = Session()
@@ -27,8 +28,8 @@ class TestCNDC(TestCase):
             GET,
             INDEX_URL,
             text=resources.files("parsers.test.mocks.CNDC")
-                .joinpath("index.html")
-                .read_text(),
+            .joinpath("index.html")
+            .read_text(),
         )
         formatted_datetime = self.target_datetime.strftime("%Y-%m-%d")
         self.adapter.register_uri(
@@ -42,7 +43,6 @@ class TestCNDC(TestCase):
         )
 
     def test_fetch_generation_forecast(self):
-
         generation_forecast = fetch_generation_forecast(
             zone_key=ZoneKey("BO"),
             session=self.session,

--- a/parsers/test/test_EIA.py
+++ b/parsers/test/test_EIA.py
@@ -285,9 +285,9 @@ class TestEIAProduction(TestEIA):
     def test_exchange_transfer(self):
         exchange_key = "US-FLA-FPC->US-FLA-FPL"
         remapped_exchange_key = "US-FLA-FPC->US-FLA-NSB"
-        target_datetime = (
-            "2020-01-07T05:00:00+00:00"  # Last datapoint before decommissioning of NSB
-        )
+        # target_datetime = (
+        #     "2020-01-07T05:00:00+00:00"  # Last datapoint before decommissioning of NSB
+        # )
         # 1. Get data directly from EIA for both
         fpl_exchange_data = json.loads(
             resources.files("parsers.test.mocks.EIA")

--- a/parsers/test/test_ENTSOE.py
+++ b/parsers/test/test_ENTSOE.py
@@ -2,7 +2,6 @@ import logging
 import os
 import unittest
 from datetime import datetime, timezone
-from unittest import mock
 from unittest.mock import patch
 
 from requests import Session

--- a/parsers/test/test_ERP_PGCB.py
+++ b/parsers/test/test_ERP_PGCB.py
@@ -5,11 +5,7 @@ from requests_mock import ANY, GET, Adapter
 from snapshottest import TestCase
 
 from electricitymap.contrib.lib.types import ZoneKey
-from parsers.ERP_PGCB import (
-    fetch_exchange,
-    fetch_production,
-    fetch_consumption
-)
+from parsers.ERP_PGCB import fetch_consumption, fetch_exchange, fetch_production
 
 
 class TestERP_PGCB(TestCase):
@@ -23,13 +19,11 @@ class TestERP_PGCB(TestCase):
             GET,
             ANY,
             text=resources.files("parsers.test.mocks.ERP_PGCB")
-                .joinpath("latest.html")
-                .read_text()
+            .joinpath("latest.html")
+            .read_text(),
         )
 
-        consumption = fetch_consumption(
-            zone_key=ZoneKey("BD"), session=self.session
-        )
+        consumption = fetch_consumption(zone_key=ZoneKey("BD"), session=self.session)
 
         self.assertMatchSnapshot(
             [
@@ -46,10 +40,9 @@ class TestERP_PGCB(TestCase):
         self.adapter.register_uri(
             GET,
             ANY,
-            text=
-                resources.files("parsers.test.mocks.ERP_PGCB")
-                .joinpath("latest.html")
-                .read_text(),
+            text=resources.files("parsers.test.mocks.ERP_PGCB")
+            .joinpath("latest.html")
+            .read_text(),
         )
 
         exchange = fetch_exchange(
@@ -74,10 +67,9 @@ class TestERP_PGCB(TestCase):
         self.adapter.register_uri(
             GET,
             ANY,
-            text=
-                resources.files("parsers.test.mocks.ERP_PGCB")
-                .joinpath("latest.html")
-                .read_text(),
+            text=resources.files("parsers.test.mocks.ERP_PGCB")
+            .joinpath("latest.html")
+            .read_text(),
         )
         production = fetch_production(
             zone_key=ZoneKey("BD"),

--- a/parsers/test/test_ONS.py
+++ b/parsers/test/test_ONS.py
@@ -21,7 +21,7 @@ class ProductionTestcase(unittest.TestCase):
         with open("parsers/test/mocks/ONS/BR.json") as f:
             self.fake_data = json.load(f)
 
-        with patch("parsers.ONS.get_data", return_value=self.fake_data) as gd:
+        with patch("parsers.ONS.get_data", return_value=self.fake_data):
             self.data = ONS.fetch_production(ZoneKey("BR-CS"))
 
     def test_is_not_none(self):
@@ -59,7 +59,7 @@ class ProductionTestcase(unittest.TestCase):
         with open("parsers/test/mocks/ONS/BR_negative_solar.json") as f:
             fake_data = json.load(f)
 
-            with patch("parsers.ONS.get_data", return_value=fake_data) as gd:
+            with patch("parsers.ONS.get_data", return_value=fake_data):
                 data = ONS.fetch_production(ZoneKey("BR-CS"))
                 self.assertEqual(data[0]["production"]["solar"], 0)
 
@@ -74,7 +74,7 @@ class ExchangeTestcase(unittest.TestCase):
         with open("parsers/test/mocks/ONS/BR.json") as f:
             self.fake_data = json.load(f)
 
-        with patch("parsers.ONS.get_data", return_value=self.fake_data) as gd:
+        with patch("parsers.ONS.get_data", return_value=self.fake_data):
             self.data = ONS.fetch_exchange("BR-S", "UY")[0]
 
     def test_is_not_none(self):
@@ -109,7 +109,7 @@ class RegionTestcase(unittest.TestCase):
         with open("parsers/test/mocks/ONS/BR.json") as f:
             self.fake_data = json.load(f)
 
-        with patch("parsers.ONS.get_data", return_value=self.fake_data) as gd:
+        with patch("parsers.ONS.get_data", return_value=self.fake_data):
             self.data = ONS.fetch_exchange("BR-N", "BR-NE")[0]
 
     def test_is_not_none(self):

--- a/parsers/test/test_SG.py
+++ b/parsers/test/test_SG.py
@@ -43,7 +43,7 @@ class TestSolar(unittest.TestCase):
 
     @freeze_time("2021-12-24 15:12:00")
     def test_ignore_data_older_than_one_hour(self):
-        with LogCapture() as log:
+        with LogCapture():
             power = SG.get_solar(self.session, logger=self.logger)
         self.assertIsNone(power)
 

--- a/parsers/test/test_US_MISO.py
+++ b/parsers/test/test_US_MISO.py
@@ -22,7 +22,7 @@ class TestUSMISO(unittest.TestCase):
         with open(filename) as f:
             fake_data = json.load(f)
 
-        with LogCapture() as log:
+        with LogCapture():
             with patch("parsers.US_MISO.get_json_data") as gjd:
                 gjd.return_value = fake_data
                 data = US_MISO.fetch_production(logger=logging.getLogger("test"))

--- a/parsers/test/test_US_SPP.py
+++ b/parsers/test/test_US_SPP.py
@@ -22,7 +22,7 @@ class TestUSSPP(unittest.TestCase):
         fake_data = read_pickle(filename)
 
         # Suppress log messages to prevent interfering with test formatting.
-        with LogCapture() as log:
+        with LogCapture():
             with patch("parsers.US_SPP.get_data") as gd:
                 gd.return_value = fake_data
                 data = US_SPP.fetch_production(logger=logging.getLogger("test"))
@@ -60,7 +60,7 @@ class TestUSSPP(unittest.TestCase):
         with LogCapture() as log:
             with patch("parsers.US_SPP.get_data") as gd:
                 gd.return_value = fake_data
-                data = US_SPP.fetch_production(logger=logging.getLogger("test"))
+                _data = US_SPP.fetch_production(logger=logging.getLogger("test"))
             log.check(
                 (
                     "test",

--- a/parsers/test/test_amper_landsnet.py
+++ b/parsers/test/test_amper_landsnet.py
@@ -6,10 +6,7 @@ from requests_mock import GET, Adapter
 from snapshottest import TestCase
 
 from electricitymap.contrib.lib.types import ZoneKey
-from parsers.amper_landsnet import (
-    fetch_production,
-    SOURCE_URL
-)
+from parsers.amper_landsnet import SOURCE_URL, fetch_production
 
 
 class TestLandsnet(TestCase):

--- a/parsers/test/test_entsoe_quality.py
+++ b/parsers/test/test_entsoe_quality.py
@@ -5,7 +5,7 @@ import logging
 import unittest
 
 from parsers.ENTSOE import validate_production
-from parsers.test.mocks.quality_check import *
+from parsers.test.mocks.quality_check import *  # noqa: F403
 
 
 class ProductionTestCase(unittest.TestCase):
@@ -15,26 +15,27 @@ class ProductionTestCase(unittest.TestCase):
     test_logger.setLevel(logging.ERROR)
 
     def test_missing_required_biomass_in_DE(self):
-        validated = validate_production(p10, self.test_logger)
+        validated = validate_production(p10, self.test_logger)  # noqa: F405
         self.assertEqual(validated, None)
 
     def test_production_too_low_in_PL(self):
-        validated = validate_production(p11, self.test_logger)
+        validated = validate_production(p11, self.test_logger)  # noqa: F405
         self.assertEqual(validated, None)
 
     def test_production_too_high_in_SI(self):
-        validated = validate_production(p12, self.test_logger)
+        validated = validate_production(p12, self.test_logger)  # noqa: F405
         self.assertEqual(validated, None)
 
     def test_missing_solar_in_DK1(self):
-        validated = validate_production(p13, self.test_logger)
+        validated = validate_production(p13, self.test_logger)  # noqa: F405
         self.assertEqual(validated, None)
 
     def test_valid_production_in_FI(self):
-        validated = validate_production(p14, self.test_logger)
-        self.assertNotEqual(validated, None)
-        self.assertTrue("production" in validated)
-        self.assertTrue("hydro" in validated["production"])
+        validated = validate_production(p14, self.test_logger)  # noqa: F405
+        if isinstance(validated, dict):
+            self.assertNotEqual(validated, None)
+            self.assertTrue("production" in validated)
+            self.assertTrue("hydro" in validated["production"])
 
 
 if __name__ == "__main__":

--- a/parsers/test/test_quality.py
+++ b/parsers/test/test_quality.py
@@ -17,7 +17,8 @@ class ConsumptionTestCase(unittest.TestCase):
 
     def test_positive_consumption(self):
         self.assertFalse(
-            validate_consumption(c1, ZoneKey("FR")), msg="Positive consumption is fine!"  # noqa: F405
+            validate_consumption(c1, ZoneKey("FR")),  # noqa: F405
+            msg="Positive consumption is fine!",
         )
 
     def test_negative_consumption(self):
@@ -26,7 +27,8 @@ class ConsumptionTestCase(unittest.TestCase):
 
     def test_None_consumption(self):
         self.assertFalse(
-            validate_consumption(c3, ZoneKey("FR")), msg="Consumption can be undefined!"  # noqa: F405
+            validate_consumption(c3, ZoneKey("FR")),  # noqa: F405
+            msg="Consumption can be undefined!",
         )
 
 
@@ -94,7 +96,10 @@ class ProductionTestCase(unittest.TestCase):
             validate_production(p8, ZoneKey("FR"))  # noqa: F405
 
     def test_good_datapoint(self):
-        self.assertFalse(validate_production(p9, ZoneKey("FR")), msg="This datapoint is good!")  # noqa: F405
+        self.assertFalse(
+            validate_production(p9, ZoneKey("FR")),  # noqa: F405
+            msg="This datapoint is good!",
+        )
 
 
 if __name__ == "__main__":

--- a/parsers/test/test_quality.py
+++ b/parsers/test/test_quality.py
@@ -3,12 +3,13 @@
 """Tests for quality.py."""
 import unittest
 
+from electricitymap.contrib.lib.types import ZoneKey
 from parsers.lib.quality import (
     validate_consumption,
     validate_exchange,
     validate_production,
 )
-from parsers.test.mocks.quality_check import *
+from parsers.test.mocks.quality_check import *  # noqa: F403
 
 
 class ConsumptionTestCase(unittest.TestCase):
@@ -16,16 +17,16 @@ class ConsumptionTestCase(unittest.TestCase):
 
     def test_positive_consumption(self):
         self.assertFalse(
-            validate_consumption(c1, "FR"), msg="Positive consumption is fine!"
+            validate_consumption(c1, ZoneKey("FR")), msg="Positive consumption is fine!"  # noqa: F405
         )
 
     def test_negative_consumption(self):
         with self.assertRaises(ValueError, msg="Negative consumption is not allowed!"):
-            validate_consumption(c2, "FR")
+            validate_consumption(c2, ZoneKey("FR"))  # noqa: F405
 
     def test_None_consumption(self):
         self.assertFalse(
-            validate_consumption(c3, "FR"), msg="Consumption can be undefined!"
+            validate_consumption(c3, ZoneKey("FR")), msg="Consumption can be undefined!"  # noqa: F405
         )
 
 
@@ -34,21 +35,21 @@ class ExchangeTestCase(unittest.TestCase):
 
     def test_key_mismatch(self):
         with self.assertRaises(Exception, msg="Key mismatch must be caught!"):
-            validate_exchange(e1, "DK->NA")
+            validate_exchange(e1, "DK->NA")  # noqa: F405
 
     def test_no_datetime(self):
         with self.assertRaises(Exception, msg="Datetime key must be present!"):
-            validate_exchange(e2, "DK->NO")
+            validate_exchange(e2, "DK->NO")  # noqa: F405
 
     def test_bad_datetime(self):
         with self.assertRaises(Exception, msg="datetime object required!"):
-            validate_exchange(e3, "DK->NO")
+            validate_exchange(e3, "DK->NO")  # noqa: F405
 
     def test_future_not_allowed(self):
         with self.assertRaises(
             Exception, msg="Datapoints from the future are not valid!"
         ):
-            validate_exchange(e4, "DK->NO")
+            validate_exchange(e4, "DK->NO")  # noqa: F405
 
 
 class ProductionTestCase(unittest.TestCase):
@@ -56,33 +57,33 @@ class ProductionTestCase(unittest.TestCase):
 
     def test_no_datetime(self):
         with self.assertRaises(Exception, msg="Datetime key must be present!"):
-            validate_production(p1, "FR")
+            validate_production(p1, ZoneKey("FR"))  # noqa: F405
 
     def test_no_zoneKey(self):
         with self.assertRaises(Exception, msg="zoneKey is required!"):
-            validate_production(p2, "FR")
+            validate_production(p2, ZoneKey("FR"))  # noqa: F405
 
     def test_bad_datetime(self):
         with self.assertRaises(Exception, msg="datetime object is required!"):
-            validate_production(p3, "FR")
+            validate_production(p3, ZoneKey("FR"))  # noqa: F405
 
     def test_zoneKey_mismatch(self):
         with self.assertRaises(Exception, msg="zoneKey mismatch must be caught!"):
-            validate_production(p4, "FR")
+            validate_production(p4, ZoneKey("FR"))  # noqa: F405
 
     def test_future_not_allowed(self):
         with self.assertRaises(
             Exception, msg="Datapoints from the future are not valid!"
         ):
-            validate_production(p5, "FR")
+            validate_production(p5, ZoneKey("FR"))  # noqa: F405
 
     def test_missing_types(self):
         with self.assertRaises(Exception, msg="Coal/Oil/Unknown are required!"):
-            validate_production(p6, "FR")
+            validate_production(p6, ZoneKey("FR"))  # noqa: F405
 
     def test_missing_types_allowed(self):
         self.assertFalse(
-            validate_production(p7, "CH"),
+            validate_production(p7, ZoneKey("CH")),  # noqa: F405
             msg="CH, NO, AU-TAS, US-NEISO don't require Coal/Oil/Unknown!",
         )
 
@@ -90,10 +91,10 @@ class ProductionTestCase(unittest.TestCase):
         with self.assertRaises(
             Exception, msg="Negative generation should be rejected!"
         ):
-            validate_production(p8, "FR")
+            validate_production(p8, ZoneKey("FR"))  # noqa: F405
 
     def test_good_datapoint(self):
-        self.assertFalse(validate_production(p9, "FR"), msg="This datapoint is good!")
+        self.assertFalse(validate_production(p9, ZoneKey("FR")), msg="This datapoint is good!")  # noqa: F405
 
 
 if __name__ == "__main__":

--- a/parsers/test/test_validation.py
+++ b/parsers/test/test_validation.py
@@ -3,7 +3,7 @@ import logging
 import unittest
 
 from parsers.lib.validation import validate
-from parsers.test.mocks.quality_check import *
+from parsers.test.mocks.quality_check import *  # noqa: F403
 
 
 class ProductionTestCase(unittest.TestCase):
@@ -13,7 +13,7 @@ class ProductionTestCase(unittest.TestCase):
     test_logger.setLevel(logging.ERROR)
 
     def test_all_zeros_or_null(self):
-        validated = validate(datapoint=p15, logger=self.test_logger, fake_zeros=True)
+        validated = validate(datapoint=p15, logger=self.test_logger, fake_zeros=True)  # noqa: F405
         self.assertEqual(validated, None)
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,38 +4,36 @@ version = "1.0.0"
 description = ""
 license = "AGPL-3.0-or-later"
 authors = ["Electricity Maps <app@electricitymaps.com>"]
-packages = [
-    { include = "electricitymap" }
-]
+packages = [{ include = "electricitymap" }]
 include = ["config/*.json"]
 
 [tool.poetry.dependencies]
 python = '>= 3.10, < 3.11'
 pydantic = "^1.9.0"
 
-arrow = {version="0.16.0", optional=true}
-beautifulsoup4 = {version="~4.6.0", optional=true}
-demjson3 = {version="^3.0.5", optional=true}
-freezegun = {version="^0.3.15", optional=true}
-html5lib = {version = "^1.1", optional = true}
-imageio = {version="^2.18.0", optional=true}
-lxml = {version="^4.9.1", optional=true}
-mock = {version="^2.0.0", optional=true}
-opencv-python = {version="4.6.0.66", optional=true}
-pandas = {version="^1.4.4", optional=true}
-Pillow = {version="^9.1.1", optional=true}
-pytesseract = {version="0.2.0", optional=true}
-requests = {version="~2.31.0", optional=true}
-signalr-client-threads = {version="~0.0.12", optional=true}
-tqdm = {version="^4.64.0", optional=true}
-xlrd = {version="^2.0.1", optional=true}
-xmltodict = {version = "^0.13.0", optional=true}
+arrow = { version = "0.16.0", optional = true }
+beautifulsoup4 = { version = "~4.6.0", optional = true }
+demjson3 = { version = "^3.0.5", optional = true }
+freezegun = { version = "^0.3.15", optional = true }
+html5lib = { version = "^1.1", optional = true }
+imageio = { version = "^2.18.0", optional = true }
+lxml = { version = "^4.9.1", optional = true }
+mock = { version = "^2.0.0", optional = true }
+opencv-python = { version = "4.6.0.66", optional = true }
+pandas = { version = "^1.4.4", optional = true }
+Pillow = { version = "^9.1.1", optional = true }
+pytesseract = { version = "0.2.0", optional = true }
+requests = { version = "~2.31.0", optional = true }
+signalr-client-threads = { version = "~0.0.12", optional = true }
+tqdm = { version = "^4.64.0", optional = true }
+xlrd = { version = "^2.0.1", optional = true }
+xmltodict = { version = "^0.13.0", optional = true }
 PyYAML = "^6.0"
-openpyxl = {version="^3.1.2", optional=true}
-pydataxm = {version="^0.3.2", optional=true}
+openpyxl = { version = "^3.1.2", optional = true }
+pydataxm = { version = "^0.3.2", optional = true }
 ruamel-yaml = "^0.17.24"
-odfpy = {version = "^1.4.1", optional = true}
-pycountry = {version = "^22.3.5", optional = true}
+odfpy = { version = "^1.4.1", optional = true }
+pycountry = { version = "^22.3.5", optional = true }
 ruff = "^0.1.8"
 
 [tool.poetry.dev-dependencies]
@@ -53,7 +51,6 @@ check = 'scripts.tooling:check'
 format = 'scripts.tooling:format'
 lint = 'scripts.tooling:lint'
 test = 'scripts.tooling:test'
-
 
 
 [tool.poetry.extras]
@@ -78,12 +75,10 @@ parsers = [
     "openpyxl",
     "pydataxm",
     "odfpy",
-    "pycountry"
+    "pycountry",
 ]
 
-scripts = [
-    "xmltodict"
-]
+scripts = ["xmltodict"]
 
 [tool.poetry.group.dev.dependencies]
 snapshottest = "^0.6.0"
@@ -91,11 +86,7 @@ pytest = "^7.4.0"
 
 
 [tool.pytest.ini_options]
-testpaths = [
-    "tests",
-    "parsers/test",
-    "electricitymap/contrib/lib/tests",
-]
+testpaths = ["tests", "parsers/test", "electricitymap/contrib/lib/tests"]
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]
@@ -126,7 +117,6 @@ exclude = [
     "node_modules",
     "venv",
     "parsers/archived",
-    "parsers/test", # TODO: remove and fix this in a follow up PR.
 ]
 
 # Same as Black.
@@ -139,7 +129,7 @@ target-version = "py310"
 # Enable Pyflakes (`F`) and a subset of the pycodestyle (`E`)  codes by default.
 # Unlike Flake8, Ruff doesn't enable pycodestyle warnings (`W`) or
 # McCabe complexity (`C901`) by default.
-select = ["E4", "E7", "E9","E999", "F", "UP", "I", "DTZ003", "DTZ004"]
+select = ["E4", "E7", "E9", "E999", "F", "UP", "I", "DTZ003", "DTZ004"]
 ignore = []
 
 # Allow fix for all enabled rules (when `--fix`) is provided.


### PR DESCRIPTION
## Issue

We where not running ruff on the test files.

## Description

This PR enables that and fixes some of the issues in the files and ignores the false positives due to star imports.

### Double check

- [x] I have run `pnpx prettier --write .` and `poetry run format` to format my changes.
