### PR TITLE
Update emission factors in SE-SE1, SE-SE2, SE-SE3, SE-SE4, and SE.yaml

### DIFF
--- a/config/zones/SE-SE1.yaml
+++ b/config/zones/SE-SE1.yaml
@@ -46,7 +46,7 @@ emissionFactors:
         _url: https://ec.europa.eu/eurostat/documents/38154/4956218/Energy-Balances-January-2022-edition.zip/2dc71f1b-806a-b9ed-e77d-67b7c705197b?t=1643660477829
         datetime: '2022-01-01'
         source: assumes 98.26% biomass, 1.09% oil, 0.64% peat, 0.01% coal
-        value: 16.4
+        value: 28.6
   lifecycle:
     biomass:
       datetime: '2014-01-01'
@@ -93,7 +93,7 @@ emissionFactors:
         _url: https://ec.europa.eu/eurostat/documents/38154/4956218/Energy-Balances-January-2022-edition.zip/2dc71f1b-806a-b9ed-e77d-67b7c705197b?t=1643660477829
         datetime: '2022-01-01'
         source: assumes 98.26% biomass, 1.09% oil, 0.64% peat, 0.01% coal
-        value: 245.7
+        value: 258
     wind:
       datetime: '2014-01-01'
       source: UNECE 2022, WindEurope "Wind energy in Europe, 2021 Statistics and the

--- a/config/zones/SE-SE2.yaml
+++ b/config/zones/SE-SE2.yaml
@@ -90,7 +90,7 @@ emissionFactors:
         _url: https://ec.europa.eu/eurostat/documents/38154/4956218/Energy-Balances-January-2022-edition.zip/2dc71f1b-806a-b9ed-e77d-67b7c705197b?t=1643660477829
         datetime: '2022-01-01'
         source: assumes 98.26% biomass, 1.09% oil, 0.64% peat, 0.01% coal
-        value: 16.4
+        value: 28.6
   lifecycle:
     battery discharge:
       - datetime: '2015-01-01'
@@ -181,7 +181,7 @@ emissionFactors:
         _url: https://ec.europa.eu/eurostat/documents/38154/4956218/Energy-Balances-January-2022-edition.zip/2dc71f1b-806a-b9ed-e77d-67b7c705197b?t=1643660477829
         datetime: '2022-01-01'
         source: assumes 98.26% biomass, 1.09% oil, 0.64% peat, 0.01% coal
-        value: 245.7
+        value: 258
     wind:
       datetime: '2014-01-01'
       source: UNECE 2022, WindEurope "Wind energy in Europe, 2021 Statistics and the

--- a/config/zones/SE-SE3.yaml
+++ b/config/zones/SE-SE3.yaml
@@ -90,7 +90,7 @@ emissionFactors:
         _url: https://ec.europa.eu/eurostat/documents/38154/4956218/Energy-Balances-January-2022-edition.zip/2dc71f1b-806a-b9ed-e77d-67b7c705197b?t=1643660477829
         datetime: '2022-01-01'
         source: assumes 98.26% biomass, 1.09% oil, 0.64% peat, 0.01% coal
-        value: 16.4
+        value: 28.6
   lifecycle:
     battery discharge:
       - datetime: '2015-01-01'
@@ -181,7 +181,7 @@ emissionFactors:
         _url: https://ec.europa.eu/eurostat/documents/38154/4956218/Energy-Balances-January-2022-edition.zip/2dc71f1b-806a-b9ed-e77d-67b7c705197b?t=1643660477829
         datetime: '2022-01-01'
         source: assumes 98.26% biomass, 1.09% oil, 0.64% peat, 0.01% coal
-        value: 245.7
+        value: 258
     wind:
       datetime: '2021-01-01'
       source: UNECE 2022, WindEurope "Wind energy in Europe, 2021 Statistics and the

--- a/config/zones/SE-SE4.yaml
+++ b/config/zones/SE-SE4.yaml
@@ -90,7 +90,7 @@ emissionFactors:
         _url: https://ec.europa.eu/eurostat/documents/38154/4956218/Energy-Balances-January-2022-edition.zip/2dc71f1b-806a-b9ed-e77d-67b7c705197b?t=1643660477829
         datetime: '2022-01-01'
         source: assumes 98.26% biomass, 1.09% oil, 0.64% peat, 0.01% coal
-        value: 16.4
+        value: 28.6
   lifecycle:
     battery discharge:
       - datetime: '2015-01-01'
@@ -181,7 +181,7 @@ emissionFactors:
         _url: https://ec.europa.eu/eurostat/documents/38154/4956218/Energy-Balances-January-2022-edition.zip/2dc71f1b-806a-b9ed-e77d-67b7c705197b?t=1643660477829
         datetime: '2022-01-01'
         source: assumes 98.26% biomass, 1.09% oil, 0.64% peat, 0.01% coal
-        value: 245.7
+        value: 258
     wind:
       datetime: '2021-01-01'
       source: UNECE 2022, WindEurope "Wind energy in Europe, 2021 Statistics and the

--- a/config/zones/SE.yaml
+++ b/config/zones/SE.yaml
@@ -139,10 +139,10 @@ emissionFactors:
         source: assumes 86.72% biomass, 7.17% solar, 4.58% gas, 0.96% oil, 0.56% peat,
           0.01% coal
         value: 35.5
-      - _comment: Uses the 2020 values with 2021 emission factors minus solar and gas
+      - _comment: Uses the 2020 values with 2022 emission factors minus solar and gas
         datetime: '2022-01-01'
         source: assumes 98.26% biomass, 1.09% oil, 0.64% peat, 0.01% coal
-        value: 16.4
+        value: 28.6
   lifecycle:
     battery discharge:
       - datetime: '2015-01-01'
@@ -275,10 +275,10 @@ emissionFactors:
         source: assumes 86.72% biomass, 7.17% solar, 4.58% gas, 0.96% oil, 0.56% peat,
           0.01% coal
         value: 245.8
-      - _comment: Uses the 2020 with 2021 emission factors minus solar and gas
+      - _comment: Uses the 2020 values with 2022 emission factors minus solar and gas
         datetime: '2022-01-01'
         source: assumes 98.26% biomass, 1.09% oil, 0.64% peat, 0.01% coal
-        value: 245.7
+        value: 258
     wind:
       datetime: '2021-01-01'
       source: UNECE 2022, WindEurope "Wind energy in Europe, 2021 Statistics and the


### PR DESCRIPTION
## Issue

The emission factors used for Sweden for 2022 has been updated, the unknown emission factor override still used the 2021 factors.

## Description

Uses the 2022 emission factors instead.

It seems like the source I originally used to get the total production seems to have moved and the replacement data I found was not as granular so I will update the 2023 emission factors at a later date if I can find the correct data.

### Double check

- [x] I have run `pnpx prettier --write .` and `poetry run format` to format my changes.
