### PR TITLE
translations(web): Remove references to 5 years and add dynamic yearly range

### DIFF
--- a/web/public/locales/de.json
+++ b/web/public/locales/de.json
@@ -87,11 +87,10 @@
     "Getdata": "Zugang zu historischen Daten und zur Vorhersage-API",
     "not-enough-data": "Für die Diagrammanzeige sind nicht genügend Daten verfügbar",
     "carbonintensity": {
-      "default": "Spezifische CO₂-Emissionen in den letzten %1$s",
       "hourly": "Spezifische CO₂-Emissionen in den letzten 24 Stunden",
       "daily": "Spezifische CO₂-Emissionen im letzten Monat",
       "monthly": "Spezifische CO₂-Emissionen im letzten Jahr",
-      "yearly": "Spezifische CO₂-Emissionen in den letzten 5 Jahren"
+      "default": "Spezifische CO₂-Emissionen in den letzten %1$s"
     },
     "emissionsorigin": {
       "default": "Ursprung der Emissionen in den letzten %1$s",

--- a/web/public/locales/es.json
+++ b/web/public/locales/es.json
@@ -83,11 +83,10 @@
   },
   "country-history": {
     "carbonintensity": {
-      "default": "Intensidad de carbono en los últimos %1$s",
       "hourly": "Intensidad de carbono en las últimas 24 horas",
       "daily": "Intensidad de carbono en el último mes",
       "monthly": "Intensidad de carbono en el último año",
-      "yearly": "Intensidad de carbono en los últimos 5 años"
+      "default": "Intensidad de carbono en los últimos %1$s"
     },
     "Getdata": "Obtener datos históricos por horas y en tiempo real + pronóstico con la API de Electricity Maps",
     "not-enough-data": "No hay datos suficientes disponibles para mostrar el gráfico",

--- a/web/public/locales/fr.json
+++ b/web/public/locales/fr.json
@@ -85,10 +85,9 @@
     "not-enough-data": "Pas assez de données disponibles pour afficher le graphique",
     "carbonintensity": {
       "hourly": "Intensité carbone des 24 dernières heures",
-      "default": "Intensité en carbone dans les derniers %1$s",
       "daily": "Intensité en carbone du dernier mois",
       "monthly": "Intensité carbone au cours de la dernière année",
-      "yearly": "Intensité carbone au cours des 5 dernières années"
+      "default": "Intensité en carbone dans les derniers %1$s"
     },
     "emissionsorigin": {
       "hourly": "Origine des émissions des 24 dernières heures",

--- a/web/public/locales/it.json
+++ b/web/public/locales/it.json
@@ -83,11 +83,10 @@
   },
   "country-history": {
     "carbonintensity": {
-      "default": "Intensità di carbonio nell'ultimo %1$s",
       "hourly": "Intensità di carbonio nelle ultime 24 ore",
       "daily": "Intensità di carbonio nell'ultimo mese",
       "monthly": "Intensità di carbonio nell'ultimo anno",
-      "yearly": "Intensità di carbonio negli ultimi 5 anni"
+      "default": "Intensità di carbonio nell'ultimo %1$s"
     },
     "emissions": {
       "default": "Emissioni nell'ultimo %1$s",
@@ -111,25 +110,22 @@
       "yearly": "Emissioni prodotte negli ultimi 5 anni"
     },
     "electricityorigin": {
-      "default": "Origine dell'elettricità nell' ultimo %1$s",
       "hourly": "Origine dell'elettricità nelle ultime 24 ore",
       "daily": "Origine dell'elettricità nell'ultimo mese",
       "monthly": "Origine dell'elettricità nell'ultimo anno",
-      "yearly": "Origine dell'elettricità negli ultimi 5 anni"
+      "default": "Origine dell'elettricità nell' ultimo %1$s"
     },
     "electricityproduction": {
-      "default": "Produzione elettrica nell' ultimo %1$s",
       "hourly": "Produzione elettrica nelle ultime 24 ore",
       "daily": "Produzione elettrica nell'ultimo mese",
       "monthly": "Produzione elettrica nell'ultimo anno",
-      "yearly": "Produzione elettrica negli ultimi 5 anni"
+      "default": "Produzione elettrica nell' ultimo %1$s"
     },
     "electricityprices": {
-      "default": "Prezzi dell'elettricità nell' ultimo %1$s",
       "hourly": "Prezzi dell'elettricità nelle ultime 24 ore",
       "daily": "Prezzi dell'elettricità nell'ultimo mese",
       "monthly": "Prezzi dell'elettricità nell'ultimo anno",
-      "yearly": "Prezzi dell'elettricità negli ultimi 5 anni"
+      "default": "Prezzi dell'elettricità nell' ultimo %1$s"
     },
     "Getdata": "Ottieni dati orari storici, in tempo reale e previsioni con le API di Electricity Maps"
   },

--- a/web/public/locales/pt-BR.json
+++ b/web/public/locales/pt-BR.json
@@ -68,10 +68,9 @@
     "Getdata": "Obtenha dados históricos, marginais e de previsão da API",
     "carbonintensity": {
       "hourly": "Intensidade da emissão de carbono nas últimas 24 horas",
-      "default": "Intensidade de carbono nas últimas %1$s",
       "daily": "Intensidade de carbono no último mês",
       "monthly": "Intensidade de carbono no último ano",
-      "yearly": "Intensidade de carbono nos últimos 5 anos"
+      "default": "Intensidade de carbono nas últimas %1$s"
     },
     "emissionsorigin": {
       "hourly": "Origem da emissão de carbono nas últimas 24 horas",

--- a/web/public/locales/sl.json
+++ b/web/public/locales/sl.json
@@ -83,11 +83,10 @@
   },
   "country-history": {
     "carbonintensity": {
-      "default": "Intenzivnost ogljika v zadnjih%1$s",
       "hourly": "Intenzivnost ogljika v zadnjih 24 urah",
       "daily": "Intenzivnost ogljika v zadnjem mesecu",
       "monthly": "Intenzivnost ogljika v zadnjem letu",
-      "yearly": "Intenzivnost ogljika v zadnjih 5 letih"
+      "default": "Intenzivnost ogljika v zadnjih%1$s"
     },
     "emissions": {
       "default": "Emisije v zadnji(h) %1$s"

--- a/web/public/locales/sv.json
+++ b/web/public/locales/sv.json
@@ -86,60 +86,52 @@
   },
   "country-history": {
     "carbonintensity": {
-      "default": "Kolintensitet under de senaste %1$s",
       "hourly": "Kolintensitet de senaste 24 timmarna",
       "daily": "Kolintensitet den senaste månaden",
       "monthly": "Kolintensitet det senaste året",
-      "yearly": "Kolintensitet de senaste 5 åren"
+      "default": "Kolintensitet under de senaste %1$s"
     },
     "emissions": {
-      "default": "Utsläpp de senaste %1$s",
       "hourly": "Utsläpp de senaste 24 timmarna",
       "daily": "Utsläpp den senaste månaden",
       "monthly": "Utsläpp det senaste året",
-      "yearly": "Utsläpp de senaste 5 åren"
+      "default": "Utsläpp de senaste %1$s"
     },
     "emissionsorigin": {
-      "default": "Källa för utsläpp de senaste %1$s",
       "hourly": "Källa för utsläpp de senaste 24 timmarna",
       "daily": "Källa för utsläpp den senaste månaden",
       "monthly": "Källa för utsläpp det senaste året",
-      "yearly": "Källa för utsläpp de senaste 5 åren"
+      "default": "Källa för utsläpp de senaste %1$s"
     },
     "emissionsproduction": {
-      "default": "Utsläpp producerad de senaste %1$s",
       "hourly": "Utsläpp producerad de senaste 24 timmarna",
       "daily": "Utsläpp producerad den senaste månaden",
       "monthly": "Utsläpp producerad det senaste året",
-      "yearly": "Utsläpp producerad de senaste 5 åren"
+      "default": "Utsläpp producerad de senaste %1$s"
     },
     "electricityorigin": {
-      "default": "Källa för el de senaste %1$s",
       "hourly": "Källa för el de senaste 24 timmarna",
       "daily": "Källa för el den senaste månaden",
       "monthly": "Källa för el det senaste året",
-      "yearly": "Källa för el de senaste 5 åren"
+      "default": "Källa för el de senaste %1$s"
     },
     "electricityproduction": {
-      "default": "El producerad de senaste %1$s",
       "hourly": "El producerad de senaste 24 timmarna",
       "daily": "El producerad den senaste månaden",
       "monthly": "El producerad det senaste året",
-      "yearly": "El producerad de senaste 5 åren"
+      "default": "El producerad de senaste %1$s"
     },
     "electricityprices": {
-      "default": "Elpriser de senaste %1$s",
       "hourly": "Elpriser de senaste 24 timmarna",
       "daily": "Elpriser den senaste månaden",
       "monthly": "Elpriser det senaste året",
-      "yearly": "Elpriser de senaste 5 åren"
+      "default": "Elpriser de senaste %1$s"
     },
     "netExchange": {
-      "default": "Nettoöverföring de senaste %1$s",
       "hourly": "Nettoöverföring de senaste 24 timmarna",
       "daily": "Nettoöverföring den senaste månaden",
       "monthly": "Nettoöverföring det senaste året",
-      "yearly": "Nettoöverföring de senaste 5 åren"
+      "default": "Nettoöverföring de senaste %1$s"
     },
     "Getdata": "Hämta timvis historisk data, aktuell data och prognosdata med Electricity Maps API",
     "not-enough-data": "Inte tillräckligt med data för att visa diagrammet"


### PR DESCRIPTION
## Issue
5 year period is referenced in our translations

## Description
This PR includes the yearly period (currently 7 years) variable into more of the translations and removes the fixed yearly string in favour of the default. 

### Preview
Issue from user:
Dans les données agrégées par pays le titre concernant le carbone parle de 5 années au lieu de 7.

Merci de prendre en compte,

 

Pierre Picard
![Bug small from](https://github.com/electricitymaps/electricitymaps-contrib/assets/18622768/136ab6e0-102b-433c-87fa-ad9649363a44)



### Double check

- [x] I have tested my parser changes locally with `poetry run test_parser "zone_key"`
- [x] I have run `pnpx prettier --write .` and `poetry run format` to format my changes.
