### PR TITLE
Short term fix for the EIA parser

### DIFF
--- a/electricitymap/contrib/lib/models/event_lists.py
+++ b/electricitymap/contrib/lib/models/event_lists.py
@@ -3,11 +3,11 @@ from collections.abc import Sequence
 from datetime import datetime
 from logging import Logger
 from typing import Any
-from electricitymap.contrib.config import ZONES_CONFIG
-from electricitymap.contrib.config.capacity import get_capacity_data
 
 import pandas as pd
 
+from electricitymap.contrib.config import ZONES_CONFIG
+from electricitymap.contrib.config.capacity import get_capacity_data
 from electricitymap.contrib.lib.models.events import (
     Event,
     EventSourceType,
@@ -247,8 +247,11 @@ class ProductionBreakdownList(AggregatableEventList):
             prod = ProductionBreakdown.aggregate(row)
             production_breakdowns.events.append(prod)
         return production_breakdowns
+
     @staticmethod
-    def filter_expected_modes(breakdowns: "ProductionBreakdownList", strict_storage: bool = False) -> "ProductionBreakdownList":
+    def filter_expected_modes(
+        breakdowns: "ProductionBreakdownList", strict_storage: bool = False
+    ) -> "ProductionBreakdownList":
         """A temporary method to filter out incomplete production breakdowns which are missing expected modes.
         This method is only to be used on zones for which we know the expected modes and that the source sometimes returns Nones.
         TODO: Remove this method once the outlier detection is able to handle it.
@@ -262,10 +265,15 @@ class ProductionBreakdownList(AggregatableEventList):
                 mode for mode, capacity_value in capacity.items() if capacity_value > 0
             ]
             if not strict_storage:
-                required_modes = [mode for mode in required_modes if "storage" not in mode]
+                required_modes = [
+                    mode for mode in required_modes if "storage" not in mode
+                ]
             for mode in required_modes:
                 value = event.get_value(mode)
-                if value is None and mode not in event.production.corrected_negative_modes:
+                if (
+                    value is None
+                    and mode not in event.production.corrected_negative_modes
+                ):
                     valid = False
                     events.logger.warning(
                         f"Discarded production event for {event.zoneKey} at {event.datetime} due to missing {mode} value."

--- a/electricitymap/contrib/lib/models/event_lists.py
+++ b/electricitymap/contrib/lib/models/event_lists.py
@@ -250,7 +250,9 @@ class ProductionBreakdownList(AggregatableEventList):
 
     @staticmethod
     def filter_expected_modes(
-        breakdowns: "ProductionBreakdownList", strict_storage: bool = False
+        breakdowns: "ProductionBreakdownList",
+        strict_storage: bool = False,
+        by_passed_modes: list[str] = [],
     ) -> "ProductionBreakdownList":
         """A temporary method to filter out incomplete production breakdowns which are missing expected modes.
         This method is only to be used on zones for which we know the expected modes and that the source sometimes returns Nones.
@@ -268,6 +270,9 @@ class ProductionBreakdownList(AggregatableEventList):
                 required_modes = [
                     mode for mode in required_modes if "storage" not in mode
                 ]
+            required_modes = [
+                mode for mode in required_modes if mode not in by_passed_modes
+            ]
             for mode in required_modes:
                 value = event.get_value(mode)
                 if (

--- a/electricitymap/contrib/lib/models/event_lists.py
+++ b/electricitymap/contrib/lib/models/event_lists.py
@@ -3,6 +3,8 @@ from collections.abc import Sequence
 from datetime import datetime
 from logging import Logger
 from typing import Any
+from electricitymap.contrib.config import ZONES_CONFIG
+from electricitymap.contrib.config.capacity import get_capacity_data
 
 import pandas as pd
 
@@ -245,6 +247,37 @@ class ProductionBreakdownList(AggregatableEventList):
             prod = ProductionBreakdown.aggregate(row)
             production_breakdowns.events.append(prod)
         return production_breakdowns
+    @staticmethod
+    def filter_expected_modes(breakdowns: "ProductionBreakdownList") -> "ProductionBreakdownList":
+        """A temporary method to filter out malformed production breakdowns which are missing expected modes.
+        This method is only to be used on zones for which we know the expected modes and that the source sometimes returns Nones.
+        TODO: Remove this method once the outlier detection is able to handle it.
+        """
+        events = ProductionBreakdownList(breakdowns.logger)
+        for event in breakdowns.events:
+            capacity_config = ZONES_CONFIG.get(event.zoneKey, {}).get("capacity", {})
+            capacity = get_capacity_data(capacity_config, event.datetime)
+            valid = True
+            required_modes = [
+                mode for mode, capacity_value in capacity.items() if capacity_value > 0
+            ]
+            for mode in required_modes:
+                value = event.get_value(mode)
+                if value is None:
+                    valid = False
+                    events.logger.warning(
+                        f"Discarded production event for {event.zone_key} at {event.datetime} due to missing {mode} value."
+                    )
+                    break
+            if valid:
+                events.append(
+                    zoneKey=event.zoneKey,
+                    datetime=event.datetime,
+                    production=event.production,
+                    storage=event.storage,
+                    source=event.source,
+                )
+        return events
 
 
 class TotalProductionList(EventList):

--- a/electricitymap/contrib/lib/models/event_lists.py
+++ b/electricitymap/contrib/lib/models/event_lists.py
@@ -249,7 +249,7 @@ class ProductionBreakdownList(AggregatableEventList):
         return production_breakdowns
     @staticmethod
     def filter_expected_modes(breakdowns: "ProductionBreakdownList") -> "ProductionBreakdownList":
-        """A temporary method to filter out malformed production breakdowns which are missing expected modes.
+        """A temporary method to filter out incomplete production breakdowns which are missing expected modes.
         This method is only to be used on zones for which we know the expected modes and that the source sometimes returns Nones.
         TODO: Remove this method once the outlier detection is able to handle it.
         """
@@ -263,10 +263,10 @@ class ProductionBreakdownList(AggregatableEventList):
             ]
             for mode in required_modes:
                 value = event.get_value(mode)
-                if value is None:
+                if value is None and mode not in event.production.corrected_negative_modes:
                     valid = False
                     events.logger.warning(
-                        f"Discarded production event for {event.zone_key} at {event.datetime} due to missing {mode} value."
+                        f"Discarded production event for {event.zoneKey} at {event.datetime} due to missing {mode} value."
                     )
                     break
             if valid:

--- a/electricitymap/contrib/lib/models/event_lists.py
+++ b/electricitymap/contrib/lib/models/event_lists.py
@@ -248,7 +248,7 @@ class ProductionBreakdownList(AggregatableEventList):
             production_breakdowns.events.append(prod)
         return production_breakdowns
     @staticmethod
-    def filter_expected_modes(breakdowns: "ProductionBreakdownList") -> "ProductionBreakdownList":
+    def filter_expected_modes(breakdowns: "ProductionBreakdownList", strict_storage: bool = False) -> "ProductionBreakdownList":
         """A temporary method to filter out incomplete production breakdowns which are missing expected modes.
         This method is only to be used on zones for which we know the expected modes and that the source sometimes returns Nones.
         TODO: Remove this method once the outlier detection is able to handle it.
@@ -261,6 +261,8 @@ class ProductionBreakdownList(AggregatableEventList):
             required_modes = [
                 mode for mode, capacity_value in capacity.items() if capacity_value > 0
             ]
+            if not strict_storage:
+                required_modes = [mode for mode in required_modes if "storage" not in mode]
             for mode in required_modes:
                 value = event.get_value(mode)
                 if value is None and mode not in event.production.corrected_negative_modes:

--- a/electricitymap/contrib/lib/models/events.py
+++ b/electricitymap/contrib/lib/models/events.py
@@ -477,6 +477,20 @@ class ProductionBreakdown(AggregatableEvent):
                 return None
         return v
 
+    def get_value(self, mode: str) -> float | None:
+        """Returns the value of the provided mode this can be production or storage.
+        To retrieve the value of a storage mode, the mode should be prefixed with storage_.
+        Ex: retrive hydro production: get_value("hydro")
+        Ex: retrive hydro storage: get_value("storage_hydro")
+        """
+        if "storage" in mode:
+            if self.storage is None:
+                return None
+            return getattr(self.storage, mode.split("_")[1])
+        if self.production is None:
+            return None
+        return getattr(self.production, mode)
+
     @staticmethod
     def create(
         logger: Logger,

--- a/electricitymap/contrib/lib/models/events.py
+++ b/electricitymap/contrib/lib/models/events.py
@@ -479,14 +479,15 @@ class ProductionBreakdown(AggregatableEvent):
 
     def get_value(self, mode: str) -> float | None:
         """Returns the value of the provided mode this can be production or storage.
-        To retrieve the value of a storage mode, the mode should be prefixed with storage_.
+        To retrieve the value of a storage mode, the mode should be suffixed with storage.
         Ex: retrive hydro production: get_value("hydro")
-        Ex: retrive hydro storage: get_value("storage_hydro")
+        Ex: retrive hydro storage: get_value("hydro storage")
         """
         if "storage" in mode:
             if self.storage is None:
                 return None
-            return getattr(self.storage, mode.split("_")[1])
+            # This naming is the same as the capacity naming in the config.
+            return getattr(self.storage, mode.split(" ")[0])
         if self.production is None:
             return None
         return getattr(self.production, mode)

--- a/electricitymap/contrib/lib/tests/test_event_lists.py
+++ b/electricitymap/contrib/lib/tests/test_event_lists.py
@@ -553,6 +553,16 @@ class TestProductionBreakdownList(unittest.TestCase):
         assert len(output.events) == 1
         assert output.events[0].production.corrected_negative_modes == {"solar"}
 
+    def test_not_strict_mode(self):
+        production_list = ProductionBreakdownList(logging.Logger("test"))
+        production_list.append(
+            zoneKey=ZoneKey("AT"),
+            datetime=datetime(2023, 1, 1, tzinfo=timezone.utc),
+            production=ProductionMix(wind=10, coal=None, solar=10, biomass=10, gas=10, unknown=10, hydro=10, oil=10),
+            source="trust.me",
+        )
+        assert len(production_list.events) == 1
+
 class TestTotalProductionList(unittest.TestCase):
     def test_total_production_list(self):
         total_production = TotalProductionList(logging.Logger("test"))

--- a/electricitymap/contrib/lib/tests/test_event_lists.py
+++ b/electricitymap/contrib/lib/tests/test_event_lists.py
@@ -582,7 +582,7 @@ class TestProductionBreakdownList(unittest.TestCase):
             source="trust.me",
         )
         output = ProductionBreakdownList.filter_expected_modes(production_list_1)
-        assert len(output.events) == 1
+        assert len(output) == 1
         assert output.events[0].production.corrected_negative_modes == {"solar"}
 
     def test_not_strict_mode(self):
@@ -602,7 +602,29 @@ class TestProductionBreakdownList(unittest.TestCase):
             ),
             source="trust.me",
         )
-        assert len(production_list.events) == 1
+        output = ProductionBreakdownList.filter_expected_modes(production_list)
+        assert len(output) == 1
+
+    def test_filter_by_passed_modes(self):
+        production_list = ProductionBreakdownList(logging.Logger("test"))
+        production_list.append(
+            zoneKey=ZoneKey("US-NW-PGE"),
+            datetime=datetime(2023, 1, 1, tzinfo=timezone.utc),
+            production=ProductionMix(
+                wind=10,
+                coal=None,
+                solar=10,
+                gas=10,
+                unknown=10,
+                hydro=10,
+                oil=10,
+            ),
+            source="trust.me",
+        )
+        output = ProductionBreakdownList.filter_expected_modes(
+            production_list, by_passed_modes=["biomass"]
+        )
+        assert len(output) == 1
 
 
 class TestTotalProductionList(unittest.TestCase):

--- a/electricitymap/contrib/lib/tests/test_event_lists.py
+++ b/electricitymap/contrib/lib/tests/test_event_lists.py
@@ -501,26 +501,40 @@ class TestProductionBreakdownList(unittest.TestCase):
             "solar",
             "biomass",
         }
+
     def test_filter_expected_modes(self):
         production_list_1 = ProductionBreakdownList(logging.Logger("test"))
         production_list_1.append(
             zoneKey=ZoneKey("AT"),
             datetime=datetime(2023, 1, 1, tzinfo=timezone.utc),
-            production=ProductionMix(wind=10, coal=None, solar=10, biomass=10, gas=10, unknown=10, hydro=10, oil=10),
+            production=ProductionMix(
+                wind=10,
+                coal=None,
+                solar=10,
+                biomass=10,
+                gas=10,
+                unknown=10,
+                hydro=10,
+                oil=10,
+            ),
             storage=StorageMix(hydro=1),
             source="trust.me",
         )
         production_list_1.append(
             zoneKey=ZoneKey("AT"),
             datetime=datetime(2023, 1, 3, tzinfo=timezone.utc),
-            production=ProductionMix(wind=12, coal=12, solar=12, gas=12, unknown=12, hydro=12),
+            production=ProductionMix(
+                wind=12, coal=12, solar=12, gas=12, unknown=12, hydro=12
+            ),
             storage=StorageMix(hydro=1),
             source="trust.me",
         )
         production_list_1.append(
             zoneKey=ZoneKey("AT"),
             datetime=datetime(2023, 1, 4, tzinfo=timezone.utc),
-            production=ProductionMix(wind=12, coal=12, solar=12, gas=12, unknown=12, hydro=12),
+            production=ProductionMix(
+                wind=12, coal=12, solar=12, gas=12, unknown=12, hydro=12
+            ),
             storage=StorageMix(hydro=1),
             source="trust.me",
         )
@@ -533,7 +547,16 @@ class TestProductionBreakdownList(unittest.TestCase):
         production_list_1.append(
             zoneKey=ZoneKey("AT"),
             datetime=datetime(2023, 1, 1, tzinfo=timezone.utc),
-            production=ProductionMix(wind=10, coal=None, solar=None, biomass=10, gas=10, unknown=10, hydro=10, oil=10),
+            production=ProductionMix(
+                wind=10,
+                coal=None,
+                solar=None,
+                biomass=10,
+                gas=10,
+                unknown=10,
+                hydro=10,
+                oil=10,
+            ),
             storage=StorageMix(hydro=1),
             source="trust.me",
         )
@@ -545,7 +568,16 @@ class TestProductionBreakdownList(unittest.TestCase):
         production_list_1.append(
             zoneKey=ZoneKey("AT"),
             datetime=datetime(2023, 1, 1, tzinfo=timezone.utc),
-            production=ProductionMix(wind=10, coal=None, solar=-10, biomass=10, gas=10, unknown=10, hydro=10, oil=10),
+            production=ProductionMix(
+                wind=10,
+                coal=None,
+                solar=-10,
+                biomass=10,
+                gas=10,
+                unknown=10,
+                hydro=10,
+                oil=10,
+            ),
             storage=StorageMix(hydro=1),
             source="trust.me",
         )
@@ -558,10 +590,20 @@ class TestProductionBreakdownList(unittest.TestCase):
         production_list.append(
             zoneKey=ZoneKey("AT"),
             datetime=datetime(2023, 1, 1, tzinfo=timezone.utc),
-            production=ProductionMix(wind=10, coal=None, solar=10, biomass=10, gas=10, unknown=10, hydro=10, oil=10),
+            production=ProductionMix(
+                wind=10,
+                coal=None,
+                solar=10,
+                biomass=10,
+                gas=10,
+                unknown=10,
+                hydro=10,
+                oil=10,
+            ),
             source="trust.me",
         )
         assert len(production_list.events) == 1
+
 
 class TestTotalProductionList(unittest.TestCase):
     def test_total_production_list(self):

--- a/parsers/EIA.py
+++ b/parsers/EIA.py
@@ -582,7 +582,9 @@ def fetch_production_mix(
     events = ProductionBreakdownList.merge_production_breakdowns(
         all_production_breakdowns, logger
     )
-    filtered_events = ProductionBreakdownList.filter_expected_modes(events)
+    filtered_events = ProductionBreakdownList.filter_expected_modes(
+        events, by_passed_modes=["biomass"]
+    )
     return filtered_events.to_list()
 
 

--- a/parsers/EIA.py
+++ b/parsers/EIA.py
@@ -370,6 +370,17 @@ PRODUCTION_MIX = (
 )
 EXCHANGE = f"{BASE_URL}/interchange-data/data/" "?data[]=value{}&frequency=hourly"
 
+FILTER_INCOMPLETE_DATA_BYPASSED_MODES = {
+    "US-TEX-ERCO": ["biomass", "geothermal", "oil"],
+    "US-NW-PGE": ["biomass", "geothermal"],
+    "US-NW-PACE": ["biomass", "geothermal"],
+    "US-MIDW-MISO": ["biomass", "geothermal"],
+    "US-TEN-TVA": ["biomass", "geothermal"],
+    "US-SE-SOCO": ["biomass", "geothermal"],
+    "US-SE-SEPA": ["biomass", "geothermal"],
+    "US-FLA-FPL": ["biomass", "geothermal"],
+}
+
 
 @refetch_frequency(timedelta(days=1))
 def fetch_production(
@@ -582,10 +593,11 @@ def fetch_production_mix(
     events = ProductionBreakdownList.merge_production_breakdowns(
         all_production_breakdowns, logger
     )
-    filtered_events = ProductionBreakdownList.filter_expected_modes(
-        events, by_passed_modes=["biomass", "geothermal"]
-    )
-    return filtered_events.to_list()
+    if zone_key in FILTER_INCOMPLETE_DATA_BYPASSED_MODES:
+        events = ProductionBreakdownList.filter_expected_modes(
+            events, by_passed_modes=FILTER_INCOMPLETE_DATA_BYPASSED_MODES[zone_key]
+        )
+    return events.to_list()
 
 
 @refetch_frequency(timedelta(days=1))

--- a/parsers/EIA.py
+++ b/parsers/EIA.py
@@ -16,6 +16,8 @@ import arrow
 from dateutil import parser, tz
 from requests import Session
 
+from electricitymap.contrib.config import ZONES_CONFIG
+from electricitymap.contrib.config.capacity import get_capacity_data
 from electricitymap.contrib.lib.models.event_lists import (
     ExchangeList,
     ProductionBreakdownList,
@@ -468,6 +470,7 @@ def fetch_production_mix(
     logger: Logger = getLogger(__name__),
 ):
     all_production_breakdowns: list[ProductionBreakdownList] = []
+    # TODO: We could be smarter in the future and only fetch the expected production types.
     for production_mode, code in TYPES.items():
         negative_threshold = NEGATIVE_PRODUCTION_THRESHOLDS_TYPE.get(
             production_mode, NEGATIVE_PRODUCTION_THRESHOLDS_TYPE["default"]
@@ -578,9 +581,11 @@ def fetch_production_mix(
             if production_mix.datetime in latest_timeframe:
                 correct_mix.append(production_mix)
         production_list.events = correct_mix
-    return ProductionBreakdownList.merge_production_breakdowns(
+    events = ProductionBreakdownList.merge_production_breakdowns(
         all_production_breakdowns, logger
-    ).to_list()
+    )
+    filtered_events = filter_valid_production_events(zone_key, events, logger)
+    return filtered_events.to_list()
 
 
 @refetch_frequency(timedelta(days=1))
@@ -694,6 +699,41 @@ def _get_utc_datetime_from_datapoint(dt: datetime):
     dt_beginning_hour = _conform_timestamp_convention(dt)
     dt_utc = arrow.get(dt_beginning_hour).to("utc")
     return dt_utc.datetime
+
+
+def filter_valid_production_events(
+    zone_key: ZoneKey, production_events: ProductionBreakdownList, logger: Logger
+) -> ProductionBreakdownList:
+    """Returns a new production breakdown list with only valid events.
+    Valid events are determined by looking at the capacity data for the zone. If a mode has capacity we expect it to be present.
+    This is a temporary fix for the EIA only until the outlier detection is fully implemented.
+    """
+    capacity_config = ZONES_CONFIG.get(zone_key, {}).get("capacity", {})
+    events = ProductionBreakdownList(logger)
+    for event in production_events.events:
+        capacity = get_capacity_data(capacity_config, event.datetime)
+        valid = True
+        for mode, capacity_value in capacity.items():
+            if capacity_value > 0:
+                if "storage" in mode:
+                    value = event.storage.__getattribute__(mode.split("_")[1])
+                else:
+                    value = event.production.__getattribute__(mode)
+                if value is None:
+                    valid = False
+                    logger.warning(
+                        f"Discarded production event for {zone_key} at {event.datetime} due to missing {mode} value."
+                    )
+                    break
+        if valid:
+            events.append(
+                zoneKey=event.zoneKey,
+                datetime=event.datetime,
+                production=event.production,
+                storage=event.storage,
+                source=event.source,
+            )
+    return events
 
 
 if __name__ == "__main__":

--- a/parsers/EIA.py
+++ b/parsers/EIA.py
@@ -713,18 +713,20 @@ def filter_valid_production_events(
     for event in production_events.events:
         capacity = get_capacity_data(capacity_config, event.datetime)
         valid = True
-        for mode, capacity_value in capacity.items():
-            if capacity_value > 0:
-                if "storage" in mode:
-                    value = event.storage.__getattribute__(mode.split("_")[1])
-                else:
-                    value = event.production.__getattribute__(mode)
-                if value is None:
-                    valid = False
-                    logger.warning(
-                        f"Discarded production event for {zone_key} at {event.datetime} due to missing {mode} value."
-                    )
-                    break
+        required_modes = [
+            mode for mode, capacity_value in capacity.items() if capacity_value > 0
+        ]
+        for mode in required_modes:
+            if "storage" in mode:
+                value = event.storage.__getattribute__(mode.split("_")[1])
+            else:
+                value = event.production.__getattribute__(mode)
+            if value is None:
+                valid = False
+                logger.warning(
+                    f"Discarded production event for {zone_key} at {event.datetime} due to missing {mode} value."
+                )
+                break
         if valid:
             events.append(
                 zoneKey=event.zoneKey,

--- a/parsers/EIA.py
+++ b/parsers/EIA.py
@@ -583,7 +583,7 @@ def fetch_production_mix(
         all_production_breakdowns, logger
     )
     filtered_events = ProductionBreakdownList.filter_expected_modes(
-        events, by_passed_modes=["biomass"]
+        events, by_passed_modes=["biomass", "geothermal"]
     )
     return filtered_events.to_list()
 

--- a/parsers/test/mocks/EIA/US_SMTH-coal.json
+++ b/parsers/test/mocks/EIA/US_SMTH-coal.json
@@ -1,0 +1,31 @@
+{
+  "response": {
+    "query execution": 0.008633325,
+    "count query execution": 0.021634831,
+    "total": 3,
+    "dateFormat": "YYYY-MM-DD\"T\"HH24",
+    "frequency": "hourly",
+    "data": [
+      {
+        "period": "2022-10-31T11",
+        "respondent": "AVRN",
+        "respondent-name": "Avangrid Renewables, LLC",
+        "fueltype": "COAL",
+        "type-name": "Natural gas",
+        "value": 300,
+        "value-units": "megawatthours"
+      },
+      {
+        "period": "2022-10-31T12",
+        "respondent": "AVRN",
+        "respondent-name": "Avangrid Renewables, LLC",
+        "fueltype": "COAL",
+        "type-name": "Natural gas",
+        "value": 400,
+        "value-units": "megawatthours"
+      }
+    ],
+    "description": "Hourly net generation by balancing authority and energy source.  \n    Source: Form EIA-930\n    Product: Hourly Electric Grid Monitor"
+  },
+  "apiVersion": "2.0.3"
+}

--- a/parsers/test/test_EIA.py
+++ b/parsers/test/test_EIA.py
@@ -8,7 +8,6 @@ from requests import Session
 from requests_mock import ANY, GET, Adapter
 
 from electricitymap.contrib.lib.models.events import EventSourceType
-from electricitymap.contrib.lib.models.event_lists import ProductionBreakdownList
 from electricitymap.contrib.lib.types import ZoneKey
 from parsers import EIA
 

--- a/parsers/test/test_EIA.py
+++ b/parsers/test/test_EIA.py
@@ -239,6 +239,51 @@ class TestEIAProduction(TestEIA):
         )
         self.adapter.register_uri(
             GET,
+            EIA.PRODUCTION_MIX.format("SRP", "COL"),
+            json=json.loads(
+                resources.files("parsers.test.mocks.EIA")
+                .joinpath("US_SMTH-coal.json")
+                .read_text()
+            ),
+        )
+        self.adapter.register_uri(
+            GET,
+            EIA.PRODUCTION_MIX.format("SRP", "NG"),
+            json=json.loads(
+                resources.files("parsers.test.mocks.EIA")
+                .joinpath("US_SMTH-coal.json")
+                .read_text()
+            ),
+        )
+        self.adapter.register_uri(
+            GET,
+            EIA.PRODUCTION_MIX.format("SRP", "NUC"),
+            json=json.loads(
+                resources.files("parsers.test.mocks.EIA")
+                .joinpath("US_SMTH-coal.json")
+                .read_text()
+            ),
+        )
+        self.adapter.register_uri(
+            GET,
+            EIA.PRODUCTION_MIX.format("SRP", "SUN"),
+            json=json.loads(
+                resources.files("parsers.test.mocks.EIA")
+                .joinpath("US_SMTH-coal.json")
+                .read_text()
+            ),
+        )
+        self.adapter.register_uri(
+            GET,
+            EIA.PRODUCTION_MIX.format("SRP", "WND"),
+            json=json.loads(
+                resources.files("parsers.test.mocks.EIA")
+                .joinpath("US_SMTH-coal.json")
+                .read_text()
+            ),
+        )
+        self.adapter.register_uri(
+            GET,
             EIA.PRODUCTION_MIX.format("DEAA", "WAT"),
             json=json.loads(
                 resources.files("parsers.test.mocks.EIA")
@@ -270,13 +315,27 @@ class TestEIAProduction(TestEIA):
             {
                 "zoneKey": "US-SW-SRP",
                 "source": "eia.gov",
-                "production": {"hydro": 7.0},  # 4 from HGMA, 3 from DEAA
+                "production": {
+                    "hydro": 7.0,
+                    "coal": 300,
+                    "gas": 300,
+                    "nuclear": 300,
+                    "solar": 300,
+                    "wind": 300,
+                },  # hydro 4 from HGMA, 3 from DEAA
                 "storage": {"hydro": 5.0},  # 5 from SRP
             },
             {
                 "zoneKey": "US-SW-SRP",
                 "source": "eia.gov",
-                "production": {"hydro": 800.0},  # 400 from SRP, 400 from HGMA
+                "production": {
+                    "hydro": 800.0,
+                    "coal": 400,
+                    "gas": 400,
+                    "nuclear": 400,
+                    "solar": 400,
+                    "wind": 400,
+                },  # hydro 400 from SRP, 400 from HGMA
                 "storage": {"hydro": 900.0},  # 900 from DEAA
             },
         ]
@@ -336,7 +395,6 @@ class TestEIAProduction(TestEIA):
         self.assertIsNotNone(actual)
         self.assertEqual(len(expected), len(actual))
         for i, data in enumerate(actual):
-            print(data)
             self.assertEqual(data["zoneKey"], expected[i]["zoneKey"])
             self.assertEqual(data["source"], expected[i]["source"])
             self.assertIsNotNone(data["datetime"])
@@ -421,6 +479,7 @@ class TestEIAExchanges(TestEIA):
             self.assertEqual(data["sortedZoneKeys"], expected[i]["sortedZoneKeys"])
             self.assertEqual(data["netFlow"], expected[i]["netFlow"])
 
+
 class TestEIAConsumption(TestEIA):
     def test_fetch_consumption(self):
         self.adapter.register_uri(
@@ -480,6 +539,9 @@ class TestEIAConsumption(TestEIA):
             self.assertEqual(data["datetime"], expected[i]["datetime"])
             self.assertEqual(data["consumption"], expected[i]["consumption"])
             self.assertEqual(data["sourceType"], EventSourceType.forecasted)
+
+    def test_texas_loses_one_mode(self):
+        """A temporary test to make sure that if texas loses one of its modes we discard the datapoint."""
 
 
 if __name__ == "__main__":

--- a/parsers/test/test_EIA.py
+++ b/parsers/test/test_EIA.py
@@ -96,10 +96,73 @@ class TestEIAProduction(TestEIA):
         )
         self.adapter.register_uri(
             GET,
+            EIA.PRODUCTION_MIX.format("PACW", "WAT"),
+            json=json.loads(
+                resources.files("parsers.test.mocks.EIA")
+                .joinpath("US_SMTH-coal.json")
+                .read_text()
+            ),
+        )
+        self.adapter.register_uri(
+            GET,
+            EIA.PRODUCTION_MIX.format("PACW", "SUN"),
+            json=json.loads(
+                resources.files("parsers.test.mocks.EIA")
+                .joinpath("US_SMTH-coal.json")
+                .read_text()
+            ),
+        )
+        self.adapter.register_uri(
+            GET,
+            EIA.PRODUCTION_MIX.format("PACW", "WND"),
+            json=json.loads(
+                resources.files("parsers.test.mocks.EIA")
+                .joinpath("US_SMTH-coal.json")
+                .read_text()
+            ),
+        )
+        self.adapter.register_uri(
+            GET,
             EIA.PRODUCTION_MIX.format("BPAT", "WND"),
             json=json.loads(
                 resources.files("parsers.test.mocks.EIA")
                 .joinpath("US_NW_BPAT-wind.json")
+                .read_text()
+            ),
+        )
+        self.adapter.register_uri(
+            GET,
+            EIA.PRODUCTION_MIX.format("BPAT", "NG"),
+            json=json.loads(
+                resources.files("parsers.test.mocks.EIA")
+                .joinpath("US_SMTH-coal.json")
+                .read_text()
+            ),
+        )
+        self.adapter.register_uri(
+            GET,
+            EIA.PRODUCTION_MIX.format("BPAT", "WAT"),
+            json=json.loads(
+                resources.files("parsers.test.mocks.EIA")
+                .joinpath("US_SMTH-coal.json")
+                .read_text()
+            ),
+        )
+        self.adapter.register_uri(
+            GET,
+            EIA.PRODUCTION_MIX.format("BPAT", "NUC"),
+            json=json.loads(
+                resources.files("parsers.test.mocks.EIA")
+                .joinpath("US_SMTH-coal.json")
+                .read_text()
+            ),
+        )
+        self.adapter.register_uri(
+            GET,
+            EIA.PRODUCTION_MIX.format("BPAT", "SUN"),
+            json=json.loads(
+                resources.files("parsers.test.mocks.EIA")
+                .joinpath("US_SMTH-coal.json")
                 .read_text()
             ),
         )
@@ -118,13 +181,13 @@ class TestEIAProduction(TestEIA):
             {
                 "zoneKey": "US-NW-PACW",
                 "source": "eia.gov",
-                "production": {"gas": 330},
+                "production": {"gas": 330, "hydro": 300, "solar": 300, "wind": 300},
                 "storage": {},
             },
             {
                 "zoneKey": "US-NW-PACW",
                 "source": "eia.gov",
-                "production": {"gas": 450},
+                "production": {"gas": 450, "hydro": 400, "solar": 400, "wind": 400},
                 "storage": {},
             },
         ]
@@ -134,13 +197,25 @@ class TestEIAProduction(TestEIA):
             {
                 "zoneKey": "US-NW-BPAT",
                 "source": "eia.gov",
-                "production": {"wind": 21},
+                "production": {
+                    "wind": 21,
+                    "gas": 300,
+                    "hydro": 300,
+                    "nuclear": 300,
+                    "solar": 300,
+                },
                 "storage": {},
             },
             {
                 "zoneKey": "US-NW-BPAT",
                 "source": "eia.gov",
-                "production": {"wind": 42},
+                "production": {
+                    "wind": 42,
+                    "gas": 400,
+                    "hydro": 400,
+                    "nuclear": 400,
+                    "solar": 400,
+                },
                 "storage": {},
             },
         ]
@@ -153,6 +228,51 @@ class TestEIAProduction(TestEIA):
             json=json.loads(
                 resources.files("parsers.test.mocks.EIA")
                 .joinpath("US_NW_AVRN-other.json")
+                .read_text()
+            ),
+        )
+        self.adapter.register_uri(
+            GET,
+            EIA.PRODUCTION_MIX.format("SC", "COL"),
+            json=json.loads(
+                resources.files("parsers.test.mocks.EIA")
+                .joinpath("US_SMTH-coal.json")
+                .read_text()
+            ),
+        )
+        self.adapter.register_uri(
+            GET,
+            EIA.PRODUCTION_MIX.format("SC", "NG"),
+            json=json.loads(
+                resources.files("parsers.test.mocks.EIA")
+                .joinpath("US_SMTH-coal.json")
+                .read_text()
+            ),
+        )
+        self.adapter.register_uri(
+            GET,
+            EIA.PRODUCTION_MIX.format("SC", "WAT"),
+            json=json.loads(
+                resources.files("parsers.test.mocks.EIA")
+                .joinpath("US_SMTH-coal.json")
+                .read_text()
+            ),
+        )
+        self.adapter.register_uri(
+            GET,
+            EIA.PRODUCTION_MIX.format("SC", "OIL"),
+            json=json.loads(
+                resources.files("parsers.test.mocks.EIA")
+                .joinpath("US_SMTH-coal.json")
+                .read_text()
+            ),
+        )
+        self.adapter.register_uri(
+            GET,
+            EIA.PRODUCTION_MIX.format("SC", "SUN"),
+            json=json.loads(
+                resources.files("parsers.test.mocks.EIA")
+                .joinpath("US_SMTH-coal.json")
                 .read_text()
             ),
         )
@@ -174,19 +294,78 @@ class TestEIAProduction(TestEIA):
                 .read_text()
             ),
         )
+        self.adapter.register_uri(
+            GET,
+            EIA.PRODUCTION_MIX.format("SCEG", "COL"),
+            json=json.loads(
+                resources.files("parsers.test.mocks.EIA")
+                .joinpath("US_SMTH-coal.json")
+                .read_text()
+            ),
+        )
+        self.adapter.register_uri(
+            GET,
+            EIA.PRODUCTION_MIX.format("SCEG", "NG"),
+            json=json.loads(
+                resources.files("parsers.test.mocks.EIA")
+                .joinpath("US_SMTH-coal.json")
+                .read_text()
+            ),
+        )
+        self.adapter.register_uri(
+            GET,
+            EIA.PRODUCTION_MIX.format("SCEG", "WAT"),
+            json=json.loads(
+                resources.files("parsers.test.mocks.EIA")
+                .joinpath("US_SMTH-coal.json")
+                .read_text()
+            ),
+        )
+        self.adapter.register_uri(
+            GET,
+            EIA.PRODUCTION_MIX.format("SCEG", "OIL"),
+            json=json.loads(
+                resources.files("parsers.test.mocks.EIA")
+                .joinpath("US_SMTH-coal.json")
+                .read_text()
+            ),
+        )
+        self.adapter.register_uri(
+            GET,
+            EIA.PRODUCTION_MIX.format("SCEG", "SUN"),
+            json=json.loads(
+                resources.files("parsers.test.mocks.EIA")
+                .joinpath("US_SMTH-coal.json")
+                .read_text()
+            ),
+        )
 
         data_list = EIA.fetch_production_mix(ZoneKey("US-CAR-SC"), self.session)
         expected = [
             {
                 "zoneKey": "US-CAR-SC",
                 "source": "eia.gov",
-                "production": {"nuclear": 330.666634},
+                "production": {
+                    "nuclear": 330.666634,
+                    "coal": 300,
+                    "gas": 300,
+                    "oil": 300,
+                    "solar": 300,
+                    "hydro": 300,
+                },
                 "storage": {},
             },
             {
                 "zoneKey": "US-CAR-SC",
                 "source": "eia.gov",
-                "production": {"nuclear": 330.3333},
+                "production": {
+                    "nuclear": 330.3333,
+                    "coal": 400,
+                    "gas": 400,
+                    "oil": 400,
+                    "solar": 400,
+                    "hydro": 400,
+                },
                 "storage": {},
             },
         ]
@@ -196,13 +375,27 @@ class TestEIAProduction(TestEIA):
             {
                 "zoneKey": "US-CAR-SCEG",
                 "source": "eia.gov",
-                "production": {"nuclear": 661.333366},
+                "production": {
+                    "nuclear": 661.333366,
+                    "coal": 300,
+                    "gas": 300,
+                    "oil": 300,
+                    "solar": 300,
+                    "hydro": 300,
+                },
                 "storage": {},
             },
             {
                 "zoneKey": "US-CAR-SCEG",
                 "source": "eia.gov",
-                "production": {"nuclear": 660.6667},
+                "production": {
+                    "nuclear": 660.6667,
+                    "coal": 400,
+                    "gas": 400,
+                    "oil": 400,
+                    "solar": 400,
+                    "hydro": 400,
+                },
                 "storage": {},
             },
         ]

--- a/parsers/test/test_EIA.py
+++ b/parsers/test/test_EIA.py
@@ -8,6 +8,7 @@ from requests import Session
 from requests_mock import ANY, GET, Adapter
 
 from electricitymap.contrib.lib.models.events import EventSourceType
+from electricitymap.contrib.lib.models.event_lists import ProductionBreakdownList
 from electricitymap.contrib.lib.types import ZoneKey
 from parsers import EIA
 
@@ -420,7 +421,6 @@ class TestEIAExchanges(TestEIA):
             self.assertEqual(data["datetime"], expected[i]["datetime"])
             self.assertEqual(data["sortedZoneKeys"], expected[i]["sortedZoneKeys"])
             self.assertEqual(data["netFlow"], expected[i]["netFlow"])
-
 
 class TestEIAConsumption(TestEIA):
     def test_fetch_consumption(self):

--- a/parsers/test/test_EIA.py
+++ b/parsers/test/test_EIA.py
@@ -735,6 +735,28 @@ class TestEIAConsumption(TestEIA):
 
     def test_texas_loses_one_mode(self):
         """A temporary test to make sure that if texas loses one of its modes we discard the datapoint."""
+        # All modes are loaded with some data
+        self.adapter.register_uri(
+            GET,
+            ANY,
+            json=json.loads(
+                resources.files("parsers.test.mocks.EIA")
+                .joinpath("US_SMTH-coal.json")
+                .read_text()
+            ),
+        )
+        # Nuclear is missing data
+        self.adapter.register_uri(
+            GET,
+            EIA.PRODUCTION_MIX.format("ERCO", "NUC"),
+            json=json.loads(
+                resources.files("parsers.test.mocks.EIA")
+                .joinpath("US_NW_AVRN-other.json")
+                .read_text()
+            ),
+        )
+        data = EIA.fetch_production_mix(ZoneKey("US-TEX-ERCO"), self.session)
+        self.assertEqual(len(data), 0)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Issue

We are currently seeing frequent instances of the EIA parser returning incomplete data points due to the EIA publishing incomplete data. This has consequences on our estimation models as they are picking up the trend on missing modes.

We are working on our outlier detection layer but it's not ready yet to handle those cases. Therefore as a short term fix we would like the parser to discard incomplete datapoints so that our estimation models are not poisoned by those.

## Description

Create a general filter static method for production breakdown using the zone's capacity. If a zone has capacity for a mode we expect it to have a value for this mode at all time which is not None.

### Preview

Testing in progress.

### Double check

- [ ] I have tested my parser changes locally with `poetry run test_parser "zone_key"`
- [ ] I have run `pnpx prettier --write .` and `poetry run format` to format my changes.
