### PR TITLE
bug(web): Style not loaded on jump to zone from URL

### DIFF
--- a/web/src/features/map/Map.tsx
+++ b/web/src/features/map/Map.tsx
@@ -173,7 +173,7 @@ export default function MapPage({ onMapLoad }: MapPageProps): ReactElement {
       setHoveredZone(null);
     }
     // Center the map on the selected zone
-    const zoneId = matchPath('/zone/:zoneId', location.pathname)?.params.zoneId;
+    const selectedZoneId = matchPath('/zone/:zoneId', location.pathname)?.params.zoneId;
     setSelectedZoneId(zoneId);
     if (map && !isLoadingMap && zoneId) {
       const feature = worldGeometries.features.find(

--- a/web/src/features/map/Map.tsx
+++ b/web/src/features/map/Map.tsx
@@ -173,18 +173,18 @@ export default function MapPage({ onMapLoad }: MapPageProps): ReactElement {
       setHoveredZone(null);
     }
     // Center the map on the selected zone
-    const selectedZoneId = matchPath('/zone/:zoneId', location.pathname)?.params.zoneId;
-    setSelectedZoneId(zoneId);
-    if (map && !isLoadingMap && zoneId) {
+    const pathZoneId = matchPath('/zone/:zoneId', location.pathname)?.params.zoneId;
+    setSelectedZoneId(pathZoneId);
+    if (map && !isLoadingMap && pathZoneId) {
       const feature = worldGeometries.features.find(
-        (feature) => feature?.properties?.zoneId === zoneId
+        (feature) => feature?.properties?.zoneId === pathZoneId
       );
       // if no feature matches, it means that the selected zone is not in current spatial resolution.
       // We cannot include geometries in dependencies, as we don't want to flyTo when user switches
       // between spatial resolutions. Therefore we find an approximate feature based on the zoneId.
       if (feature) {
         const center = feature.properties.center;
-        map.setFeatureState({ source: ZONE_SOURCE, id: zoneId }, { selected: true });
+        map.setFeatureState({ source: ZONE_SOURCE, id: pathZoneId }, { selected: true });
         setLeftPanelOpen(true);
         const centerMinusLeftPanelWidth = [center[0] - 10, center[1]] as [number, number];
         map.flyTo({ center: isMobile ? center : centerMinusLeftPanelWidth, zoom: 3.5 });

--- a/web/src/features/map/Map.tsx
+++ b/web/src/features/map/Map.tsx
@@ -177,7 +177,7 @@ export default function MapPage({ onMapLoad }: MapPageProps): ReactElement {
     setSelectedZoneId(zoneId);
     if (map && !isLoadingMap && zoneId) {
       const feature = worldGeometries.features.find(
-        (feature) => feature.properties.zoneId === zoneId
+        (feature) => feature?.properties?.zoneId === zoneId
       );
       // if no feature matches, it means that the selected zone is not in current spatial resolution.
       // We cannot include geometries in dependencies, as we don't want to flyTo when user switches

--- a/web/src/features/map/Map.tsx
+++ b/web/src/features/map/Map.tsx
@@ -182,15 +182,13 @@ export default function MapPage({ onMapLoad }: MapPageProps): ReactElement {
       // if no feature matches, it means that the selected zone is not in current spatial resolution.
       // We cannot include geometries in dependencies, as we don't want to flyTo when user switches
       // between spatial resolutions. Therefore we find an approximate feature based on the zoneId.
-      if (!feature) {
-        return;
+      if (feature) {
+        const center = feature.properties.center;
+        map.setFeatureState({ source: ZONE_SOURCE, id: zoneId }, { selected: true });
+        setLeftPanelOpen(true);
+        const centerMinusLeftPanelWidth = [center[0] - 10, center[1]] as [number, number];
+        map.flyTo({ center: isMobile ? center : centerMinusLeftPanelWidth, zoom: 3.5 });
       }
-
-      const center = feature.properties.center;
-      map.setFeatureState({ source: ZONE_SOURCE, id: zoneId }, { selected: true });
-      setLeftPanelOpen(true);
-      const centerMinusLeftPanelWidth = [center[0] - 10, center[1]] as [number, number];
-      map.flyTo({ center: isMobile ? center : centerMinusLeftPanelWidth, zoom: 3.5 });
     }
   }, [map, location.pathname, isLoadingMap]);
 

--- a/web/src/features/map/Map.tsx
+++ b/web/src/features/map/Map.tsx
@@ -175,7 +175,7 @@ export default function MapPage({ onMapLoad }: MapPageProps): ReactElement {
     // Center the map on the selected zone
     const zoneId = matchPath('/zone/:zoneId', location.pathname)?.params.zoneId;
     setSelectedZoneId(zoneId);
-    if (map && zoneId) {
+    if (map && !isLoadingMap && zoneId) {
       const feature = worldGeometries.features.find(
         (feature) => feature.properties.zoneId === zoneId
       );


### PR DESCRIPTION
## Issue
Style not done loading error when loading map with a zone in url.

We had a bunch of sentry errors coming in from app crashes, to replicate try opening a tab that jumps to a zone. I.e [this one](https://app.electricitymaps.com/zone/AU-QLD) and change tabs or open another before it loads.


Here's a user feedback from Sentry:
"Crash happened when I attempted to open a URL that I have previously used and saved, that URL is https://app.electricitymaps.com/zone/US-NW-PSCO?utm_source=electricitymap.org&utm_medium=website&utm_campaign=product-details ... similarly, I just tried https://app.electricitymaps.com/zone/US-NW-PSCO and it crashed, too."

## Description
This PR updates the map file to check that the map is not loading before trying to execute the fly to zone feature.

### Double check

- [x] I have tested my parser changes locally with `poetry run test_parser "zone_key"`
- [x] I have run `pnpx prettier --write .` and `poetry run format` to format my changes.
