### PR TITLE
Update data sources and capacity values for Poland

### DIFF
--- a/DATA_SOURCES.md
+++ b/DATA_SOURCES.md
@@ -378,7 +378,7 @@ For many European countries, data is available from [ENTSO-E](https://transparen
   - Biomass: [Secretaría de Energía de Panamá](http://www.energia.gob.pa/mercado-energetico/?tag=84#documents-list)
 - Peru: [IRENA](https://www.irena.org/publications/2022/Apr/Renewable-Capacity-Statistics-2022)
 - Philippines: [Philippine Department of Energy](https://www.doe.gov.ph/sites/default/files/pdf/electric_power/04_LVM-Grid-Summary-June-2023-updated.pdf)
-- Poland: [ARE](https://www.are.waw.pl/badania-statystyczne/wynikowe-informacje-statystyczne/publikacje-miesieczne#informacja-statystyczna-o-energii-elektrycznej)
+- Poland: [ENTSO-E](https://transparency.entsoe.eu/generation/r2/installedGenerationCapacityAggregation/show)
 - Portugal:
   - Biomass, Hydro, Solar, Wind, Gas: [REN](https://datahub.ren.pt/en/electricity/monthly-balance/)
   - Other: [ENTSO-E](https://transparency.entsoe.eu/generation/r2/installedGenerationCapacityAggregation/show)

--- a/config/zones/PL.yaml
+++ b/config/zones/PL.yaml
@@ -4,18 +4,59 @@ bounding_box:
   - - 24.0299857927
     - 54.8515359564
 capacity:
-  battery storage: 0
-  biomass: 1121.9
-  coal: 30666.6
-  gas: 3845.3
-  geothermal: 0
-  hydro: 984.9
-  hydro storage: 1413
-  nuclear: 0
-  oil: 678.8
-  solar: 12434.5
-  unknown: 0
-  wind: 8190.9
+  biomass:
+    - datetime: '2023-01-01'
+      source: entsoe.eu
+      value: 664.0
+    - datetime: '2024-01-01'
+      source: entsoe.eu
+      value: 678.0
+  coal:
+    - datetime: '2023-01-01'
+      source: entsoe.eu
+      value: 26568.0
+    - datetime: '2024-01-01'
+      source: entsoe.eu
+      value: 26235.0
+  gas:
+    - datetime: '2023-01-01'
+      source: entsoe.eu
+      value: 4067.0
+    - datetime: '2024-01-01'
+      source: entsoe.eu
+      value: 5424.0
+  hydro:
+    - datetime: '2023-01-01'
+      source: entsoe.eu
+      value: 2383.0
+    - datetime: '2024-01-01'
+      source: entsoe.eu
+      value: 2382.0
+  oil:
+    datetime: '2023-01-01'
+    source: entsoe.eu
+    value: 393.0
+  solar:
+    - datetime: '2023-01-01'
+      source: entsoe.eu
+      value: 10643.0
+    - datetime: '2024-01-01'
+      source: entsoe.eu
+      value: 14282.0
+  unknown:
+    - datetime: '2023-01-01'
+      source: entsoe.eu
+      value: 1520.0
+    - datetime: '2024-01-01'
+      source: entsoe.eu
+      value: 1734.0
+  wind:
+    - datetime: '2023-01-01'
+      source: entsoe.eu
+      value: 8978.0
+    - datetime: '2024-01-01'
+      source: entsoe.eu
+      value: 9628.0
 contributors:
   - corradio
   - wojciej


### PR DESCRIPTION
## Issue

PL capacity was out of data.

## Description

Switched the source to ENTSO-E and used the update_capacity script to add 2023 and 2024 capacity data.

### Double check

- [x] I have tested my parser changes locally with `poetry run test_parser "zone_key"`
- [x] I have run `pnpx prettier --write .` and `poetry run format` to format my changes.
