### PR TITLE
fix(EIA): add oil to the bypassed expected modes

### DIFF
--- a/parsers/EIA.py
+++ b/parsers/EIA.py
@@ -372,13 +372,13 @@ EXCHANGE = f"{BASE_URL}/interchange-data/data/" "?data[]=value{}&frequency=hourl
 
 FILTER_INCOMPLETE_DATA_BYPASSED_MODES = {
     "US-TEX-ERCO": ["biomass", "geothermal", "oil"],
-    "US-NW-PGE": ["biomass", "geothermal"],
-    "US-NW-PACE": ["biomass", "geothermal"],
-    "US-MIDW-MISO": ["biomass", "geothermal"],
-    "US-TEN-TVA": ["biomass", "geothermal"],
-    "US-SE-SOCO": ["biomass", "geothermal"],
-    "US-SE-SEPA": ["biomass", "geothermal"],
-    "US-FLA-FPL": ["biomass", "geothermal"],
+    "US-NW-PGE": ["biomass", "geothermal", "oil"],
+    "US-NW-PACE": ["biomass", "geothermal", "oil"],
+    "US-MIDW-MISO": ["biomass", "geothermal", "oil"],
+    "US-TEN-TVA": ["biomass", "geothermal", "oil"],
+    "US-SE-SOCO": ["biomass", "geothermal", "oil"],
+    "US-SE-SEPA": ["biomass", "geothermal", "oil"],
+    "US-FLA-FPL": ["biomass", "geothermal", "oil"],
 }
 
 


### PR DESCRIPTION
## Issue

We are seeing some zones data being discarded (MISO) because of oil not being always reported.

## Description

Add oil to the bypassed modes. Quick fix until we have time to look more into it.


### Double check

- [ ] I have tested my parser changes locally with `poetry run test_parser "zone_key"`
- [ ] I have run `pnpx prettier --write .` and `poetry run format` to format my changes.
