### PR TITLE
Update Singapore solar capacity

### DIFF
--- a/DATA_SOURCES.md
+++ b/DATA_SOURCES.md
@@ -390,7 +390,7 @@ For many European countries, data is available from [ENTSO-E](https://transparen
 - Russia: [Minenergo](https://minenergo.gov.ru/node/532)
 - Serbia: [ENTSO-E](https://transparency.entsoe.eu/generation/r2/installedGenerationCapacityAggregation/show?)
 - Singapore
-  - Solar: [Energy Market Authority Statistics](https://www.ema.gov.sg/statistic.aspx?sta_sid=20170711hc85chOLVvWp)
+  - Solar: [Energy Market Authority](https://www.ema.gov.sg/consumer-information/solar/solar-irradiance-map)
   - Other: [Energy Market Authority](https://www.ema.gov.sg/statistic.aspx?sta_sid=20140730XofavKNX5Ti7)
 - Slovakia:
   - Nuclear: [IAEA](https://pris.iaea.org/PRIS/CountryStatistics/CountryDetails.aspx?current=SK)

--- a/config/zones/SG.yaml
+++ b/config/zones/SG.yaml
@@ -9,7 +9,7 @@ capacity:
   gas: 10671
   geothermal: 0
   oil: 0
-  solar: 486.9
+  solar: 989.796
 contributors:
   - corradio
   - jarek


### PR DESCRIPTION
Source: https://www.ema.gov.sg/consumer-information/solar/solar-irradiance-map

This is also the page used to fetch the solar data by the production parser.

---
I also updated the capacity data source, as the old URL 404's.