### PR TITLE
Add more accurate Cyprus emission factors

### DIFF
--- a/config/zones/CY.yaml
+++ b/config/zones/CY.yaml
@@ -145,16 +145,16 @@ emissionFactors:
       value: 5.13
     oil:
       - datetime: '2018-01-01'
-        source: EU-ETS, CERA 2018 Report
+        source: EU-ETS, CERA 2018 Report; IPCC 2014
         value: 974.57
       - datetime: '2019-01-01'
-        source: EU-ETS, CERA 2019 Report
+        source: EU-ETS, CERA 2019 Report; IPCC 2014
         value: 954.54
       - datetime: '2020-01-01'
-        source: EU-ETS, CERA 2020 Report
+        source: EU-ETS, CERA 2020 Report; IPCC 2014
         value: 951.44
       - datetime: '2021-01-01'
-        source: EU-ETS, TSOC 2021 Report
+        source: EU-ETS, TSOC 2021 Report; IPCC 2014
         value: 953.61
     solar:
       datetime: '2021-01-01'

--- a/config/zones/CY.yaml
+++ b/config/zones/CY.yaml
@@ -248,16 +248,12 @@ parsers:
 sources:
   EU-ETS, CERA 2018 Report:
     link: https://tsoc.org.cy/files/reports/annual-reports/CERA_Annual_Report_2018_gr.pdf#page=128
-    comment: Total CO2 from ETS, Total Energy from TSOC report
   EU-ETS, CERA 2019 Report:
     link: https://tsoc.org.cy/files/reports/annual-reports/CERA_Annual_Report_2019_gr.pdf#page=143
-    comment: Total CO2 from ETS, Total Energy from TSOC report
   EU-ETS, CERA 2020 Report:
     link: https://tsoc.org.cy/files/reports/annual-reports/CERA_Annual_Report_2020_gr.pdf#page=164
-    comment: Total CO2 from ETS, Total Energy from TSOC report
   EU-ETS, TSOC 2021 Report:
     link: https://tsoc.org.cy/files/reports/annual-reports/TSOC_Annual_Report_2021.pdf#page=34
-    comment: Total CO2 from ETS, Total Energy from TSOC report
   EU-ETS, ENTSO-E 2021:
     link: https://drive.google.com/file/d/15UeUHyhcjVw8fGLc0Zx_HELSx20cw_-e/view?usp=share_link
   EU-ETS, ENTSO-E 2022:

--- a/config/zones/CY.yaml
+++ b/config/zones/CY.yaml
@@ -72,12 +72,18 @@ emissionFactors:
         source: Electricity Maps, 2021 average
         value: 752.432349872631
     oil:
+      - datetime: '2018-01-01'
+        source: EU-ETS, CERA 2018 Report
+        value: 730.57
+      - datetime: '2019-01-01'
+        source: EU-ETS, CERA 2019 Report
+        value: 710.54
+      - datetime: '2020-01-01'
+        source: EU-ETS, CERA 2020 Report
+        value: 707.44
       - datetime: '2021-01-01'
-        source: EU-ETS, ENTSO-E 2021
-        value: 880.903938
-      - datetime: '2022-01-01'
-        source: EU-ETS, ENTSO-E 2022
-        value: 925.95
+        source: EU-ETS, TSOC 2021 Report
+        value: 709.61
   lifecycle:
     battery discharge:
       - datetime: '2017-01-01'
@@ -138,12 +144,18 @@ emissionFactors:
       source: UNECE 2022
       value: 5.13
     oil:
+      - datetime: '2018-01-01'
+        source: EU-ETS, CERA 2018 Report
+        value: 974.57
+      - datetime: '2019-01-01'
+        source: EU-ETS, CERA 2019 Report
+        value: 954.54
+      - datetime: '2020-01-01'
+        source: EU-ETS, CERA 2020 Report
+        value: 951.44
       - datetime: '2021-01-01'
-        source: EU-ETS, ENTSO-E 2021; IPCC 2014
-        value: 1124.903938
-      - datetime: '2022-01-01'
-        source: EU-ETS, ENTSO-E 2022; IPCC 2014
-        value: 1169.95
+        source: EU-ETS, TSOC 2021 Report
+        value: 953.61
     solar:
       datetime: '2021-01-01'
       source: INCER ACV
@@ -234,6 +246,18 @@ parsers:
   production: CY.fetch_production
   productionCapacity: EMBER.fetch_production_capacity
 sources:
+  EU-ETS, CERA 2018 Report:
+    link: https://tsoc.org.cy/files/reports/annual-reports/CERA_Annual_Report_2018_gr.pdf#page=128
+    comment: Total CO2 from ETS, Total Energy from TSOC report
+  EU-ETS, CERA 2019 Report:
+    link: https://tsoc.org.cy/files/reports/annual-reports/CERA_Annual_Report_2019_gr.pdf#page=143
+    comment: Total CO2 from ETS, Total Energy from TSOC report
+  EU-ETS, CERA 2020 Report:
+    link: https://tsoc.org.cy/files/reports/annual-reports/CERA_Annual_Report_2020_gr.pdf#page=164
+    comment: Total CO2 from ETS, Total Energy from TSOC report
+  EU-ETS, TSOC 2021 Report:
+    link: https://tsoc.org.cy/files/reports/annual-reports/TSOC_Annual_Report_2021.pdf#page=34
+    comment: Total CO2 from ETS, Total Energy from TSOC report
   EU-ETS, ENTSO-E 2021:
     link: https://drive.google.com/file/d/15UeUHyhcjVw8fGLc0Zx_HELSx20cw_-e/view?usp=share_link
   EU-ETS, ENTSO-E 2022:


### PR DESCRIPTION
## Issue

Closes #6014 

## Description

I've added more accurate emission factors for Cyprus. I've used the fact that the 3 power plants of the country are in ETS, and that the total electricity produced by these plants in each given year is published by the cypriot grid operator.

I've found the production data in the grid operator web, in 3 different places:
- [Annual reports](https://tsoc.org.cy/organization/annual-reports/)
- [XLSX files of the 15 minutes data](https://tsoc.org.cy/electrical-system/archive-total-daily-system-generation-on-the-transmission-system/)
- [These other reports](https://tsoc.org.cy/electrical-system/energy-generation-records/res-penetration/)

The values provided by these sources were very similar but not equal, I've used the one provided in the annual reports. In the case of the year 2022, each source gave a very different value, so I have not added any factor for it. I have removed the one already present as I think the one from the previous year is much more accurate.

As a side note, the yearly production data is also in the EM app. It should be the same as the one in the XLSX files, but it differed for some years, a refetch with the historical parser may be needed.

Also, I've added only up to 2018, as there are no xlsx files for previous years to compare to. Factors could be added based on the annual reports data for completeness, if you wish so.

### Double check

- [x] I have run `pnpx prettier --write .` and `poetry run format` to format my changes.
