### PR TITLE
Add missing tzdata package

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -873,6 +873,7 @@ files = [
     {file = "PyYAML-6.0.1-cp311-cp311-win_amd64.whl", hash = "sha256:bf07ee2fef7014951eeb99f56f39c9bb4af143d8aa3c21b1677805985307da34"},
     {file = "PyYAML-6.0.1-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:855fb52b0dc35af121542a76b9a84f8d1cd886ea97c84703eaa6d88e37a2ad28"},
     {file = "PyYAML-6.0.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:40df9b996c2b73138957fe23a16a4f0ba614f4c0efce1e9406a184b6d07fa3a9"},
+    {file = "PyYAML-6.0.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a08c6f0fe150303c1c6b71ebcd7213c2858041a7e01975da3a99aed1e7a378ef"},
     {file = "PyYAML-6.0.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6c22bec3fbe2524cde73d7ada88f6566758a8f7227bfbf93a408a9d86bcc12a0"},
     {file = "PyYAML-6.0.1-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:8d4e9c88387b0f5c7d5f281e55304de64cf7f9c0021a3525bd3b1c542da3b0e4"},
     {file = "PyYAML-6.0.1-cp312-cp312-win32.whl", hash = "sha256:d483d2cdf104e7c9fa60c544d92981f12ad66a457afae824d146093b8c294c54"},
@@ -1200,6 +1201,17 @@ files = [
 ]
 
 [[package]]
+name = "tzdata"
+version = "2023.4"
+description = "Provider of IANA time zone data"
+optional = false
+python-versions = ">=2"
+files = [
+    {file = "tzdata-2023.4-py2.py3-none-any.whl", hash = "sha256:aa3ace4329eeacda5b7beb7ea08ece826c28d761cda36e747cfbf97996d39bf3"},
+    {file = "tzdata-2023.4.tar.gz", hash = "sha256:dd54c94f294765522c77399649b4fefd95522479a664a0cec87f41bebc6148c9"},
+]
+
+[[package]]
 name = "urllib3"
 version = "2.1.0"
 description = "HTTP library with thread-safe connection pooling, file post, and more."
@@ -1375,4 +1387,4 @@ scripts = ["xmltodict"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">= 3.10, < 3.11"
-content-hash = "944e02cf28c357fd803521960c56da6a844b5c9a63f89e344c582e151f3aedcb"
+content-hash = "bc0fdbe1aa1f7578366fed2d27a24431062e8c43d0df9d78130a4e9f1f9bccf9"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,7 @@ ruamel-yaml = "^0.17.24"
 odfpy = { version = "^1.4.1", optional = true }
 pycountry = { version = "^22.3.5", optional = true }
 ruff = "^0.1.8"
+tzdata = "^2023.4"
 
 [tool.poetry.dev-dependencies]
 mock = "^2.0.0"


### PR DESCRIPTION
This package was missing from poetry requirements, causing an error when running poetry run test_parser on my Windows machine.

## Issue

When running `poetry run test_parser ZONE_KEY`, I got the following error:
````batch
C:\Users\My Name\Documents\electricitymap-contrib>poetry run test_parser LK
Traceback (most recent call last):
  File "C:\Users\My Name\AppData\Local\Python3\Python310\lib\zoneinfo\_common.py", line 12, in load_tzdata
    return importlib.resources.open_binary(package_name, resource_name)
  File "C:\Users\My Name\AppData\Local\Python3\Python310\lib\importlib\resources.py", line 43, in open_binary
    package = _common.get_package(package)
  File "C:\Users\My Name\AppData\Local\Python3\Python310\lib\importlib\_common.py", line 66, in get_package
    resolved = resolve(package)
  File "C:\Users\My Name\AppData\Local\Python3\Python310\lib\importlib\_common.py", line 57, in resolve
    return cand if isinstance(cand, types.ModuleType) else importlib.import_module(cand)
  File "C:\Users\My Name\AppData\Local\Python3\Python310\lib\importlib\__init__.py", line 126, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
  File "<frozen importlib._bootstrap>", line 1050, in _gcd_import
  File "<frozen importlib._bootstrap>", line 1027, in _find_and_load
  File "<frozen importlib._bootstrap>", line 992, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 241, in _call_with_frames_removed
  File "<frozen importlib._bootstrap>", line 1050, in _gcd_import
  File "<frozen importlib._bootstrap>", line 1027, in _find_and_load
  File "<frozen importlib._bootstrap>", line 992, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 241, in _call_with_frames_removed
  File "<frozen importlib._bootstrap>", line 1050, in _gcd_import
  File "<frozen importlib._bootstrap>", line 1027, in _find_and_load
  File "<frozen importlib._bootstrap>", line 1004, in _find_and_load_unlocked
ModuleNotFoundError: No module named 'tzdata'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "C:\Users\My Name\AppData\Local\Python3\Python310\lib\importlib\__init__.py", line 126, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
  File "<frozen importlib._bootstrap>", line 1050, in _gcd_import
  File "<frozen importlib._bootstrap>", line 1027, in _find_and_load
  File "<frozen importlib._bootstrap>", line 1006, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 688, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 883, in exec_module
  File "<frozen importlib._bootstrap>", line 241, in _call_with_frames_removed
  File "C:\Users\My Name\Documents\electricitymap-contrib\test_parser.py", line 16, in <module>
    from parsers.lib.parsers import PARSER_KEY_TO_DICT
  File "C:\Users\My Name\Documents\electricitymap-contrib\parsers\lib\parsers.py", line 43, in <module>
    mod = importlib.import_module(
  File "C:\Users\My Name\AppData\Local\Python3\Python310\lib\importlib\__init__.py", line 126, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
  File "C:\Users\My Name\Documents\electricitymap-contrib\parsers\GCCIA.py", line 39, in <module>
    "AE": ZoneInfo("Asia/Dubai"),
  File "C:\Users\My Name\AppData\Local\Python3\Python310\lib\zoneinfo\_common.py", line 24, in load_tzdata
    raise ZoneInfoNotFoundError(f"No time zone found with key {key}")
zoneinfo._common.ZoneInfoNotFoundError: 'No time zone found with key Asia/Dubai'
````

<!-- If you want to close an issue automatically when your PR is merged, write "Closes X" where X is the PR number. For example: Closes #000 -->

## Description

<!-- Explains the goal of this PR -->



### Preview

<!-- Please add screenshots and/or gif that shows visual changes (if applicable) -->

### Double check

- [ ] I have tested my parser changes locally with `poetry run test_parser "zone_key"`
- [ ] I have run `pnpx prettier --write .` and `poetry run format` to format my changes.
