### PR TITLE
Remove nuclear from required energy sources for DE

### DIFF
--- a/parsers/ENTSOE.py
+++ b/parsers/ENTSOE.py
@@ -373,7 +373,6 @@ VALIDATIONS: dict[str, dict[str, Any]] = {
         "required": [
             "coal",
             "gas",
-            "nuclear",
             "wind",
             "biomass",
             "hydro",


### PR DESCRIPTION
## Issue

Nuclear has stopped being reported to the ENTSO-E transparency platform but we required it to be present. Likely because they no longer have any nuclear power plants.

## Description

Removes the above requirement.

> [!IMPORTANT]
> This NEEDS to be merged to the backend ASAP!

### Preview

<!-- Please add screenshots and/or gif that shows visual changes (if applicable) -->

### Double check

- [x] I have tested my parser changes locally with `poetry run test_parser "zone_key"`
- [x] I have run `pnpx prettier --write .` and `poetry run format` to format my changes.
