### PR TITLE
workflows(contrib): turn off auto review / describe / improve PR agent

### DIFF
--- a/.github/workflows/pr_agent.yml
+++ b/.github/workflows/pr_agent.yml
@@ -32,5 +32,6 @@ jobs:
         env:
           OPENAI_KEY: ${{ secrets.TONYS_OPENAI_KEY }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          GITHUB_ACTION.AUTO_REVIEW: false
-          GITHUB_ACTION.AUTO_IMPROVE: false
+          github_action_config.auto_review: 'false'
+          github_action_config.auto_describe: 'false'
+          github_action_config.auto_improve: 'false'


### PR DESCRIPTION
## Issue
PR agent started running automatically again 🤦 

## Description
The codium team has changed the naming of their github action environment because of [this issue](https://github.com/Codium-ai/pr-agent/issues/626) variables for setting the automatic reviewing, descriptions and improving of PRs. This caused the action to be on by default on our repo. 

This PR disables it again to make it opt in only.




### Double check

- [x] I have tested my parser changes locally with `poetry run test_parser "zone_key"`
- [x] I have run `pnpx prettier@2 --write .` and `poetry run format` in the top level directory to format my changes.
