### PR TITLE
fix(exchange tooltip): Add optional chaining to prevent crash if there is no data for exchanges

### DIFF
--- a/web/src/features/charts/tooltipCalculations.ts
+++ b/web/src/features/charts/tooltipCalculations.ts
@@ -90,10 +90,9 @@ export function getExchangeTooltipData(
 ) {
   const { zoneKey, exchangeCo2Intensities, exchangeCapacities } = zoneDetail;
 
-  const co2Intensity = exchangeCo2Intensities[exchangeKey];
-
-  const exchangeCapacityRange = (exchangeCapacities || {})[exchangeKey];
-  const exchange = (zoneDetail.exchange || {})[exchangeKey];
+  const co2Intensity = exchangeCo2Intensities?.[exchangeKey];
+  const exchangeCapacityRange = exchangeCapacities?.[exchangeKey];
+  const exchange = zoneDetail?.exchange?.[exchangeKey];
 
   const isExport = exchange < 0;
 


### PR DESCRIPTION
## Issue

In the exchange tooltip we used direct property access to get the data, this works great if there is data, however if there is not this causes a hard crash.

## Description

This PR adds optional chaining so things fail gracefully and don't crash if there is no data for an exchange. This matches the behaviour we use in other places to access the same data.

### Double check

- [x] I have tested my parser changes locally with `poetry run test_parser "zone_key"`
- [x] I have run `pnpx prettier@2 --write .` and `poetry run format` in the top level directory to format my changes.
