### PR TITLE
Add poetry-lock artifact from contrib

### DIFF
--- a/Earthfile
+++ b/Earthfile
@@ -16,6 +16,10 @@ src-files:
   COPY pyproject.toml .
   SAVE ARTIFACT .
 
+poetry-lock:
+  COPY poetry.lock .
+  SAVE ARTIFACT .
+
 prepare:
   FROM +src-files
   RUN pip install poetry==1.6.1


### PR DESCRIPTION
## Issue

To test that we're using the same ruff versions throughout, I need to access the poetry lock file from contrib 

## Description

Exposes poetry-lock as a possible artifact from contrib

### Preview

<!-- Please add screenshots and/or gif that shows visual changes (if applicable) -->

### Double check

- [x] I have tested my parser changes locally with `poetry run test_parser "zone_key"`
- [x] I have run `pnpx prettier@2 --write .` and `poetry run format` in the top level directory to format my changes.
