### PR TITLE
fix(CA-NS) - data gets overwritten by 0

### DIFF
--- a/parsers/CA_NS.py
+++ b/parsers/CA_NS.py
@@ -14,7 +14,9 @@ from electricitymap.contrib.lib.models.event_lists import (
 from electricitymap.contrib.lib.models.events import ProductionMix
 from electricitymap.contrib.lib.types import ZoneKey
 
-SOURCE ="nspower.ca"
+SOURCE = "nspower.ca"
+
+
 def _get_ns_info(requests_obj, logger: Logger):
     zone_key = ZoneKey("CA-NS")
 
@@ -53,10 +55,10 @@ def _get_ns_info(requests_obj, logger: Logger):
     load_data = requests_obj.get(load_url).json()
 
     # filter load_data that has a value of 0 MW
-    filtered_load_data = [load_elem for load_elem in load_data if load_elem["Base Load"] > 0]
+    filtered_load_data = [
+        load_elem for load_elem in load_data if load_elem["Base Load"] > 0
+    ]
 
-    production = []
-    imports = []
     all_production_breakdowns = ProductionBreakdownList(logger)
     all_exchanges = ExchangeList(logger)
     for mix in mix_data:
@@ -99,7 +101,6 @@ def _get_ns_info(requests_obj, logger: Logger):
             if load_period["datetime"] == mix["datetime"]
         ]
 
-
         if corresponding_load:
             load = corresponding_load[0]["Base Load"]
         else:
@@ -112,7 +113,7 @@ def _get_ns_info(requests_obj, logger: Logger):
             )
 
         electricity_mix = {
-            gen_type: round(percent_value * load,3)
+            gen_type: round(percent_value * load, 3)
             for gen_type, percent_value in percent_mix.items()
         }
 
@@ -138,11 +139,12 @@ def _get_ns_info(requests_obj, logger: Logger):
             if mode in PRODUCTION_MODES:
                 productionMix.add_value(mode, electricity_mix[mode])
             else:
-                all_exchanges.append(zoneKey=ZoneKey( "CA-NB->CA-NS"),
-            netFlow=electricity_mix["imports"],
-            datetime=data_date,
-            source=SOURCE,
-        )
+                all_exchanges.append(
+                    zoneKey=ZoneKey("CA-NB->CA-NS"),
+                    netFlow=electricity_mix["imports"],
+                    datetime=data_date,
+                    source=SOURCE,
+                )
         all_production_breakdowns.append(
             zoneKey=zone_key,
             datetime=data_date,

--- a/parsers/CA_NS.py
+++ b/parsers/CA_NS.py
@@ -106,7 +106,7 @@ def _get_ns_info(requests_obj, logger: Logger):
 
         load = corresponding_load[0]["Base Load"]
         electricity_mix = {
-            gen_type: round(percent_value * load, 3)
+            gen_type: percent_value * load
             for gen_type, percent_value in percent_mix.items()
         }
 

--- a/parsers/CA_NS.py
+++ b/parsers/CA_NS.py
@@ -101,17 +101,10 @@ def _get_ns_info(requests_obj, logger: Logger):
             if load_period["datetime"] == mix["datetime"]
         ]
 
-        if corresponding_load:
-            load = corresponding_load[0]["Base Load"]
-        else:
-            # if not found, assume 1244 MW, based on average yearly electricity available for use
-            # in 2014 and 2015 (Statistics Canada table Table 127-0008 for Nova Scotia)
-            load = 1244
-            logger.warning(
-                f"unable to find load for {data_date}, assuming 1244 MW",
-                extra={"key": zone_key},
-            )
+        if not corresponding_load:
+            continue
 
+        load = corresponding_load[0]["Base Load"]
         electricity_mix = {
             gen_type: round(percent_value * load, 3)
             for gen_type, percent_value in percent_mix.items()


### PR DESCRIPTION
## Issue

Data in the DB would get overwritten by 0 MW a day later because the first data point in the response was 0MW
<img width="946" alt="image" src="https://github.com/electricitymaps/electricitymaps-contrib/assets/107848894/1f0754a5-d3fd-497b-80f2-62a922f4376a">

Also it seems like the data is delayed by over a week but we haven't been able to confirm if this is a bug or not (@lav-julien)


## Description

Load data points at 0MW are filtered out as total demand should never be 0 MW
- added parser validation

### Preview

<!-- Please add screenshots and/or gif that shows visual changes (if applicable) -->

### Double check

- [ ] I have tested my parser changes locally with `poetry run test_parser "zone_key"`
- [ ] I have run `pnpx prettier@2 --write .` and `poetry run format` in the top level directory to format my changes.
