### PR TITLE
update(ENTSOe) - query_ENTSOE update to enable use for capacity parser

### DIFF
--- a/electricitymap/contrib/capacity_parsers/ENTSOE.py
+++ b/electricitymap/contrib/capacity_parsers/ENTSOE.py
@@ -47,7 +47,8 @@ def query_capacity(
     return query_ENTSOE(
         session,
         params,
-        target_datetime=target_datetime, span=(0, 72),
+        target_datetime=target_datetime,
+        span=(0, 72),
         function_name=query_capacity.__name__,
     )
 

--- a/electricitymap/contrib/capacity_parsers/ENTSOE.py
+++ b/electricitymap/contrib/capacity_parsers/ENTSOE.py
@@ -43,13 +43,11 @@ def query_capacity(
         "documentType": "A68",
         "processType": "A33",
         "in_Domain": in_domain,
-        "periodStart": target_datetime.strftime("%Y01010000"),
-        "periodEnd": target_datetime.strftime("%Y12312300"),
     }
     return query_ENTSOE(
         session,
         params,
-        target_datetime=target_datetime,
+        target_datetime=target_datetime, span=(0, 72),
         function_name=query_capacity.__name__,
     )
 

--- a/parsers/ENTSOE.py
+++ b/parsers/ENTSOE.py
@@ -475,7 +475,7 @@ def closest_in_time_key(x, target_datetime: datetime | None, datetime_key="datet
 def query_ENTSOE(
     session: Session,
     params: dict[str, str],
-    span: tuple | None =None,
+    span: tuple,
     target_datetime: datetime | None = None,
     function_name: str = "",
 ) -> str:
@@ -493,13 +493,13 @@ def query_ENTSOE(
             parser="ENTSOE.py",
             message="target_datetime has to be a datetime in query_entsoe",
         )
-    if span is not None:
-        params["periodStart"] = (target_datetime + timedelta(hours=span[0])).strftime(
-            "%Y%m%d%H00"  # YYYYMMDDHH00
-        )
-        params["periodEnd"] = (target_datetime + timedelta(hours=span[1])).strftime(
-            "%Y%m%d%H00"  # YYYYMMDDHH00
-        )
+
+    params["periodStart"] = (target_datetime + timedelta(hours=span[0])).strftime(
+        "%Y%m%d%H00"  # YYYYMMDDHH00
+    )
+    params["periodEnd"] = (target_datetime + timedelta(hours=span[1])).strftime(
+        "%Y%m%d%H00"  # YYYYMMDDHH00
+    )
 
     token = get_token("ENTSOE_TOKEN")
     params["securityToken"] = token

--- a/parsers/ENTSOE.py
+++ b/parsers/ENTSOE.py
@@ -475,7 +475,7 @@ def closest_in_time_key(x, target_datetime: datetime | None, datetime_key="datet
 def query_ENTSOE(
     session: Session,
     params: dict[str, str],
-    span: tuple,
+    span: tuple | None =None,
     target_datetime: datetime | None = None,
     function_name: str = "",
 ) -> str:
@@ -493,13 +493,13 @@ def query_ENTSOE(
             parser="ENTSOE.py",
             message="target_datetime has to be a datetime in query_entsoe",
         )
-
-    params["periodStart"] = (target_datetime + timedelta(hours=span[0])).strftime(
-        "%Y%m%d%H00"  # YYYYMMDDHH00
-    )
-    params["periodEnd"] = (target_datetime + timedelta(hours=span[1])).strftime(
-        "%Y%m%d%H00"  # YYYYMMDDHH00
-    )
+    if span is not None:
+        params["periodStart"] = (target_datetime + timedelta(hours=span[0])).strftime(
+            "%Y%m%d%H00"  # YYYYMMDDHH00
+        )
+        params["periodEnd"] = (target_datetime + timedelta(hours=span[1])).strftime(
+            "%Y%m%d%H00"  # YYYYMMDDHH00
+        )
 
     token = get_token("ENTSOE_TOKEN")
     params["securityToken"] = token


### PR DESCRIPTION
## Issue

<img width="875" alt="image" src="https://github.com/electricitymaps/electricitymaps-contrib/assets/107848894/5bc8ac5a-5bcc-48ae-b16d-d360407bc730">

## Description

set `span` as optional so that the `query_ENTSOE` function can keep working for the capacity update as the params already define the `periodStart` and `periodEnd` (annual frequency rather than hourly)

@VIKTORVAV99 I saw that this was updated last week, idk what the best way to go about this. Let me know if you have a better suggestion :)

### Double check

- [ ] I have tested my parser changes locally with `poetry run test_parser "zone_key"`
- [ ] I have run `pnpx prettier@2 --write .` and `poetry run format` in the top level directory to format my changes.
