### PR TITLE
update(capacity-config) - ONS zone

### DIFF
--- a/config/zones/BR-CS.yaml
+++ b/config/zones/BR-CS.yaml
@@ -4,11 +4,22 @@ bounding_box:
   - - -59.32226030077226
     - -7.500493258457112
 capacity:
-  hydro: 40384
-  nuclear: 1990
-  solar: 14133
-  unknown: 22800
-  wind: 28
+  hydro:
+    datetime: '2023-01-01'
+    source: ons.org.br
+    value: 54189.0
+  nuclear:
+    datetime: '2023-01-01'
+    source: ons.org.br
+    value: 1990.0
+  solar:
+    datetime: '2023-01-01'
+    source: ons.org.br
+    value: 17163.0
+  unknown:
+    datetime: '2023-01-01'
+    source: ons.org.br
+    value: 14936.0
 contributors:
   - alexanmtz
   - corradio

--- a/config/zones/BR-N.yaml
+++ b/config/zones/BR-N.yaml
@@ -4,10 +4,22 @@ bounding_box:
   - - -49.37304648399993
     - 4.941122259000181
 capacity:
-  hydro: 33384
-  solar: 1491
-  unknown: 4031
-  wind: 426
+  hydro:
+    datetime: '2023-01-01'
+    source: ons.org.br
+    value: 22090.0
+  solar:
+    datetime: '2023-01-01'
+    source: ons.org.br
+    value: 1815.0
+  unknown:
+    datetime: '2023-01-01'
+    source: ons.org.br
+    value: 4725.0
+  wind:
+    datetime: '2023-01-01'
+    source: ons.org.br
+    value: 426.0
 contributors:
   - alexanmtz
   - corradio

--- a/config/zones/BR-NE.yaml
+++ b/config/zones/BR-NE.yaml
@@ -4,10 +4,22 @@ bounding_box:
   - - -35.90615240593988
     - -9.026808362815672
 capacity:
-  hydro: 11036
-  solar: 9121
-  unknown: 8152
-  wind: 23148
+  hydro:
+    datetime: '2023-01-01'
+    source: ons.org.br
+    value: 10831.0
+  solar:
+    datetime: '2023-01-01'
+    source: ons.org.br
+    value: 9851.0
+  unknown:
+    datetime: '2023-01-01'
+    source: ons.org.br
+    value: 7332.0
+  wind:
+    datetime: '2023-01-01'
+    source: ons.org.br
+    value: 24209.0
 contributors:
   - alexanmtz
   - corradio

--- a/config/zones/BR-S.yaml
+++ b/config/zones/BR-S.yaml
@@ -4,10 +4,22 @@ bounding_box:
   - - -47.53248898038211
     - -22.021725762533777
 capacity:
-  hydro: 24609
-  solar: 5685
-  unknown: 4473
-  wind: 2026
+  hydro:
+    datetime: '2023-01-01'
+    source: ons.org.br
+    value: 15493.0
+  solar:
+    datetime: '2023-01-01'
+    source: ons.org.br
+    value: 6319.0
+  unknown:
+    datetime: '2023-01-01'
+    source: ons.org.br
+    value: 3608.0
+  wind:
+    datetime: '2023-01-01'
+    source: ons.org.br
+    value: 2000.0
 contributors:
   - alexanmtz
   - corradio


### PR DESCRIPTION
## Description
Update of BR zones 
Solar adjusted manually with data from [ONS](https://www.ons.org.br/Paginas/resultados-da-operacao/historico-da-operacao/capacidade_instalada.aspx ). Geracao distribuida is reallocated as solar
<img width="1087" alt="image" src="https://github.com/electricitymaps/electricitymaps-contrib/assets/107848894/92c267d6-c5e8-4149-a4bf-10c2287d69e6">


### Preview

<!-- Please add screenshots and/or gif that shows visual changes (if applicable) -->

### Double check

- [ ] I have tested my parser changes locally with `poetry run test_parser "zone_key"`
- [ ] I have run `pnpx prettier@2 --write .` and `poetry run format` in the top level directory to format my changes.
