### PR TITLE
improvement(capcity-update): Improve get capacity types

### DIFF
--- a/electricitymap/contrib/config/capacity.py
+++ b/electricitymap/contrib/config/capacity.py
@@ -1,4 +1,5 @@
 from datetime import datetime
+from dataclasses import dataclass
 from pathlib import Path
 
 from electricitymap.contrib.config.reading import read_zones_config
@@ -22,9 +23,12 @@ ZONE_TO_CAPACITY_PARSER_SOURCE = {
     for source, zones in CAPACITY_PARSER_SOURCE_TO_ZONES.items()
     for zone in zones
 }
+@dataclass
+class CapacityData:
+    value: float | None
+    source: str | None = None
 
-
-def get_capacity_data(capacity_config: dict, dt: datetime) -> dict[str, float]:
+def get_capacity_data(capacity_config: dict, dt: datetime) -> dict[str, float | None]:
     """Gets the capacity data for a given zone and datetime from ZONES_CONFIG."""
     capacity = {}
     for mode, capacity_value in capacity_config.items():
@@ -32,36 +36,34 @@ def get_capacity_data(capacity_config: dict, dt: datetime) -> dict[str, float]:
             # TODO: This part is used for the old capacity format. It shoud be removed once all capacity configs are updated
             capacity[mode] = capacity_value
         else:
-            capacity[mode] = get_capacity_from_dict_or_list(capacity_value, dt)[0]
+            capacity[mode] = _get_capacity_from_dict_or_list(capacity_value, dt).value
     return capacity
 
 
 def get_capacity_data_with_source(
     capacity_config: dict, dt: datetime
-) -> dict[str, dict[str, float | str | None]]:
+) -> dict[str, CapacityData]:
     """Gets the capacity data for a given zone and datetime from ZONES_CONFIG."""
     capacity = {}
     for mode, capacity_value in capacity_config.items():
         if isinstance(capacity_value, int | float):
             # TODO: This part is used for the old capacity format. It shoud be removed once all capacity configs are updated
-            capacity[mode] = {"value": capacity_value, "source": None}
+            capacity[mode] = CapacityData(capacity_value)
         else:
-            capacity[mode] = {
-                "value": get_capacity_from_dict_or_list(capacity_value, dt)[0],
-                "source": get_capacity_from_dict_or_list(capacity_value, dt)[1],
-            }
+            capacity[mode] = _get_capacity_from_dict_or_list(capacity_value, dt)
 
     return capacity
 
 
-def get_capacity_from_dict_or_list(
+def _get_capacity_from_dict_or_list(
     mode_capacity: list | dict, dt: datetime
-) -> tuple[float, str] | float | None:
+) -> CapacityData:
     if isinstance(mode_capacity, dict):
-        return (mode_capacity["value"], mode_capacity.get("source", "unknown source"))
+        # TODO: To be removed as eventually we should only have lists.
+        return CapacityData(mode_capacity["value"], mode_capacity.get("source"))
     elif isinstance(mode_capacity, list):
         capacity_tuples = [
-            (d["datetime"], d["value"], d.get("source", "unknown source"))
+            (d["datetime"], d["value"], d.get("source"))
             for d in mode_capacity
         ]
 
@@ -73,4 +75,4 @@ def get_capacity_from_dict_or_list(
             max_tuple = max(
                 [(d, v, s) for d, v, s in capacity_tuples if d <= dt.isoformat()]
             )
-            return (max_tuple[1], max_tuple[2])
+            return CapacityData(max_tuple[1], max_tuple[2])

--- a/electricitymap/contrib/config/capacity.py
+++ b/electricitymap/contrib/config/capacity.py
@@ -68,7 +68,7 @@ def _get_capacity_from_dict_or_list(
         ]
 
         if dt.isoformat() <= min(capacity_tuples)[0]:
-            return (min(capacity_tuples)[1], min(capacity_tuples)[2])
+            return CapacityData(min(capacity_tuples)[1], min(capacity_tuples)[2])
         else:
             # valid datetime is the max datetime that is lower than the given datetime
             # In other words, it is the most recent value that is valid for the given dt

--- a/electricitymap/contrib/config/capacity.py
+++ b/electricitymap/contrib/config/capacity.py
@@ -1,5 +1,5 @@
-from datetime import datetime
 from dataclasses import dataclass
+from datetime import datetime
 from pathlib import Path
 
 from electricitymap.contrib.config.reading import read_zones_config
@@ -23,10 +23,13 @@ ZONE_TO_CAPACITY_PARSER_SOURCE = {
     for source, zones in CAPACITY_PARSER_SOURCE_TO_ZONES.items()
     for zone in zones
 }
+
+
 @dataclass
 class CapacityData:
     value: float | None
     source: str | None = None
+
 
 def get_capacity_data(capacity_config: dict, dt: datetime) -> dict[str, float | None]:
     """Gets the capacity data for a given zone and datetime from ZONES_CONFIG."""
@@ -63,8 +66,7 @@ def _get_capacity_from_dict_or_list(
         return CapacityData(mode_capacity["value"], mode_capacity.get("source"))
     elif isinstance(mode_capacity, list):
         capacity_tuples = [
-            (d["datetime"], d["value"], d.get("source"))
-            for d in mode_capacity
+            (d["datetime"], d["value"], d.get("source")) for d in mode_capacity
         ]
 
         if dt.isoformat() <= min(capacity_tuples)[0]:

--- a/tests/test_capacity.py
+++ b/tests/test_capacity.py
@@ -3,6 +3,7 @@ from datetime import datetime
 import pytest
 
 from electricitymap.contrib.config.capacity import (
+    CapacityData,
     get_capacity_data,
     get_capacity_data_with_source,
 )
@@ -74,11 +75,11 @@ def test_get_capacity_with_source():
     )
 
     assert capacity_data == {
-        "solar": {"value": 3, "source": "abc"},
-        "wind": {"value": 4, "source": "abc"},
+        "solar": CapacityData(3, "abc"),
+        "wind": CapacityData(4, "abc"),
     }
 
     assert get_capacity_data_with_source(capacity_config, datetime(2023, 11, 1)) == {
-        "solar": {"value": 3, "source": "abc"},
-        "wind": {"value": 5, "source": "abc"},
+        "solar": CapacityData(3, "abc"),
+        "wind": CapacityData(5, "abc"),
     }


### PR DESCRIPTION
## Issue

When starting to work more with the gat_capacity functions we started struggling with the different types and cases which required a bit of refactoring of the outputs of each function.

## Description

- make `get_capacity_from_dict_or_list` private
- Create CapacityData dataclass to clarify the return of each function
- Unify the different cases.

### Preview

Currently testing it locally with the flowtracing pipeline.

### Double check

- [ ] I have tested my parser changes locally with `poetry run test_parser "zone_key"`
- [ ] I have run `pnpx prettier@2 --write .` and `poetry run format` in the top level directory to format my changes.
