### PR TITLE
fix(arrows): Add arrows that are not part of either exclusion set to both sets

### DIFF
--- a/web/src/hooks/arrows.test.ts
+++ b/web/src/hooks/arrows.test.ts
@@ -27,17 +27,36 @@ const mockExchangesResponses = {
     '2024-01-31T20:00:00Z': { co2intensity: 188.22, netFlow: -11 },
     '2024-01-31T21:00:00Z': { co2intensity: 178.86, netFlow: -50 },
   },
+  exchange6: {
+    '2024-01-31T22:00:00Z': { co2intensity: 150.5, netFlow: -20 },
+    '2024-01-31T23:00:00Z': { co2intensity: 140.7, netFlow: -30 },
+  },
 };
 
 const expectedAfterZoneViewFilter = {
   exchange3: mockExchangesResponses.exchange3,
   exchange5: mockExchangesResponses.exchange5,
+  exchange6: mockExchangesResponses.exchange6,
 };
 
 const expectedAfterCountryViewFilter = {
   exchange1: mockExchangesResponses.exchange1,
   exchange2: mockExchangesResponses.exchange2,
   exchange4: mockExchangesResponses.exchange4,
+  exchange6: mockExchangesResponses.exchange6,
+};
+
+const expectedAfterNoZone = {
+  exchange1: mockExchangesResponses.exchange1,
+  exchange2: mockExchangesResponses.exchange2,
+  exchange4: mockExchangesResponses.exchange4,
+  exchange6: mockExchangesResponses.exchange6,
+};
+
+const expectedAfterNoCountryViewFilter = {
+  exchange3: mockExchangesResponses.exchange3,
+  exchange5: mockExchangesResponses.exchange5,
+  exchange6: mockExchangesResponses.exchange6,
 };
 
 describe('filterExchanges', () => {
@@ -65,13 +84,13 @@ describe('filterExchanges', () => {
     it('no zone filter', () => {
       expect(
         filterExchanges(mockExchangesResponses, [], mockExchangesToExcludeCountryView)
-      ).toEqual([expectedAfterZoneViewFilter, {}]);
+      ).toEqual([mockExchangesResponses, expectedAfterNoZone]);
     });
 
     it('no country filter', () => {
       expect(
         filterExchanges(mockExchangesResponses, mockExchangesToExcludeZoneView, [])
-      ).toEqual([{}, expectedAfterCountryViewFilter]);
+      ).toEqual([expectedAfterNoCountryViewFilter, mockExchangesResponses]);
     });
   });
 

--- a/web/src/hooks/arrows.ts
+++ b/web/src/hooks/arrows.ts
@@ -31,9 +31,10 @@ export function filterExchanges(
   for (const [key, value] of Object.entries(exchanges)) {
     if (exclusionSetCountries.has(key)) {
       resultZones[key] = value;
-      continue;
-    }
-    if (exclusionSetZones.has(key)) {
+    } else if (exclusionSetZones.has(key)) {
+      resultCountries[key] = value;
+    } else {
+      resultZones[key] = value;
       resultCountries[key] = value;
     }
   }


### PR DESCRIPTION
## **User description**
## Issue

In https://github.com/electricitymaps/electricitymaps-contrib/pull/6437 I made the false assumption that a exchange is part of either the exclude from zone view set or exclude from country view set where in fact it can be part of neither. The current implementation doesn't show arrows that are part of neither.

## Description

This PR fixes the above issue.

### Preview


### Double check

- [x] I have run `pnpx prettier@2 --write .` and `poetry run format` in the top level directory to format my changes.


___

## **Type**
bug_fix


___

## **Description**
- Fixed an issue where exchanges not part of either exclusion set were not being added to any set.
- Updated unit tests to cover the scenario where an exchange is not part of either exclusion set.
- Simplified the logic in `filterExchanges` for better readability and efficiency.


___

## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>arrows.test.ts</strong><dd><code>Unit Tests Update for Handling Exchanges Not in Exclusion Sets</code></dd></summary>
<hr>

web/src/hooks/arrows.test.ts
<li>Added tests for a new exchange (<code>exchange6</code>) that is not part of either <br>exclusion set.<br> <li> Updated expected results for zone and country view filters to include <br><code>exchange6</code>.<br> <li> Introduced tests for scenarios with no zone or country filter, <br>expecting all exchanges including <code>exchange6</code>.


</details>
    

  </td>
  <td><a href="https://github.com/electricitymaps/electricitymaps-contrib/pull/6477/files#diff-0f0029bb7afd704196d32625b81bb0e8b03fab9a093ef088781bbc859674ac27">+21/-2</a>&nbsp; &nbsp; </td>
</tr>                    
</table></td></tr><tr><td><strong>Bug_fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>arrows.ts</strong><dd><code>Fix for Including Exchanges Not in Exclusion Sets</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

web/src/hooks/arrows.ts
<li>Modified the <code>filterExchanges</code> function to add exchanges not part of <br>either exclusion set to both sets.<br> <li> Simplified conditional logic for assigning exchanges to result <br>objects.


</details>
    

  </td>
  <td><a href="https://github.com/electricitymaps/electricitymaps-contrib/pull/6477/files#diff-eca68a824b3bab38bc89b0be58e84cb0adc73083dc456edbf8dafcabe6624b7f">+4/-3</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table><hr>

<details> <summary><strong>✨ Usage guide:</strong></summary><hr> 

**Overview:**
The `describe` tool scans the PR code changes, and generates a description for the PR - title, type, summary, walkthrough and labels. The tool can be triggered [automatically](https://github.com/Codium-ai/pr-agent/blob/main/Usage.md#github-app-automatic-tools) every time a new PR is opened, or can be invoked manually by commenting on a PR.

When commenting, to edit [configurations](https://github.com/Codium-ai/pr-agent/blob/main/pr_agent/settings/configuration.toml#L46) related to the describe tool (`pr_description` section), use the following template:
```
/describe --pr_description.some_config1=... --pr_description.some_config2=...
```
With a [configuration file](https://github.com/Codium-ai/pr-agent/blob/main/Usage.md#working-with-github-app), use the following template:
```
[pr_description]
some_config1=...
some_config2=...
```


<table><tr><td><details> <summary><strong> Enabling\disabling automation </strong></summary><hr>

- When you first install the app, the [default mode](https://github.com/Codium-ai/pr-agent/blob/main/Usage.md#github-app-automatic-tools) for the describe tool is:
```
pr_commands = ["/describe --pr_description.add_original_user_description=true" 
                         "--pr_description.keep_original_user_title=true", ...]
```
meaning the `describe` tool will run automatically on every PR, will keep the original title, and will add the original user description above the generated description. 

- Markers are an alternative way to control the generated description, to give maximal control to the user. If you set:
```
pr_commands = ["/describe --pr_description.use_description_markers=true", ...]
```
the tool will replace every marker of the form `pr_agent:marker_name` in the PR description with the relevant content, where `marker_name` is one of the following:
  - `type`: the PR type.
  - `summary`: the PR summary.
  - `walkthrough`: the PR walkthrough.

Note that when markers are enabled, if the original PR description does not contain any markers, the tool will not alter the description at all.
        


</details></td></tr>

<tr><td><details> <summary><strong> Custom labels </strong></summary><hr>

The default labels of the `describe` tool are quite generic: [`Bug fix`, `Tests`, `Enhancement`, `Documentation`, `Other`].

If you specify [custom labels](https://github.com/Codium-ai/pr-agent/blob/main/docs/DESCRIBE.md#handle-custom-labels-from-the-repos-labels-page-gem) in the repo's labels page or via configuration file, you can get tailored labels for your use cases.
Examples for custom labels:
- `Main topic:performance` - pr_agent:The main topic of this PR is performance
- `New endpoint` - pr_agent:A new endpoint was added in this PR
- `SQL query` - pr_agent:A new SQL query was added in this PR
- `Dockerfile changes` - pr_agent:The PR contains changes in the Dockerfile
- ...

The list above is eclectic, and aims to give an idea of different possibilities. Define custom labels that are relevant for your repo and use cases.
Note that Labels are not mutually exclusive, so you can add multiple label categories.
Make sure to provide proper title, and a detailed and well-phrased description for each label, so the tool will know when to suggest it.        


</details></td></tr>

<tr><td><details> <summary><strong> Inline File Walkthrough 💎</strong></summary><hr>

For enhanced user experience, the `describe` tool can add file summaries directly to the "Files changed" tab in the PR page.
This will enable you to quickly understand the changes in each file, while reviewing the code changes (diffs).

To enable inline file summary, set `pr_description.inline_file_summary` in the configuration file, possible values are:
- `'table'`: File changes walkthrough table will be displayed on the top of the "Files changed" tab, in addition to the "Conversation" tab.
- `true`: A collapsable file comment with changes title and a changes summary for each file in the PR.
- `false` (default): File changes walkthrough will be added only to the "Conversation" tab.
<tr><td><details> <summary><strong> Utilizing extra instructions</strong></summary><hr>

The `describe` tool can be configured with extra instructions, to guide the model to a feedback tailored to the needs of your project.

Be specific, clear, and concise in the instructions. With extra instructions, you are the prompter. Notice that the general structure of the description is fixed, and cannot be changed. Extra instructions can change the content or style of each sub-section of the PR description.

Examples for extra instructions:
```
[pr_description] 
extra_instructions="""
- The PR title should be in the format: '<PR type>: <title>'
- The title should be short and concise (up to 10 words)
- ...
"""
```
Use triple quotes to write multi-line instructions. Use bullet points to make the instructions more readable.


</details></td></tr>



<tr><td><details> <summary><strong> More PR-Agent commands</strong></summary><hr> 

> To invoke the PR-Agent, add a comment using one of the following commands:  
> - **/review**: Request a review of your Pull Request.   
> - **/describe**: Update the PR title and description based on the contents of the PR.   
> - **/improve [--extended]**: Suggest code improvements. Extended mode provides a higher quality feedback.   
> - **/ask \<QUESTION\>**: Ask a question about the PR.   
> - **/update_changelog**: Update the changelog based on the PR's contents.   
> - **/add_docs** 💎: Generate docstring for new components introduced in the PR.   
> - **/generate_labels** 💎: Generate labels for the PR based on the PR's contents.   
> - **/analyze** 💎: Automatically analyzes the PR, and presents changes walkthrough for each component.   

>See the [tools guide](https://github.com/Codium-ai/pr-agent/blob/main/docs/TOOLS_GUIDE.md) for more details.
>To list the possible configuration parameters, add a **/config** comment.   
 


</details></td></tr>

</table>

See the [describe usage](https://github.com/Codium-ai/pr-agent/blob/main/docs/DESCRIBE.md) page for a comprehensive guide on using this tool.


</details>
