### PR TITLE
Fix entsoe capacity parser

### DIFF
--- a/capacity_update.py
+++ b/capacity_update.py
@@ -53,4 +53,4 @@ def capacity_update(
         update_zone(zone, parsed_target_datetime, session, update_aggregate)
 
     print("Running prettier...")
-    run_shell_command("pnpx prettier@2 --write .", cwd=ROOT_PATH)
+    run_shell_command("pnpx prettier@2 --write config/zones --cache", cwd=ROOT_PATH)

--- a/config/zones/AT.yaml
+++ b/config/zones/AT.yaml
@@ -57,7 +57,7 @@ capacity:
       value: 3265.0
     - datetime: '2024-01-01'
       source: entsoe.eu
-      value: 5884.0
+      value: 6305.0
   unknown:
     - datetime: '2023-01-01'
       source: entsoe.eu
@@ -71,7 +71,7 @@ capacity:
       value: 3569.0
     - datetime: '2024-01-01'
       source: entsoe.eu
-      value: 3954.0
+      value: 3967.0
 contributors:
   - corradio
   - brandongalbraith

--- a/config/zones/BE.yaml
+++ b/config/zones/BE.yaml
@@ -8,17 +8,17 @@ capacity:
   biomass:
     - datetime: '2023-01-01'
       source: entsoe.eu
-      value: 1115.0
+      value: 1114.0
     - datetime: '2024-01-01'
       source: entsoe.eu
-      value: 1116.0
+      value: 1115.0
   gas:
     - datetime: '2023-01-01'
       source: entsoe.eu
-      value: 6995.0
+      value: 6988.0
     - datetime: '2024-01-01'
       source: entsoe.eu
-      value: 6999.0
+      value: 6995.0
   hydro:
     - datetime: '2023-01-01'
       source: entsoe.eu
@@ -30,14 +30,17 @@ capacity:
   nuclear:
     - datetime: '2023-01-01'
       source: entsoe.eu
-      value: 5943.0
+      value: 4937.0
+    - datetime: '2024-01-01'
+      source: entsoe.eu
+      value: 3929.0
   oil:
     - datetime: '2023-01-01'
       source: entsoe.eu
-      value: 448.0
+      value: 450.0
     - datetime: '2024-01-01'
       source: entsoe.eu
-      value: 432.0
+      value: 452.0
   solar:
     - datetime: '2023-01-01'
       source: entsoe.eu

--- a/config/zones/HU.yaml
+++ b/config/zones/HU.yaml
@@ -19,6 +19,9 @@ capacity:
     - datetime: '2023-01-01'
       source: entsoe.eu
       value: 3151.0
+    - datetime: '2024-01-01'
+      source: entsoe.eu
+      value: 3148.0
   geothermal:
     - datetime: '2023-01-01'
       source: entsoe.eu
@@ -41,7 +44,7 @@ capacity:
       value: 3300.0
     - datetime: '2024-01-01'
       source: entsoe.eu
-      value: 3330.0
+      value: 3378.0
   unknown:
     - datetime: '2023-01-01'
       source: entsoe.eu
@@ -50,6 +53,9 @@ capacity:
     - datetime: '2023-01-01'
       source: entsoe.eu
       value: 323.0
+    - datetime: '2024-01-01'
+      source: entsoe.eu
+      value: 325.0
 contributors:
   - corradio
   - nessie2013

--- a/config/zones/LV.yaml
+++ b/config/zones/LV.yaml
@@ -10,7 +10,7 @@ capacity:
       value: 177.0
     - datetime: '2024-01-01'
       source: entsoe.eu
-      value: 160.0
+      value: 166.0
   gas:
     - datetime: '2023-01-01'
       source: entsoe.eu
@@ -31,14 +31,14 @@ capacity:
       value: 63.0
     - datetime: '2024-01-01'
       source: entsoe.eu
-      value: 200.0
+      value: 303.0
   wind:
     - datetime: '2023-01-01'
       source: entsoe.eu
       value: 165.0
     - datetime: '2024-01-01'
       source: entsoe.eu
-      value: 133.0
+      value: 136.0
 contributors:
   - corradio
 emissionFactors:

--- a/config/zones/PT.yaml
+++ b/config/zones/PT.yaml
@@ -7,10 +7,10 @@ capacity:
   biomass:
     - datetime: '2023-01-01'
       source: entsoe.eu
-      value: 681.0
+      value: 647.0
     - datetime: '2024-01-01'
       source: entsoe.eu
-      value: 647.0
+      value: 681.0
   coal:
     - datetime: '2023-01-01'
       source: entsoe.eu
@@ -18,10 +18,10 @@ capacity:
   gas:
     - datetime: '2023-01-01'
       source: entsoe.eu
-      value: 4520.0
+      value: 4585.0
     - datetime: '2024-01-01'
       source: entsoe.eu
-      value: 4585.0
+      value: 4433.0
   geothermal:
     - datetime: '2023-01-01'
       source: entsoe.eu
@@ -29,15 +29,12 @@ capacity:
   hydro:
     - datetime: '2023-01-01'
       source: entsoe.eu
-      value: 4371.0
+      value: 4489.0
     - datetime: '2024-01-01'
       source: entsoe.eu
-      value: 4489.0
+      value: 4485.0
   hydro storage:
     - datetime: '2023-01-01'
-      source: entsoe.eu
-      value: 2827.0
-    - datetime: '2024-01-01'
       source: entsoe.eu
       value: 3707.0
   nuclear:
@@ -51,10 +48,10 @@ capacity:
   solar:
     - datetime: '2023-01-01'
       source: entsoe.eu
-      value: 1032.0
+      value: 1332.0
     - datetime: '2024-01-01'
       source: entsoe.eu
-      value: 1332.0
+      value: 1811.0
   unknown:
     - datetime: '2023-01-01'
       source: entsoe.eu
@@ -63,6 +60,9 @@ capacity:
     - datetime: '2023-01-01'
       source: entsoe.eu
       value: 5353.0
+    - datetime: '2024-01-01'
+      source: entsoe.eu
+      value: 5358.0
 contributors:
   - corradio
   - nessie2013

--- a/config/zones/SI.yaml
+++ b/config/zones/SI.yaml
@@ -9,6 +9,9 @@ capacity:
     - datetime: '2023-01-01'
       source: entsoe.eu
       value: 47.0
+    - datetime: '2024-01-01'
+      source: entsoe.eu
+      value: 49.0
   coal:
     - datetime: '2023-01-01'
       source: entsoe.eu
@@ -16,11 +19,17 @@ capacity:
   gas:
     - datetime: '2023-01-01'
       source: entsoe.eu
-      value: 742.0
+      value: 618.0
+    - datetime: '2024-01-01'
+      source: entsoe.eu
+      value: 756.0
   hydro:
     - datetime: '2023-01-01'
       source: entsoe.eu
-      value: 1102.0
+      value: 1129.0
+    - datetime: '2024-01-01'
+      source: entsoe.eu
+      value: 1125.0
   hydro storage:
     - datetime: '2023-01-01'
       source: entsoe.eu
@@ -36,11 +45,17 @@ capacity:
   solar:
     - datetime: '2023-01-01'
       source: entsoe.eu
-      value: 294.0
+      value: 702.0
+    - datetime: '2024-01-01'
+      source: entsoe.eu
+      value: 1110.0
   wind:
     - datetime: '2023-01-01'
       source: entsoe.eu
       value: 2.0
+    - datetime: '2024-01-01'
+      source: entsoe.eu
+      value: 3.0
 contributors:
   - corradio
 emissionFactors:

--- a/electricitymap/contrib/capacity_parsers/ENTSOE.py
+++ b/electricitymap/contrib/capacity_parsers/ENTSOE.py
@@ -70,25 +70,12 @@ def fetch_production_capacity(
         fuel_code = str(
             timeseries.find_all("mktpsrtype")[0].find_all("psrtype")[0].contents[0]
         )
-        start_date = datetime.fromisoformat(
-            zulu_to_utc(timeseries.find_all("start")[0].contents[0])
-        )
-
-        end_date = datetime.fromisoformat(
-            zulu_to_utc(timeseries.find_all("end")[0].contents[0])
-        )
-        year = 0
-        if end_date.year == target_datetime.year:
-            year = end_date.year
-        elif start_date.year == target_datetime.year:
-            year = start_date.year
-
         point = timeseries.find_all("point")
         value = float(point[0].find_all("quantity")[0].contents[0])
         if ENTSOE_CODE_TO_EM_MAPPING[fuel_code] not in capacity_dict:
             capacity_dict[ENTSOE_CODE_TO_EM_MAPPING[fuel_code]] = {
                 "value": 0,
-                "datetime": f"{year}-01-01",
+                "datetime": f"{target_datetime.year}-01-01",
                 "source": SOURCE,
             }
         capacity_dict[ENTSOE_CODE_TO_EM_MAPPING[fuel_code]]["value"] += value


### PR DESCRIPTION
## Issue

The parser was still operating under the assumption that we fetched 2 years of data when we do not. It also didn't use the new internal mapping for the fuel types aggregating hydro storage with hydro production.

## Description

Fixes the parser + updates the capacities for 2023 and 2024.

### Double check

- [x] I have tested my parser changes locally with `poetry run test_parser "zone_key"`
- [x] I have run `pnpx prettier@2 --write .` and `poetry run format` in the top level directory to format my changes.
