### PR TITLE
Use special "displayName" for zones and show full name in tooltip

### DIFF
--- a/web/src/features/panels/zone/ZoneHeaderTitle.tsx
+++ b/web/src/features/panels/zone/ZoneHeaderTitle.tsx
@@ -3,7 +3,12 @@ import { TimeDisplay } from 'components/TimeDisplay';
 import TooltipWrapper from 'components/tooltips/TooltipWrapper';
 import { HiArrowLeft } from 'react-icons/hi2';
 import { Link } from 'react-router-dom';
-import { getCountryName, getZoneName, useTranslation } from 'translation/translation';
+import {
+  getCountryName,
+  getFullZoneName,
+  getZoneName,
+  useTranslation,
+} from 'translation/translation';
 import { createToWithState } from 'utils/helpers';
 
 import { getDisclaimer } from './util';
@@ -14,13 +19,19 @@ interface ZoneHeaderTitleProps {
   isAggregated?: boolean;
 }
 
+const MAX_TITLE_LENGTH = 25;
+
 export default function ZoneHeaderTitle({ zoneId }: ZoneHeaderTitleProps) {
   const { __ } = useTranslation();
-  const title = getZoneName(zoneId);
+  const zoneNameShort = getZoneName(zoneId);
+  const zoneNameFull = getFullZoneName(zoneId);
+  const zoneName = zoneNameFull.length < MAX_TITLE_LENGTH ? zoneNameFull : zoneNameShort;
+  const showTooltip =
+    zoneName !== zoneNameFull || zoneNameShort.length >= MAX_TITLE_LENGTH;
   const returnToMapLink = createToWithState('/map');
   const countryName = getCountryName(zoneId);
   const disclaimer = getDisclaimer(zoneId);
-  const showCountryPill = zoneId.includes('-') && !title.includes(countryName);
+  const showCountryPill = zoneId.includes('-') && !zoneNameShort.includes(countryName);
 
   return (
     <div className="flex w-full grow flex-row overflow-hidden pb-2 pl-2">
@@ -42,12 +53,12 @@ export default function ZoneHeaderTitle({ zoneId }: ZoneHeaderTitleProps) {
                 className="shadow-[0_0px_3px_rgba(0,0,0,0.2)]"
               />
               <TooltipWrapper
-                tooltipContent={title.length > 20 ? title : undefined}
+                tooltipContent={showTooltip ? zoneNameFull : undefined}
                 side="bottom"
               >
                 <div className="ml-2 flex w-full flex-row overflow-hidden">
                   <h2 className="truncate text-lg font-medium" data-test-id="zone-name">
-                    {title}
+                    {zoneName}
                   </h2>
                   {showCountryPill && (
                     <div className="ml-2 flex w-auto items-center rounded-full bg-gray-200 px-2 py-0.5  text-sm dark:bg-gray-800/80">

--- a/web/src/translation/translation.test.ts
+++ b/web/src/translation/translation.test.ts
@@ -1,0 +1,27 @@
+import { afterEach, vi } from 'vitest';
+
+import i18next from './i18n';
+import { translateIfExists } from './translation';
+
+describe('translateIfExists', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('should return the translation if the key exists', () => {
+    vi.spyOn(i18next, 'exists').mockImplementationOnce(() => true);
+    vi.spyOn(i18next, 't').mockImplementationOnce(() => 'Austria');
+
+    const translation = translateIfExists('zoneShortName.AT.zoneName');
+
+    expect(translation).to.equal('Austria');
+  });
+
+  it('should return an empty string if the key does not exist', () => {});
+  vi.spyOn(i18next, 'exists').mockImplementationOnce(() => false);
+  vi.spyOn(i18next, 't').mockImplementationOnce(() => 'Austria');
+
+  const translation = translateIfExists('zoneShortName.AT.zoneName');
+
+  expect(translation).to.equal('');
+});

--- a/web/src/translation/translation.ts
+++ b/web/src/translation/translation.ts
@@ -37,6 +37,11 @@ export const getZoneName = (zoneCode: string) =>
 export const getCountryName = (zoneCode: string) =>
   translateIfExists(`zoneShortName.${zoneCode}.countryName`);
 
+export const getZoneDisplayName = (zoneCode: string) => {
+  const displayName = translateIfExists(`zoneShortName.${zoneCode}.displayName`);
+  return displayName || getZoneName(zoneCode);
+};
+
 const DEFAULT_ZONE_NAME_LIMIT = 40;
 /**
  * Gets the name of a zone with the country name in parentheses and zone-name ellipsified if too long.
@@ -47,7 +52,7 @@ export function getShortenedZoneNameWithCountry(
   zoneCode: string,
   limit = DEFAULT_ZONE_NAME_LIMIT
 ) {
-  const zoneName = getZoneName(zoneCode);
+  const zoneName = getZoneDisplayName(zoneCode);
   if (!zoneName) {
     return zoneCode;
   }

--- a/web/src/translation/translation.ts
+++ b/web/src/translation/translation.ts
@@ -37,24 +37,6 @@ export const getZoneName = (zoneCode: string) =>
 export const getCountryName = (zoneCode: string) =>
   translateIfExists(`zoneShortName.${zoneCode}.countryName`);
 
-/**
- * Gets the full name of a zone with the country name in parentheses.
- * @param {string} zoneCode
- * @returns string
- */
-export function getZoneNameWithCountry(zoneCode: string) {
-  const zoneName = getZoneName(zoneCode);
-  if (!zoneName) {
-    return zoneCode;
-  }
-  const countryName = getCountryName(zoneCode);
-  if (!countryName) {
-    return zoneName;
-  }
-
-  return `${zoneName} (${countryName})`;
-}
-
 const DEFAULT_ZONE_NAME_LIMIT = 40;
 /**
  * Gets the name of a zone with the country name in parentheses and zone-name ellipsified if too long.

--- a/web/src/translation/translation.ts
+++ b/web/src/translation/translation.ts
@@ -32,15 +32,17 @@ export const translateIfExists = (key: string) => {
   return i18next.exists(key) ? i18next.t(key) : '';
 };
 
-export const getZoneName = (zoneCode: string) =>
-  translateIfExists(`zoneShortName.${zoneCode}.zoneName`);
+export const getFullZoneName = (zoneCode: string) => {
+  return translateIfExists(`zoneShortName.${zoneCode}.zoneName`);
+};
+export const getZoneName = (zoneCode: string) => {
+  const displayName = translateIfExists(`zoneShortName.${zoneCode}.displayName`);
+  const fullName = getFullZoneName(zoneCode);
+  return displayName || fullName;
+};
+
 export const getCountryName = (zoneCode: string) =>
   translateIfExists(`zoneShortName.${zoneCode}.countryName`);
-
-export const getZoneDisplayName = (zoneCode: string) => {
-  const displayName = translateIfExists(`zoneShortName.${zoneCode}.displayName`);
-  return displayName || getZoneName(zoneCode);
-};
 
 const DEFAULT_ZONE_NAME_LIMIT = 40;
 /**
@@ -52,7 +54,7 @@ export function getShortenedZoneNameWithCountry(
   zoneCode: string,
   limit = DEFAULT_ZONE_NAME_LIMIT
 ) {
-  const zoneName = getZoneDisplayName(zoneCode);
+  const zoneName = getZoneName(zoneCode);
   if (!zoneName) {
     return zoneCode;
   }


### PR DESCRIPTION
## Issue

Part 1 of #5837

## Description

This makes it possible show to a shorter name for a zone, while having the full name shown in a tooltip. This means we can use "ERCOT" for Texas in tooltips, while still having the actual name available to anyone curious :)

I will follow up with a second PR with the actual translation updates.

### Preview



### Double check

- [ ] I have run `pnpx prettier@2 --write .` and `poetry run format` in the top level directory to format my changes.
