### PR TITLE
Avoid showing the "estimated" badge on graphs only based on outage message

### DIFF
--- a/web/src/features/panels/zone/ZoneDetails.tsx
+++ b/web/src/features/panels/zone/ZoneDetails.tsx
@@ -63,7 +63,7 @@ export default function ZoneDetails(): JSX.Element {
   const zoneMessage = data?.zoneMessage;
   const cardType = getCardType({ estimationMethod, zoneMessage, timeAverage });
   const hasEstimationPill =
-    ['estimated', 'outage'].includes(cardType) || Boolean(estimatedPercentage);
+    ['estimated'].includes(cardType) || Boolean(estimatedPercentage);
   return (
     <>
       <ZoneHeaderTitle zoneId={zoneId} />

--- a/web/src/features/panels/zone/ZoneDetails.tsx
+++ b/web/src/features/panels/zone/ZoneDetails.tsx
@@ -62,8 +62,7 @@ export default function ZoneDetails(): JSX.Element {
   const { estimationMethod, estimatedPercentage } = selectedData || {};
   const zoneMessage = data?.zoneMessage;
   const cardType = getCardType({ estimationMethod, zoneMessage, timeAverage });
-  const hasEstimationPill =
-    ['estimated'].includes(cardType) || Boolean(estimatedPercentage);
+  const hasEstimationPill = cardType === 'estimated' || Boolean(estimatedPercentage);
   return (
     <>
       <ZoneHeaderTitle zoneId={zoneId} />


### PR DESCRIPTION
## Issue

Closes https://github.com/electricitymaps/electricitymaps-contrib/issues/6499


## Description

We should not assume data is estimated just because there is an outage message as it can be there for other reasons :)

### Preview

See staging branch.

### Double check

- [x] I have run `pnpx prettier@2 --write .` and `poetry run format` in the top level directory to format my changes.
