### PR TITLE
add translated spanish text

### DIFF
--- a/web/public/locales/es.json
+++ b/web/public/locales/es.json
@@ -78,6 +78,46 @@
     "fully-estimated": "Estimado"
   },
   "estimation-card": {
+    "link": "Más información sobre nuestros modelos de estimación",
+    "estimated_time_slicer_average": {
+      "title": "Los datos son estimados",
+      "pill": "Retraso",
+      "body": "Los datos de esta hora aún no se han transmitido. Los valores mostrados son estimaciones y se reemplazarán por mediciones cuando estén disponibles."
+    },
+    "estimated_mode_breakdown": {
+      "title": "Datos parcialmente estimados",
+      "pill": "Datos incompletos",
+      "body": "Los datos de generación de electricidad correspondientes a zona son incompletos.Los valores faltantes se han calculado mediante un modelo de estimación."
+    },
+    "estimated_reconstruct_breakdown": {
+      "title": "Los datos son siempre estimados",
+      "pill": "Datos imprecisos",
+      "body": "Los datos publicados correspondientes a  esta zona sólo proporcionan la generación total. Las fuentes renovables se estiman utilizando datos meteorológicos en tiempo real, mientras que las fuentes fósiles se deducen basándose en los datos históricos de cada fuente de producción."
+    },
+    "estimated_generic_method": {
+      "title": "Los datos son estimados",
+      "pill": "Datos imprecisos",
+      "body": "Los datos publicados para esta zona no están disponibles o son incompletos. Los datos que aparecen en el mapa se han estimado utilizando nuestro mejor esfuerzo, pero podrían diferir de los valores reales."
+    },
+    "estimated_construct_breakdown": {
+      "title": "Los datos son siempre estimados",
+      "pill": "Datos no disponibles en tiempo real",
+      "body": "Los datos para esta zona no están disponibles en tiempo real y sólo proporcionan la generación total. Tanto los valores horarios como el desglose por fuente de generación se estiman a partir de datos históricos."
+    },
+    "estimated_construct_zero_breakdown": {
+      "title": "Los datos son siempre estimados",
+      "pill": "Datos no disponibles en tiempo real",
+      "body": "Los datos para esta zona no están disponibles en tiempo real y sólo proporcionan la generación total. Tanto los valores horarios como el desglose por fuente de generación se estiman a partir de datos históricos."
+    },
+    "threshold_filtered": {
+      "title": "Datos no disponibles",
+      "pill": "Corte de datos",
+      "body": "El proveedor de datos para esta zona ha estado perdiendo datos durante un período prolongado. Estamos supervisando el problema y la zona se actualizará en cuanto los datos vuelvan a estar disponibles."
+    },
+    "outage": {
+      "title": "Cuestiones pendientes",
+      "pill": "No disponible"
+    },
     "aggregated": {
       "title": "Datos agregados",
       "body": "Los datos mostrados son el resultado de la agregación de valores horarios."


### PR DESCRIPTION
## Issue

<!-- If you want to close an issue automatically when your PR is merged, write "Closes X" where X is the PR number. For example: Closes #000 -->
[ELE-3829](https://linear.app/electricitymaps/issue/ELE-3829/add-translated-es-text)

## Description

<!-- Explains the goal of this PR -->
Translate estimation text to Spanish.

For reviewer:
You can compare es.json to the en.json. Extra focus on `threshold_filtered`, `outage` and `estimated_generic_method` would be appreciated, as they have been translated using DeepL and has not been reviewed by anyone yet. It would also be nice if we could come up with a shorter pill text than "Datos no disponibles en tiempo real” for `estimated_construct_breakdown `and `estimated_construct_zero_breakdown`.

### Preview

<!-- Please add screenshots and/or gif that shows visual changes (if applicable) -->

### Double check

- [x] I have run `pnpx prettier@2 --write .` and `poetry run format` in the top level directory to format my changes.
