### PR TITLE
fix(UY): Sanitise UY parser

### DIFF
--- a/parsers/UY.py
+++ b/parsers/UY.py
@@ -18,6 +18,7 @@ from electricitymap.contrib.lib.models.event_lists import (
     TotalConsumptionList,
 )
 from electricitymap.contrib.lib.models.events import ProductionMix
+from electricitymap.contrib.lib.types import ZoneKey
 from parsers.lib.config import refetch_frequency
 from parsers.lib.exceptions import ParserException
 
@@ -106,7 +107,7 @@ def fetch_data(
         )
 
 
-def fix_solar_production(dt: datetime, value: pd.Series) -> int:
+def fix_solar_production(dt: datetime, value: float) -> int:
     """sets solar production to 0 during the night as there is only solar PV in UY"""
     if (dt.hour <= 5 or dt.hour >= 20) and value != 0:
         return 0
@@ -150,7 +151,7 @@ def fetch_production(
                     correct_negative_with_zero=True,
                 )
         production_list.append(
-            zoneKey=zone_key,
+            zoneKey=ZoneKey(zone_key),
             datetime=dt.to_pydatetime().replace(tzinfo=UY_TZ),
             source=UY_SOURCE,
             production=production_mix,
@@ -185,7 +186,7 @@ def fetch_consumption(
 
     for dt, row in consumption.iterrows():
         consumption_list.append(
-            zoneKey=zone_key,
+            zoneKey=ZoneKey(zone_key),
             datetime=dt.to_pydatetime().replace(tzinfo=UY_TZ),
             consumption=row["consumption"],
             source=UY_SOURCE,
@@ -226,7 +227,7 @@ def fetch_exchange(
 
     for dt, row in exchange.iterrows():
         exchange_list.append(
-            zoneKey=sorted_zone_keys,
+            zoneKey=ZoneKey(sorted_zone_keys),
             datetime=dt.to_pydatetime().replace(tzinfo=UY_TZ),
             netFlow=row[sorted_zone_keys],
             source=UY_SOURCE,

--- a/parsers/UY.py
+++ b/parsers/UY.py
@@ -4,19 +4,20 @@ import io
 from datetime import datetime, timedelta
 from logging import Logger, getLogger
 from zoneinfo import ZoneInfo
-from electricitymap.contrib.lib.models.events import ProductionMix
+
 import pandas as pd
-from electricitymap.contrib.lib.models.event_lists import (
-    ExchangeList,
-    ProductionBreakdownList,
-    TotalConsumptionList,
-)
 
 # BeautifulSoup is used to parse HTML to get information
 from bs4 import BeautifulSoup
 from requests import Session
 
 from electricitymap.contrib.config.constants import PRODUCTION_MODES
+from electricitymap.contrib.lib.models.event_lists import (
+    ExchangeList,
+    ProductionBreakdownList,
+    TotalConsumptionList,
+)
+from electricitymap.contrib.lib.models.events import ProductionMix
 from parsers.lib.config import refetch_frequency
 from parsers.lib.exceptions import ParserException
 

--- a/parsers/UY.py
+++ b/parsers/UY.py
@@ -4,8 +4,13 @@ import io
 from datetime import datetime, timedelta
 from logging import Logger, getLogger
 from zoneinfo import ZoneInfo
-
+from electricitymap.contrib.lib.models.events import ProductionMix
 import pandas as pd
+from electricitymap.contrib.lib.models.event_lists import (
+    ExchangeList,
+    ProductionBreakdownList,
+    TotalConsumptionList,
+)
 
 # BeautifulSoup is used to parse HTML to get information
 from bs4 import BeautifulSoup
@@ -16,6 +21,7 @@ from parsers.lib.config import refetch_frequency
 from parsers.lib.exceptions import ParserException
 
 UY_TZ = ZoneInfo("America/Montevideo")
+UY_SOURCE = "pronos.adme.com.uy"
 
 ADME_URL = "https://pronos.adme.com.uy/gpf.php?fecha_ini="
 PRODUCTION_MODE_MAPPING = {
@@ -99,12 +105,12 @@ def fetch_data(
         )
 
 
-def fix_solar_production(dt: datetime, row: pd.Series) -> int:
+def fix_solar_production(dt: datetime, value: pd.Series) -> int:
     """sets solar production to 0 during the night as there is only solar PV in UY"""
-    if (dt.hour <= 5 or dt.hour >= 20) and row.get("value") != 0:
+    if (dt.hour <= 5 or dt.hour >= 20) and value != 0:
         return 0
     else:
-        return round(row.get("value"), 3)
+        return round(value, 3)
 
 
 @refetch_frequency(timedelta(days=1))
@@ -119,6 +125,8 @@ def fetch_production(
         target_datetime = datetime.now(tz=UY_TZ)
     session = session or Session()
 
+    production_list = ProductionBreakdownList(logger)
+
     data = fetch_data(
         session=session,
         target_datetime=target_datetime,
@@ -128,26 +136,26 @@ def fetch_production(
     data = data.rename(columns=PRODUCTION_MODE_MAPPING)
     data = data.groupby(data.columns, axis=1).sum()
     production = data[[col for col in data.columns if col in PRODUCTION_MODES]]
-    production = pd.melt(production, var_name="production_mode", ignore_index=False)
-    all_data_points = []
-    for dt in production.index.unique():
-        production_dict = {}
-        data_dt = production.loc[production.index == dt]
-        for i in range(len(data_dt)):
-            row = data_dt.iloc[i]
-            mode = row["production_mode"]
-            if mode == "solar":
-                production_dict[mode] = fix_solar_production(dt=dt, row=row)
-            else:
-                production_dict[mode] = round(row.get("value"), 3)
-        data_point = {
-            "zoneKey": "UY",
-            "datetime": dt.to_pydatetime().replace(tzinfo=UY_TZ),
-            "production": production_dict,
-            "source": "pronos.adme.com.uy",
-        }
-        all_data_points += [data_point]
-    return all_data_points
+
+    for dt, row in production.iterrows():
+        production_mix = ProductionMix()
+        if not row.eq(0).all() and not row.isna().all():
+            for mode, value in row.items():
+                if mode == "solar":
+                    value = fix_solar_production(dt, value)
+                production_mix.add_value(
+                    mode,
+                    round(float(value), 3),
+                    correct_negative_with_zero=True,
+                )
+        production_list.append(
+            zoneKey=zone_key,
+            datetime=dt.to_pydatetime().replace(tzinfo=UY_TZ),
+            source=UY_SOURCE,
+            production=production_mix,
+        )
+
+    return production_list.to_list()
 
 
 @refetch_frequency(timedelta(days=1))
@@ -162,6 +170,8 @@ def fetch_consumption(
         target_datetime = datetime.now(tz=UY_TZ)
     session = session or Session()
 
+    consumption_list = TotalConsumptionList(logger)
+
     data = fetch_data(
         session=session,
         target_datetime=target_datetime,
@@ -170,17 +180,17 @@ def fetch_consumption(
     )
     data = data.rename(columns={"Demanda": "consumption"})
 
-    consumption = data[["consumption"]].to_dict(orient="index")
-    all_data_points = []
-    for dt in consumption:
-        data_point = {
-            "zoneKey": "UY",
-            "datetime": dt.to_pydatetime().replace(tzinfo=UY_TZ),
-            "consumption": round(consumption[dt]["consumption"], 3),
-            "source": "pronos.adme.com.uy",
-        }
-        all_data_points += [data_point]
-    return all_data_points
+    consumption = data[["consumption"]]
+
+    for dt, row in consumption.iterrows():
+        consumption_list.append(
+            zoneKey=zone_key,
+            datetime=dt.to_pydatetime().replace(tzinfo=UY_TZ),
+            consumption=row["consumption"],
+            source=UY_SOURCE,
+        )
+
+    return consumption_list.to_list()
 
 
 @refetch_frequency(timedelta(days=1))
@@ -196,6 +206,8 @@ def fetch_exchange(
         target_datetime = datetime.now(tz=UY_TZ)
     session = session or Session()
 
+    exchange_list = ExchangeList(logger)
+
     data = fetch_data(
         session=session,
         target_datetime=target_datetime,
@@ -208,18 +220,18 @@ def fetch_exchange(
 
     data = data.rename(columns=EXCHANGES_MAPPING)
     data = data.groupby(data.columns, axis=1).sum()
-    sortedZoneKeys = "->".join(sorted([zone_key1, zone_key2]))
-    exchange = data[[sortedZoneKeys]].to_dict(orient="index")
-    all_data_points = []
-    for dt in exchange:
-        data_point = {
-            "netFlow": round(exchange[dt][sortedZoneKeys], 3),
-            "sortedZoneKeys": sortedZoneKeys,
-            "datetime": dt.to_pydatetime().replace(tzinfo=UY_TZ),
-            "source": "pronos.adme.com.uy",
-        }
-        all_data_points += [data_point]
-    return all_data_points
+    sorted_zone_keys = "->".join(sorted([zone_key1, zone_key2]))
+    exchange = data[[sorted_zone_keys]]
+
+    for dt, row in exchange.iterrows():
+        exchange_list.append(
+            zoneKey=sorted_zone_keys,
+            datetime=dt.to_pydatetime().replace(tzinfo=UY_TZ),
+            netFlow=row[sorted_zone_keys],
+            source=UY_SOURCE,
+        )
+
+    return exchange_list.to_list()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Issue

We've been parsing production events where all modes are at 0 for UY. These events cause downstream issues as they are not flagged for estimation.

## Description

* Adopts parser validation for the fetch function in the `UY` parser. 
* Sets all production to null if all is 0

### Preview

<!-- Please add screenshots and/or gif that shows visual changes (if applicable) -->

### Double check

- [x] I have tested my parser changes locally with `poetry run test_parser "zone_key"`
- [x] I have run `pnpx prettier@2 --write .` and `poetry run format` in the top level directory to format my changes.
