### PR TITLE
chore(dependency): Bump date-fns and tree-shake debug logging

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -76,7 +76,7 @@
     "d3-scale": "^4.0.2",
     "d3-selection": "^3.0.0",
     "d3-shape": "^3.2.0",
-    "date-fns": "^2.30.0",
+    "date-fns": "^3.3.1",
     "geojson": "^0.5.0",
     "i18next": "^23.8.2",
     "i18next-browser-languagedetector": "^7.2.0",

--- a/web/pnpm-lock.yaml
+++ b/web/pnpm-lock.yaml
@@ -87,8 +87,8 @@ dependencies:
     specifier: ^3.2.0
     version: 3.2.0
   date-fns:
-    specifier: ^2.30.0
-    version: 2.30.0
+    specifier: ^3.3.1
+    version: 3.3.1
   geojson:
     specifier: ^0.5.0
     version: 0.5.0
@@ -8947,11 +8947,8 @@ packages:
       whatwg-url: 11.0.0
     dev: true
 
-  /date-fns@2.30.0:
-    resolution: {integrity: sha512-fnULvOpxnC5/Vg3NCiWelDsLiUc9bRwAPs/+LfTLNvetFCtCTN+yQz15C/fs4AwX1R9K5GLtLfn8QW+dWisaAw==}
-    engines: {node: '>=0.11'}
-    dependencies:
-      '@babel/runtime': 7.23.9
+  /date-fns@3.3.1:
+    resolution: {integrity: sha512-y8e109LYGgoQDveiEBD3DYXKba1jWf5BA8YU1FL5Tvm0BTdEfy54WLCwnuYWZNnzzvALy/QQ4Hov+Q9RVRv+Zw==}
     dev: false
 
   /dayjs@1.11.10:

--- a/web/src/features/weather-layers/hooks.ts
+++ b/web/src/features/weather-layers/hooks.ts
@@ -28,21 +28,23 @@ export function useInterpolatedData(
     );
     return null;
   }
-  console.info(
-    `#1 ${type} forecast target ${formatDistance(tBefore, new Date(), {
-      addSuffix: true,
-    })} made ${formatDistance(getReferenceTime(gribs1[0]), new Date(), {
-      addSuffix: true,
-    })}`
-  );
+  if (import.meta.env.DEV) {
+    console.debug(
+      `#1 ${type} forecast target ${formatDistance(tBefore, new Date(), {
+        addSuffix: true,
+      })} made ${formatDistance(getReferenceTime(gribs1[0]), new Date(), {
+        addSuffix: true,
+      })}`
+    );
 
-  console.info(
-    `#2 ${type} forecast target ${formatDistance(tAfter, new Date(), {
-      addSuffix: true,
-    })} made ${formatDistance(getReferenceTime(gribs2[0]), new Date(), {
-      addSuffix: true,
-    })}`
-  );
+    console.debug(
+      `#2 ${type} forecast target ${formatDistance(tAfter, new Date(), {
+        addSuffix: true,
+      })} made ${formatDistance(getReferenceTime(gribs2[0]), new Date(), {
+        addSuffix: true,
+      })}`
+    );
+  }
 
   return gribs1.map((grib, outerIndex) => ({
     ...grib,


### PR DESCRIPTION
## Issue

date-fns is outdated and we are adding ~10kb to our bundle for a console log statement.

## Description

Updates date-fns that cuts some of the bundle size and tree-shake another ~10kb by wrapping the console logging with a `import.meta.env.DEV` clause so it can be tree-shaked in production builds.

### Preview
Before:
```
dist/assets/MapWrapper-0333f9ce.js       810.19 kB │ gzip: 222.47 kB │ map: 1,887.25 kB
```
After package bump:
```
dist/assets/MapWrapper-09ee6264.js       808.74 kB │ gzip: 222.08 kB │ map: 1,890.27 kB
```
After tree-shaking and package bump:
```
dist/assets/MapWrapper-f8e675e1.js       798.92 kB │ gzip: 218.79 kB │ map: 1,841.40 kB
```
### Double check

- [x] I have run `pnpx prettier@2 --write .` and `poetry run format` in the top level directory to format my changes.
