### PR TITLE
refactor: use event classes in TR parser

### DIFF
--- a/parsers/TR.py
+++ b/parsers/TR.py
@@ -42,7 +42,9 @@ PRODUCTION_MAPPING = {
     "coal": ["blackCoal", "asphaltiteCoal", "lignite", "importCoal"],
     "hydro": ["river", "dammedHydro"],
 }
-
+INVERT_PRODUCTION_MAPPPING = {
+    val: mode for mode in PRODUCTION_MAPPING for val in PRODUCTION_MAPPING[mode]
+}
 SOURCE = "epias.com.tr"
 
 
@@ -113,9 +115,11 @@ def fetch_production(
     production_breakdowns = ProductionBreakdownList(logger)
     for item in data:
         mix = ProductionMix()
-        for mode in PRODUCTION_MAPPING:
-            value = sum([item[key] for key in item if key in PRODUCTION_MAPPING[mode]])
-            mix.add_value(mode, round(value, 4))
+        for key in item:
+            try:
+                mix.add_value(INVERT_PRODUCTION_MAPPPING[key], item[key])
+            except KeyError:
+                continue
 
         production_breakdowns.append(
             zoneKey=zone_key,

--- a/parsers/TR.py
+++ b/parsers/TR.py
@@ -41,10 +41,13 @@ PRODUCTION_MAPPING = {
     "wind": ["wind"],
     "coal": ["blackCoal", "asphaltiteCoal", "lignite", "importCoal"],
     "hydro": ["river", "dammedHydro"],
+    "nuclear": ["nucklear"],
+    "unknown": ["wasteheat"],
 }
 INVERT_PRODUCTION_MAPPPING = {
     val: mode for mode in PRODUCTION_MAPPING for val in PRODUCTION_MAPPING[mode]
 }
+IGNORED_KEYS = ["total", "date", "importExport"]
 SOURCE = "epias.com.tr"
 
 
@@ -115,11 +118,11 @@ def fetch_production(
     production_breakdowns = ProductionBreakdownList(logger)
     for item in data:
         mix = ProductionMix()
-        for key in item:
-            try:
-                mix.add_value(INVERT_PRODUCTION_MAPPPING[key], item[key])
-            except KeyError:
-                continue
+        for key, value in item.items():
+            if key in INVERT_PRODUCTION_MAPPPING:
+                mix.add_value(INVERT_PRODUCTION_MAPPPING[key], value)
+            elif key not in IGNORED_KEYS:
+                logger.warning("Unrecognized key '%s' in data skipped", key)
 
         production_breakdowns.append(
             zoneKey=zone_key,

--- a/parsers/TR.py
+++ b/parsers/TR.py
@@ -1,10 +1,18 @@
 #!/usr/bin/env python3
 from datetime import datetime, timedelta
 from logging import Logger, getLogger
+from typing import Any
 from zoneinfo import ZoneInfo
 
 from requests import Response, Session
 
+from electricitymap.contrib.config import ZoneKey
+from electricitymap.contrib.lib.models.event_lists import (
+    PriceList,
+    ProductionBreakdownList,
+    TotalConsumptionList,
+)
+from electricitymap.contrib.lib.models.events import ProductionMix
 from parsers.lib.config import refetch_frequency
 from parsers.lib.exceptions import ParserException
 from parsers.lib.session import get_session_with_legacy_adapter
@@ -34,6 +42,8 @@ PRODUCTION_MAPPING = {
     "coal": ["blackCoal", "asphaltiteCoal", "lignite", "importCoal"],
     "hydro": ["river", "dammedHydro"],
 }
+
+SOURCE = "epias.com.tr"
 
 
 def _str_to_datetime(date_string: str) -> datetime:
@@ -87,11 +97,11 @@ def validate_production_data(
 
 @refetch_frequency(timedelta(days=1))
 def fetch_production(
-    zone_key: str = "TR",
+    zone_key: ZoneKey = ZoneKey("TR"),
     session: Session | None = None,
     target_datetime: datetime | None = None,
     logger: Logger = getLogger(__name__),
-) -> list:
+) -> list[dict[str, Any]]:
     # For real-time data, the last data point seems to but continously updated thoughout the hour and will be excluded as not final
     exclude_last_data_point = False
     if target_datetime is None:
@@ -100,23 +110,22 @@ def fetch_production(
 
     data = fetch_data(target_datetime=target_datetime, kind="production")
 
-    all_data_points = []
+    production_breakdowns = ProductionBreakdownList(logger)
     for item in data:
-        production = {}
+        mix = ProductionMix()
         for mode in PRODUCTION_MAPPING:
             value = sum([item[key] for key in item if key in PRODUCTION_MAPPING[mode]])
-            production[mode] = round(value, 4)
-        data_point = {
-            "zoneKey": zone_key,
-            "datetime": _str_to_datetime(item.get("date")),
-            "production": production,
-            "source": "epias.com.tr",
-        }
+            mix.add_value(mode, round(value, 4))
 
-        all_data_points += [data_point]
+        production_breakdowns.append(
+            zoneKey=zone_key,
+            datetime=_str_to_datetime(item.get("date")),
+            production=mix,
+            source=SOURCE,
+        )
 
     all_data_points_validated = validate_production_data(
-        data=all_data_points,
+        data=production_breakdowns.to_list(),
         exclude_last_data_point=exclude_last_data_point,
         logger=logger,
     )
@@ -126,52 +135,50 @@ def fetch_production(
 
 @refetch_frequency(timedelta(days=1))
 def fetch_consumption(
-    zone_key: str = "TR",
+    zone_key: ZoneKey = ZoneKey("TR"),
     session: Session | None = None,
     target_datetime: datetime | None = None,
     logger: Logger = getLogger(__name__),
-) -> list:
+) -> list[dict[str, Any]]:
     if target_datetime is None:
         target_datetime = datetime.now(tz=TR_TZ) - timedelta(hours=2)
 
     data = fetch_data(target_datetime=target_datetime, kind="consumption")
 
-    all_data_points = []
+    consumptions = TotalConsumptionList(logger)
     for item in data:
-        data_point = {
-            "zoneKey": zone_key,
-            "datetime": _str_to_datetime(item.get("date")),
-            "consumption": item.get("consumption"),
-            "source": "epias.com.tr",
-        }
+        consumptions.append(
+            zoneKey=zone_key,
+            datetime=_str_to_datetime(item.get("date")),
+            consumption=item.get("consumption"),
+            source=SOURCE,
+        )
 
-        all_data_points += [data_point]
-    return all_data_points
+    return consumptions.to_list()
 
 
 @refetch_frequency(timedelta(days=1))
 def fetch_price(
-    zone_key: str = "TR",
+    zone_key: ZoneKey = ZoneKey("TR"),
     session: Session | None = None,
     target_datetime: datetime | None = None,
     logger: Logger = getLogger(__name__),
-) -> list:
+) -> list[dict[str, Any]]:
     if target_datetime is None:
         target_datetime = datetime.now(tz=TR_TZ)
 
     data = fetch_data(target_datetime=target_datetime, kind="price")
-    all_data_points = []
+    prices = PriceList(logger)
     for item in data:
-        data_point = {
-            "zoneKey": zone_key,
-            "datetime": _str_to_datetime(item.get("date")),
-            "price": item.get("price"),
-            "source": "epias.com.tr",
-            "currency": "TRY",
-        }
+        prices.append(
+            zoneKey=zone_key,
+            datetime=_str_to_datetime(item.get("date")),
+            price=item.get("price"),
+            source=SOURCE,
+            currency="TRY",
+        )
 
-        all_data_points += [data_point]
-    return all_data_points
+    return prices.to_list()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Issue

[6011](https://github.com/electricitymaps/electricitymaps-contrib/issues/6011)

## Description

Use event classes in TR parser.

For the validation of the production, I applied the validation function after calling to_list() on the ProductionBreakdownList, I think it would be better validate the object instead of the list but it seems to require much more refactoring as the validate function in the lib takes as input the old format of dictionary, not sure if there's an equivalent for the object?

### Preview

<!-- Please add screenshots and/or gif that shows visual changes (if applicable) -->

### Double check

- [x] I have tested my parser changes locally with `poetry run test_parser "zone_key"`
- [x] I have run `pnpx prettier@2 --write .` and `poetry run format` in the top level directory to format my changes.
