### PR TITLE
Update RS validation parameters

### DIFF
--- a/parsers/ENTSOE.py
+++ b/parsers/ENTSOE.py
@@ -455,8 +455,12 @@ VALIDATIONS: dict[str, dict[str, Any]] = {
         "expected_range": (2000, 25000),
     },
     "RS": {
-        "required": ["coal"],
+        "required": ["biomass", "coal", "gas", "hydro", "unknown"],
         "expected_range": {
+            "coal": (
+                800,
+                7000,
+            ),  # 7 GW is 1 GW more than the production capacity of Serbia.
             "hydro": (0, 5000),  # 5 GW is double the production capacity of Serbia.
         },
     },


### PR DESCRIPTION
## Issue

We are sometimes getting junk data from ENTSO-E, and the current validation is not sufficient enough.

Closes: https://github.com/electricitymaps/electricitymaps-contrib/issues/6468
Closes: [ELE-3864](https://linear.app/electricitymaps/issue/ELE-3864/update-validation-rules-in-the-entso-e-parser-for-rs)

## Description

This PR updated the validation to filter out more bad data.

I think the 800 MW is the lower limit we can use without discarding good data.

### Double check

- [x] I have tested my parser changes locally with `poetry run test_parser "zone_key"`
- [x] I have run `pnpx prettier@2 --write .` and `poetry run format` in the top level directory to format my changes.
