### PR TITLE
Add german estimation text 

### DIFF
--- a/web/public/locales/de.json
+++ b/web/public/locales/de.json
@@ -98,6 +98,40 @@
       "pill": "Nicht verfügbar",
       "body": "Unsere Datenquellen stellen aktuell keine Werte für diese Zone zur Verfügung. Die angezeigten Werte sind Schätzungen, die auf historischen Messungen basieren und durch verifizierte Daten ersetzt werden, sobald diese verfügbar sind. Bitte beachten Sie, dass geschätzte Werte nicht immer genau sind, da sie aktuelle Wetterereignisse nicht berücksichtigen."
     },
+    "estimated_mode_breakdown": {
+      "title": "Teils geschätzte Daten",
+      "pill": "Unvollständig",
+      "body": "Die Daten zur Stromerzeugung in diesem Gebiet sind unvollständig. Die fehlenden Werte wurden anhand eines statistischen Schätzmodells berechnet."
+    },
+    "estimated_reconstruct_breakdown": {
+      "title": "Ausschließlich geschätzte Daten",
+      "pill": "Unpräzise",
+      "body": "Die veröffentlichten Daten für diese Zone geben nur die Gesamtproduktion an. Die erneuerbaren Quellen werden anhand aktueller Wetterdaten geschätzt, während die fossilen Quellen auf der Grundlage historischer Daten für jede Produktionsquelle abgezogen werden."
+    },
+    "estimated_generic_method": {
+      "title": "Daten werden geschätzt",
+      "pill": "Unpräzise",
+      "body": "Die veröffentlichten Daten für diese Zone sind nicht verfügbar oder unvollständig. Die auf der Karte gezeigten Daten sind nach bestem Wissen und Gewissen geschätzt, können aber von den tatsächlichen Werten abweichen."
+    },
+    "estimated_construct_breakdown": {
+      "title": "Ausschließlich geschätzte Daten",
+      "pill": "Nicht in Echtzeit",
+      "body": "Die Daten für diese Zone werden nicht in Echtzeit veröffentlicht und geben nur die Gesamtproduktion an. Sowohl die stündliche Produktion als auch die Produktionsquellen werden auf der Grundlage historischer Daten für jede Produktionsquelle geschätzt."
+    },
+    "estimated_construct_zero_breakdown": {
+      "title": "Ausschließlich geschätzte Daten",
+      "pill": "Nicht in Echtzeit",
+      "body": "Die Daten für diese Zone werden nicht in Echtzeit veröffentlicht und geben nur die Gesamtproduktion an. Sowohl die stündliche Produktion als auch die Produktionsquellen werden auf der Grundlage historischer Daten für jede Produktionsquelle geschätzt."
+    },
+    "threshold_filtered": {
+      "title": "Fehlende Daten",
+      "pill": "Ausfall von Daten",
+      "body": "Der Datenanbieter für diese Zone hat über einen längeren Zeitraum keine Daten geliefert. Wir beobachten das Problem und werden die Zone aktualisieren, sobald die Daten wieder verfügbar sind."
+    },
+    "outage": {
+      "title": "Daten sind geschätzt",
+      "pill": "Nicht verfügbar"
+    },
     "aggregated": {
       "title": "Aggregierte Daten",
       "body": "Die angezeigten Daten sind eine Zusammenlegung stündlich gemessener Werte."


### PR DESCRIPTION
## Issue

[ELE-3830](https://linear.app/electricitymaps/issue/ELE-3830/add-translated-de-text)

## Description

Translate estimation text to German.

For reviewer:
You can compare de.json to en.json. Extra focus on `threshold_filtered` and `estimated_generic_method` would be appreciated, as they have been translated using DeepL and has not been reviewed by anyone yet.

### Preview

<!-- Please add screenshots and/or gif that shows visual changes (if applicable) -->

### Double check

- [x] I have run `pnpx prettier@2 --write .` and `poetry run format` in the top level directory to format my changes.
