### PR TITLE
Capacity update AE and OM

### DIFF
--- a/config/zones/AE.yaml
+++ b/config/zones/AE.yaml
@@ -4,12 +4,78 @@ bounding_box:
   - - 56.88363691500007
     - 26.574791972000085
 capacity:
-  biomass: 1
-  hydro: 0
-  solar: 2705
-  wind: 0
+    gas:
+      - datetime: '2016-01-01'
+        source: Climatescope
+        value: 26394
+      - datetime: '2017-01-01'
+        source: Climatescope
+        value: 26569
+      - datetime: '2018-01-01'
+        source: Climatescope
+        value: 28280
+      - datetime: '2019-01-01'
+        source: Climatescope
+        value: 25980
+      - datetime: '2020-01-01'
+        source: Climatescope
+        value: 29059
+      - datetime: '2021-01-01'
+        source: Climatescope
+        value: 33493.8
+      - datetime: '2022-01-01'
+        source: Climatescope
+        value: 39976.8
+      - datetime: '2023-01-01'
+        source: Climatescope
+        value: 39451.8
+    solar:
+      - datetime: '2016-01-01'
+        source: Climatescope
+        value: 1
+      - datetime: '2017-01-01'
+        source: Climatescope
+        value: 24
+      - datetime: '2018-01-01'
+        source: Climatescope
+        value: 239
+      - datetime: '2019-01-01'
+        source: Climatescope
+        value: 513
+      - datetime: '2020-01-01'
+        source: Climatescope
+        value: 2092
+      - datetime: '2021-01-01'
+        source: Climatescope
+        value: 2459
+      - datetime: '2022-01-01'
+        source: Climatescope
+        value: 3309
+      - datetime: '2022-10-01'
+        source: Climatescope
+        value: 5414
+    nuclear:
+      - datetime: '2022-01-01'
+        source: Climatescope
+        value: 1390
+      - datetime: '2023-10-01'
+        source: Climatescope
+        value: 2780
+    oil:
+      - datetime: '2016-01-01'
+        source: Climatescope
+        value: 219.9
+      - datetime: '2017-01-01'
+        source: Climatescope
+        value: 218.6
+      - datetime: '2018-01-01'
+        source: Climatescope
+        value: 71.4
 contributors:
   - q--
 parsers:
   consumption: GCCIA.fetch_consumption
+sources:
+  Climatescope:
+    link: https://www.global-climatescope.org/markets/ae/
 timezone: Asia/Dubai

--- a/config/zones/AE.yaml
+++ b/config/zones/AE.yaml
@@ -4,73 +4,73 @@ bounding_box:
   - - 56.88363691500007
     - 26.574791972000085
 capacity:
-    gas:
-      - datetime: '2016-01-01'
-        source: Climatescope
-        value: 26394
-      - datetime: '2017-01-01'
-        source: Climatescope
-        value: 26569
-      - datetime: '2018-01-01'
-        source: Climatescope
-        value: 28280
-      - datetime: '2019-01-01'
-        source: Climatescope
-        value: 25980
-      - datetime: '2020-01-01'
-        source: Climatescope
-        value: 29059
-      - datetime: '2021-01-01'
-        source: Climatescope
-        value: 33493.8
-      - datetime: '2022-01-01'
-        source: Climatescope
-        value: 39976.8
-      - datetime: '2023-01-01'
-        source: Climatescope
-        value: 39451.8
-    solar:
-      - datetime: '2016-01-01'
-        source: Climatescope
-        value: 1
-      - datetime: '2017-01-01'
-        source: Climatescope
-        value: 24
-      - datetime: '2018-01-01'
-        source: Climatescope
-        value: 239
-      - datetime: '2019-01-01'
-        source: Climatescope
-        value: 513
-      - datetime: '2020-01-01'
-        source: Climatescope
-        value: 2092
-      - datetime: '2021-01-01'
-        source: Climatescope
-        value: 2459
-      - datetime: '2022-01-01'
-        source: Climatescope
-        value: 3309
-      - datetime: '2022-10-01'
-        source: Climatescope
-        value: 5414
-    nuclear:
-      - datetime: '2022-01-01'
-        source: Climatescope
-        value: 1390
-      - datetime: '2023-10-01'
-        source: Climatescope
-        value: 2780
-    oil:
-      - datetime: '2016-01-01'
-        source: Climatescope
-        value: 219.9
-      - datetime: '2017-01-01'
-        source: Climatescope
-        value: 218.6
-      - datetime: '2018-01-01'
-        source: Climatescope
-        value: 71.4
+  gas:
+    - datetime: '2016-01-01'
+      source: Climatescope
+      value: 26394
+    - datetime: '2017-01-01'
+      source: Climatescope
+      value: 26569
+    - datetime: '2018-01-01'
+      source: Climatescope
+      value: 28280
+    - datetime: '2019-01-01'
+      source: Climatescope
+      value: 25980
+    - datetime: '2020-01-01'
+      source: Climatescope
+      value: 29059
+    - datetime: '2021-01-01'
+      source: Climatescope
+      value: 33493.8
+    - datetime: '2022-01-01'
+      source: Climatescope
+      value: 39976.8
+    - datetime: '2023-01-01'
+      source: Climatescope
+      value: 39451.8
+  solar:
+    - datetime: '2016-01-01'
+      source: Climatescope
+      value: 1
+    - datetime: '2017-01-01'
+      source: Climatescope
+      value: 24
+    - datetime: '2018-01-01'
+      source: Climatescope
+      value: 239
+    - datetime: '2019-01-01'
+      source: Climatescope
+      value: 513
+    - datetime: '2020-01-01'
+      source: Climatescope
+      value: 2092
+    - datetime: '2021-01-01'
+      source: Climatescope
+      value: 2459
+    - datetime: '2022-01-01'
+      source: Climatescope
+      value: 3309
+    - datetime: '2022-10-01'
+      source: Climatescope
+      value: 5414
+  nuclear:
+    - datetime: '2022-01-01'
+      source: Climatescope
+      value: 1390
+    - datetime: '2023-10-01'
+      source: Climatescope
+      value: 2780
+  oil:
+    - datetime: '2016-01-01'
+      source: Climatescope
+      value: 219.9
+    - datetime: '2017-01-01'
+      source: Climatescope
+      value: 218.6
+    - datetime: '2018-01-01'
+      source: Climatescope
+      value: 71.4
 contributors:
   - q--
 parsers:

--- a/config/zones/OM.yaml
+++ b/config/zones/OM.yaml
@@ -43,4 +43,7 @@ contributors:
   - nessie2013
 parsers:
   consumption: GCCIA.fetch_consumption
+sources:
+  Climatescope:
+    link: https://www.global-climatescope.org/markets/om/
 timezone: Asia/Muscat

--- a/config/zones/OM.yaml
+++ b/config/zones/OM.yaml
@@ -4,8 +4,40 @@ bounding_box:
   - - 60.34457441500007
     - 26.885972398000035
 capacity:
-  solar: 138
-  wind: 50
+    gas:
+    - datetime: '2020-01-01'
+      source: Climatescope
+      value: 10544
+    - datetime: '2021-01-01'
+      source: Climatescope
+      value: 9764
+    - datetime: '2022-01-01'
+      source: Climatescope
+      value: 9495
+    - datetime: '2023-01-01'
+      source: Climatescope
+      value: 9044
+    solar:
+      - datetime: '2020-01-01'
+        source: Climatescope
+        value: 43
+      - datetime: '2021-01-01'
+        source: Climatescope
+        value: 329
+      - datetime: '2022-01-01'
+        source: Climatescope
+        value: 924
+      - datetime: '2022-10-01'
+        source: Climatescope
+        value: 1224
+    wind:
+      - datetime: '2020-01-01'
+        source: Climatescope
+        value: 49
+    oil:
+      - datetime: '2020-01-01'
+        source: Climatescope
+        value: 150
 contributors:
   - q--
   - nessie2013

--- a/config/zones/OM.yaml
+++ b/config/zones/OM.yaml
@@ -4,7 +4,7 @@ bounding_box:
   - - 60.34457441500007
     - 26.885972398000035
 capacity:
-    gas:
+  gas:
     - datetime: '2020-01-01'
       source: Climatescope
       value: 10544
@@ -17,27 +17,27 @@ capacity:
     - datetime: '2023-01-01'
       source: Climatescope
       value: 9044
-    solar:
-      - datetime: '2020-01-01'
-        source: Climatescope
-        value: 43
-      - datetime: '2021-01-01'
-        source: Climatescope
-        value: 329
-      - datetime: '2022-01-01'
-        source: Climatescope
-        value: 924
-      - datetime: '2022-10-01'
-        source: Climatescope
-        value: 1224
-    wind:
-      - datetime: '2020-01-01'
-        source: Climatescope
-        value: 49
-    oil:
-      - datetime: '2020-01-01'
-        source: Climatescope
-        value: 150
+  solar:
+    - datetime: '2020-01-01'
+      source: Climatescope
+      value: 43
+    - datetime: '2021-01-01'
+      source: Climatescope
+      value: 329
+    - datetime: '2022-01-01'
+      source: Climatescope
+      value: 924
+    - datetime: '2022-10-01'
+      source: Climatescope
+      value: 1224
+  wind:
+    - datetime: '2020-01-01'
+      source: Climatescope
+      value: 49
+  oil:
+    - datetime: '2020-01-01'
+      source: Climatescope
+      value: 150
 contributors:
   - q--
   - nessie2013


### PR DESCRIPTION
## Issue

Missing recent capacity data for AE and OM, which are required for new estimation model.

## Description

Using Climatescope data, I updated the respective capacity values.

### Preview

N/A

### Double check

- [ ] I have tested my parser changes locally with `poetry run test_parser "zone_key"`
- [ ] I have run `pnpx prettier@2 --write .` and `poetry run format` in the top level directory to format my changes.
