### PR TITLE
Fix: make sure that text doesn't start with estimation-card.

### DIFF
--- a/web/src/features/panels/zone/EstimationCard.tsx
+++ b/web/src/features/panels/zone/EstimationCard.tsx
@@ -75,7 +75,9 @@ function getEstimationTranslation(
       : t(`estimation-card.${estimationMethod?.toLowerCase()}.${field}`);
 
   const genericTranslation = t(`estimation-card.estimated_generic_method.${field}`);
-  return exactTranslation.length > 0 ? exactTranslation : genericTranslation;
+  return exactTranslation.length > 0 && !exactTranslation.startsWith('estimation-card.')
+    ? exactTranslation
+    : genericTranslation;
 }
 
 function BaseCard({


### PR DESCRIPTION
## Issue

<!-- If you want to close an issue automatically when your PR is merged, write "Closes X" where X is the PR number. For example: Closes #000 -->
[ELE-3897](https://linear.app/electricitymaps/issue/ELE-3897/qa-estimation-tag-on-app)

## Description

<!-- Explains the goal of this PR -->
This PR makes sure that estimation card never shows any text that starts with the 'estimation-card.', and instead use the default text.

### Preview

<!-- Please add screenshots and/or gif that shows visual changes (if applicable) -->

Before:
<img width="413" alt="image" src="https://github.com/electricitymaps/electricitymaps-contrib/assets/95029552/b1213da9-bffc-43af-8963-8938dd31480e">
After:
<img width="369" alt="image" src="https://github.com/electricitymaps/electricitymaps-contrib/assets/95029552/4985b350-97e2-4f61-8fcc-c3f4aeea21cb">


### Double check

- [x] I have run `pnpx prettier@2 --write .` and `poetry run format` in the top level directory to format my changes.
