### PR TITLE
replace the use of badge with estimationbadge and outagebadge

### DIFF
--- a/web/src/components/Badge.tsx
+++ b/web/src/components/Badge.tsx
@@ -13,6 +13,7 @@ export default function Badge({ pillText, type, icon }: BadgeProps) {
   return (
     <span
       className={`ml-2 flex h-[22px] flex-row gap-1 whitespace-nowrap rounded-full px-2 py-1 text-[10px] font-semibold ${classes}`}
+      data-test-id="badge"
     >
       {icon != undefined && <div className={`${icon}`} />}
       {pillText}

--- a/web/src/features/charts/ChartTitle.tsx
+++ b/web/src/features/charts/ChartTitle.tsx
@@ -1,5 +1,5 @@
 /* eslint-disable react/jsx-no-target-blank */
-import Badge from 'components/Badge';
+import EstimationBadge from 'components/EstimationBadge';
 import { useAtom } from 'jotai';
 import { useTranslation } from 'react-i18next';
 import { HiOutlineArrowDownTray } from 'react-icons/hi2';
@@ -25,13 +25,7 @@ export function ChartTitle({
     <>
       <div className="flex flex-row justify-between pb-0.5 pt-4">
         <h3 className="text-md font-bold">{t(`${translationKey}.${timeAverage}`)}</h3>
-        {badgeText != undefined && (
-          <Badge
-            pillText={badgeText}
-            type="warning"
-            icon="h-[16px] w-[16px] bg-[url('/images/estimated_light.svg')] bg-center dark:bg-[url('/images/estimated_dark.svg')]"
-          />
-        )}
+        {badgeText != undefined && <EstimationBadge text={badgeText} />}
       </div>
       {hasLink && (
         <div className="flex flex-row items-center pb-2 text-center text-[0.7rem]">

--- a/web/src/features/charts/bar-breakdown/elements/BySource.tsx
+++ b/web/src/features/charts/bar-breakdown/elements/BySource.tsx
@@ -1,4 +1,4 @@
-import Badge from 'components/Badge';
+import EstimationBadge from 'components/EstimationBadge';
 import { TFunction } from 'i18next';
 import { useAtom } from 'jotai';
 import { useTranslation } from 'react-i18next';
@@ -53,16 +53,14 @@ export default function BySource({
     >
       {text}
       {hasEstimationPill && (
-        <Badge
-          pillText={
+        <EstimationBadge
+          text={
             estimatedPercentage
               ? t('estimation-card.aggregated_estimated.pill', {
                   percentage: estimatedPercentage,
                 })
               : t('estimation-badge.fully-estimated')
           }
-          type="warning"
-          icon="h-[16px] w-[16px] bg-[url('/images/estimated_light.svg')] bg-center dark:bg-[url('/images/estimated_dark.svg')]"
         />
       )}
     </div>

--- a/web/src/features/charts/tooltips/AreaGraphTooltipHeader.tsx
+++ b/web/src/features/charts/tooltips/AreaGraphTooltipHeader.tsx
@@ -1,4 +1,4 @@
-import Badge from 'components/Badge';
+import EstimationBadge from 'components/EstimationBadge';
 import { useTranslation } from 'react-i18next';
 import { TimeAverages } from 'utils/constants';
 import { formatDate } from 'utils/formatting';
@@ -39,16 +39,14 @@ export default function AreaGraphToolTipHeader(props: AreaGraphToolTipHeaderProp
         </div>
         <div className="inline-flex items-center gap-x-2">
           {hasEstimationPill && estimatedPercentage !== 0 && (
-            <Badge
-              pillText={
+            <EstimationBadge
+              text={
                 estimatedPercentage
                   ? t('estimation-card.aggregated_estimated.pill', {
                       percentage: estimatedPercentage,
                     })
                   : t('estimation-badge.fully-estimated')
               }
-              type="warning"
-              icon="h-[16px] w-[16px] bg-[url('/images/estimated_light.svg')] bg-center dark:bg-[url('/images/estimated_dark.svg')]"
             />
           )}
           <div className="my-1 h-[32px] max-w-[165px] select-none whitespace-nowrap rounded-full bg-brand-green/10 px-3 py-2 text-sm text-brand-green dark:bg-gray-700 dark:text-white">

--- a/web/src/features/panels/zone/EstimationCard.cy.tsx
+++ b/web/src/features/panels/zone/EstimationCard.cy.tsx
@@ -6,7 +6,7 @@ import EstimationCard from './EstimationCard';
 
 const queryClient = new QueryClient();
 
-describe('EstimationCard', () => {
+describe('EstimationCard with FeedbackCard', () => {
   beforeEach(() => {
     cy.mount(
       <I18nextProvider i18n={i18n}>
@@ -31,6 +31,7 @@ describe('EstimationCard', () => {
     cy.get('[data-test-id=collapse-button]').click();
     cy.get('[data-test-id=feedback-card]').should('exist');
   });
+
   it('feedback card should only be visible if feature-flag is enabled', () => {
     cy.intercept('/feature-flags', {
       body: { 'feedback-estimation-labels': false },
@@ -38,5 +39,146 @@ describe('EstimationCard', () => {
     cy.get('[data-test-id=feedback-card]').should('not.exist');
     cy.get('[data-test-id=collapse-button]').click();
     cy.get('[data-test-id=feedback-card]').should('exist');
+  });
+});
+
+describe('EstimationCard with known estimation method', () => {
+  beforeEach(() => {
+    cy.mount(
+      <I18nextProvider i18n={i18n}>
+        <QueryClientProvider client={queryClient}>
+          <EstimationCard
+            cardType="estimated"
+            estimationMethod="ESTIMATED_CONSTRUCT_BREAKDOWN"
+            outageMessage={undefined}
+          />
+        </QueryClientProvider>
+      </I18nextProvider>
+    );
+  });
+
+  it('Estimation card contains expected information', () => {
+    cy.get('[data-test-id=title]').contains('Data is always estimated');
+    cy.get('[data-test-id=badge]').contains('Not realtime');
+    cy.get('[data-test-id="collapse-button"]').click();
+    cy.get('[data-test-id="body-text"]').contains(
+      'The data for this zone is not published in realtime and only provides the total production. Both hourly production and production sources are estimated based on historical data for each production source.'
+    );
+  });
+
+  it('Toggles when collapse button is clicked', () => {
+    cy.get('[data-test-id="collapse-up"]').should('not.exist');
+    cy.get('[data-test-id="collapse-down"]').should('exist');
+    cy.get('[data-test-id="body-text"]').should('not.exist');
+    cy.get('[data-test-id="methodology-link"]').should('not.exist');
+    cy.get('[data-test-id="collapse-button"]').click();
+    cy.get('[data-test-id="collapse-up"]').should('exist');
+    cy.get('[data-test-id="collapse-down"]').should('not.exist');
+    cy.get('[data-test-id="body-text"]').should('exist');
+    cy.get('[data-test-id="methodology-link"]').should('exist');
+  });
+});
+
+describe('EstimationCard', () => {
+  it('Estimation card with unknown estimation method contains expected information', () => {
+    cy.mount(
+      <I18nextProvider i18n={i18n}>
+        <QueryClientProvider client={queryClient}>
+          <EstimationCard
+            cardType="estimated"
+            estimationMethod=""
+            outageMessage={undefined}
+          />
+        </QueryClientProvider>
+      </I18nextProvider>
+    );
+    cy.get('[data-test-id=title]').contains('Data is estimated');
+    cy.get('[data-test-id=badge]').contains('Imprecise');
+    cy.get('[data-test-id="collapse-button"]').click();
+    cy.get('[data-test-id="body-text"]').contains(
+      'The published data for this zone is unavailable or incomplete. The data shown on the map is estimated using our best effort, but might differ from the actual values.'
+    );
+  });
+
+  it('Estimation card with unknown card type should not return an estimation card', () => {
+    cy.mount(
+      <I18nextProvider i18n={i18n}>
+        <QueryClientProvider client={queryClient}>
+          <EstimationCard cardType="" estimationMethod="" outageMessage={undefined} />
+        </QueryClientProvider>
+      </I18nextProvider>
+    );
+    cy.get('[data-test-id=title]').should('not.exist');
+  });
+});
+
+describe('OutageCard', () => {
+  beforeEach(() => {
+    cy.mount(
+      <I18nextProvider i18n={i18n}>
+        <QueryClientProvider client={queryClient}>
+          <EstimationCard
+            cardType="outage"
+            estimationMethod="ESTIMATED_CONSTRUCT_BREAKDOWN"
+            outageMessage={{ message: 'Outage Message', issue: 'issue' }}
+          />
+        </QueryClientProvider>
+      </I18nextProvider>
+    );
+  });
+
+  it('Outage message contains expected information', () => {
+    cy.get('[data-test-id=title]').contains('Ongoing issues');
+    cy.get('[data-test-id=badge]').contains('Unavailable');
+  });
+
+  it('For outage start as expanded and toggles collapse when collapse button is clicked', () => {
+    cy.get('[data-test-id="collapse-up"]').should('exist');
+    cy.get('[data-test-id="collapse-down"]').should('not.exist');
+    cy.get('[data-test-id="collapse-button"]').click();
+    cy.get('[data-test-id="collapse-up"]').should('not.exist');
+    cy.get('[data-test-id="collapse-down"]').should('exist');
+  });
+});
+
+describe('AggregatedCard', () => {
+  it('Aggregated card with estimation contains expected information', () => {
+    cy.mount(
+      <I18nextProvider i18n={i18n}>
+        <QueryClientProvider client={queryClient}>
+          <EstimationCard
+            cardType="aggregated"
+            estimatedPercentage={50}
+            outageMessage={undefined}
+          />
+        </QueryClientProvider>
+      </I18nextProvider>
+    );
+    cy.get('[data-test-id=title]').contains('Data is aggregated');
+    cy.get('[data-test-id=badge]').contains('50% estimated');
+    cy.get('[data-test-id="collapse-button"]').click();
+    cy.get('[data-test-id="body-text"]').contains(
+      'The data consists of an aggregation of hourly values. 50% of the production values are estimated.'
+    );
+  });
+
+  it('Aggregated card contains expected information', () => {
+    cy.mount(
+      <I18nextProvider i18n={i18n}>
+        <QueryClientProvider client={queryClient}>
+          <EstimationCard
+            cardType="aggregated"
+            estimationMethod="ESTIMATED_CONSTRUCT_BREAKDOWN"
+            outageMessage={undefined}
+          />
+        </QueryClientProvider>
+      </I18nextProvider>
+    );
+    cy.get('[data-test-id=title]').contains('Data is aggregated');
+    cy.get('[data-test-id=badge]').should('not.exist');
+    cy.get('[data-test-id="collapse-button"]').click();
+    cy.get('[data-test-id="body-text"]').contains(
+      'The data consists of an aggregation of hourly values.'
+    );
   });
 });

--- a/web/src/features/panels/zone/EstimationCard.tsx
+++ b/web/src/features/panels/zone/EstimationCard.tsx
@@ -1,4 +1,6 @@
 import Badge from 'components/Badge';
+import EstimationBadge from 'components/EstimationBadge';
+import OutageBadge from 'components/OutageBadge';
 import { useFeatureFlag } from 'features/feature-flags/api';
 import { useAtom } from 'jotai';
 import { useEffect, useState } from 'react';
@@ -82,22 +84,18 @@ function getEstimationTranslation(
 
 function BaseCard({
   estimationMethod,
-  estimatedPercentage,
-  outageMessage,
   icon,
-  iconPill,
+  badge,
   showMethodologyLink,
-  pillType,
   textColorTitle,
+  bodyText,
 }: {
   estimationMethod?: string;
-  estimatedPercentage?: number;
-  outageMessage: ZoneDetails['zoneMessage'];
   icon: string;
-  iconPill?: string;
+  badge?: JSX.Element;
   showMethodologyLink: boolean;
-  pillType?: string;
   textColorTitle: string;
+  bodyText: string | JSX.Element;
 }) {
   const [isCollapsed, setIsCollapsed] = useState(
     estimationMethod == 'outage' ? false : true
@@ -114,20 +112,6 @@ function BaseCard({
   const { t } = useTranslation();
 
   const title = getEstimationTranslation('title', estimationMethod);
-  const pillText = getEstimationTranslation(
-    'pill',
-    estimationMethod,
-    estimatedPercentage
-  );
-  const bodyText = getEstimationTranslation(
-    'body',
-    estimationMethod,
-    estimatedPercentage
-  );
-  const showBadge =
-    estimationMethod == 'aggregated'
-      ? Boolean(estimatedPercentage)
-      : pillType != undefined;
 
   return (
     <div
@@ -151,9 +135,7 @@ function BaseCard({
               </h2>
             </div>
             <div className="flex h-fit flex-row gap-2 text-nowrap">
-              {showBadge && (
-                <Badge type={pillType} icon={iconPill} pillText={pillText}></Badge>
-              )}
+              {badge}
               <div className="text-lg">
                 {isCollapsed ? <HiChevronDown /> : <HiChevronUp />}
               </div>
@@ -163,10 +145,7 @@ function BaseCard({
         {!isCollapsed && (
           <div className="gap-2 pt-1.5">
             <div className={`text-sm font-normal text-neutral-600 dark:text-neutral-400`}>
-              {estimationMethod != 'outage' && bodyText}
-              {estimationMethod == 'outage' && (
-                <OutageMessage outageData={outageMessage} />
-              )}
+              {bodyText}
             </div>
             {showMethodologyLink && (
               <div className="">
@@ -191,12 +170,11 @@ function OutageCard({ outageMessage }: { outageMessage: ZoneDetails['zoneMessage
   return (
     <BaseCard
       estimationMethod={'outage'}
-      outageMessage={outageMessage}
       icon="bg-[url('/images/estimated_light.svg')] dark:bg-[url('/images/estimated_dark.svg')]"
-      iconPill="h-[12px] w-[12px] mt-[1px] bg-[url('/images/warning_light.svg')] bg-center dark:bg-[url('/images/warning_dark.svg')]"
+      badge={<OutageBadge />}
       showMethodologyLink={false}
-      pillType="warning"
       textColorTitle="text-amber-700 dark:text-amber-500"
+      bodyText={<OutageMessage outageData={outageMessage} />}
     />
   );
 }
@@ -205,13 +183,17 @@ function AggregatedCard({ estimatedPercentage }: { estimatedPercentage?: number 
   return (
     <BaseCard
       estimationMethod={'aggregated'}
-      estimatedPercentage={estimatedPercentage}
-      outageMessage={undefined}
       icon="bg-[url('/images/aggregated_light.svg')] dark:bg-[url('/images/aggregated_dark.svg')]"
-      iconPill={undefined}
       showMethodologyLink={false}
-      pillType={'warning'}
+      badge={
+        estimatedPercentage ? (
+          <EstimationBadge
+            text={getEstimationTranslation('pill', 'aggregated', estimatedPercentage)}
+          />
+        ) : undefined
+      }
       textColorTitle="text-black dark:text-white"
+      bodyText={getEstimationTranslation('body', 'aggregated', estimatedPercentage)}
     />
   );
 }
@@ -220,12 +202,16 @@ function EstimatedCard({ estimationMethod }: { estimationMethod: string | undefi
   return (
     <BaseCard
       estimationMethod={estimationMethod}
-      outageMessage={undefined}
       icon="bg-[url('/images/estimated_light.svg')] dark:bg-[url('/images/estimated_dark.svg')]"
-      iconPill={undefined}
+      badge={
+        <Badge
+          pillText={getEstimationTranslation('pill', estimationMethod)}
+          type="default"
+        />
+      }
       showMethodologyLink={true}
-      pillType="default"
       textColorTitle="text-amber-700 dark:text-amber-500"
+      bodyText={getEstimationTranslation('body', estimationMethod)}
     />
   );
 }

--- a/web/src/features/panels/zone/EstimationCard.tsx
+++ b/web/src/features/panels/zone/EstimationCard.tsx
@@ -130,6 +130,7 @@ function BaseCard({
               </div>
               <h2
                 className={`text-left text-sm font-semibold ${textColorTitle} self-center`}
+                data-test-id="title"
               >
                 {title}
               </h2>
@@ -137,14 +138,25 @@ function BaseCard({
             <div className="flex h-fit flex-row gap-2 text-nowrap">
               {badge}
               <div className="text-lg">
-                {isCollapsed ? <HiChevronDown /> : <HiChevronUp />}
+                {isCollapsed ? (
+                  <div data-test-id="collapse-down">
+                    <HiChevronDown />
+                  </div>
+                ) : (
+                  <div data-test-id="collapse-up">
+                    <HiChevronUp />
+                  </div>
+                )}
               </div>
             </div>
           </div>
         </button>
         {!isCollapsed && (
           <div className="gap-2 pt-1.5">
-            <div className={`text-sm font-normal text-neutral-600 dark:text-neutral-400`}>
+            <div
+              data-test-id="body-text"
+              className={`text-sm font-normal text-neutral-600 dark:text-neutral-400`}
+            >
               {bodyText}
             </div>
             {showMethodologyLink && (
@@ -153,6 +165,7 @@ function BaseCard({
                   href="https://www.electricitymaps.com/methodology"
                   target="_blank"
                   rel="noreferrer"
+                  data-test-id="methodology-link"
                   className={`text-sm font-semibold text-black underline dark:text-white`}
                 >
                   <span className="underline">{t(`estimation-card.link`)}</span>


### PR DESCRIPTION
## Issue

<!-- If you want to close an issue automatically when your PR is merged, write "Closes X" where X is the PR number. For example: Closes #000 -->
[ELE-3909](https://linear.app/electricitymaps/issue/ELE-3909/replace-the-use-of-badge-with-estimationbadge-and-outagebadge)

## Description

<!-- Explains the goal of this PR -->
The goal of this PR is to reduce the amount of duplicate code by using the `OutageBadge` and `EstimationBadge` instead of `Badge` whenever possible.

### Preview

<!-- Please add screenshots and/or gif that shows visual changes (if applicable) -->

### Double check

- [ ] I have run `pnpx prettier@2 --write .` and `poetry run format` in the top level directory to format my changes.
