### PR TITLE
bug(config): AE, OM capacity typos

### DIFF
--- a/config/zones/AE.yaml
+++ b/config/zones/AE.yaml
@@ -51,14 +51,14 @@ capacity:
     - datetime: '2022-01-01'
       source: Climatescope
       value: 3309
-    - datetime: '2022-10-01'
+    - datetime: '2022-01-01'
       source: Climatescope
       value: 5414
   nuclear:
     - datetime: '2022-01-01'
       source: Climatescope
       value: 1390
-    - datetime: '2023-10-01'
+    - datetime: '2023-01-01'
       source: Climatescope
       value: 2780
   oil:
@@ -73,6 +73,7 @@ capacity:
       value: 71.4
 contributors:
   - q--
+  - florianscheidl
 parsers:
   consumption: GCCIA.fetch_consumption
 sources:

--- a/config/zones/OM.yaml
+++ b/config/zones/OM.yaml
@@ -27,7 +27,7 @@ capacity:
     - datetime: '2022-01-01'
       source: Climatescope
       value: 924
-    - datetime: '2022-10-01'
+    - datetime: '2023-01-01'
       source: Climatescope
       value: 1224
   wind:
@@ -41,6 +41,7 @@ capacity:
 contributors:
   - q--
   - nessie2013
+  - florianscheidl
 parsers:
   consumption: GCCIA.fetch_consumption
 sources:


### PR DESCRIPTION
## Issue

A previous PR (#6518) contained typos in the capacity specification

## Description

This PR contains the corrected datetimes belonging to the capacities.
