### PR TITLE
remove the use of badge

### DIFF
--- a/web/src/features/charts/ChartTitle.tsx
+++ b/web/src/features/charts/ChartTitle.tsx
@@ -1,5 +1,5 @@
 /* eslint-disable react/jsx-no-target-blank */
-import Badge from 'components/Badge';
+import EstimationBadge from 'components/EstimationBadge';
 import { useAtom } from 'jotai';
 import { useTranslation } from 'react-i18next';
 import { HiOutlineArrowDownTray } from 'react-icons/hi2';
@@ -25,13 +25,7 @@ export function ChartTitle({
     <>
       <div className="flex flex-row justify-between pb-0.5 pt-4">
         <h3 className="text-md font-bold">{t(`${translationKey}.${timeAverage}`)}</h3>
-        {badgeText != undefined && (
-          <Badge
-            pillText={badgeText}
-            type="warning"
-            icon="h-[16px] w-[16px] bg-[url('/images/estimated_light.svg')] bg-center dark:bg-[url('/images/estimated_dark.svg')]"
-          />
-        )}
+        {badgeText != undefined && <EstimationBadge text={badgeText} />}
       </div>
       {hasLink && (
         <div className="flex flex-row items-center pb-2 text-center text-[0.7rem]">

--- a/web/src/features/charts/bar-breakdown/elements/BySource.tsx
+++ b/web/src/features/charts/bar-breakdown/elements/BySource.tsx
@@ -1,4 +1,4 @@
-import Badge from 'components/Badge';
+import EstimationBadge from 'components/EstimationBadge';
 import { TFunction } from 'i18next';
 import { useAtom } from 'jotai';
 import { useTranslation } from 'react-i18next';
@@ -53,16 +53,14 @@ export default function BySource({
     >
       {text}
       {hasEstimationPill && (
-        <Badge
-          pillText={
+        <EstimationBadge
+          text={
             estimatedPercentage
               ? t('estimation-card.aggregated_estimated.pill', {
                   percentage: estimatedPercentage,
                 })
               : t('estimation-badge.fully-estimated')
           }
-          type="warning"
-          icon="h-[16px] w-[16px] bg-[url('/images/estimated_light.svg')] bg-center dark:bg-[url('/images/estimated_dark.svg')]"
         />
       )}
     </div>

--- a/web/src/features/charts/tooltips/AreaGraphTooltipHeader.tsx
+++ b/web/src/features/charts/tooltips/AreaGraphTooltipHeader.tsx
@@ -1,4 +1,4 @@
-import Badge from 'components/Badge';
+import EstimationBadge from 'components/EstimationBadge';
 import { useTranslation } from 'react-i18next';
 import { TimeAverages } from 'utils/constants';
 import { formatDate } from 'utils/formatting';
@@ -39,16 +39,14 @@ export default function AreaGraphToolTipHeader(props: AreaGraphToolTipHeaderProp
         </div>
         <div className="inline-flex items-center gap-x-2">
           {hasEstimationPill && estimatedPercentage !== 0 && (
-            <Badge
-              pillText={
+            <EstimationBadge
+              text={
                 estimatedPercentage
                   ? t('estimation-card.aggregated_estimated.pill', {
                       percentage: estimatedPercentage,
                     })
                   : t('estimation-badge.fully-estimated')
               }
-              type="warning"
-              icon="h-[16px] w-[16px] bg-[url('/images/estimated_light.svg')] bg-center dark:bg-[url('/images/estimated_dark.svg')]"
             />
           )}
           <div className="my-1 h-[32px] max-w-[165px] select-none whitespace-nowrap rounded-full bg-brand-green/10 px-3 py-2 text-sm text-brand-green dark:bg-gray-700 dark:text-white">


### PR DESCRIPTION
## Issue

<!-- If you want to close an issue automatically when your PR is merged, write "Closes X" where X is the PR number. For example: Closes #000 -->
[ELE-3909](https://linear.app/electricitymaps/issue/ELE-3909/replace-the-use-of-badge-with-estimationbadge-and-outagebadge)

## Description

<!-- Explains the goal of this PR -->
The goal of this PR is to reduce the amount of duplicate code by using the `OutageBadge` and `EstimationBadge` instead of `Badge` whenever possible.

I tried to do some rework in `EstimationCard` but decided that it was okay the way it is.

### Double check

- [x] I have run `pnpx prettier@2 --write .` and `poetry run format` in the top level directory to format my changes.
