### PR TITLE
refactor: use event classes in US-MISO parser

### DIFF
--- a/parsers/US_MISO.py
+++ b/parsers/US_MISO.py
@@ -4,10 +4,19 @@
 
 from datetime import datetime
 from logging import Logger, getLogger
+from typing import Any
 
 from dateutil import parser, tz
 from requests import Session
 
+from electricitymap.contrib.config import ZoneKey
+from electricitymap.contrib.lib.models.event_lists import (
+    ProductionBreakdownList,
+)
+from electricitymap.contrib.lib.models.events import EventSourceType, ProductionMix
+
+SOURCE = "misoenergy.org"
+ZONE = "US-MIDW-MISO"
 mix_url = (
     "https://api.misoenergy.org/MISORTWDDataBroker/DataBrokerServices.asmx?messageType"
     "=getfuelmix&returnType=json"
@@ -32,7 +41,7 @@ wind_forecast_url = "https://api.misoenergy.org/MISORTWDDataBroker/DataBrokerSer
 # Unsure exactly why EST is used, possibly due to operational connections with PJM.
 
 
-def get_json_data(logger: Logger, session: Session | None = None):
+def get_json_data(logger: Logger, session: Session | None = None) -> dict:
     """Returns 5 minute generation data in json format."""
 
     s = session or Session()
@@ -41,7 +50,7 @@ def get_json_data(logger: Logger, session: Session | None = None):
     return json_data
 
 
-def data_processer(json_data, logger: Logger):
+def data_processer(json_data, logger: Logger) -> tuple[datetime, ProductionMix]:
     """
     Identifies any unknown fuel types and logs a warning.
     Returns a tuple containing datetime object and production dictionary.
@@ -49,7 +58,7 @@ def data_processer(json_data, logger: Logger):
 
     generation = json_data["Fuel"]["Type"]
 
-    production = {}
+    mix = ProductionMix()
     for fuel in generation:
         try:
             k = mapping[fuel["CATEGORY"]]
@@ -60,8 +69,7 @@ def data_processer(json_data, logger: Logger):
                 )
             )
             k = "unknown"
-        v = float(fuel["ACT"])
-        production[k] = production.get(k, 0.0) + v
+        mix.add_value(k, float(fuel["ACT"]))
 
     # Remove unneeded parts of timestamp to allow datetime parsing.
     timestamp = json_data["RefId"]
@@ -76,40 +84,39 @@ def data_processer(json_data, logger: Logger):
     tzinfos = {"EST": tz.gettz("America/New_York")}
     dt = parser.parse(time_data, tzinfos=tzinfos)
 
-    return dt, production
+    return dt, mix
 
 
 def fetch_production(
-    zone_key: str = "US-MISO",
+    zone_key: ZoneKey = ZoneKey(ZONE),
     session: Session | None = None,
     target_datetime: datetime | None = None,
     logger: Logger = getLogger(__name__),
-) -> dict:
+) -> list[dict[str, Any]]:
     """Requests the last known production mix (in MW) of a given country."""
 
     if target_datetime:
         raise NotImplementedError("This parser is not yet able to parse past dates")
 
     json_data = get_json_data(logger, session=session)
-    processed_data = data_processer(json_data, logger)
+    dt, mix = data_processer(json_data, logger)
 
-    data = {
-        "zoneKey": zone_key,
-        "datetime": processed_data[0],
-        "production": processed_data[1],
-        "storage": {},
-        "source": "misoenergy.org",
-    }
-
-    return data
+    production_breakdowns = ProductionBreakdownList(logger)
+    production_breakdowns.append(
+        zoneKey=zone_key,
+        datetime=dt,
+        production=mix,
+        source=SOURCE,
+    )
+    return production_breakdowns.to_list()
 
 
 def fetch_wind_forecast(
-    zone_key: str = "US-MISO",
+    zone_key: ZoneKey = ZoneKey(ZONE),
     session: Session | None = None,
     target_datetime: datetime | None = None,
     logger: Logger = getLogger(__name__),
-) -> list:
+) -> list[dict[str, Any]]:
     """Requests the day ahead wind forecast (in MW) of a given zone."""
 
     if target_datetime:
@@ -120,22 +127,22 @@ def fetch_wind_forecast(
     raw_json = req.json()
     raw_data = raw_json["Forecast"]
 
-    data = []
+    production_breakdowns = ProductionBreakdownList(logger)
     for item in raw_data:
         dt = parser.parse(item["DateTimeEST"]).replace(
             tzinfo=tz.gettz("America/New_York")
         )
-        value = float(item["Value"])
+        mix = ProductionMix(wind=float(item["Value"]))
 
-        datapoint = {
-            "datetime": dt,
-            "production": {"wind": value},
-            "source": "misoenergy.org",
-            "zoneKey": zone_key,
-        }
-        data.append(datapoint)
+        production_breakdowns.append(
+            datetime=dt,
+            production=mix,
+            source=SOURCE,
+            zoneKey=zone_key,
+            sourceType=EventSourceType.forecasted,
+        )
 
-    return data
+    return production_breakdowns.to_list()
 
 
 if __name__ == "__main__":

--- a/parsers/test/test_US_MISO.py
+++ b/parsers/test/test_US_MISO.py
@@ -7,8 +7,8 @@ import logging
 import unittest
 from datetime import datetime
 from unittest.mock import patch
+from zoneinfo import ZoneInfo
 
-from arrow import get
 from testfixtures import LogCapture
 
 from parsers import US_MISO
@@ -29,20 +29,22 @@ class TestUSMISO(unittest.TestCase):
         with self.subTest():
             self.assertIsNotNone(data)
         with self.subTest():
-            self.assertEqual(data["production"]["coal"], 40384.0)
+            self.assertEqual(data[0]["production"]["coal"], 40384.0)
         with self.subTest():
-            expected_dt = get(datetime(2018, 1, 25, 4, 30), "America/New_York").datetime
-            self.assertEqual(data["datetime"], expected_dt)
+            expected_dt = datetime(
+                2018, 1, 25, 4, 30, tzinfo=ZoneInfo("America/New_York")
+            )
+            self.assertEqual(data[0]["datetime"], expected_dt)
         with self.subTest():
-            self.assertEqual(data["source"], "misoenergy.org")
+            self.assertEqual(data[0]["source"], "misoenergy.org")
         with self.subTest():
-            self.assertEqual(data["zoneKey"], "US-MISO")
+            self.assertEqual(data[0]["zoneKey"], "US-MIDW-MISO")
         with self.subTest():
-            self.assertIsInstance(data["storage"], dict)
+            self.assertIsInstance(data[0]["storage"], dict)
 
         # Make sure the unmapped Antimatter type is set to 'unknown'.
         with self.subTest():
-            self.assertGreaterEqual(data["production"]["unknown"], 256.0)
+            self.assertGreaterEqual(data[0]["production"]["unknown"], 256.0)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Issue

[6011](https://github.com/electricitymaps/electricitymaps-contrib/issues/6011)

## Description

Use event classes in US-MISO parser. I assumed the corresponding ZoneKey is US-MIDW-MISO but if that's not the right one I'll update it!

### Preview

<!-- Please add screenshots and/or gif that shows visual changes (if applicable) -->

### Double check

- [x] I have tested my parser changes locally with `poetry run test_parser "zone_key"`
- [x] I have run `pnpx prettier@2 --write .` and `poetry run format` in the top level directory to format my changes.
