### PR TITLE
Change exchange parser for US-NY-NYIS to get realtime data

### DIFF
--- a/config/exchanges/US-MIDA-PJM_US-NY-NYIS.yaml
+++ b/config/exchanges/US-MIDA-PJM_US-NY-NYIS.yaml
@@ -2,5 +2,5 @@ lonlat:
   - -77.069
   - 42.0
 parsers:
-  exchange: US_PJM.fetch_exchange
+  exchange: US_NY.fetch_exchange
 rotation: 0


### PR DESCRIPTION
## Issue

The current parser don't have realtime data.

## Description

We currently have 2 parsers capable of parsing this exchange. The US_PJM parser and the US_NY parser. The US_PJM parser don't have realtime data but the US_NY parser does so this PR switches the exchange to use the US_NY parser.

### Preview
Small snippet:
```log
 {'datetime': datetime.datetime(2024, 3, 17, 17, 50, tzinfo=zoneinfo.ZoneInfo(key='America/New_York')),
  'netFlow': 2306.47,
  'sortedZoneKeys': 'US-MIDA-PJM->US-NY-NYIS',
  'source': 'nyiso.com',
  'sourceType': <EventSourceType.measured: 'measured'>}]
---------------------
took 1.43s
min returned datetime: 2024-03-17 04:00:00+00:00 UTC
max returned datetime: 2024-03-17 21:50:00+00:00 UTC  -- OK, <2h from now :) (now=2024-03-17T21:51:38+00:00 UTC)
```

### Double check

- [x] I have tested my parser changes locally with `poetry run test_parser "zone_key"`
- [x] I have run `pnpx prettier@2 --write .` and `poetry run format` in the top level directory to format my changes.
