### PR TITLE
fix(capacity_parsers/EIA): typesafe addition of per power plant capacity

### DIFF
--- a/electricitymap/contrib/capacity_parsers/EIA.py
+++ b/electricitymap/contrib/capacity_parsers/EIA.py
@@ -53,6 +53,7 @@ def format_capacity(df: pd.DataFrame, target_datetime: datetime) -> dict[str, An
     df = df.copy()
     df = df.loc[df["statusDescription"] == "Operating"]
     df["mode"] = df["technology"].map(TECHNOLOGY_TO_MODE)
+    df["nameplate-capacity-mw"] = pd.to_numeric(df["nameplate-capacity-mw"], errors="coerce")
     df_aggregated = df.groupby(["mode"])[["nameplate-capacity-mw"]].sum().reset_index()
     capacity_dict = {}
     for mode in CAPACITY_MODES:

--- a/electricitymap/contrib/capacity_parsers/EIA.py
+++ b/electricitymap/contrib/capacity_parsers/EIA.py
@@ -53,7 +53,9 @@ def format_capacity(df: pd.DataFrame, target_datetime: datetime) -> dict[str, An
     df = df.copy()
     df = df.loc[df["statusDescription"] == "Operating"]
     df["mode"] = df["technology"].map(TECHNOLOGY_TO_MODE)
-    df["nameplate-capacity-mw"] = pd.to_numeric(df["nameplate-capacity-mw"], errors="coerce")
+    df["nameplate-capacity-mw"] = pd.to_numeric(
+        df["nameplate-capacity-mw"], errors="coerce"
+    )
     df_aggregated = df.groupby(["mode"])[["nameplate-capacity-mw"]].sum().reset_index()
     capacity_dict = {}
     for mode in CAPACITY_MODES:


### PR DESCRIPTION
## Issue

For some reason the data received had an object column (string) for the nameplate capacity. Summing the value was therefore concatenating the strings, which made it impossible to convert to float.
<img width="431" alt="Screenshot 2024-03-21 at 13 39 32" src="https://github.com/electricitymaps/electricitymaps-contrib/assets/32778266/510b33f7-9309-47c8-a25c-9a9df6f8254e">

<img width="531" alt="Screenshot 2024-03-21 at 13 39 18" src="https://github.com/electricitymaps/electricitymaps-contrib/assets/32778266/4bb37884-a2e2-47cd-946f-6fe4c1e1883b">

with `poetry run capacity_update --zone US-NW-NEVP --target_datetime 2022-01-01`


## Description

Safe conversion of the column to numeric before the aggregation

### Preview

<!-- Please add screenshots and/or gif that shows visual changes (if applicable) -->

### Double check

- [x] I have tested my parser changes locally with `poetry run test_parser "zone_key"`
- [x] I have run `pnpx prettier@2 --write .` and `poetry run format` in the top level directory to format my changes.
