### PR TITLE
Update unknown capacity for CA-SK

### DIFF
--- a/DATA_SOURCES.md
+++ b/DATA_SOURCES.md
@@ -216,7 +216,7 @@ For many European countries, data is available from [ENTSO-E](https://transparen
   - Wind: [Province of Manitoba](https://gov.mb.ca/sd/environment_and_biodiversity/energy/wind/windfarms.html)
 - Canada (Ontario): [IESO](http://www.ieso.ca/en/Power-Data/Supply-Overview/Transmission-Connected-Generation)
 - Canada (Québec): [Hydro-Québec](https://www.hydroquebec.com/generation/generating-stations.html)
-- Canada (Saskatchewan): [SaskPower](http://www.saskpower.com/our-power-future/our-electricity/)
+- Canada (Saskatchewan): [SaskPower](https://www.saskpower.com/Our-Power-Future)
 - Canada (Yukon)
   - Hydro: [YukonEnergy](https://yukonenergy.ca/energy-in-yukon/projects-facilities)
 - Chile (SEN, SEA, SEM): [energiaabierta.cl](http://energiaabierta.cl/visualizaciones/capacidad-instalada/)

--- a/config/zones/CA-SK.yaml
+++ b/config/zones/CA-SK.yaml
@@ -8,13 +8,30 @@ bounding_box:
   - - -100.86433964677866
     - 60.50005890629359
 capacity:
-  biomass: 16
-  coal: 1389
-  gas: 2160
-  hydro: 864
-  solar: 82
-  wind: 617
-  unknown: 324
+  coal:
+    - datetime: '2024-01-01'
+      source: saskpower.com
+      value: 1389
+  gas:
+    - datetime: '2024-01-01'
+      source: saskpower.com
+      value: 2065
+  hydro:
+    - datetime: '2024-01-01'
+      source: saskpower.com
+      value: 865
+  solar:
+    - datetime: '2024-01-01'
+      source: saskpower.com
+      value: 93
+  wind:
+    - datetime: '2024-01-01'
+      source: saskpower.com
+      value: 617
+  unknown:
+    - datetime: '2024-01-01'
+      source: saskpower.com
+      value: 324
 contributors:
   - VIKTORVAV99
 disclaimer: The hourly production mix is estimated based on the daily average production mix.

--- a/config/zones/CA-SK.yaml
+++ b/config/zones/CA-SK.yaml
@@ -14,7 +14,7 @@ capacity:
   hydro: 864
   solar: 82
   wind: 617
-  unknown: 26
+  unknown: 324
 contributors:
   - VIKTORVAV99
 disclaimer: The hourly production mix is estimated based on the daily average production mix.


### PR DESCRIPTION
## Issue

Capacity for unknown does not respect the data we parse for production

## Description

On https://www.saskpower.com/Our-Power-Future/Our-Electricity/Electrical-System/Where-Your-Power-Comes-From they explain how they map power plants to different power modes:
<img width="586" alt="Screenshot 2024-03-21 at 14 51 04" src="https://github.com/electricitymaps/electricitymaps-contrib/assets/32778266/2e055579-0d2d-4c9f-bee5-5ed2a797f702">

Capacities per plant are given here: https://www.saskpower.com/Our-Power-Future/Our-Electricity/Electrical-System/System-Map
<img width="611" alt="Screenshot 2024-03-21 at 14 51 14" src="https://github.com/electricitymaps/electricitymaps-contrib/assets/32778266/510fccc8-f931-406d-817c-60b20c26d4ce">

Note the PPA from Manitoba, if we do get data from there, then we should make sure to take that into account when computing the Manitoba capacities.

I also removed biomass as it's integrated into unknown

<!-- Explains the goal of this PR -->

### Preview

<!-- Please add screenshots and/or gif that shows visual changes (if applicable) -->

### Double check

- [x] I have tested my parser changes locally with `poetry run test_parser "zone_key"`
- [x] I have run `pnpx prettier@2 --write .` and `poetry run format` in the top level directory to format my changes.
