### PR TITLE
refactor(JP-KY): remove arrow usage

### DIFF
--- a/parsers/JP-KY.py
+++ b/parsers/JP-KY.py
@@ -10,7 +10,7 @@ from requests import Session, get
 
 from parsers import occtonet
 
-TIMEZONE = ZoneInfo('Asia/Tokyo')
+TIMEZONE = ZoneInfo("Asia/Tokyo")
 
 
 def fetch_production(
@@ -22,6 +22,7 @@ def fetch_production(
     """Requests the last known production mix (in MW) of a given zone."""
     if target_datetime:
         raise NotImplementedError("This parser is not yet able to parse past dates")
+
     data = {
         "zoneKey": zone_key,
         "datetime": None,
@@ -40,81 +41,85 @@ def fetch_production(
         "storage": {},
         "source": "www.kyuden.co.jp",
     }
+
     # url for consumption and solar
     url = "https://www.kyuden.co.jp/td_power_usages/pc.html"
     r = get(url)
     r.encoding = "utf-8"
     html = r.text
     soup = BeautifulSoup(html, "lxml")
-    # get hours, minutes
-    ts = soup.find("p", class_="puProgressNow__time").get_text()
-    hours = int(re.findall(r"[\d]+(?=時)", ts)[0])
-    minutes = int(re.findall(r"(?<=時)[\d]+(?=分)", ts)[0])
+
     # get date
-    ds = soup.find("div", class_="puChangeGraph")
-    date = re.findall(r"(?<=chart/chart)[\d]+(?=.gif)", str(ds))[0]
+    date_div = soup.find("div", class_="puChangeGraph")
+    date_str = re.findall(r"(?<=chart/chart)[\d]+(?=.gif)", str(date_div))[0]
+    year_str = date_str[:4]
+    month_str = date_str[4:6]
+    day_str = date_str[6:]
+
+    # get hours and minutes
+    time_str = soup.find("p", class_="puProgressNow__time").get_text()
+    hours = int(re.findall(r"[\d]+(?=時)", time_str)[0])
+    minutes = int(re.findall(r"(?<=時)[\d]+(?=分)", time_str)[0])
+
     # parse datetime
-    dt = f"{date[:4]}-{date[4:6]}-{date[6:]} {hours:02d}:{minutes:02d}"
-    dt = datetime.fromisoformat(dt).replace(tzinfo=TIMEZONE)
+    datetime_str = f"{year_str}-{month_str}-{day_str}T{hours:02d}:{minutes:02d}"
+    dt = datetime.fromisoformat(datetime_str).replace(tzinfo=TIMEZONE)
     data["datetime"] = dt
+
     # consumption
-    cons = soup.find("p", class_="puProgressNow__useAmount").get_text()
-    cons = re.findall(
+    consumption = soup.find("p", class_="puProgressNow__useAmount").get_text()
+    consumption = re.findall(
         r"(?<=使用量\xa0)[-+]?[.]?[\d]+(?:,\d\d\d)*[\.]?\d*(?:[eE][-+]?\d+)?(?=万kW／)",
-        cons,
+        consumption,
     )
-    cons = cons[0].replace(",", "")
-    # convert from 万kW to MW
-    cons = float(cons) * 10
+    consumption = consumption[0].replace(",", "")
+    # convert from 万kW to MW (note: '万' is the unit of 10K)
+    consumption = float(consumption) * 10
+
     # solar
     solar = soup.find("td", class_="puProgressSun__num").get_text()
     # convert from 万kW to MW
     solar = float(solar) * 10
 
-    # add nuclear power plants
-    # Sendai and Genkai
-    url_s = "".join(
-        [
-            "http://www.kyuden.co.jp/php/nuclear/sendai/rename.php?",
-            "A=s_power.fdat&B=ncp_state.fdat&_=1520532401043",
-        ]
+    # add two nuclear power plants at Sendai and Genkai
+    sendai_url = (
+        "http://www.kyuden.co.jp/php/nuclear/sendai/rename.php?"
+        "A=s_power.fdat&B=ncp_state.fdat&_=1520532401043"
     )
-    url_g = "".join(
-        [
-            "http://www.kyuden.co.jp/php/nuclear/genkai/rename.php?",
-            "A=g_power.fdat&B=ncp_state.fdat&_=1520532904073",
-        ]
+    genkai_url = (
+        "http://www.kyuden.co.jp/php/nuclear/genkai/rename.php?"
+        "A=g_power.fdat&B=ncp_state.fdat&_=1520532904073"
     )
-    sendai = get(url_s).text
-    sendai = re.findall(
-        r"(?<=gouki=)[-+]?[.]?[\d]+(?:,\d\d\d)*[\.]?\d*" + r"(?:[eE][-+]?\d+)?(?=&)",
-        sendai,
-    )
-    genkai = get(url_g).text
-    genkai = re.findall(
-        r"(?<=gouki=)[-+]?[.]?[\d]+(?:,\d\d\d)*[\.]?\d*" + r"(?:[eE][-+]?\d+)?(?=&)",
-        genkai,
-    )
-    nuclear = 0
-    for sendai_i in sendai:
-        nuclear += float(sendai_i)
-    for genkai_i in genkai:
-        nuclear += float(genkai_i)
+
+    sendai_raw_text = get(sendai_url).text
+    genkai_raw_text = get(genkai_url).text
+
+    regex = r"(?<=gouki=)[-+]?[.]?[\d]+(?:,\d\d\d)*[\.]?\d*" + r"(?:[eE][-+]?\d+)?(?=&)"
+    sendai_values = re.findall(regex, sendai_raw_text)
+    genkai_values = re.findall(regex, genkai_raw_text)
+
+    sendai_total = sum(map(float, sendai_values))
+    genkai_total = sum(map(float, genkai_values))
+
+    nuclear = sendai_total + genkai_total
     # convert from 万kW to MW
-    nuclear = nuclear * 10
+    nuclear *= 10
 
     # add the exchange JP-CG->JP-KY
-    exch_list = occtonet.fetch_exchange("JP-KY", "JP-CG")
+    exchanges = occtonet.fetch_exchange("JP-KY", "JP-CG")
     # find the nearest exchanges in time to consumption timestamp
-    nearest_exchanges = sorted(exch_list, key=lambda exch: abs(exch["datetime"] - dt))
+    nearest_exchanges = sorted(
+        exchanges, key=lambda exchange: abs(exchange["datetime"] - dt)
+    )
     # take the nearest exchange
-    exch = nearest_exchanges[0]
+    exchange = nearest_exchanges[0]
     # check that consumption and exchange timestamps are within a 15 minute window
-    if abs(dt - exch["datetime"]).seconds <= 900:
-        generation = cons - exch["netFlow"]
+    if abs(dt - exchange["datetime"]).seconds <= 900:
+        generation = consumption - exchange["netFlow"]
+        unknown = generation - nuclear - solar
         data["production"]["solar"] = solar
         data["production"]["nuclear"] = nuclear
-        data["production"]["unknown"] = generation - nuclear - solar
+        data["production"]["unknown"] = unknown
 
         return data
     else:

--- a/parsers/JP-KY.py
+++ b/parsers/JP-KY.py
@@ -59,7 +59,9 @@ def fetch_production(
     minutes = int(re.findall(r"(?<=時)[\d]+(?=分)", time_str)[0])
 
     # parse datetime
-    dt = datetime.strptime(date_str, '%Y%m%d').replace(hour=hours, minute=minutes, tzinfo=TIMEZONE)
+    dt = datetime.strptime(date_str, "%Y%m%d").replace(
+        hour=hours, minute=minutes, tzinfo=TIMEZONE
+    )
     data["datetime"] = dt
 
     # consumption

--- a/parsers/JP-KY.py
+++ b/parsers/JP-KY.py
@@ -2,15 +2,15 @@
 import re
 from datetime import datetime
 from logging import Logger, getLogger
-
-# The arrow library is used to handle datetimes
-import arrow
+from zoneinfo import ZoneInfo
 
 # The request library is used to fetch content through HTTP
 from bs4 import BeautifulSoup
 from requests import Session, get
 
 from parsers import occtonet
+
+TIMEZONE = ZoneInfo('Asia/Tokyo')
 
 
 def fetch_production(
@@ -55,7 +55,7 @@ def fetch_production(
     date = re.findall(r"(?<=chart/chart)[\d]+(?=.gif)", str(ds))[0]
     # parse datetime
     dt = f"{date[:4]}-{date[4:6]}-{date[6:]} {hours:02d}:{minutes:02d}"
-    dt = arrow.get(dt).replace(tzinfo="Asia/Tokyo").datetime
+    dt = datetime.fromisoformat(dt).replace(tzinfo=TIMEZONE)
     data["datetime"] = dt
     # consumption
     cons = soup.find("p", class_="puProgressNow__useAmount").get_text()

--- a/parsers/JP-KY.py
+++ b/parsers/JP-KY.py
@@ -52,9 +52,6 @@ def fetch_production(
     # get date
     date_div = soup.find("div", class_="puChangeGraph")
     date_str = re.findall(r"(?<=chart/chart)[\d]+(?=.gif)", str(date_div))[0]
-    year_str = date_str[:4]
-    month_str = date_str[4:6]
-    day_str = date_str[6:]
 
     # get hours and minutes
     time_str = soup.find("p", class_="puProgressNow__time").get_text()
@@ -62,8 +59,7 @@ def fetch_production(
     minutes = int(re.findall(r"(?<=時)[\d]+(?=分)", time_str)[0])
 
     # parse datetime
-    datetime_str = f"{year_str}-{month_str}-{day_str}T{hours:02d}:{minutes:02d}"
-    dt = datetime.fromisoformat(datetime_str).replace(tzinfo=TIMEZONE)
+    dt = datetime.strptime(date_str, '%Y%m%d').replace(hour=hours, minute=minutes, tzinfo=TIMEZONE)
     data["datetime"] = dt
 
     # consumption


### PR DESCRIPTION
## Issue

<!-- If you want to close an issue automatically when your PR is merged, write "Closes X" where X is the PR number. For example: Closes #000 -->
#6135

## Description

<!-- Explains the goal of this PR -->
- This PR removes `arrow` from `parsers/JP-KY.py`. (fa9f0b0f0731e12ab353fa16c863facb4ed7f69a)
- Also, I did some refactoring on the code to improve code readability. (72ca498896bbe114002a6699217267109a2a61be) (I run the test before/after the refactoring so the behavior should not be changed.)

### Preview

<!-- Please add screenshots and/or gif that shows visual changes (if applicable) -->
N/A

### Double check

- [x] I have tested my parser changes locally with `poetry run test_parser "zone_key"`
- [x] I have run `pnpx prettier@2 --write .` and `poetry run format` in the top level directory to format my changes.
