### PR TITLE
refactor(JP): remove arrow usage

### DIFF
--- a/parsers/JP.py
+++ b/parsers/JP.py
@@ -1,9 +1,8 @@
 #!/usr/bin/env python3
-from datetime import datetime, timedelta
+from datetime import datetime, time, timedelta
 from logging import Logger, getLogger
+from zoneinfo import ZoneInfo
 
-# The arrow library is used to handle datetimes
-import arrow
 import pandas as pd
 from requests import Session
 
@@ -36,6 +35,7 @@ sources = {
     "JP-ON": "www.okiden.co.jp/denki/",
 }
 ZONES_ONLY_LIVE = ["JP-TK", "JP-CB", "JP-SK"]
+TIMEZONE = ZoneInfo("Asia/Tokyo")
 
 
 def get_wind_capacity(datetime: datetime, zone_key, logger: Logger):
@@ -156,7 +156,12 @@ def fetch_consumption_df(
     """
     if target_datetime is not None and zone_key in ZONES_ONLY_LIVE:
         raise NotImplementedError("This parser can only fetch live data")
-    datestamp = arrow.get(target_datetime).to("Asia/Tokyo").strftime("%Y%m%d")
+
+    if target_datetime is None:
+        datestamp = datetime.now(tz=TIMEZONE).strftime("%Y%m%d")
+    else:
+        datestamp = target_datetime.replace(tzinfo=TIMEZONE).strftime("%Y%m%d")
+
     consumption_url = {
         "JP-HKD": f"http://denkiyoho.hepco.co.jp/area/data/juyo_01_{datestamp}.csv",
         "JP-TH": f"https://setsuden.nw.tohoku-epco.co.jp/common/demand/juyo_02_{datestamp}.csv",
@@ -210,9 +215,14 @@ def fetch_consumption_forecast(
     # Currently past dates not implemented for areas with no date in their demand csv files
     if target_datetime and zone_key == "JP-HKD":
         raise NotImplementedError("Past dates not yet implemented for selected region")
-    datestamp = arrow.get(target_datetime).to("Asia/Tokyo").strftime("%Y%m%d")
+
+    if target_datetime is None:
+        datestamp = datetime.now(tz=TIMEZONE).strftime("%Y%m%d")
+    else:
+        datestamp = target_datetime.replace(tzinfo=TIMEZONE).strftime("%Y%m%d")
+
     # Forecasts ahead of current date are not available
-    if datestamp > arrow.get().to("Asia/Tokyo").strftime("%Y%m%d"):
+    if datestamp > datetime.now(tz=TIMEZONE).strftime("%Y%m%d"):
         raise NotImplementedError(
             "Future dates(local time) not implemented for selected region"
         )
@@ -306,9 +316,10 @@ def fetch_price(
     df = df[(df["Date"] >= start.date()) & (df["Date"] <= target_datetime.date())]
 
     df["datetime"] = df.apply(
-        lambda row: arrow.get(row["Date"])
-        .shift(minutes=30 * (row["Period"] - 1))
-        .replace(tzinfo="Asia/Tokyo"),
+        lambda row: (
+            datetime.combine(row["Date"], time(0, 0))
+            - timedelta(minutes=30 * (row["Period"] - 1))
+        ).replace(tzinfo=TIMEZONE),
         axis=1,
     )
 
@@ -329,26 +340,19 @@ def fetch_price(
     return data
 
 
-def parse_dt(row):
+def parse_dt(row) -> datetime:
     """Parses timestamps from date and time."""
-    if "AM" in row["Time"] or "PM" in row["Time"]:
-        timestamp = (
-            arrow.get(
-                " ".join([row["Date"], row["Time"]]).replace("/", "-"),
-                "YYYY-M-D H:mm A",
-            )
-            .replace(tzinfo="Asia/Tokyo")
-            .datetime
+    date = row["Date"]
+    time = row["Time"]
+    datetime_str = f"{date} {time}".replace("/", "-")
+    if "AM" in time or "PM" in time:
+        return datetime.strptime(datetime_str, "%Y-%m-%d %I:%M %p").replace(
+            tzinfo=ZoneInfo("Asia/Tokyo")
         )
     else:
-        timestamp = (
-            arrow.get(
-                " ".join([row["Date"], row["Time"]]).replace("/", "-"), "YYYY-M-D H:mm"
-            )
-            .replace(tzinfo="Asia/Tokyo")
-            .datetime
+        return datetime.strptime(datetime_str, "%Y-%m-%d %H:%M").replace(
+            tzinfo=ZoneInfo("Asia/Tokyo")
         )
-    return timestamp
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Issue

<!-- If you want to close an issue automatically when your PR is merged, write "Closes X" where X is the PR number. For example: Closes #000 -->
#6135

## Description

<!-- Explains the goal of this PR -->
It looks like the price exchange data source was updated and failed to run it by `poetry run ./test_parser.py JP-KY price` so I couldn't test the change for `price` task.

Execution result on `master` and this branch:

```
poetry run ./test_parser.py JP-KY price
Traceback (most recent call last):
  File "/home/shuuji3/dev/electricitymap-contrib/./test_parser.py", line 137, in <module>
    print(test_parser())
  File "/home/shuuji3/dev/electricitymap-contrib/venv/lib/python3.10/site-packages/click/core.py", line 1134, in __call__
    return self.main(*args, **kwargs)
  File "/home/shuuji3/dev/electricitymap-contrib/venv/lib/python3.10/site-packages/click/core.py", line 1059, in main
    rv = self.invoke(ctx)
  File "/home/shuuji3/dev/electricitymap-contrib/venv/lib/python3.10/site-packages/click/core.py", line 1401, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/home/shuuji3/dev/electricitymap-contrib/venv/lib/python3.10/site-packages/click/core.py", line 767, in invoke
    return __callback(*args, **kwargs)
  File "/home/shuuji3/dev/electricitymap-contrib/./test_parser.py", line 66, in test_parser
    res = parser(
  File "/home/shuuji3/dev/electricitymap-contrib/parsers/lib/config.py", line 20, in wrapped_f
    result = f(*args, **kwargs)
  File "/home/shuuji3/dev/electricitymap-contrib/parsers/JP.py", line 284, in fetch_price
    df = pd.read_csv(url, encoding="shift-jis")
  File "/home/shuuji3/dev/electricitymap-contrib/venv/lib/python3.10/site-packages/pandas/util/_decorators.py", line 211, in wrapper
    return func(*args, **kwargs)
  File "/home/shuuji3/dev/electricitymap-contrib/venv/lib/python3.10/site-packages/pandas/util/_decorators.py", line 331, in wrapper
    return func(*args, **kwargs)
  File "/home/shuuji3/dev/electricitymap-contrib/venv/lib/python3.10/site-packages/pandas/io/parsers/readers.py", line 950, in read_csv
    return _read(filepath_or_buffer, kwds)
  File "/home/shuuji3/dev/electricitymap-contrib/venv/lib/python3.10/site-packages/pandas/io/parsers/readers.py", line 605, in _read
    parser = TextFileReader(filepath_or_buffer, **kwds)
  File "/home/shuuji3/dev/electricitymap-contrib/venv/lib/python3.10/site-packages/pandas/io/parsers/readers.py", line 1442, in __init__
    self._engine = self._make_engine(f, self.engine)
  File "/home/shuuji3/dev/electricitymap-contrib/venv/lib/python3.10/site-packages/pandas/io/parsers/readers.py", line 1753, in _make_engine
    return mapping[engine](f, **self.options)
  File "/home/shuuji3/dev/electricitymap-contrib/venv/lib/python3.10/site-packages/pandas/io/parsers/c_parser_wrapper.py", line 79, in __init__
    self._reader = parsers.TextReader(src, **kwds)
  File "pandas/_libs/parsers.pyx", line 547, in pandas._libs.parsers.TextReader.__cinit__
  File "pandas/_libs/parsers.pyx", line 636, in pandas._libs.parsers.TextReader._get_header
  File "pandas/_libs/parsers.pyx", line 852, in pandas._libs.parsers.TextReader._tokenize_rows
  File "pandas/_libs/parsers.pyx", line 1965, in pandas._libs.parsers.raise_parser_error
UnicodeDecodeError: 'shift_jis' codec can't decode byte 0x80 in position 140: illegal multibyte sequence
```

### Preview

<!-- Please add screenshots and/or gif that shows visual changes (if applicable) -->
N/A

### Double check

- [x] I have tested my parser changes locally with `poetry run test_parser "zone_key"`
- [x] I have run `pnpx prettier@2 --write .` and `poetry run format` in the top level directory to format my changes.
