### PR TITLE
refactor: remove arrow from CA_BC parser

### DIFF
--- a/parsers/CA_BC.py
+++ b/parsers/CA_BC.py
@@ -1,12 +1,10 @@
 #!/usr/bin/env python3
 
-# The arrow library is used to handle datetimes
 from datetime import datetime, timedelta
 from logging import Logger, getLogger
 from typing import Any
 from zoneinfo import ZoneInfo
 
-import arrow
 import pandas as pd
 from requests import Response, Session
 
@@ -94,9 +92,9 @@ def fetch_exchange(
     response = r.get(EXCHANGES_URL)
     obj = response.text.split("\r\n")[1].replace("\r", "").split(",")
 
-    datetime = arrow.get(
-        arrow.get(obj[0], "DD-MMM-YY HH:mm:ss").datetime, TIMEZONE
-    ).datetime
+    parsed_datetime = datetime.strptime(obj[0], "%d-%b-%y %H:%M:%S").replace(
+        tzinfo=TIMEZONE
+    )
 
     sortedZoneKeys = ZoneKey("->".join(sorted([zone_key1, zone_key2])))
     if sortedZoneKeys not in EXCHANGE_POSITION_MULTIPLIER:
@@ -106,7 +104,7 @@ def fetch_exchange(
     exchanges = ExchangeList(logger)
     exchanges.append(
         sortedZoneKeys,
-        datetime,
+        parsed_datetime,
         SOURCE,
         float(obj[position]) * multiplier,
     )


### PR DESCRIPTION
## Issue #6135 

<!-- If you want to close an issue automatically when your PR is merged, write "Closes X" where X is the PR number. For example: Closes #000 -->

## Description
Removes arrow dependency from CA_BC parser
renames datetime variable to parsed_datetime to avoid conflict
<!-- Explains the goal of this PR -->

### Preview

<!-- Please add screenshots and/or gif that shows visual changes (if applicable) -->

### Double check

- [X] I have tested my parser changes locally with `poetry run test_parser "zone_key"`
- [X] I have run `pnpx prettier@2 --write .` and `poetry run format` in the top level directory to format my changes.
