### PR TITLE
Fix: move flag and fix text length in breakdownchart

### DIFF
--- a/web/src/features/charts/bar-breakdown/BarBreakdownEmissionsChart.tsx
+++ b/web/src/features/charts/bar-breakdown/BarBreakdownEmissionsChart.tsx
@@ -7,7 +7,7 @@ import { ElectricityModeType, ZoneDetail, ZoneKey } from 'types';
 import { modeColor } from 'utils/constants';
 import { formatCo2 } from 'utils/formatting';
 
-import { LABEL_MAX_WIDTH, PADDING_X } from './constants';
+import { LABEL_MAX_WIDTH, PADDING_X, PADDING_Y } from './constants';
 import Axis from './elements/Axis';
 import HorizontalBar from './elements/HorizontalBar';
 import Row from './elements/Row';
@@ -115,7 +115,9 @@ function BarBreakdownEmissionsChart({
             onMouseOut={onExchangeRowMouseOut}
             isMobile={isMobile}
           >
-            <CountryFlag zoneId={d.zoneKey} className="pointer-events-none" />
+            <g transform={`translate(${LABEL_MAX_WIDTH - 1.5 * PADDING_Y - 12}, 0)`}>
+              <CountryFlag zoneId={d.zoneKey} className="pointer-events-none" />
+            </g>
             <HorizontalBar
               className="exchange"
               fill={'gray'}

--- a/web/src/features/charts/bar-breakdown/BarElectricityBreakdownChart.tsx
+++ b/web/src/features/charts/bar-breakdown/BarElectricityBreakdownChart.tsx
@@ -10,7 +10,7 @@ import { modeColor, TimeAverages } from 'utils/constants';
 import { formatEnergy, formatPower } from 'utils/formatting';
 import { timeAverageAtom } from 'utils/state/atoms';
 
-import { LABEL_MAX_WIDTH, PADDING_X } from './constants';
+import { LABEL_MAX_WIDTH, PADDING_X, PADDING_Y } from './constants';
 import Axis from './elements/Axis';
 import HorizontalBar from './elements/HorizontalBar';
 import Row from './elements/Row';
@@ -153,7 +153,9 @@ function BarElectricityBreakdownChart({
             onMouseOut={onExchangeRowMouseOut}
             isMobile={isMobile}
           >
-            <CountryFlag zoneId={d.zoneKey} className="pointer-events-none" />
+            <g transform={`translate(${LABEL_MAX_WIDTH - 1.5 * PADDING_Y - 12}, 0)`}>
+              <CountryFlag zoneId={d.zoneKey} className="pointer-events-none" />
+            </g>
 
             <HorizontalBar
               className="text-black/10 dark:text-white/10"

--- a/web/src/features/charts/bar-breakdown/constants.ts
+++ b/web/src/features/charts/bar-breakdown/constants.ts
@@ -1,4 +1,4 @@
-export const LABEL_MAX_WIDTH = 118;
+export const LABEL_MAX_WIDTH = 122;
 export const TEXT_ADJUST_Y = 11;
 export const ROW_HEIGHT = 13;
 export const PADDING_Y = 7;

--- a/web/src/features/charts/bar-breakdown/elements/Row.tsx
+++ b/web/src/features/charts/bar-breakdown/elements/Row.tsx
@@ -54,7 +54,7 @@ export default function Row({
         textAnchor="end"
         fill="currentColor"
         transform={`translate(${
-          LABEL_MAX_WIDTH - 1.5 * PADDING_Y - 16
+          LABEL_MAX_WIDTH - 1.5 * PADDING_Y - 18
         }, ${TEXT_ADJUST_Y})`}
       >
         {label}


### PR DESCRIPTION
## Issue

<!-- If you want to close an issue automatically when your PR is merged, write "Closes X" where X is the PR number. For example: Closes #000 -->

The text length in the breakdownchart was not correct after the production source legend was implemented. See the "before" screenshots, this is what it looks like on the app at the moment.

## Description

<!-- Explains the goal of this PR -->
This PR moves the flag so it is in the same place as the production source legend. I tried to fix the length without moving the flag, but I thought it looked much better when moving the flag. 

### Preview

<!-- Please add screenshots and/or gif that shows visual changes (if applicable) -->
Before:
<img width="396" alt="Screenshot 2024-03-27 at 13 48 06" src="https://github.com/electricitymaps/electricitymaps-contrib/assets/95029552/5261789d-7d91-4d30-8fa7-38c1d3949a75">
<img width="402" alt="Screenshot 2024-03-27 at 13 49 42" src="https://github.com/electricitymaps/electricitymaps-contrib/assets/95029552/d1ed347d-c3db-4caa-aed5-652674cbf31c">
Now:
<img width="398" alt="Screenshot 2024-03-27 at 13 50 37" src="https://github.com/electricitymaps/electricitymaps-contrib/assets/95029552/bb43cac2-86b2-4bb6-9bb9-cea6489251bc">
<img width="400" alt="Screenshot 2024-03-27 at 13 49 30" src="https://github.com/electricitymaps/electricitymaps-contrib/assets/95029552/3e699256-e358-40b0-a526-bc13517db65e">



### Double check

- [x] I have run `pnpx prettier@2 --write .` and `poetry run format` in the top level directory to format my changes.
