### PR TITLE
refactor_remove arrow from CA_NB

### DIFF
--- a/parsers/CA_NB.py
+++ b/parsers/CA_NB.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python3
 
-# The arrow library is used to handle datetimes consistently with other parsers
 from datetime import datetime, timezone
 from logging import Logger, getLogger
 from typing import Any


### PR DESCRIPTION
## Issue #6135 

<!-- If you want to close an issue automatically when your PR is merged, write "Closes X" where X is the PR number. For example: Closes #000 -->

## Description
Removes "usage" of arrow in CA_NB parser
Note: This parser does not seem to have used arrow at least since the upgrade to Python 3.10 - the only thing keeping this on the list when running `grep -El '(import arrow|arrow)' parsers/*.py` is a comment. The comment was removed.
<!-- Explains the goal of this PR -->

### Preview

<!-- Please add screenshots and/or gif that shows visual changes (if applicable) -->

### Double check

- [X] I have tested my parser changes locally with `poetry run test_parser "zone_key"`
- [X] I have run `pnpx prettier@2 --write .` and `poetry run format` in the top level directory to format my changes.
