### PR TITLE
improve datetime naiveness check

### DIFF
--- a/electricitymap/contrib/lib/models/events.py
+++ b/electricitymap/contrib/lib/models/events.py
@@ -1,4 +1,5 @@
 # pylint: disable=no-member
+import datetime as dt
 import math
 from abc import ABC, abstractmethod
 from collections.abc import Set
@@ -18,9 +19,9 @@ from electricitymap.contrib.lib.types import ZoneKey
 LOWER_DATETIME_BOUND = datetime(2000, 1, 1, tzinfo=timezone.utc)
 
 
-def _is_naive(dt: datetime) -> bool:
+def _is_naive(t: dt.datetime) -> bool:
     """Determines if a datetime object is naive."""
-    return dt.tzinfo is None or dt.tzinfo.utcoffset(dt) is None
+    return t.tzinfo is None or t.tzinfo.utcoffset(t) is None
 
 
 def _none_safe_round(value: float | None, precision: int = 6) -> float | None:
@@ -300,7 +301,7 @@ class Event(BaseModel, ABC):
         return v
 
     @validator("datetime")
-    def _validate_datetime(cls, v: datetime, values: dict[str, Any]):
+    def _validate_datetime(cls, v: dt.datetime, values: dict[str, Any]) -> datetime:
         if _is_naive(v):
             raise ValueError(f"Missing timezone: {v}")
         if v < LOWER_DATETIME_BOUND:
@@ -764,7 +765,7 @@ class Price(Event):
         return v
 
     @validator("datetime")
-    def _validate_datetime(cls, v: datetime) -> datetime:
+    def _validate_datetime(cls, v: dt.datetime) -> datetime:
         """Prices are given for the day ahead, so we should allow them to be in the future."""
         if _is_naive(v):
             raise ValueError(f"Missing timezone: {v}")

--- a/electricitymap/contrib/lib/models/events.py
+++ b/electricitymap/contrib/lib/models/events.py
@@ -301,7 +301,7 @@ class Event(BaseModel, ABC):
         return v
 
     @validator("datetime")
-    def _validate_datetime(cls, v: dt.datetime, values: dict[str, Any]) -> datetime:
+    def _validate_datetime(cls, v: dt.datetime, values: dict[str, Any]) -> dt.datetime:
         if _is_naive(v):
             raise ValueError(f"Missing timezone: {v}")
         if v < LOWER_DATETIME_BOUND:


### PR DESCRIPTION
## Description

A very small PR to improve datetime validation in event classes. 

According to the official [datetime docs](https://docs.python.org/3/library/datetime.html#determining-if-an-object-is-aware-or-naive):
> - d is aware iff: `d.tzinfo is not None and d.tzinfo.utcoffset(d) is not None`
> - d is naive iff: `d.tzinfo is None or d.tzinfo.utcoffset(d) is None`

This more exhaustive check shouldn't change much but It might help avoid some sneaky edge cases getting through.

### Double check

- [x] I have tested my parser changes locally with `poetry run test_parser "zone_key"`
- [x] I have run `pnpx prettier@2 --write .` and `poetry run format` in the top level directory to format my changes.
