### PR TITLE
fix(capacity_update): Sort values by datetime so they are always ordered

### DIFF
--- a/config/zones/CZ.yaml
+++ b/config/zones/CZ.yaml
@@ -12,6 +12,9 @@ capacity:
     - datetime: '2023-01-01'
       source: entsoe.eu
       value: 8360.0
+    - datetime: '2024-01-01'
+      source: entsoe.eu
+      value: 8400.0
   gas:
     - datetime: '2023-01-01'
       source: entsoe.eu
@@ -20,6 +23,9 @@ capacity:
     - datetime: '2023-01-01'
       source: entsoe.eu
       value: 1112.0
+    - datetime: '2024-01-01'
+      source: entsoe.eu
+      value: 1106.0
   hydro storage:
     - datetime: '2023-01-01'
       source: entsoe.eu
@@ -36,14 +42,23 @@ capacity:
     - datetime: '2023-01-01'
       source: entsoe.eu
       value: 2083.0
+    - datetime: '2024-01-01'
+      source: entsoe.eu
+      value: 3548.0
   unknown:
     - datetime: '2023-01-01'
       source: entsoe.eu
       value: 410.0
+    - datetime: '2024-01-01'
+      source: entsoe.eu
+      value: 460.0
   wind:
     - datetime: '2023-01-01'
       source: entsoe.eu
       value: 339.0
+    - datetime: '2024-01-01'
+      source: entsoe.eu
+      value: 342.0
 contributors:
   - corradio
   - Frantisek12

--- a/config/zones/EE.yaml
+++ b/config/zones/EE.yaml
@@ -48,7 +48,7 @@ capacity:
       value: 510.0
     - datetime: '2024-01-01'
       source: entsoe.eu
-      value: 680.0
+      value: 812.0
   unknown:
     - datetime: '2023-01-01'
       source: entsoe.eu
@@ -59,7 +59,7 @@ capacity:
       value: 317.0
     - datetime: '2024-01-01'
       source: entsoe.eu
-      value: 409.0
+      value: 447.0
 contributors:
   - corradio
   - nessie2013

--- a/config/zones/HU.yaml
+++ b/config/zones/HU.yaml
@@ -21,7 +21,7 @@ capacity:
       value: 3151.0
     - datetime: '2024-01-01'
       source: entsoe.eu
-      value: 3148.0
+      value: 3153.0
   geothermal:
     - datetime: '2023-01-01'
       source: entsoe.eu
@@ -44,7 +44,7 @@ capacity:
       value: 3300.0
     - datetime: '2024-01-01'
       source: entsoe.eu
-      value: 3378.0
+      value: 3477.0
   unknown:
     - datetime: '2023-01-01'
       source: entsoe.eu

--- a/config/zones/LU.yaml
+++ b/config/zones/LU.yaml
@@ -10,7 +10,7 @@ capacity:
       value: 68.0
     - datetime: '2024-01-01'
       source: entsoe.eu
-      value: 71.0
+      value: 107.0
   coal:
     - datetime: '2023-01-01'
       source: entsoe.eu
@@ -21,7 +21,7 @@ capacity:
       value: 70.0
     - datetime: '2024-01-01'
       source: entsoe.eu
-      value: 76.0
+      value: 72.0
   geothermal:
     - datetime: '2023-01-01'
       source: entsoe.eu
@@ -48,7 +48,7 @@ capacity:
       value: 300.0
     - datetime: '2024-01-01'
       source: entsoe.eu
-      value: 350.0
+      value: 415.0
   unknown:
     - datetime: '2023-01-01'
       source: entsoe.eu
@@ -59,7 +59,7 @@ capacity:
       value: 152.0
     - datetime: '2024-01-01'
       source: entsoe.eu
-      value: 174.0
+      value: 208.0
 contributors:
   - corradio
   - clawfire


### PR DESCRIPTION
## Issue
Values are not sorted so if we add older data later on for the outlier detection.

## Description

Sorts the values by datetime using `sorted()` and `itemgetter` as it's faster than a lambda as well as updating the ENTSO-E 2024 values.

### Preview

<!-- Please add screenshots and/or gif that shows visual changes (if applicable) -->

### Double check

- [x] I have tested my parser changes locally with `poetry run test_parser "zone_key"`
- [x] I have run `pnpx prettier@2 --write .` and `poetry run format` in the top level directory to format my changes.
