### PR TITLE
chore(app): use native tailwind annotation for 50%

### DIFF
--- a/web/src/components/Modal.tsx
+++ b/web/src/components/Modal.tsx
@@ -26,7 +26,7 @@ export default function Modal({
           // Avoid close button being auto-focused initially, as pressing space will otherwise close the modal
           onOpenAutoFocus={(event: Event) => event.preventDefault()}
           data-test-id={testId}
-          className={`fixed left-[50%] top-[50%] z-40 max-h-full w-[98vw] max-w-2xl -translate-x-[50%] -translate-y-[50%] rounded-xl bg-white/90 shadow-md backdrop-blur-sm sm:w-[90vw] dark:bg-gray-800/90 ${
+          className={`fixed left-1/2 top-1/2 z-40 max-h-full w-[98vw] max-w-2xl -translate-x-1/2 -translate-y-1/2 rounded-xl bg-white/90 shadow-md backdrop-blur-sm sm:w-[90vw] dark:bg-gray-800/90 ${
             fullWidth ? 'p-0' : 'p-4'
           }`}
         >

--- a/web/src/features/charts/BreakdownChart.tsx
+++ b/web/src/features/charts/BreakdownChart.tsx
@@ -63,7 +63,7 @@ function BreakdownChart({
         {isBreakdownGraphOverlayEnabled && (
           <div className="absolute top-0 h-full w-full">
             <div className=" h-full w-full bg-white opacity-50 dark:bg-gray-800" />
-            <div className="absolute left-[50%] top-[50%] z-10 -translate-x-1/2 -translate-y-1/2 whitespace-nowrap rounded-sm bg-gray-200 p-2 text-center text-sm shadow-lg dark:bg-gray-900">
+            <div className="absolute left-1/2 top-1/2 z-10 -translate-x-1/2 -translate-y-1/2 whitespace-nowrap rounded-sm bg-gray-200 p-2 text-center text-sm shadow-lg dark:bg-gray-900">
               Temporarily disabled for consumption. <br /> Switch to production view
             </div>
           </div>

--- a/web/src/features/charts/PriceChart.tsx
+++ b/web/src/features/charts/PriceChart.tsx
@@ -57,7 +57,7 @@ function PriceChart({ datetimes, timeAverage }: PriceChartProps) {
         {isPriceDisabled && (
           <div className="absolute top-0 -ml-3 h-full w-[115%]">
             <div className="h-full w-full rounded bg-white opacity-90 dark:bg-gray-900" />
-            <div className="absolute left-[45%] top-[50%] z-10 w-60 -translate-x-1/2 -translate-y-1/2 rounded-sm bg-gray-200 p-2 text-center text-sm shadow-lg dark:border dark:border-gray-700 dark:bg-gray-800">
+            <div className="absolute left-[45%] top-1/2 z-10 w-60 -translate-x-1/2 -translate-y-1/2 rounded-sm bg-gray-200 p-2 text-center text-sm shadow-lg dark:border dark:border-gray-700 dark:bg-gray-800">
               {t(`country-panel.disabledPriceReasons.${priceDisabledReason}`)}
             </div>
           </div>

--- a/web/src/features/charts/bar-breakdown/EmptyBarBreakdownChart.tsx
+++ b/web/src/features/charts/bar-breakdown/EmptyBarBreakdownChart.tsx
@@ -59,7 +59,7 @@ function EmptyBarBreakdownChart({
     <>
       <div style={{ width, height, position: 'absolute' }}>
         {overLayText && (
-          <div className="absolute left-[50%] top-[50%] z-10 -translate-x-1/2 -translate-y-1/2 rounded-sm bg-gray-200 p-2 text-center text-sm shadow-sm dark:bg-gray-900">
+          <div className="absolute left-1/2 top-1/2 z-10 -translate-x-1/2 -translate-y-1/2 rounded-sm bg-gray-200 p-2 text-center text-sm shadow-sm dark:bg-gray-900">
             {overLayText}
           </div>
         )}


### PR DESCRIPTION
## Issue

No real issue just though we should use native tailwind annotations for 50% and it was a quick fix.

## Description

Switches tailwind annotations matching `*-[50%]` to `*-1/2`

### Double check

- [x] I have run `pnpx prettier@2 --write .` and `poetry run format` in the top level directory to format my changes.
