### PR TITLE
refactor(gt): remove usage of arrow from GT parser

### DIFF
--- a/parsers/GT.py
+++ b/parsers/GT.py
@@ -4,21 +4,21 @@
 Mayorista (AMM) API.
 """
 
-# Standard library imports
 import collections
-from datetime import datetime
+from datetime import datetime, time, timedelta
 from logging import Logger, getLogger
+from typing import Literal
+from zoneinfo import ZoneInfo
 
-# Third-party library imports
-import arrow
 from requests import Session
 
-# Local library imports
 from parsers.lib import validation
 
 DEFAULT_ZONE_KEY = "GT"
+TIMEZONE = ZoneInfo("America/Guatemala")
+
 PRODUCTION_THRESHOLD = 10  # MW
-TIMEZONE = "America/Guatemala"
+
 DOMAIN = "wl12.amm.org.gt"
 URL = f"https://{DOMAIN}/GraficaPW/graficaCombustible"
 
@@ -32,21 +32,28 @@ def fetch_consumption(
     """Fetch a list of hourly consumption data, in MW, for the day of the
     requested date-time.
     """
-    date_time = arrow.get(target_datetime).to(TIMEZONE).floor("hour")
+
+    target_datetime = (
+        datetime.now(TIMEZONE)
+        if target_datetime is None
+        else target_datetime.astimezone(TIMEZONE)
+    )
+
+    api_data = _get_api_data(session, URL, target_datetime, target="consumption")
+
+    day_datetime = datetime.combine(
+        target_datetime, time(), tzinfo=TIMEZONE
+    )  # truncate to day
     results = [
         {
             "consumption": row["DEM SNI"],
-            "datetime": date_time.replace(hour=hour).datetime,
+            "datetime": day_datetime + timedelta(hours=hour),
             "source": DOMAIN,
             "zoneKey": zone_key,
         }
-        for hour, row in enumerate(
-            index_api_data_by_hour(get_api_data(session, URL, date_time))
-        )
+        for hour, row in enumerate(api_data)
     ]
-    # An hour's data isn't updated until the hour has passed, so the current
-    # (and future) hour(s) is/are not included in the results.
-    return results if target_datetime else results[: date_time.hour]
+    return results
 
 
 def fetch_production(
@@ -58,10 +65,21 @@ def fetch_production(
     """Fetch a list of hourly production data, in MW, for the day of the
     requested date-time.
     """
-    date_time = arrow.get(target_datetime).to(TIMEZONE).floor("hour")
+
+    target_datetime = (
+        datetime.now(TIMEZONE)
+        if target_datetime is None
+        else target_datetime.astimezone(TIMEZONE)
+    )
+
+    api_data = _get_api_data(session, URL, target_datetime, target="production")
+
+    day_datetime = datetime.combine(  # truncate to day
+        target_datetime, time(), tzinfo=TIMEZONE
+    )
     results = [
         {
-            "datetime": date_time.replace(hour=hour).datetime,
+            "datetime": day_datetime + timedelta(hours=hour),
             "production": {
                 "biomass": row["BIOGAS"] + row["BIOMASA"],
                 "coal": row["CARBÓN"],
@@ -78,15 +96,8 @@ def fetch_production(
             "source": DOMAIN,
             "zoneKey": zone_key,
         }
-        for hour, row in enumerate(
-            index_api_data_by_hour(get_api_data(session, URL, date_time))
-        )
+        for hour, row in enumerate(api_data)
     ]
-    # If the current day is selected, the API will return zero-filled future
-    # data until the end of the day. Truncate the list to avoid returning any
-    # future data.
-    if not target_datetime:
-        results = results[: date_time.hour + 1]
     return [
         validation.validate(
             result, logger, floor=PRODUCTION_THRESHOLD, remove_negative=True
@@ -95,36 +106,51 @@ def fetch_production(
     ]
 
 
-def index_api_data_by_hour(json):
-    """The JSON data returned by the API is a list of objects, each
-    representing one technology type. Collect this information into a list,
-    with the list index representing the hour of day.
-    """
+def _get_api_data(
+    session: Session,
+    url: str,
+    date_time: datetime,
+    target: Literal["consumption", "production"],
+) -> list[dict]:
+    """Get the JSON-formatted response from the AMM API for the desired date-time."""
+    session = session or Session()
+    response_payload = session.get(
+        url, params={"dt": date_time.strftime("%d/%m/%Y")}
+    ).json()
+
+    # The JSON data returned by the API is a list of objects, each
+    # representing one technology type. Collect this information into a list,
+    # with the list index representing the hour of day.
     results = [collections.defaultdict(float) for _ in range(24)]
-    for row in json:
+    for row in response_payload:
         # The API returns hours in the range [1, 24], so each one refers to the
         # past hour (e.g., 1 is the time period [00:00, 01:00)). Shift the hour
         # so each index represents the hour ahead and is in the range [0, 24),
         # e.g., hour 0 represents the period [00:00, 01:00).
         results[int(row["hora"]) - 1][row["tipo"]] = row["potencia"]
-    return results
 
+    is_historical_data = date_time.date() < datetime.now(TIMEZONE).date()
 
-def get_api_data(session: Session, url, date_time):
-    """Get the JSON-formatted response from the AMM API for the desired
-    date-time.
-    """
-    session = session or Session()
-    return session.get(url, params={"dt": date_time.format("DD/MM/YYYY")}).json()
+    # For live consumption data, an hour's data isn't updated until the hour has passed,
+    # so the current (and future) hour(s) should not be included in the results.
+    # For live production data, the API will return zero-filled future data until the end of the day,
+    # so future hours should not be included in the results.
+    cutoff_index = date_time.hour if target == "consumption" else date_time.hour + 1
+
+    return results if is_historical_data else results[:cutoff_index]
 
 
 if __name__ == "__main__":
     # Never used by the electricityMap back-end, but handy for testing.
+
+    target_datetime = datetime.fromisoformat("2022-01-01T12:00:00+00:00")
+
     print("fetch_production():")
     print(fetch_production(), end="\n\n")
-    print("fetch_production(target_datetime='2022-01-01T:12:00:00Z'):")
-    print(fetch_production(target_datetime="2022-01-01T12:00:00Z"), end="\n\n")
+    print(f"fetch_production(target_datetime={target_datetime.isoformat()!r}):")
+    print(fetch_production(target_datetime=target_datetime), end="\n\n")
+
     print("fetch_consumption():")
     print(fetch_consumption(), end="\n\n")
-    print("fetch_consumption(target_datetime='2022-01-01T:12:00:00Z'):")
-    print(fetch_consumption(target_datetime="2022-01-01T12:00:00Z"), end="\n\n")
+    print(f"fetch_consumption(target_datetime={target_datetime.isoformat()!r}):")
+    print(fetch_consumption(target_datetime=target_datetime), end="\n\n")


### PR DESCRIPTION
## Issue

https://github.com/electricitymaps/electricitymaps-contrib/issues/6135

## Description

This PR removes the dependency on `arrow` from the GT parser.

### Double check

- [x] I have tested my parser changes locally with `poetry run test_parser "zone_key"`
- [x] I have run `pnpx prettier@2 --write .` and `poetry run format` in the top level directory to format my changes.
