### PR TITLE
Add Vogtle 3 nuclear capacity

### DIFF
--- a/config/zones/US-SE-SOCO.yaml
+++ b/config/zones/US-SE-SOCO.yaml
@@ -36,6 +36,9 @@ capacity:
     - datetime: '2023-10-01'
       source: EIA.gov
       value: 7168.4
+    - datetime: '2024-04-01'
+      source: EIA.gov
+      value: 8285.4
   oil:
     - datetime: '2023-10-01'
       source: EIA.gov

--- a/config/zones/US-SE-SOCO.yaml
+++ b/config/zones/US-SE-SOCO.yaml
@@ -38,7 +38,7 @@ capacity:
       value: 7168.4
     - datetime: '2024-04-01'
       source: EIA.gov
-      value: 8285.4
+      value: 8282.4
   oil:
     - datetime: '2023-10-01'
       source: EIA.gov

--- a/config/zones/US.yaml
+++ b/config/zones/US.yaml
@@ -15,7 +15,7 @@ capacity:
   geothermal: 3910.8
   hydro: 79458.5
   hydro storage: 22008.1
-  nuclear: 101379.5
+  nuclear: 101376.5
   oil: 29667.3
   solar: 78322.4
   unknown: 1690.2

--- a/config/zones/US.yaml
+++ b/config/zones/US.yaml
@@ -15,7 +15,7 @@ capacity:
   geothermal: 3910.8
   hydro: 79458.5
   hydro storage: 22008.1
-  nuclear: 100262.5
+  nuclear: 101379.5
   oil: 29667.3
   solar: 78322.4
   unknown: 1690.2


### PR DESCRIPTION
## Issue
https://github.com/electricitymaps/electricitymaps-contrib/issues/6627
<!-- If you want to close an issue automatically when your PR is merged, write "Closes X" where X is the PR number. For example: Closes #000 -->

## Description
Implements a new nuclear generation capacity total for US-SE-SOCO & US zones. On April 1 2024 Vogtle Unit 4 reached 100% power, adding 1,114MW nameplate electrical capacity to the Southern Company grid.

🇺🇸 🦅 ⚛️
https://www.ajc.com/news/business/second-new-nuclear-reactor-at-georgia-powers-plant-vogtle-reaches-100-power/2O7O2SNFGJBRTA6HZEX7RA7XLM/
<!-- Explains the goal of this PR -->

### Preview
This PR will fix the reported capacity factor in US-SE-SOCO so it is no longer >100% for nuclear.
<!-- Please add screenshots and/or gif that shows visual changes (if applicable) -->
![image](https://github.com/electricitymaps/electricitymaps-contrib/assets/17505337/184a3c2a-064e-48c7-a3ed-83f6b467e45b)

### Double check

- [x] I have tested my parser changes locally with `poetry run test_parser "zone_key"`
- [x] I have run `pnpx prettier@2 --write .` and `poetry run format` in the top level directory to format my changes.
