### PR TITLE
fix(US-CAR-CPLW): update oil capacity

### DIFF
--- a/config/zones/US-CAR-CPLW.yaml
+++ b/config/zones/US-CAR-CPLW.yaml
@@ -36,7 +36,7 @@ capacity:
     - datetime: '2023-10-01'
       source: EIA.gov
       value: 0.0
-  #oil:
+  oil: null
   # There has been reported oil generation through the usage of diseal generators during extreme weather events.
       # We do not know yet the capacity of these generators, so we are not able to provide a value.
   solar:

--- a/config/zones/US-CAR-CPLW.yaml
+++ b/config/zones/US-CAR-CPLW.yaml
@@ -36,10 +36,8 @@ capacity:
     - datetime: '2023-10-01'
       source: EIA.gov
       value: 0.0
-  oil:
-    - datetime: '2023-10-01'
-      source: EIA.gov
-      value: null # There has been reported oil generation through the usage of diseal generators during extreme weather events.
+  #oil:
+  # There has been reported oil generation through the usage of diseal generators during extreme weather events.
       # We do not know yet the capacity of these generators, so we are not able to provide a value.
   solar:
     - datetime: '2023-10-01'

--- a/config/zones/US-CAR-CPLW.yaml
+++ b/config/zones/US-CAR-CPLW.yaml
@@ -38,7 +38,7 @@ capacity:
       value: 0.0
   oil: null
   # There has been reported oil generation through the usage of diseal generators during extreme weather events.
-      # We do not know yet the capacity of these generators, so we are not able to provide a value.
+  # We do not know yet the capacity of these generators, so we are not able to provide a value.
   solar:
     - datetime: '2023-10-01'
       source: EIA.gov

--- a/config/zones/US-CAR-CPLW.yaml
+++ b/config/zones/US-CAR-CPLW.yaml
@@ -39,7 +39,8 @@ capacity:
   oil:
     - datetime: '2023-10-01'
       source: EIA.gov
-      value: 0.0
+      value: null # There has been reported oil generation through the usage of diseal generators during extreme weather events.
+      # We do not know yet the capacity of these generators, so we are not able to provide a value.
   solar:
     - datetime: '2023-10-01'
       source: EIA.gov


### PR DESCRIPTION
## Issue

US-CAR-CPLW has 0 installed capacity of oil generators but it seems that between 18/01 and 19/01 they reported generating around 130 MWh to the EIA for a short period of time. This causes those points to be flagged by the outlier detection.
However it seems plausible that due to extreme weather conditions they might have activated diesel generators. The data is now more than 3 months old, previously the data was full of 0s due to an issue on the EIA's. It seems unlikely that the data will be corrected again so this might be the true final value.

The data gets flagged by our internal validation.

## Description

Update the capacity to null to better reflect the state of our knowledge.



### Double check

- [ ] I have tested my parser changes locally with `poetry run test_parser "zone_key"`
- [ ] I have run `pnpx prettier@2 --write .` and `poetry run format` in the top level directory to format my changes.
