### PR TITLE
fix(capacity): allow null in the new capacity format

### DIFF
--- a/config/zones/US-CAR-CPLW.yaml
+++ b/config/zones/US-CAR-CPLW.yaml
@@ -36,9 +36,10 @@ capacity:
     - datetime: '2023-10-01'
       source: EIA.gov
       value: 0.0
-  oil: null
-  # There has been reported oil generation through the usage of diseal generators during extreme weather events.
-  # We do not know yet the capacity of these generators, so we are not able to provide a value.
+  oil:
+  - datetime: '2023-10-01'
+    value: null
+    comment: There has been reported oil generation through the usage of diseal generators during extreme weather events. We do not know yet the capacity of these generators, so we are not able to provide a value.
   solar:
     - datetime: '2023-10-01'
       source: EIA.gov

--- a/config/zones/US-CAR-CPLW.yaml
+++ b/config/zones/US-CAR-CPLW.yaml
@@ -37,9 +37,9 @@ capacity:
       source: EIA.gov
       value: 0.0
   oil:
-  - datetime: '2023-10-01'
-    value: null
-    comment: There has been reported oil generation through the usage of diseal generators during extreme weather events. We do not know yet the capacity of these generators, so we are not able to provide a value.
+    - datetime: '2023-10-01'
+      value: null
+      comment: There has been reported oil generation through the usage of diseal generators during extreme weather events. We do not know yet the capacity of these generators, so we are not able to provide a value.
   solar:
     - datetime: '2023-10-01'
       source: EIA.gov

--- a/electricitymap/contrib/config/model.py
+++ b/electricitymap/contrib/config/model.py
@@ -46,7 +46,7 @@ class ModeCapacity(StrictBaseModelWithAlias):
     comment: str | None = Field(None, alias="_comment")
     url: str | list[str] | None = Field(None, alias="_url")
     datetime: date | datetime | None
-    value: NonNegativeFloat
+    value: NonNegativeFloat | None
 
 
 class Capacity(StrictBaseModel):
@@ -267,12 +267,12 @@ class ModeEmissionFactor(StrictBaseModelWithAlias):
 
 
 class AllModesEmissionFactors(StrictBaseModelWithAlias):
-    battery_charge: None | (
-        list[ModeEmissionFactor] | ModeEmissionFactor
-    ) = Field(None, alias="battery charge")
-    battery_discharge: None | (
-        list[ModeEmissionFactor] | ModeEmissionFactor
-    ) = Field(None, alias="battery discharge")
+    battery_charge: None | (list[ModeEmissionFactor] | ModeEmissionFactor) = Field(
+        None, alias="battery charge"
+    )
+    battery_discharge: None | (list[ModeEmissionFactor] | ModeEmissionFactor) = Field(
+        None, alias="battery discharge"
+    )
     biomass: list[ModeEmissionFactor] | ModeEmissionFactor | None
     coal: list[ModeEmissionFactor] | ModeEmissionFactor | None
     gas: list[ModeEmissionFactor] | ModeEmissionFactor | None
@@ -280,9 +280,9 @@ class AllModesEmissionFactors(StrictBaseModelWithAlias):
     hydro_charge: list[ModeEmissionFactor] | ModeEmissionFactor | None = Field(
         None, alias="hydro charge"
     )
-    hydro_discharge: None | (
-        list[ModeEmissionFactor] | ModeEmissionFactor
-    ) = Field(None, alias="hydro discharge")
+    hydro_discharge: None | (list[ModeEmissionFactor] | ModeEmissionFactor) = Field(
+        None, alias="hydro discharge"
+    )
     hydro: list[ModeEmissionFactor] | ModeEmissionFactor | None
     nuclear: list[ModeEmissionFactor] | ModeEmissionFactor | None
     oil: list[ModeEmissionFactor] | ModeEmissionFactor | None

--- a/electricitymap/contrib/config/model.py
+++ b/electricitymap/contrib/config/model.py
@@ -267,12 +267,12 @@ class ModeEmissionFactor(StrictBaseModelWithAlias):
 
 
 class AllModesEmissionFactors(StrictBaseModelWithAlias):
-    battery_charge: None | (list[ModeEmissionFactor] | ModeEmissionFactor) = Field(
-        None, alias="battery charge"
-    )
-    battery_discharge: None | (list[ModeEmissionFactor] | ModeEmissionFactor) = Field(
-        None, alias="battery discharge"
-    )
+    battery_charge: None | (
+        list[ModeEmissionFactor] | ModeEmissionFactor
+    ) = Field(None, alias="battery charge")
+    battery_discharge: None | (
+        list[ModeEmissionFactor] | ModeEmissionFactor
+    ) = Field(None, alias="battery discharge")
     biomass: list[ModeEmissionFactor] | ModeEmissionFactor | None
     coal: list[ModeEmissionFactor] | ModeEmissionFactor | None
     gas: list[ModeEmissionFactor] | ModeEmissionFactor | None
@@ -280,9 +280,9 @@ class AllModesEmissionFactors(StrictBaseModelWithAlias):
     hydro_charge: list[ModeEmissionFactor] | ModeEmissionFactor | None = Field(
         None, alias="hydro charge"
     )
-    hydro_discharge: None | (list[ModeEmissionFactor] | ModeEmissionFactor) = Field(
-        None, alias="hydro discharge"
-    )
+    hydro_discharge: None | (
+        list[ModeEmissionFactor] | ModeEmissionFactor
+    ) = Field(None, alias="hydro discharge")
     hydro: list[ModeEmissionFactor] | ModeEmissionFactor | None
     nuclear: list[ModeEmissionFactor] | ModeEmissionFactor | None
     oil: list[ModeEmissionFactor] | ModeEmissionFactor | None


### PR DESCRIPTION
## Issue

The previous change was not properly working and did not adhere to the fact that we want to move away from the old capacity format.

Therefore recreate the capacity timestamp with a null value. It is required that we now allow null values there.
