### PR TITLE
fix: Update GE exchange configurations to use ENTSOE.py instead of GE.py

### DIFF
--- a/config/exchanges/AM_GE.yaml
+++ b/config/exchanges/AM_GE.yaml
@@ -2,6 +2,6 @@ lonlat:
   - 44.313
   - 41.205
 parsers:
-  exchange: GE.fetch_exchange
+  exchange: ENTSOE.fetch_exchange
   exchangeForecast: ENTSOE.fetch_exchange_forecast
 rotation: 0

--- a/config/exchanges/AZ_GE.yaml
+++ b/config/exchanges/AZ_GE.yaml
@@ -2,6 +2,6 @@ lonlat:
   - 45.153
   - 41.398
 parsers:
-  exchange: GE.fetch_exchange
+  exchange: ENTSOE.fetch_exchange
   exchangeForecast: ENTSOE.fetch_exchange_forecast
 rotation: -35

--- a/config/exchanges/GE_TR.yaml
+++ b/config/exchanges/GE_TR.yaml
@@ -5,6 +5,6 @@ lonlat:
   - 42.814
   - 41.562
 parsers:
-  exchange: GE.fetch_exchange
+  exchange: ENTSOE.fetch_exchange
   exchangeForecast: ENTSOE.fetch_exchange_forecast
 rotation: -135


### PR DESCRIPTION
## Issue

We were polluting the database with a mix of ENTSOE and GE values.

Slack discussion here: https://electricitymaps.slack.com/archives/C01PWQYKX2R/p1712559608324009

## Description

Switches to use ENTSOE only to avoid the polluted data and ensure it gets properly overridden if it's updated later on.


### Double check

- [x] I have tested my parser changes locally with `poetry run test_parser "zone_key"`
- [x] I have run `pnpx prettier@2 --write .` and `poetry run format` in the top level directory to format my changes.
