### PR TITLE
refractor(app): Change App.tsx to lazy load TimeControllerWrapper component

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -10,7 +10,6 @@ import Toast from 'components/Toast';
 import ErrorComponent from 'features/error-boundary/ErrorBoundary';
 import FeatureFlagsManager from 'features/feature-flags/FeatureFlagsManager';
 import Header from 'features/header/Header';
-import TimeControllerWrapper from 'features/time/TimeControllerWrapper';
 import { useDarkMode } from 'hooks/theme';
 import { lazy, ReactElement, Suspense, useEffect, useLayoutEffect } from 'react';
 import i18n from 'translation/i18n';
@@ -22,6 +21,7 @@ const LegendContainer = lazy(() => import('components/legend/LegendContainer'));
 const FAQModal = lazy(() => import('features/modals/FAQModal'));
 const InfoModal = lazy(() => import('features/modals/InfoModal'));
 const SettingsModal = lazy(() => import('features/modals/SettingsModal'));
+const TimeControllerWrapper = lazy(() => import('features/time/TimeControllerWrapper'));
 
 const isProduction = import.meta.env.PROD;
 


### PR DESCRIPTION
## Issue
Our index bundle is render blocking as it tells the browser what other bundles are needed.

## Description
This lazy loads TimeControllerWrapper so we load it independently instead and therefore can load the index bundle faster and start all subsequent loading sooner as well.

### Preview
Before:
```
dist/assets/index-d9958387.js            425.85 kB │ gzip: 135.21 kB │ map: 2,775.15 kB
```
After:
```
dist/assets/TimeControllerWrapper-ec4c9ed1.js  134.49 kB │ gzip:  40.83 kB │ map:   633.61 kB
...
dist/assets/index-acb733e4.js                  276.05 kB │ gzip:  89.76 kB │ map: 2,047.84 kB
```

### Double check

- [x] I have run `pnpx prettier@2 --write .` and `poetry run format` in the top level directory to format my changes.
