### PR TITLE
fix(app): Fix the headers target path

### DIFF
--- a/web/public/_headers
+++ b/web/public/_headers
@@ -1,4 +1,4 @@
-/*
+/*.html
 # Set early hint headers to improve first load performance
 # === Preload fonts ===
   Link: </fonts/Inter.var.woff2>; rel=preload; as=font; type=font/woff2; crossorigin


### PR DESCRIPTION
## Issue
I underestimated how eagerly CloudFlare would apply these and thought it was just for HTML content, turns out it's for all content causing this issue:
<img width="613" alt="image" src="https://github.com/electricitymaps/electricitymaps-contrib/assets/30777521/82c7150d-187e-458f-a3ed-13103c071d32">


## Description

Hopefully by adding the .html extension we can limit this to just our HTML index file.
