### PR TITLE
Silkebonnen/avo 187 add data source accordions to other graphs

### DIFF
--- a/web/src/features/charts/BreakdownChart.tsx
+++ b/web/src/features/charts/BreakdownChart.tsx
@@ -1,8 +1,13 @@
+import Accordion from 'components/Accordion';
 import { max, sum } from 'd3-array';
+import Divider from 'features/panels/zone/Divider';
+import { WindTurbineIcon } from 'icons/windTurbineIcon';
 import { useTranslation } from 'react-i18next';
 import { Mode, TimeAverages } from 'utils/constants';
 import { formatCo2 } from 'utils/formatting';
+import { dataSourcesCollapsedBreakdown } from 'utils/state/atoms';
 
+import { DataSources } from './bar-breakdown/DataSources';
 import { ChartTitle } from './ChartTitle';
 import AreaGraph from './elements/AreaGraph';
 import { getBadgeText, noop } from './graphUtils';
@@ -21,7 +26,7 @@ function BreakdownChart({
   datetimes,
   timeAverage,
 }: BreakdownChartProps) {
-  const { data, mixMode } = useBreakdownChartData();
+  const { sources, data, mixMode } = useBreakdownChartData();
   const { t } = useTranslation();
 
   if (!data) {
@@ -93,6 +98,18 @@ function BreakdownChart({
           dangerouslySetInnerHTML={{ __html: t('country-panel.exchangesAreMissing') }}
         />
       )}
+      <Divider />
+      <Accordion
+        title={t('data-sources.title')}
+        className="text-md"
+        isCollapsedAtom={dataSourcesCollapsedBreakdown}
+      >
+        <DataSources
+          title={t('data-sources.power')}
+          icon={<WindTurbineIcon />}
+          sources={sources}
+        />
+      </Accordion>
     </>
   );
 }

--- a/web/src/features/charts/CarbonChart.tsx
+++ b/web/src/features/charts/CarbonChart.tsx
@@ -1,6 +1,11 @@
+import Accordion from 'components/Accordion';
+import Divider from 'features/panels/zone/Divider';
+import { IndustryIcon } from 'icons/industryIcon';
 import { useTranslation } from 'react-i18next';
 import { TimeAverages } from 'utils/constants';
+import { dataSourcesCollapsedEmission } from 'utils/state/atoms';
 
+import { DataSources } from './bar-breakdown/DataSources';
 import { ChartTitle } from './ChartTitle';
 import AreaGraph from './elements/AreaGraph';
 import { getBadgeText, noop } from './graphUtils';
@@ -14,7 +19,8 @@ interface CarbonChartProps {
 }
 
 function CarbonChart({ datetimes, timeAverage }: CarbonChartProps) {
-  const { data, isLoading, isError } = useCarbonChartData();
+  const { data, emissionSourceToProductionSource, isLoading, isError } =
+    useCarbonChartData();
   const { t } = useTranslation();
 
   if (isLoading || isError || !data) {
@@ -50,6 +56,18 @@ function CarbonChart({ datetimes, timeAverage }: CarbonChartProps) {
         selectedTimeAggregate={timeAverage}
         tooltip={CarbonChartTooltip}
       />
+      <Divider />
+      <Accordion
+        title={t('data-sources.title')}
+        className="text-md"
+        isCollapsedAtom={dataSourcesCollapsedEmission}
+      >
+        <DataSources
+          title={t('data-sources.emission')}
+          icon={<IndustryIcon />}
+          sources={[...emissionSourceToProductionSource.keys()].sort()}
+        />
+      </Accordion>
     </>
   );
 }

--- a/web/src/features/charts/EmissionChart.tsx
+++ b/web/src/features/charts/EmissionChart.tsx
@@ -1,7 +1,12 @@
+import Accordion from 'components/Accordion';
+import Divider from 'features/panels/zone/Divider';
+import { IndustryIcon } from 'icons/industryIcon';
 import { useTranslation } from 'react-i18next';
 import { TimeAverages } from 'utils/constants';
 import { formatCo2 } from 'utils/formatting';
+import { dataSourcesCollapsedEmission } from 'utils/state/atoms';
 
+import { DataSources } from './bar-breakdown/DataSources';
 import { ChartTitle } from './ChartTitle';
 import AreaGraph from './elements/AreaGraph';
 import { getBadgeText, noop } from './graphUtils';
@@ -14,7 +19,8 @@ interface EmissionChartProps {
 }
 
 function EmissionChart({ timeAverage, datetimes }: EmissionChartProps) {
-  const { data, isLoading, isError } = useEmissionChartData();
+  const { data, emissionSourceToProductionSource, isLoading, isError } =
+    useEmissionChartData();
   const { t } = useTranslation();
   if (isLoading || isError || !data) {
     return null;
@@ -45,6 +51,18 @@ function EmissionChart({ timeAverage, datetimes }: EmissionChartProps) {
         tooltip={EmissionChartTooltip}
         formatTick={formatAxisTick}
       />
+      <Divider />
+      <Accordion
+        title={t('data-sources.title')}
+        className="text-md"
+        isCollapsedAtom={dataSourcesCollapsedEmission}
+      >
+        <DataSources
+          title={t('data-sources.emission')}
+          icon={<IndustryIcon />}
+          sources={[...emissionSourceToProductionSource.keys()].sort()}
+        />
+      </Accordion>
     </>
   );
 }

--- a/web/src/features/charts/bar-breakdown/BarBreakdownChart.tsx
+++ b/web/src/features/charts/bar-breakdown/BarBreakdownChart.tsx
@@ -10,7 +10,10 @@ import { useTranslation } from 'react-i18next';
 import { HiXMark } from 'react-icons/hi2';
 import { ElectricityModeType, ZoneDetail, ZoneKey } from 'types';
 import trackEvent from 'utils/analytics';
-import { dataSourcesCollapsed, displayByEmissionsAtom } from 'utils/state/atoms';
+import {
+  dataSourcesCollapsedBarBreakdown,
+  displayByEmissionsAtom,
+} from 'utils/state/atoms';
 import { useBreakpoint } from 'utils/styling';
 import { useReferenceWidthHeightObserver } from 'utils/viewport';
 
@@ -162,12 +165,12 @@ function BarBreakdownChart({
           }}
           title={t('data-sources.title')}
           className="text-md"
-          isCollapsedAtom={dataSourcesCollapsed}
+          isCollapsedAtom={dataSourcesCollapsedBarBreakdown}
         >
           <div>
             {currentZoneDetail?.capacitySources && (
               <DataSources
-                title="Installed capacity data"
+                title={t('data-sources.capacity')}
                 icon={<UtilityPoleIcon />}
                 sources={[
                   ...GetSourceArrayFromDictionary(currentZoneDetail?.capacitySources),
@@ -176,14 +179,14 @@ function BarBreakdownChart({
             )}
             {currentZoneDetail?.source && (
               <DataSources
-                title="Power generation data"
+                title={t('data-sources.power')}
                 icon={<WindTurbineIcon />}
                 sources={currentZoneDetail?.source}
               />
             )}
             {emissionData && (
               <DataSources
-                title="Emission factor data"
+                title={t('data-sources.emission')}
                 icon={<IndustryIcon />}
                 sources={emissionData}
               />

--- a/web/src/features/charts/bar-breakdown/DataSources.tsx
+++ b/web/src/features/charts/bar-breakdown/DataSources.tsx
@@ -15,7 +15,7 @@ export function DataSources({
       </div>
       <div className="flex flex-col gap-2 pl-5">
         {sources.map((source, index) => (
-          <div key={index} className="text-xm">
+          <div key={index} className="text-sm">
             {source}
           </div>
         ))}

--- a/web/src/features/charts/hooks/useBreakdownChartData.ts
+++ b/web/src/features/charts/hooks/useBreakdownChartData.ts
@@ -9,6 +9,7 @@ import {
   ElectricityStorageKeyType,
   ElectricityStorageType,
   ZoneDetail,
+  ZoneDetails,
 } from 'types';
 import {
   Mode,
@@ -129,7 +130,23 @@ export default function useBreakdownChartData() {
     layerStroke: undefined,
   };
 
-  return { data: result, mixMode, isLoading, isError };
+  const sources = getSources(zoneData);
+
+  return { sources, data: result, mixMode, isLoading, isError };
+}
+
+function getSources(zoneData: ZoneDetails) {
+  const sourceSet = new Set<string>();
+
+  for (const state of Object.values(zoneData.zoneStates)) {
+    const currentSources = state.source;
+    for (const source of currentSources) {
+      sourceSet.add(source);
+    }
+  }
+
+  const sources = [...sourceSet];
+  return sources;
 }
 
 function getStorageValue(

--- a/web/src/features/charts/hooks/useCarbonChartData.ts
+++ b/web/src/features/charts/hooks/useCarbonChartData.ts
@@ -4,6 +4,7 @@ import { useAtom } from 'jotai';
 import { getCO2IntensityByMode } from 'utils/helpers';
 import { productionConsumptionAtom } from 'utils/state/atoms';
 
+import { getEmissionData } from '../bar-breakdown/utils';
 import { AreaGraphElement } from '../types';
 
 export function useCarbonChartData() {
@@ -49,5 +50,7 @@ export function useCarbonChartData() {
     layerFill,
   };
 
-  return { data: result, isLoading, isError };
+  const emissionSourceToProductionSource = getEmissionData(data);
+
+  return { data: result, emissionSourceToProductionSource, isLoading, isError };
 }

--- a/web/src/features/charts/hooks/useEmissionChartData.ts
+++ b/web/src/features/charts/hooks/useEmissionChartData.ts
@@ -4,6 +4,7 @@ import { scaleLinear } from 'd3-scale';
 import { useAtom } from 'jotai';
 import { productionConsumptionAtom } from 'utils/state/atoms';
 
+import { getEmissionData } from '../bar-breakdown/utils';
 import { getTotalEmissionsAvailable } from '../graphUtils';
 import { AreaGraphElement } from '../types';
 
@@ -45,5 +46,7 @@ export function useEmissionChartData() {
     layerStroke: undefined,
   };
 
-  return { data: result, isLoading, isError };
+  const emissionSourceToProductionSource = getEmissionData(data);
+
+  return { data: result, emissionSourceToProductionSource, isLoading, isError };
 }

--- a/web/src/utils/state/atoms.ts
+++ b/web/src/utils/state/atoms.ts
@@ -49,3 +49,5 @@ export const colorblindModeAtom = atomWithStorage('colorblindModeEnabled', false
 export const dataSourcesCollapsedBarBreakdown = atom(true);
 
 export const dataSourcesCollapsedBreakdown = atom(true);
+
+export const dataSourcesCollapsedEmission = atom(true);

--- a/web/src/utils/state/atoms.ts
+++ b/web/src/utils/state/atoms.ts
@@ -46,4 +46,6 @@ export const feedbackCardCollapsedNumberAtom = atom(0);
 
 export const colorblindModeAtom = atomWithStorage('colorblindModeEnabled', false);
 
-export const dataSourcesCollapsed = atom(true);
+export const dataSourcesCollapsedBarBreakdown = atom(true);
+
+export const dataSourcesCollapsedBreakdown = atom(true);


### PR DESCRIPTION
## Issue

<!-- If you want to close an issue automatically when your PR is merged, write "Closes X" where X is the PR number. For example: Closes #000 -->
[AVO-187](https://linear.app/electricitymaps/issue/AVO-187/add-data-source-accordions-to-other-graphs)

## Description

<!-- Explains the goal of this PR -->
The goal of this PR is to add the data source accordion to the emissionchart, carbonchart and breakdownchart.

### Preview

<!-- Please add screenshots and/or gif that shows visual changes (if applicable) -->

### Double check

- [ ] I have run `pnpx prettier@2 --write .` and `poetry run format` in the top level directory to format my changes.
