### PR TITLE
perf: Use itemgetter instead of lambda

### DIFF
--- a/electricitymap/contrib/lib/models/event_lists.py
+++ b/electricitymap/contrib/lib/models/event_lists.py
@@ -2,6 +2,7 @@ from abc import ABC, abstractmethod
 from collections.abc import Sequence
 from datetime import datetime
 from logging import Logger
+from operator import itemgetter
 from typing import Any
 
 import pandas as pd
@@ -60,7 +61,7 @@ class EventList(ABC):
 
     def to_list(self) -> list[dict[str, Any]]:
         return sorted(
-            [event.to_dict() for event in self.events], key=lambda x: x["datetime"]
+            [event.to_dict() for event in self.events], key=itemgetter("datetime")
         )
 
     @property


### PR DESCRIPTION
## Description
Itemgetter is slightly faster than using a lambda so we should probably use that.

From a stack overflow thread:
| List size | lambda | itemgetter |
|-----------|--------|------------|
| 100       | 8.19   | 5.09       |
| 1000      | 81.4   | 47         |
| 10000     | 855    | 498        |
| 100000    | 14600  | 10100      |
| 1000000   | 172000 | 131000     |
##### Source: https://stackoverflow.com/questions/17243620/operator-itemgetter-or-lambda

### Double check

- [x] I have tested my parser changes locally with `poetry run test_parser "zone_key"`
- [x] I have run `pnpx prettier@2 --write .` and `poetry run format` in the top level directory to format my changes.
