### PR TITLE
chore(web): update outage message description and improve some typing

### DIFF
--- a/web/public/locales/en.json
+++ b/web/public/locales/en.json
@@ -160,7 +160,7 @@
     "threshold_filtered": {
       "title": "Missing data",
       "pill": "Data outage",
-      "body": "The data provider for this zone has been missing data for a prolonged period. We are monitoring the issue and the zone will update as soon as data becomes available again."
+      "body": "The data provider for this zone has been missing data for a prolonged period. We are monitoring the issue and will update the zone as soon as the data meets our quality threshold again."
     },
     "outage": {
       "title": "Ongoing issues",

--- a/web/src/features/panels/zone/EstimationCard.cy.tsx
+++ b/web/src/features/panels/zone/EstimationCard.cy.tsx
@@ -14,7 +14,7 @@ describe('EstimationCard with FeedbackCard', () => {
           <EstimationCard
             cardType="estimated"
             estimationMethod="ESTIMATED_CONSTRUCT_BREAKDOWN"
-            outageMessage={undefined}
+            zoneMessage={undefined}
           />
         </QueryClientProvider>
       </I18nextProvider>
@@ -50,7 +50,7 @@ describe('EstimationCard with known estimation method', () => {
           <EstimationCard
             cardType="estimated"
             estimationMethod="ESTIMATED_CONSTRUCT_BREAKDOWN"
-            outageMessage={undefined}
+            zoneMessage={undefined}
           />
         </QueryClientProvider>
       </I18nextProvider>
@@ -87,7 +87,7 @@ describe('EstimationCard', () => {
           <EstimationCard
             cardType="estimated"
             estimationMethod=""
-            outageMessage={undefined}
+            zoneMessage={undefined}
           />
         </QueryClientProvider>
       </I18nextProvider>
@@ -104,7 +104,7 @@ describe('EstimationCard', () => {
     cy.mount(
       <I18nextProvider i18n={i18n}>
         <QueryClientProvider client={queryClient}>
-          <EstimationCard cardType="" estimationMethod="" outageMessage={undefined} />
+          <EstimationCard cardType="" estimationMethod="" zoneMessage={undefined} />
         </QueryClientProvider>
       </I18nextProvider>
     );
@@ -120,7 +120,7 @@ describe('OutageCard', () => {
           <EstimationCard
             cardType="outage"
             estimationMethod="ESTIMATED_CONSTRUCT_BREAKDOWN"
-            outageMessage={{ message: 'Outage Message', issue: 'issue' }}
+            zoneMessage={{ message: 'Outage Message', issue: 'issue' }}
           />
         </QueryClientProvider>
       </I18nextProvider>
@@ -149,7 +149,7 @@ describe('AggregatedCard', () => {
           <EstimationCard
             cardType="aggregated"
             estimatedPercentage={50}
-            outageMessage={undefined}
+            zoneMessage={undefined}
           />
         </QueryClientProvider>
       </I18nextProvider>
@@ -169,7 +169,7 @@ describe('AggregatedCard', () => {
           <EstimationCard
             cardType="aggregated"
             estimationMethod="ESTIMATED_CONSTRUCT_BREAKDOWN"
-            outageMessage={undefined}
+            zoneMessage={undefined}
           />
         </QueryClientProvider>
       </I18nextProvider>

--- a/web/src/features/panels/zone/EstimationCard.stories.tsx
+++ b/web/src/features/panels/zone/EstimationCard.stories.tsx
@@ -23,23 +23,23 @@ export const All: Story = {
     <div className="space-y-2">
       <I18nextProvider i18n={i18n}>
         <QueryClientProvider client={queryClient}>
-          <EstimationCard cardType="outage" outageMessage={instance} />
+          <EstimationCard cardType="outage" zoneMessage={instance} />
 
-          <EstimationCard cardType="estimated" outageMessage={instance} />
+          <EstimationCard cardType="estimated" zoneMessage={instance} />
 
           <EstimationCard
             cardType="estimated"
-            outageMessage={instance}
+            zoneMessage={instance}
             estimationMethod="estimated_mode_breakdown"
           />
 
           <EstimationCard
             cardType="aggregated"
-            outageMessage={instance}
+            zoneMessage={instance}
             estimatedPercentage={20}
           />
 
-          <EstimationCard cardType="aggregated" outageMessage={instance} />
+          <EstimationCard cardType="aggregated" zoneMessage={instance} />
         </QueryClientProvider>
       </I18nextProvider>
     </div>

--- a/web/src/features/panels/zone/EstimationCard.tsx
+++ b/web/src/features/panels/zone/EstimationCard.tsx
@@ -4,7 +4,7 @@ import { useFeatureFlag } from 'features/feature-flags/api';
 import { useAtom } from 'jotai';
 import { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { ZoneDetails } from 'types';
+import { ZoneMessage } from 'types';
 import trackEvent from 'utils/analytics';
 import {
   feedbackCardCollapsedNumberAtom,
@@ -18,12 +18,12 @@ export default function EstimationCard({
   cardType,
   estimationMethod,
   estimatedPercentage,
-  outageMessage,
+  zoneMessage,
 }: {
   cardType: string;
   estimationMethod?: string;
   estimatedPercentage?: number;
-  outageMessage: ZoneDetails['zoneMessage'];
+  zoneMessage?: ZoneMessage;
 }) {
   const [isFeedbackCardVisibile, setIsFeedbackCardVisibile] = useState(false);
   const [feedbackCardCollapsedNumber, _] = useAtom(feedbackCardCollapsedNumberAtom);
@@ -46,7 +46,7 @@ export default function EstimationCard({
 
   switch (cardType) {
     case 'outage': {
-      return <OutageCard outageMessage={outageMessage} />;
+      return <OutageCard zoneMessage={zoneMessage} />;
     }
     case 'aggregated': {
       return <AggregatedCard estimatedPercentage={estimatedPercentage} />;
@@ -84,7 +84,7 @@ function getEstimationTranslation(
 function BaseCard({
   estimationMethod,
   estimatedPercentage,
-  outageMessage,
+  zoneMessage,
   icon,
   iconPill,
   showMethodologyLink,
@@ -94,7 +94,7 @@ function BaseCard({
 }: {
   estimationMethod?: string;
   estimatedPercentage?: number;
-  outageMessage: ZoneDetails['zoneMessage'];
+  zoneMessage?: ZoneMessage;
   icon: string;
   iconPill?: string;
   showMethodologyLink: boolean;
@@ -157,7 +157,9 @@ function BaseCard({
             className={`text-sm font-normal text-neutral-600 dark:text-neutral-400`}
           >
             {estimationMethod != 'outage' && bodyText}
-            {estimationMethod == 'outage' && <OutageMessage outageData={outageMessage} />}
+            {estimationMethod == 'outage' && (
+              <ZoneMessageBlock zoneMessage={zoneMessage} />
+            )}
           </div>
           {showMethodologyLink && (
             <div className="">
@@ -183,11 +185,11 @@ function BaseCard({
   );
 }
 
-function OutageCard({ outageMessage }: { outageMessage: ZoneDetails['zoneMessage'] }) {
+function OutageCard({ zoneMessage }: { zoneMessage?: ZoneMessage }) {
   return (
     <BaseCard
       estimationMethod={'outage'}
-      outageMessage={outageMessage}
+      zoneMessage={zoneMessage}
       icon="bg-[url('/images/estimated_light.svg')] dark:bg-[url('/images/estimated_dark.svg')]"
       iconPill="h-[12px] w-[12px] mt-[1px] bg-[url('/images/warning_light.svg')] bg-center dark:bg-[url('/images/warning_dark.svg')]"
       showMethodologyLink={false}
@@ -203,7 +205,7 @@ function AggregatedCard({ estimatedPercentage }: { estimatedPercentage?: number 
     <BaseCard
       estimationMethod={'aggregated'}
       estimatedPercentage={estimatedPercentage}
-      outageMessage={undefined}
+      zoneMessage={undefined}
       icon="bg-[url('/images/aggregated_light.svg')] dark:bg-[url('/images/aggregated_dark.svg')]"
       iconPill={undefined}
       showMethodologyLink={false}
@@ -218,7 +220,7 @@ function EstimatedCard({ estimationMethod }: { estimationMethod: string | undefi
   return (
     <BaseCard
       estimationMethod={estimationMethod}
-      outageMessage={undefined}
+      zoneMessage={undefined}
       icon="bg-[url('/images/estimated_light.svg')] dark:bg-[url('/images/estimated_dark.svg')]"
       iconPill={undefined}
       showMethodologyLink={true}
@@ -233,23 +235,19 @@ function truncateString(string_: string, number_: number) {
   return string_.length <= number_ ? string_ : string_.slice(0, number_) + '...';
 }
 
-function OutageMessage({
-  outageData: outageData,
-}: {
-  outageData: ZoneDetails['zoneMessage'];
-}) {
-  if (!outageData || !outageData.message) {
+function ZoneMessageBlock({ zoneMessage }: { zoneMessage?: ZoneMessage }) {
+  if (!zoneMessage || !zoneMessage.message) {
     return null;
   }
   const { t } = useTranslation();
   return (
     <span className="inline overflow-hidden">
-      {truncateString(outageData.message, 300)}{' '}
-      {outageData?.issue && outageData.issue != 'None' && (
+      {truncateString(zoneMessage.message, 300)}{' '}
+      {zoneMessage?.issue && zoneMessage.issue != 'None' && (
         <span className="mt-1 inline-flex">
           <a
             className="inline-flex text-sm font-semibold text-black underline dark:text-white"
-            href={`https://github.com/electricitymaps/electricitymaps-contrib/issues/${outageData.issue}`}
+            href={`https://github.com/electricitymaps/electricitymaps-contrib/issues/${zoneMessage.issue}`}
           >
             <span className="pl-1 underline">{t('estimation-card.outage-details')}</span>
             <svg

--- a/web/src/features/panels/zone/ZoneDetails.tsx
+++ b/web/src/features/panels/zone/ZoneDetails.tsx
@@ -7,6 +7,7 @@ import { useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
 import { MdOutlineCloudDownload } from 'react-icons/md';
 import { Navigate, useParams } from 'react-router-dom';
+import { ZoneMessage } from 'types';
 import { SpatialAggregate, TimeAverages } from 'utils/constants';
 import {
   displayByEmissionsAtom,
@@ -80,7 +81,7 @@ export default function ZoneDetails(): JSX.Element {
             <EstimationCard
               cardType={cardType}
               estimationMethod={estimationMethod}
-              outageMessage={zoneMessage}
+              zoneMessage={zoneMessage}
               estimatedPercentage={selectedData?.estimatedPercentage}
             ></EstimationCard>
           )}
@@ -135,7 +136,7 @@ function getCardType({
   timeAverage,
 }: {
   estimationMethod: string | undefined;
-  zoneMessage: { message: string; issue: string } | undefined;
+  zoneMessage?: ZoneMessage;
   timeAverage: TimeAverages;
 }): 'estimated' | 'aggregated' | 'outage' | 'none' {
   if (

--- a/web/src/types.ts
+++ b/web/src/types.ts
@@ -166,7 +166,12 @@ export interface ZoneDetails {
   zoneStates: {
     [key: string]: ZoneDetail;
   };
-  zoneMessage?: { message: string; issue: string };
+  zoneMessage?: ZoneMessage;
+}
+
+export interface ZoneMessage {
+  message: string;
+  issue?: string;
 }
 
 export interface GeometryProperties {


### PR DESCRIPTION
## Issue
Improve wording of automated outage message, typing and naming consistency

## Description
This PR improves the wording of the automated outage message now it's in use. 

I also took this as an opportunity to improve the typing for the zoneMessage and add consistency to our naming. `zoneMessage` felt like the best choice as it's the key in the api object and it's not necessarily always going to be an outage.

### Double check

- [x] I have tested my parser changes locally with `poetry run test_parser "zone_key"`
- [x] I have run `pnpx prettier@2 --write .` and `poetry run format` in the top level directory to format my changes.
