### PR TITLE
Switch app-backend domain

### DIFF
--- a/web/Earthfile
+++ b/web/Earthfile
@@ -49,4 +49,4 @@ deploy:
   COPY +build/dist ./dist
   RUN npm install -g wrangler
   # TODO: Point to master after build and deploy has been tested to staging
-  RUN --push --secret CLOUDFLARE_API_TOKEN --secret CLOUDFLARE_ACCOUNT_ID wrangler pages publish ./dist --project-name electricitymaps-app --branch master
+  RUN --push --secret CLOUDFLARE_API_TOKEN --secret CLOUDFLARE_ACCOUNT_ID wrangler pages deploy ./dist --project-name electricitymaps-app --branch master

--- a/web/index.html
+++ b/web/index.html
@@ -105,7 +105,7 @@
     <link rel="canonical" href="https://app.electricitymaps.com" />
 
     <!-- Pre-connect to backend to improve performance -->
-    <link rel="preconnect" href="https://app-backend.electricitymap.org/" />
+    <link rel="preconnect" href="https://app-backend.electricitymaps.com/" />
     <link rel="preconnect" href="https://o192958.ingest.sentry.io" />
     <link rel="preconnect" href="https://plausible.io" />
 

--- a/web/public/_headers
+++ b/web/public/_headers
@@ -4,6 +4,6 @@
   Link: </fonts/Inter.var.woff2>; rel=preload; as=font; type=font/woff2; crossorigin
   Link: </fonts/Poppins-Medium.woff2>; rel=preload; as=font; type=font/woff2; crossorigin
 # === Preconnect to external servers ===
-  Link:  <https://app-backend.electricitymap.org/>; rel=preconnect
+  Link:  <https://app-backend.electricitymaps.com>; rel=preconnect
   Link:  <https://o192958.ingest.sentry.io>; rel=preconnect
   Link:  <https://plausible.io>; rel=preconnect

--- a/web/src/api/helpers.ts
+++ b/web/src/api/helpers.ts
@@ -65,7 +65,7 @@ export async function getHeaders(route: URL): Promise<Headers> {
 export function getBasePath() {
   return isUsingLocalEndpoint()
     ? 'http://127.0.0.1:8001'
-    : 'https://app-backend.electricitymap.org';
+    : 'https://app-backend.electricitymaps.com';
 }
 
 export function cacheBuster(): string {


### PR DESCRIPTION
## Description

This would make the app use the app-backend.electricitymaps.com domain that uses CloudFlare to give us better caching opportunities, lower latency and other improvements.

Fixes: AVO-144
Fixes: AVO-174

