### PR TITLE
fix(Wind & Solar layers): use v8 GFS endpoint

### DIFF
--- a/web/src/api/getWeatherData.ts
+++ b/web/src/api/getWeatherData.ts
@@ -59,7 +59,7 @@ export async function fetchGfsForecast(
 ): Promise<GfsForecastResponse> {
   const targetTime = targetTimeFunction[period](endTime);
 
-  const path: URL = new URL(`v3/gfs/${resource}`, getBasePath());
+  const path: URL = new URL(`v8/gfs/${resource}`, getBasePath());
   path.searchParams.append('refTime', startTime.toISOString());
   path.searchParams.append('targetTime', targetTime);
 
@@ -70,9 +70,7 @@ export async function fetchGfsForecast(
   const response = await fetch(path, requestOptions);
   if (response.ok) {
     const { data } = await response.json();
-    // TODO: Change this on backend instead
-    // Convert solar data to array to ensure that data is consistent between weather layers
-    return resource === 'solar' ? [data] : data;
+    return data;
   }
 
   if (retries >= 3 || response.status !== 404) {


### PR DESCRIPTION
## Issue

The old v3 endpoint could not handle the changes made for facilitate the cache busting in v8.

Fixes #6683 

## Description

This PR switches the frontend to use the v8 GFS endpoint.

>[!IMPORTANT]
> This requires a backend PR to be merged first for solar to work.

### Preview

<!-- Please add screenshots and/or gif that shows visual changes (if applicable) -->

### Double check

- [x] I have tested my parser changes locally with `poetry run test_parser "zone_key"`
- [x] I have run `pnpx prettier@2 --write .` and `poetry run format` in the top level directory to format my changes.
