### PR TITLE
fix tooltip positioning so it never goes out of the screen

### DIFF
--- a/web/src/components/tooltips/utilities.ts
+++ b/web/src/components/tooltips/utilities.ts
@@ -48,7 +48,7 @@ export const getOffsetTooltipPosition = ({
 
   const tooltipPosition = {
     x: mousePositionX + xOffset,
-    y: mousePositionY - yOffset,
+    y: Math.max(mousePositionY - yOffset, 0),
   };
 
   return tooltipPosition;


### PR DESCRIPTION
## Issue

<!-- If you want to close an issue automatically when your PR is merged, write "Closes X" where X is the PR number. For example: Closes #000 -->
The chart tooltip currently gets displayed outside of the screen at times, see image below. 

<img width="743" alt="image" src="https://github.com/electricitymaps/electricitymaps-contrib/assets/95029552/6ed583b0-88e1-485d-92db-91ea260a252b">

## Description

<!-- Explains the goal of this PR -->
This PR fixes this issue, so it will be placed at the top if it otherwise would have been outside of the screen. 

### Preview

<!-- Please add screenshots and/or gif that shows visual changes (if applicable) -->
<img width="746" alt="image" src="https://github.com/electricitymaps/electricitymaps-contrib/assets/95029552/7e1a0725-e34a-40f2-9bb9-33ce847d411c">


### Double check

- [ ] I have tested my parser changes locally with `poetry run test_parser "zone_key"`
- [x] I have run `pnpx prettier@2 --write .` and `poetry run format` in the top level directory to format my changes.
