### PR TITLE
chore(web): fix methodology link

### DIFF
--- a/web/src/features/panels/zone/EstimationCard.tsx
+++ b/web/src/features/panels/zone/EstimationCard.tsx
@@ -164,7 +164,7 @@ function BaseCard({
           {showMethodologyLink && (
             <div className="">
               <a
-                href="https://www.electricitymaps.com/methodology"
+                href="https://www.electricitymaps.com/methodology#missing-data"
                 target="_blank"
                 rel="noreferrer"
                 data-test-id="methodology-link"


### PR DESCRIPTION
## Issue

Estimation card methodology link didn't go to the right tab.

## Description

Replacing the link with the correct tab.

### Double check

- [x] I have tested my parser changes locally with `poetry run test_parser "zone_key"`
- [x] I have run `pnpx prettier@2 --write .` and `poetry run format` in the top level directory to format my changes.
