### PR TITLE
fix(options requests): Fix OPTIONS request for state

### DIFF
--- a/web/src/api/getState.ts
+++ b/web/src/api/getState.ts
@@ -10,12 +10,8 @@ import { cacheBuster, getBasePath, getHeaders, QUERY_KEYS } from './helpers';
 const getState = async (timeAverage: string): Promise<GridState> => {
   const path: URL = new URL(`v8/state/${timeAverage}`, getBasePath());
   path.searchParams.append('cacheKey', cacheBuster());
-  const requestOptions: RequestInit = {
-    method: 'GET',
-    headers: await getHeaders(path),
-  };
 
-  const response = await fetch(path, requestOptions);
+  const response = await fetch(path);
 
   if (response.ok) {
     const result = (await response.json()) as GridState;


### PR DESCRIPTION
## Issue

Same as for feature flags, every time we are fetching a state we create 2 requests, one OPTIONS request that can't be cached and one GET request that we are able to cache. This increases server load more than needed as these are not authenticated requests.

## Description

Removes the authentication headers from state requests to prevent OPTIONS requests.

### Preview

### Double check

- [x] I have run `pnpx prettier@2 --write .` and `poetry run format` in the top level directory to format my changes.
