### PR TITLE
fix(CH.py): fix capacity type for downstream insert

### DIFF
--- a/parsers/CH.py
+++ b/parsers/CH.py
@@ -14,14 +14,14 @@ def get_solar_capacity_at(date: datetime) -> float:
     # Source https://www.uvek-gis.admin.ch/BFE/storymaps/EE_Elektrizitaetsproduktionsanlagen/?lang=en
     historical_capacities = pd.DataFrame.from_records(
         [
-            ("2015-01-01", 1393),
-            ("2016-01-01", 1646),
-            ("2017-01-01", 1859),
-            ("2018-01-01", 2090),
-            ("2019-01-01", 2375),
-            ("2020-01-01", 2795),
-            ("2021-01-01", 3314),
-            ("2022-01-01", 3904),
+            ("2015-01-01", 1393.0),
+            ("2016-01-01", 1646.0),
+            ("2017-01-01", 1859.0),
+            ("2018-01-01", 2090.0),
+            ("2019-01-01", 2375.0),
+            ("2020-01-01", 2795.0),
+            ("2021-01-01", 3314.0),
+            ("2022-01-01", 3904.0),
         ],
         columns=["datetime", "capacity.solar"],
     ).set_index("datetime")


### PR DESCRIPTION
## Issue

The current implementation casts the capacity value to `int64` -> that causes ingestion issues downstream

## Description

* Use instead floats, which seem to be supported

### Preview

<!-- Please add screenshots and/or gif that shows visual changes (if applicable) -->

### Double check

- [x] I have tested my parser changes locally with `poetry run test_parser "zone_key"`
- [x] I have run `pnpx prettier@2 --write .` and `poetry run format` in the top level directory to format my changes.
