### PR TITLE
feat(web): Record time slider interactions with plausible

### DIFF
--- a/web/src/components/TimeSlider.tsx
+++ b/web/src/components/TimeSlider.tsx
@@ -74,7 +74,7 @@ export const getThumbIcon = (
 
 function trackTimeSliderEvent(selectedIndex: number, timeAverage: TimeAverages) {
   trackEvent('Time Slider Button Interaction', {
-    selectedIndex: `${timeAverage} :${selectedIndex}`,
+    selectedIndex: `${timeAverage}: ${selectedIndex}`,
   });
 }
 

--- a/web/src/components/TimeSlider.tsx
+++ b/web/src/components/TimeSlider.tsx
@@ -3,6 +3,7 @@ import { scaleLinear } from 'd3-scale';
 import { useNightTimes } from 'hooks/nightTimes';
 import { useDarkMode } from 'hooks/theme';
 import { useAtom } from 'jotai/react';
+import trackEvent from 'utils/analytics';
 import { TimeAverages } from 'utils/constants';
 import { getZoneFromPath } from 'utils/helpers';
 import { timeAverageAtom } from 'utils/state/atoms';
@@ -71,6 +72,10 @@ export const getThumbIcon = (
   return isValueAtNight ? 'slider-thumb-night.svg' : 'slider-thumb-day.svg';
 };
 
+function trackTimeSliderEvent(selectedIndex: number) {
+  trackEvent('Time Slider Button Interaction', { selectedIndex });
+}
+
 export type TimeSliderBasicProps = TimeSliderProps & {
   trackBackground: string;
   thumbIcon: ThumbIconPath;
@@ -88,7 +93,10 @@ export function TimeSliderBasic({
       max={numberOfEntries}
       step={1}
       value={selectedIndex && selectedIndex > 0 ? [selectedIndex] : [0]}
-      onValueChange={(value) => onChange(value[0])}
+      onValueChange={(value) => {
+        onChange(value[0]);
+        trackTimeSliderEvent(value[0]);
+      }}
       aria-label="choose time"
       className="relative mb-2 flex h-5 w-full touch-none items-center hover:cursor-pointer"
     >

--- a/web/src/components/TimeSlider.tsx
+++ b/web/src/components/TimeSlider.tsx
@@ -72,8 +72,10 @@ export const getThumbIcon = (
   return isValueAtNight ? 'slider-thumb-night.svg' : 'slider-thumb-day.svg';
 };
 
-function trackTimeSliderEvent(selectedIndex: number) {
-  trackEvent('Time Slider Button Interaction', { selectedIndex });
+function trackTimeSliderEvent(selectedIndex: number, timeAverage: TimeAverages) {
+  trackEvent('Time Slider Button Interaction', {
+    selectedIndex: `${timeAverage} :${selectedIndex}`,
+  });
 }
 
 export type TimeSliderBasicProps = TimeSliderProps & {
@@ -87,6 +89,7 @@ export function TimeSliderBasic({
   trackBackground,
   thumbIcon,
 }: TimeSliderBasicProps) {
+  const [timeAverage] = useAtom(timeAverageAtom);
   return (
     <SliderPrimitive.Root
       defaultValue={[0]}
@@ -95,7 +98,7 @@ export function TimeSliderBasic({
       value={selectedIndex && selectedIndex > 0 ? [selectedIndex] : [0]}
       onValueChange={(value) => {
         onChange(value[0]);
-        trackTimeSliderEvent(value[0]);
+        trackTimeSliderEvent(value[0], timeAverage);
       }}
       aria-label="choose time"
       className="relative mb-2 flex h-5 w-full touch-none items-center hover:cursor-pointer"


### PR DESCRIPTION
## Issue
We don't know how users interact with out time slider

## Description
This PR sends a custom event to Plausible for interactions with the time slider component, I've alos created a goal and custom property to record the unique interactions with the time slider and property of selected index.