### PR TITLE
feat(web): Record language selection in Plausible

### DIFF
--- a/web/src/features/map-controls/LanguageSelector.tsx
+++ b/web/src/features/map-controls/LanguageSelector.tsx
@@ -3,6 +3,7 @@ import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { HiLanguage } from 'react-icons/hi2';
 import { languageNames } from 'translation/locales';
+import trackEvent from 'utils/analytics';
 
 import MapButton from './MapButton';
 import MapOptionSelector from './MapOptionSelector';
@@ -20,6 +21,7 @@ export function LanguageSelector({ isMobile }: { isMobile?: boolean }) {
   const handleLanguageSelect = (languageKey: LanguageNamesKey) => {
     i18n.changeLanguage(languageKey);
     setSelectedLanguage(languageNames[languageKey]);
+    trackEvent('Language Selected', { language: languageNames[languageKey] });
   };
   return (
     <MapOptionSelector


### PR DESCRIPTION
## Issue
We don't know much about our users preferred languages

## Description
This PR posts an event to Plausible when a language is selected.

I've also created the following events in Plausible:
- Custom goal `Language Selected`
- Custom property `language`