### PR TITLE
feat(web): Track colorblind mode in plausible

### DIFF
--- a/web/src/features/map-controls/MapControls.tsx
+++ b/web/src/features/map-controls/MapControls.tsx
@@ -132,6 +132,7 @@ function DesktopMapControls() {
 
   const handleColorblindModeToggle = () => {
     setIsColorblindModeEnabled(!isColorblindModeEnabled);
+    trackEvent('Colorblind Mode Toggled');
   };
 
   return (


### PR DESCRIPTION
## Issue
We don't know how many people use colorblind mode

## Description
This PR posts an event to Plausible when colorblind mode is toggled.

I've also created the following event in Plausible:
- Custom goal `Colorblind Mode Toggled`