### PR TITLE
chore(web): remove mouseflow script

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -140,15 +140,6 @@
       } else {
         document.documentElement.classList.remove('dark');
       }
-      // Init Mouseflow tracking
-      window._mfq = window._mfq || [];
-      (function () {
-        var mf = document.createElement('script');
-        mf.type = 'text/javascript';
-        mf.defer = true;
-        mf.src = '//cdn.mouseflow.com/projects/8964f228-0fea-41ca-a8a6-dc23a38dc526.js';
-        document.getElementsByTagName('head')[0].appendChild(mf);
-      })();
     </script>
     <script type="module" src="/src/main.tsx"></script>
   </head>


### PR DESCRIPTION
## Issue
We currently have disabled Mouseflow but we're still running it in the app scripts
<img width="541" alt="image" src="https://github.com/electricitymaps/electricitymaps-contrib/assets/18622768/8f959952-bae0-4025-a894-a7383827e52f">

## Description
This PR removes the mouseflow script as it currently fails so all our users are downloading mouseflows js without any use.

I think it's best to clean this up for now and add it or something else again in the future if we want it.

