### PR TITLE
chore(app): Update cacheBuster logic to round down minutes to the nearest multiple of 5

### DIFF
--- a/web/src/api/helpers.ts
+++ b/web/src/api/helpers.ts
@@ -70,6 +70,8 @@ export function getBasePath() {
 
 export function cacheBuster(): string {
   const currentDate = new Date();
+  const minutes = currentDate.getMinutes();
+  currentDate.setMinutes(minutes - (minutes % 5));
   currentDate.setSeconds(0);
   currentDate.setMilliseconds(0);
 


### PR DESCRIPTION
## Issue
Closes AVO-204

## Description

Changes the cache buster to use a 5 minute cache duration.

### Double check

- [x] I have run `pnpx prettier@2 --write .` and `poetry run format` in the top level directory to format my changes.
