### PR TITLE
tmp-fix(FR parser): switch FR production parser to ENTSO-E

### DIFF
--- a/config/zones/FR.yaml
+++ b/config/zones/FR.yaml
@@ -359,7 +359,7 @@ parsers:
   consumptionForecast: ENTSOE.fetch_consumption_forecast
   generationForecast: ENTSOE.fetch_generation_forecast
   price: ENTSOE.fetch_price
-  production: FR.fetch_production
+  production: ENTSOE.fetch_production
   productionCapacity: ENTSOE.fetch_production_capacity
   productionPerModeForecast: ENTSOE.fetch_wind_solar_forecasts
 price_displayed: false

--- a/poetry.lock
+++ b/poetry.lock
@@ -1386,4 +1386,4 @@ scripts = ["xmltodict"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">= 3.10, < 3.11"
-content-hash = "ad142d6791f2052f4bbb070fdfbe59d31bc441fa1391e4c0f767af55469b0f31"
+content-hash = "fb4520c62079e0d6ed5a815fb6bea6fd5aa2aeee7b6854a00eacb8fe586a905a"


### PR DESCRIPTION
## Issue

From @florianscheidl's investigations: the FR parser is currently not working returning only timestamps and no data. Because of the long week-end we cannot expect any fix before next week earliest. 

## Description

Switch temporarely FR to ENTSO-E until we have an update on the parser.

### Double check

- [ ] I have tested my parser changes locally with `poetry run test_parser "zone_key"`
- [ ] I have run `pnpx prettier@2 --write .` and `poetry run format` in the top level directory to format my changes.
