### PR TITLE
Fix mockserver solar data parsing

### DIFF
--- a/mockserver/server.js
+++ b/mockserver/server.js
@@ -39,7 +39,7 @@ app.get('/v8/gfs/solar', (req, res, next) => {
 
   fs.readFile(`./public/v8/gfs/solar.json`, (err, data) => {
     const jsonData = JSON.parse(data);
-    jsonData.data.header.refTime = targetTime;
+    jsonData.data[0].header.refTime = targetTime;
 
     res.json(jsonData);
   });


### PR DESCRIPTION
## Issue

Mock server provided for frontend didn't respect new data format introduced by #6715. More specifically, solar data wasn't parsed correctly.

### Double check

- [x] I have run `pnpx prettier@2 --write .` in the top level directory to format my changes.
