### PR TITLE
chore(deps): Update i18next-browser-languagedetector to version 8.0.0

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -78,7 +78,7 @@
     "date-fns": "^3.6.0",
     "geojson": "^0.5.0",
     "i18next": "^23.10.0",
-    "i18next-browser-languagedetector": "^7.2.0",
+    "i18next-browser-languagedetector": "^8.0.0",
     "i18next-http-backend": "^2.5.0",
     "jotai": "^2.7.0",
     "js-yaml": "^4.1.0",

--- a/web/pnpm-lock.yaml
+++ b/web/pnpm-lock.yaml
@@ -96,8 +96,8 @@ importers:
         specifier: ^23.10.0
         version: 23.10.0
       i18next-browser-languagedetector:
-        specifier: ^7.2.0
-        version: 7.2.0
+        specifier: ^8.0.0
+        version: 8.0.0
       i18next-http-backend:
         specifier: ^2.5.0
         version: 2.5.0
@@ -5192,8 +5192,8 @@ packages:
     engines: {node: '>=14'}
     hasBin: true
 
-  i18next-browser-languagedetector@7.2.0:
-    resolution: {integrity: sha512-U00DbDtFIYD3wkWsr2aVGfXGAj2TgnELzOX9qv8bT0aJtvPV9CRO77h+vgmHFBMe7LAxdwvT/7VkCWGya6L3tA==}
+  i18next-browser-languagedetector@8.0.0:
+    resolution: {integrity: sha512-zhXdJXTTCoG39QsrOCiOabnWj2jecouOqbchu3EfhtSHxIB5Uugnm9JaizenOy39h7ne3+fLikIjeW88+rgszw==}
 
   i18next-http-backend@2.5.0:
     resolution: {integrity: sha512-Z/aQsGZk1gSxt2/DztXk92DuDD20J+rNudT7ZCdTrNOiK8uQppfvdjq9+DFQfpAnFPn3VZS+KQIr1S/W1KxhpQ==}
@@ -14935,7 +14935,7 @@ snapshots:
 
   husky@8.0.3: {}
 
-  i18next-browser-languagedetector@7.2.0:
+  i18next-browser-languagedetector@8.0.0:
     dependencies:
       '@babel/runtime': 7.24.1
 


### PR DESCRIPTION
## Description
I made some upstream changes that reduces the code bundle by `1,54 kb`, let's use them 🙂

### Double check

- [x] I have run `pnpx prettier@2 --write .` and `poetry run format` in the top level directory to format my changes.
