### PR TITLE
feat(parsers): Allow the usage of wind_onshore and wind_offshore internally

### DIFF
--- a/electricitymap/contrib/lib/models/events.py
+++ b/electricitymap/contrib/lib/models/events.py
@@ -120,6 +120,7 @@ class ProductionMix(Mix):
         """
         if self.wind is not None:
             return self.wind
+
         if self.wind_onshore is not None and self.wind_offshore is not None:
             return _none_safe_round(self.wind_onshore + self.wind_offshore)
         if (
@@ -130,6 +131,16 @@ class ProductionMix(Mix):
             return _none_safe_round(
                 (self.wind_onshore or 0) + (self.wind_offshore or 0)
             )
+        if (
+            "wind_onshore" in self.__fields_set__
+            and "wind_offshore" not in self.__fields_set__
+        ):
+            return self.wind_onshore
+        if (
+            "wind_offshore" in self.__fields_set__
+            and "wind_onshore" not in self.__fields_set__
+        ):
+            return self.wind_offshore
 
     def dict(  # noqa: A003
         self,

--- a/electricitymap/contrib/lib/models/events.py
+++ b/electricitymap/contrib/lib/models/events.py
@@ -126,8 +126,7 @@ class ProductionMix(Mix):
         if (
             "wind_onshore" in self.corrected_negative_modes
             or "wind_offshore" in self._corrected_negative_values
-            and (self.wind_onshore is not None or self.wind_offshore is not None)
-        ):
+        ) and (self.wind_onshore is not None or self.wind_offshore is not None):
             return _none_safe_round(
                 (self.wind_onshore or 0) + (self.wind_offshore or 0)
             )

--- a/electricitymap/contrib/lib/tests/test_event_lists.py
+++ b/electricitymap/contrib/lib/tests/test_event_lists.py
@@ -961,6 +961,34 @@ class TestProductionBreakdownList(unittest.TestCase):
         assert updated_list.events[0].storage.hydro == 1
         assert updated_list.events[0].source == "trust.me"
 
+    def test_update_production_with_wind_onshore_and_offshore(self):
+        production_list1 = ProductionBreakdownList(logging.Logger("test"))
+        production_list1.append(
+            zoneKey=ZoneKey("DE"),
+            datetime=datetime(2023, 1, 1, tzinfo=timezone.utc),
+            production=ProductionMix(wind_onshore=10, wind_offshore=10),
+            source="trust.me",
+        )
+        production_list2 = ProductionBreakdownList(logging.Logger("test"))
+        production_list2.append(
+            zoneKey=ZoneKey("DE"),
+            datetime=datetime(2023, 1, 1, tzinfo=timezone.utc),
+            production=ProductionMix(wind_onshore=20),
+            source="trust.me",
+        )
+        updated_list = ProductionBreakdownList.update_production_breakdowns(
+            production_list1, production_list2, logging.Logger("test")
+        )
+        assert len(updated_list.events) == 1
+        assert updated_list.events[0].datetime == datetime(
+            2023, 1, 1, tzinfo=timezone.utc
+        )
+        assert updated_list.events[0].production is not None
+        assert updated_list.events[0].production.wind_onshore == 20
+        assert updated_list.events[0].production.wind_offshore == 10
+        dict_form = updated_list.events[0].to_dict()
+        assert dict_form["production"]["wind"] == 30
+
     def test_filter_expected_modes(self):
         production_list_1 = ProductionBreakdownList(logging.Logger("test"))
         production_list_1.append(

--- a/electricitymap/contrib/lib/tests/test_events.py
+++ b/electricitymap/contrib/lib/tests/test_events.py
@@ -820,6 +820,49 @@ class TestMixAddValue(unittest.TestCase):
         mix = StorageMix(hydro=np.nan)
         assert mix.hydro is None
 
+    def test_wind_onshore_and_wind_offshore(self):
+        mix = ProductionMix(
+            wind_onshore=10,
+            wind_offshore=20,
+        )
+        dict_form = mix.dict()
+        assert dict_form["wind"] == 30
+        # Asset that the individual wind_onshore and wind_offshore values not present in the dict.
+        assert "wind_onshore" not in dict_form
+        assert "wind_offshore" not in dict_form
+
+    def test_wind_onshore_and_wind_offshore_with_negative_value(self):
+        mix = ProductionMix(
+            wind_onshore=10,
+            wind_offshore=-20,
+        )
+        dict_form = mix.dict()
+        assert dict_form["wind"] == 10
+
+    def test_wind_onshore_and_wind_offshore_with_none(self):
+        mix = ProductionMix(
+            wind_onshore=10,
+            wind_offshore=None,
+        )
+        dict_form = mix.dict()
+        assert dict_form["wind"] is None
+
+    def test_wind_onshore_and_wind_offshore_with_nan(self):
+        mix = ProductionMix(
+            wind_onshore=10,
+            wind_offshore=math.nan,
+        )
+        dict_form = mix.dict()
+        assert dict_form["wind"] is None
+
+    def test_wind_with_wind_onshore_and_wind_offshore(self):
+        mix = ProductionMix(
+            wind=10,
+            wind_onshore=7,
+            wind_offshore=5,
+        )
+        assert mix.wind == 10
+
 
 class TestMixUpdate:
     def test_update_production(self):

--- a/electricitymap/contrib/lib/tests/test_events.py
+++ b/electricitymap/contrib/lib/tests/test_events.py
@@ -532,6 +532,20 @@ class TestProductionBreakdown(unittest.TestCase):
         assert dict_form["production"]["wind"] == 10
         assert dict_form["production"]["solar"] is None
 
+    def test_mix_with_just_offshore_and_onshore_wind(self):
+        mix = ProductionMix(
+            wind_onshore=10,
+            wind_offshore=20,
+        )
+        breakdown = ProductionBreakdown(
+            zoneKey=ZoneKey("DE"),
+            datetime=datetime(2023, 1, 1, tzinfo=timezone.utc),
+            production=mix,
+            source="trust.me",
+        )
+        dict_form = breakdown.to_dict()
+        assert dict_form["production"]["wind"] == 30
+
 
 class TestTotalProduction(unittest.TestCase):
     def test_create_generation(self):
@@ -854,6 +868,13 @@ class TestMixAddValue(unittest.TestCase):
         )
         dict_form = mix.dict()
         assert dict_form["wind"] is None
+
+    def test_just_one_wind_submode(self):
+        mix = ProductionMix(
+            wind_onshore=10,
+        )
+        dict_form = mix.dict()
+        assert dict_form["wind"] == 10
 
     def test_wind_with_wind_onshore_and_wind_offshore(self):
         mix = ProductionMix(


### PR DESCRIPTION
## Issue


## Description

This these changes need more testing to ensure it works for all current implementation and works well with the update methods.

It will serve as the base for supporting both offshore and onshore wind internally in the parsers so we can better handle when one of them is missing.

### Double check
- [ ] I added tests for the relevant changes.
- [x] I have run `pnpx prettier@2 --write .` and `poetry run format` in the top level directory to format my changes.
