### PR TITLE
fix(web): Add FAQModal auto-open on /faq page load

### DIFF
--- a/web/src/features/modals/FAQModal.tsx
+++ b/web/src/features/modals/FAQModal.tsx
@@ -1,7 +1,9 @@
 import Modal from 'components/Modal';
 import FAQContent from 'features/panels/faq/FAQContent';
 import { useAtom } from 'jotai';
+import { useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
+import { useLocation } from 'react-router-dom';
 
 import { isFAQModalOpenAtom } from './modalAtoms';
 
@@ -17,7 +19,14 @@ export function FAQModalContent() {
 
 export default function FAQModal() {
   const { t } = useTranslation();
+  const location = useLocation();
   const [isOpen, setIsOpen] = useAtom(isFAQModalOpenAtom);
+
+  useEffect(() => {
+    if (location.pathname === '/faq') {
+      setIsOpen(true);
+    }
+  }, [location, setIsOpen]);
 
   return (
     <Modal isOpen={isOpen} setIsOpen={setIsOpen} title={t('misc.faq')}>


### PR DESCRIPTION
## Issue

Closes #6667

## Description

Show the FAQ modal when url is /faq

### Preview

![CleanShot 2024-05-13 at 17 28 01](https://github.com/electricitymaps/electricitymaps-contrib/assets/767647/3bd123cc-5496-4edd-8b0c-54872d154f86)


### Double check

- [ ] I have tested my parser changes locally with `poetry run test_parser "zone_key"`
- [x] I have run `pnpx prettier@2 --write .` and `poetry run format` in the top level directory to format my changes.
