### PR TITLE
Fix mobile app solar layer

### DIFF
--- a/web/src/features/weather-layers/solar/SolarLayer.tsx
+++ b/web/src/features/weather-layers/solar/SolarLayer.tsx
@@ -1,6 +1,6 @@
 import { useGetSolar } from 'api/getWeatherData';
 import { useAtom, useSetAtom } from 'jotai';
-import { useEffect, useMemo, useRef } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import { ToggleOptions } from 'utils/constants';
 import {
   selectedDatetimeIndexAtom,
@@ -47,14 +47,27 @@ export default function SolarLayer({ map }: { map?: maplibregl.Map }) {
   const isVisibleReference = useRef(false);
   isVisibleReference.current = isSuccess && isSolarLayerEnabled;
 
-  const canvasScale = 4;
+  const [canvasScale, setCanvasScale] = useState(4);
+
+  // Shrink canvasScale so that canvas dimensions don't exceed WebGL MAX_TEXTURE_SIZE of the user's device
+  useEffect(() => {
+    const gl = document.createElement('canvas').getContext('webgl');
+    if (gl) {
+      const targetCanvasScale =
+        gl.getParameter(gl.MAX_TEXTURE_SIZE) /
+        Math.max(3 * (solarData?.header.nx ?? 360), solarData?.header.ny ?? 180);
+      const newCanvasScale = Math.max(1, Math.min(4, Math.floor(targetCanvasScale)));
+      setCanvasScale(newCanvasScale);
+    }
+  }, [solarData?.header.nx, solarData?.header.ny]);
+
   const node: HTMLCanvasElement = useMemo(() => {
     const canvas = document.createElement('canvas');
     // wrap around Earth three times to avoid a seam where 180 and -180 meet
     canvas.width = 3 * canvasScale * (solarData?.header.nx ?? 360);
     canvas.height = canvasScale * (solarData?.header.ny ?? 180);
     return canvas;
-  }, [solarData?.header.nx, solarData?.header.ny]);
+  }, [canvasScale, solarData?.header.nx, solarData?.header.ny]);
 
   useEffect(() => {
     if (!node || !map?.isStyleLoaded()) {


### PR DESCRIPTION
## Issue
<!-- If you want to close an issue automatically when your PR is merged, write "Closes X" where X is the PR number. For example: Closes #000 -->
The screen is blacked out when enabling the solar layer on the mobile app. As observed in issues: #6243, #6327 (this one also mentions wind layers)
Closes #6243

There seems to be a problem with canvas size exceeding WebGL limits of certain devices. E.g. warning on a mobile device:
![Screenshot 2024-05-14 183514_crop](https://github.com/electricitymaps/electricitymaps-contrib/assets/73378276/56e3f01a-d595-4a6a-a6bc-eac8709f71e6)

## Description
<!-- Explains the goal of this PR -->
This change aims to lower the canvasScale parameter whenever necessary to modify the canvas dimensions. Calculations made utilize MAX_TEXTURE_SIZE provided by the [getContext](https://developer.mozilla.org/en-US/docs/Web/API/HTMLCanvasElement/getContext) method.


### Preview

<!-- Please add screenshots and/or gif that shows visual changes (if applicable) -->
No WebGL errors are thrown and solar layer is displayed (here canvasScale is set to 3)
![image](https://github.com/electricitymaps/electricitymaps-contrib/assets/73378276/c19558c3-bad5-48c5-8563-190c5340b196)
Tested on Chrome v124, Android 11


### Double check

- [x] I have run `pnpx prettier@2 --write .` in the top level directory to format my changes.
