### PR TITLE
chore(app): Remove SentryRoutes as we don't use performance monitoring

### DIFF
--- a/web/src/features/panels/LeftPanel.tsx
+++ b/web/src/features/panels/LeftPanel.tsx
@@ -8,6 +8,7 @@ import { HiChevronLeft, HiChevronRight } from 'react-icons/hi2';
 import {
   Navigate,
   Route,
+  Routes,
   useLocation,
   useParams,
   useSearchParams,
@@ -115,26 +116,28 @@ function OuterPanel({ children }: { children: React.ReactNode }) {
 export default function LeftPanel() {
   return (
     <OuterPanel>
-      <Route path="/" element={<HandleLegacyRoutes />} />
-      <Route
-        path="/zone/:zoneId"
-        element={
-          <ValidZoneIdGuardWrapper>
+      <Routes>
+        <Route path="/" element={<HandleLegacyRoutes />} />
+        <Route
+          path="/zone/:zoneId"
+          element={
+            <ValidZoneIdGuardWrapper>
+              <Suspense fallback={<LoadingSpinner />}>
+                <ZoneDetails />
+              </Suspense>
+            </ValidZoneIdGuardWrapper>
+          }
+        />
+        {/* Alternative: add /map here and have a NotFound component for anything else*/}
+        <Route
+          path="*"
+          element={
             <Suspense fallback={<LoadingSpinner />}>
-              <ZoneDetails />
+              <RankingPanel />
             </Suspense>
-          </ValidZoneIdGuardWrapper>
-        }
-      />
-      {/* Alternative: add /map here and have a NotFound component for anything else*/}
-      <Route
-        path="*"
-        element={
-          <Suspense fallback={<LoadingSpinner />}>
-            <RankingPanel />
-          </Suspense>
-        }
-      />
+          }
+        />
+      </Routes>
     </OuterPanel>
   );
 }

--- a/web/src/features/panels/LeftPanel.tsx
+++ b/web/src/features/panels/LeftPanel.tsx
@@ -1,4 +1,3 @@
-import * as Sentry from '@sentry/react';
 import LoadingSpinner from 'components/LoadingSpinner';
 import { TimeDisplay } from 'components/TimeDisplay';
 import Logo from 'features/header/Logo';
@@ -9,7 +8,6 @@ import { HiChevronLeft, HiChevronRight } from 'react-icons/hi2';
 import {
   Navigate,
   Route,
-  Routes,
   useLocation,
   useParams,
   useSearchParams,
@@ -114,32 +112,29 @@ function OuterPanel({ children }: { children: React.ReactNode }) {
     </aside>
   );
 }
-const SentryRoutes = Sentry.withSentryReactRouterV6Routing(Routes);
 export default function LeftPanel() {
   return (
     <OuterPanel>
-      <SentryRoutes>
-        <Route path="/" element={<HandleLegacyRoutes />} />
-        <Route
-          path="/zone/:zoneId"
-          element={
-            <ValidZoneIdGuardWrapper>
-              <Suspense fallback={<LoadingSpinner />}>
-                <ZoneDetails />
-              </Suspense>
-            </ValidZoneIdGuardWrapper>
-          }
-        />
-        {/* Alternative: add /map here and have a NotFound component for anything else*/}
-        <Route
-          path="*"
-          element={
+      <Route path="/" element={<HandleLegacyRoutes />} />
+      <Route
+        path="/zone/:zoneId"
+        element={
+          <ValidZoneIdGuardWrapper>
             <Suspense fallback={<LoadingSpinner />}>
-              <RankingPanel />
+              <ZoneDetails />
             </Suspense>
-          }
-        />
-      </SentryRoutes>
+          </ValidZoneIdGuardWrapper>
+        }
+      />
+      {/* Alternative: add /map here and have a NotFound component for anything else*/}
+      <Route
+        path="*"
+        element={
+          <Suspense fallback={<LoadingSpinner />}>
+            <RankingPanel />
+          </Suspense>
+        }
+      />
     </OuterPanel>
   );
 }


### PR DESCRIPTION
## Issue

We don't use performance monitoring with Sentry so we should not import code related to that.

## Description

Removes code and imports we don't use related to Sentry performance monitoring.

Sentry documentation: https://docs.sentry.io/platforms/javascript/guides/react/features/react-router/#react-router-v6

### Preview
The sentry bundle goes from `76.15 kB` to `75.82 kB` and the index bundle goes from `257.26 kB` to `257.23 kB` but there are runtime benefits as well (even though I did not measure this 😅).

### Double check

- [x] I have run `pnpx prettier@2 --write .` and `poetry run format` in the top level directory to format my changes.
