### PR TITLE
Bugfix - Show correct final month

### DIFF
--- a/web/src/features/charts/elements/AreaGraph.tsx
+++ b/web/src/features/charts/elements/AreaGraph.tsx
@@ -8,7 +8,7 @@ import { useAtom } from 'jotai';
 import React, { useMemo, useRef, useState } from 'react';
 import { ZoneDetail } from 'types';
 import useResizeObserver from 'use-resize-observer';
-import { TimeAverages,timeAxisMapping } from 'utils/constants';
+import { TimeAverages, timeAxisMapping } from 'utils/constants';
 import { selectedDatetimeIndexAtom } from 'utils/state/atoms';
 import { useBreakpoint } from 'utils/styling';
 

--- a/web/src/features/charts/elements/AreaGraph.tsx
+++ b/web/src/features/charts/elements/AreaGraph.tsx
@@ -154,7 +154,7 @@ function AreaGraph({
 
     //add exactly 1 interval to the last time, e.g. 1 hour or 1 day or 1 month, etc.
     return duration ? add(lastTime, { [duration]: 1 }) : null;
-  }, [lastTime]);
+  }, [lastTime, selectedTimeAggregate]);
 
   const datetimesWithNext = useMemo(
     // The as Date[] assertion is needed because the filter removes the null values but typescript can't infer that

--- a/web/src/features/charts/elements/AreaGraph.tsx
+++ b/web/src/features/charts/elements/AreaGraph.tsx
@@ -2,12 +2,13 @@
 /* eslint-disable react/display-name */
 import { scaleLinear } from 'd3-scale';
 import { stack, stackOffsetDiverging } from 'd3-shape';
+import { add } from 'date-fns';
 import TimeAxis from 'features/time/TimeAxis'; // TODO: Move to a shared folder
 import { useAtom } from 'jotai';
 import React, { useMemo, useRef, useState } from 'react';
 import { ZoneDetail } from 'types';
 import useResizeObserver from 'use-resize-observer';
-import { TimeAverages } from 'utils/constants';
+import { TimeAverages,timeAxisMapping } from 'utils/constants';
 import { selectedDatetimeIndexAtom } from 'utils/state/atoms';
 import { useBreakpoint } from 'utils/styling';
 
@@ -142,17 +143,18 @@ function AreaGraph({
   );
   const startTime = datetimes.at(0);
   const lastTime = datetimes.at(-1);
-  const interval = datetimes.at(-2);
 
-  const intervalMs =
-    datetimes.length > 1 && interval && lastTime
-      ? lastTime.getTime() - interval.getTime()
-      : 0;
   // The endTime needs to include the last interval so it can be shown
-  const endTime = useMemo(
-    () => (lastTime ? new Date(lastTime.getTime() + intervalMs) : null),
-    [lastTime, intervalMs]
-  );
+  const endTime = useMemo(() => {
+    if (!lastTime) {
+      return null;
+    }
+
+    const duration = timeAxisMapping[selectedTimeAggregate];
+
+    //add exactly 1 interval to the last time, e.g. 1 hour or 1 day or 1 month, etc.
+    return duration ? add(lastTime, { [duration]: 1 }) : null;
+  }, [lastTime]);
 
   const datetimesWithNext = useMemo(
     // The as Date[] assertion is needed because the filter removes the null values but typescript can't infer that

--- a/web/src/utils/constants.ts
+++ b/web/src/utils/constants.ts
@@ -1,3 +1,4 @@
+import type { Duration } from 'date-fns';
 import { ElectricityModeType } from 'types';
 
 // The order here determines the order displayed
@@ -68,3 +69,11 @@ export const modeOrder = [
   'oil',
   'unknown',
 ] as const;
+
+//A mapping between the TimeAverages enum and the corresponding Duration for the date-fns add/substract method
+export const timeAxisMapping: Record<TimeAverages, keyof Duration> = {
+  daily: 'days',
+  hourly: 'hours',
+  monthly: 'months',
+  yearly: 'years',
+};


### PR DESCRIPTION
## Issue
Closes #6217 

## Description
Aims to fix the duplicate month label issue on the area graph axis

### Preview
Bug vs Fix
![bug](https://github.com/electricitymaps/electricitymaps-contrib/assets/64623892/f3df20cc-33ac-4c4c-adc7-802ba54355fc)
![fix](https://github.com/electricitymaps/electricitymaps-contrib/assets/64623892/20dffdbf-faae-4e3b-9cad-6f7b823e9360)

### Double check
- [x] I have run `pnpx prettier@2 --write .` and `poetry run format` in the top level directory to format my changes.
