### PR TITLE
feat(web): simplify moving logic

### DIFF
--- a/web/src/features/map/Map.tsx
+++ b/web/src/features/map/Map.tsx
@@ -66,8 +66,6 @@ export default function MapPage({ onMapLoad }: MapPageProps): ReactElement {
   const [currentMode] = useAtom(productionConsumptionAtom);
   const mixMode = currentMode === Mode.CONSUMPTION ? 'consumption' : 'production';
   const [selectedZoneId, setSelectedZoneId] = useState<FeatureId>();
-  const [isDragging, setIsDragging] = useState(false);
-  const [isZooming, setIsZooming] = useState(false);
   const [spatialAggregate] = useAtom(spatialAggregateAtom);
   // Calculate layer styles only when the theme changes
   // To keep the stable and prevent excessive rerendering.
@@ -304,26 +302,12 @@ export default function MapPage({ onMapLoad }: MapPageProps): ReactElement {
     }
   };
 
-  const onZoomStart = () => {
-    setIsZooming(true);
-    setIsMoving(true);
-  };
-  const onDragStart = () => {
-    setIsDragging(true);
+  const onMoveStart = () => {
     setIsMoving(true);
   };
 
-  const onZoomEnd = () => {
-    setIsZooming(false);
-    if (!isDragging) {
-      setIsMoving(false);
-    }
-  };
-  const onDragEnd = () => {
-    setIsDragging(false);
-    if (!isZooming) {
-      setIsMoving(false);
-    }
+  const onMoveEnd = () => {
+    setIsMoving(false);
   };
 
   return (
@@ -342,10 +326,8 @@ export default function MapPage({ onMapLoad }: MapPageProps): ReactElement {
       onError={onError}
       onMouseMove={onMouseMove}
       onMouseOut={onMouseOut}
-      onDragStart={onDragStart}
-      onDragEnd={onDragEnd}
-      onZoomStart={onZoomStart}
-      onZoomEnd={onZoomEnd}
+      onMoveStart={onMoveStart}
+      onMoveEnd={onMoveEnd}
       dragPan={{ maxSpeed: 0 }} // Disables easing effect to improve performance on exchange layer
       dragRotate={false}
       minZoom={0.7}


### PR DESCRIPTION
## Issue
You can currently move the map with the arrow keys and the exchanges persist on the screen location

## Description
This PR removes some of the map properties for dragging and zooming and simplifies them to `onMoveStart` and `onMoveEnd`.

