### PR TITLE
2024-03 capacity updates for EIA zones

### DIFF
--- a/config/zones/US-CAL-BANC.yaml
+++ b/config/zones/US-CAL-BANC.yaml
@@ -44,6 +44,9 @@ capacity:
     - datetime: '2023-10-01'
       source: EIA.gov
       value: 325.7
+    - datetime: '2024-03-01'
+      source: EIA.gov
+      value: 327.0
   unknown:
     - datetime: '2023-10-01'
       source: EIA.gov

--- a/config/zones/US-CAL-CISO.yaml
+++ b/config/zones/US-CAL-CISO.yaml
@@ -8,10 +8,22 @@ capacity:
     - datetime: '2023-10-01'
       source: EIA.gov
       value: 6887.1
+    - datetime: '2023-12-01'
+      source: EIA.gov
+      value: 7985.9
+    - datetime: '2024-03-01'
+      source: EIA.gov
+      value: 8430.5
   biomass:
     - datetime: '2023-10-01'
       source: EIA.gov
       value: 993.1
+    - datetime: '2023-12-01'
+      source: EIA.gov
+      value: 970.9
+    - datetime: '2024-03-01'
+      source: EIA.gov
+      value: 970.5
   coal:
     - datetime: '2023-10-01'
       source: EIA.gov
@@ -20,6 +32,12 @@ capacity:
     - datetime: '2023-10-01'
       source: EIA.gov
       value: 32732.4
+    - datetime: '2023-12-01'
+      source: EIA.gov
+      value: 31904.0
+    - datetime: '2024-03-01'
+      source: EIA.gov
+      value: 31888.3
   geothermal:
     - datetime: '2023-10-01'
       source: EIA.gov
@@ -28,10 +46,19 @@ capacity:
     - datetime: '2023-10-01'
       source: EIA.gov
       value: 6333.6
+    - datetime: '2023-12-01'
+      source: EIA.gov
+      value: 6343.6
+    - datetime: '2024-03-01'
+      source: EIA.gov
+      value: 6149.4
   hydro storage:
     - datetime: '2023-10-01'
       source: EIA.gov
       value: 1568.8
+    - datetime: '2024-03-01'
+      source: EIA.gov
+      value: 1877.8
   nuclear:
     - datetime: '2023-10-01'
       source: EIA.gov
@@ -40,18 +67,36 @@ capacity:
     - datetime: '2023-10-01'
       source: EIA.gov
       value: 164.8
+    - datetime: '2024-03-01'
+      source: EIA.gov
+      value: 160.3
   solar:
     - datetime: '2023-10-01'
       source: EIA.gov
       value: 19674.0
+    - datetime: '2023-12-01'
+      source: EIA.gov
+      value: 20526.9
+    - datetime: '2024-03-01'
+      source: EIA.gov
+      value: 20969.3
   unknown:
     - datetime: '2023-10-01'
       source: EIA.gov
       value: 66.7
+    - datetime: '2024-03-01'
+      source: EIA.gov
+      value: 62.7
   wind:
     - datetime: '2023-10-01'
       source: EIA.gov
       value: 6027.7
+    - datetime: '2023-12-01'
+      source: EIA.gov
+      value: 6123.0
+    - datetime: '2024-03-01'
+      source: EIA.gov
+      value: 6106.5
 comment: California Independent System Operator
 contributors:
   - systemcatch

--- a/config/zones/US-CAL-IID.yaml
+++ b/config/zones/US-CAL-IID.yaml
@@ -24,6 +24,9 @@ capacity:
     - datetime: '2023-10-01'
       source: EIA.gov
       value: 742.7
+    - datetime: '2024-03-01'
+      source: EIA.gov
+      value: 811.7
   hydro:
     - datetime: '2023-10-01'
       source: EIA.gov

--- a/config/zones/US-CAL-LDWP.yaml
+++ b/config/zones/US-CAL-LDWP.yaml
@@ -20,6 +20,9 @@ capacity:
     - datetime: '2023-10-01'
       source: EIA.gov
       value: 4854.6
+    - datetime: '2024-03-01'
+      source: EIA.gov
+      value: 4631.7
   geothermal:
     - datetime: '2023-10-01'
       source: EIA.gov
@@ -44,6 +47,9 @@ capacity:
     - datetime: '2023-10-01'
       source: EIA.gov
       value: 999.1
+    - datetime: '2023-12-01'
+      source: EIA.gov
+      value: 1000.9
   unknown:
     - datetime: '2023-10-01'
       source: EIA.gov

--- a/config/zones/US-CAR-CPLE.yaml
+++ b/config/zones/US-CAR-CPLE.yaml
@@ -8,10 +8,16 @@ capacity:
     - datetime: '2023-10-01'
       source: EIA.gov
       value: 23.1
+    - datetime: '2024-03-01'
+      source: EIA.gov
+      value: 41.1
   biomass:
     - datetime: '2023-10-01'
       source: EIA.gov
       value: 336.4
+    - datetime: '2024-03-01'
+      source: EIA.gov
+      value: 327.4
   coal:
     - datetime: '2023-10-01'
       source: EIA.gov
@@ -28,6 +34,9 @@ capacity:
     - datetime: '2023-10-01'
       source: EIA.gov
       value: 225.2
+    - datetime: '2024-03-01'
+      source: EIA.gov
+      value: 224.0
   hydro storage:
     - datetime: '2023-10-01'
       source: EIA.gov
@@ -44,6 +53,12 @@ capacity:
     - datetime: '2023-10-01'
       source: EIA.gov
       value: 2853.2
+    - datetime: '2023-12-01'
+      source: EIA.gov
+      value: 2911.6
+    - datetime: '2024-03-01'
+      source: EIA.gov
+      value: 2913.4
   unknown:
     - datetime: '2023-10-01'
       source: EIA.gov

--- a/config/zones/US-CAR-CPLW.yaml
+++ b/config/zones/US-CAR-CPLW.yaml
@@ -37,9 +37,15 @@ capacity:
       source: EIA.gov
       value: 0.0
   oil:
-    - datetime: '2023-10-01'
+    - comment:
+        There has been reported oil generation through the usage of diseal generators
+        during extreme weather events. We do not know yet the capacity of these generators,
+        so we are not able to provide a value.
+      datetime: '2023-10-01'
       value: null
-      comment: There has been reported oil generation through the usage of diseal generators during extreme weather events. We do not know yet the capacity of these generators, so we are not able to provide a value.
+    - datetime: '2023-12-01'
+      source: EIA.gov
+      value: 0.0
   solar:
     - datetime: '2023-10-01'
       source: EIA.gov

--- a/config/zones/US-CAR-DUK.yaml
+++ b/config/zones/US-CAR-DUK.yaml
@@ -12,6 +12,9 @@ capacity:
     - datetime: '2023-10-01'
       source: EIA.gov
       value: 76.1
+    - datetime: '2024-03-01'
+      source: EIA.gov
+      value: 71.6
   coal:
     - datetime: '2023-10-01'
       source: EIA.gov
@@ -32,6 +35,9 @@ capacity:
     - datetime: '2023-10-01'
       source: EIA.gov
       value: 2358.0
+    - datetime: '2024-03-01'
+      source: EIA.gov
+      value: 2454.0
   nuclear:
     - datetime: '2023-10-01'
       source: EIA.gov
@@ -44,6 +50,12 @@ capacity:
     - datetime: '2023-10-01'
       source: EIA.gov
       value: 2033.6
+    - datetime: '2023-12-01'
+      source: EIA.gov
+      value: 2038.6
+    - datetime: '2024-03-01'
+      source: EIA.gov
+      value: 2063.6
   unknown:
     - datetime: '2023-10-01'
       source: EIA.gov

--- a/config/zones/US-CAR-SC.yaml
+++ b/config/zones/US-CAR-SC.yaml
@@ -44,6 +44,9 @@ capacity:
     - datetime: '2023-10-01'
       source: EIA.gov
       value: 248.2
+    - datetime: '2023-12-01'
+      source: EIA.gov
+      value: 303.2
   unknown:
     - datetime: '2023-10-01'
       source: EIA.gov

--- a/config/zones/US-CAR-SCEG.yaml
+++ b/config/zones/US-CAR-SCEG.yaml
@@ -12,6 +12,9 @@ capacity:
     - datetime: '2023-10-01'
       source: EIA.gov
       value: 120.0
+    - datetime: '2024-03-01'
+      source: EIA.gov
+      value: 20.8
   coal:
     - datetime: '2023-10-01'
       source: EIA.gov

--- a/config/zones/US-CENT-SPA.yaml
+++ b/config/zones/US-CENT-SPA.yaml
@@ -28,6 +28,9 @@ capacity:
     - datetime: '2023-10-01'
       source: EIA.gov
       value: 1327.6
+    - datetime: '2024-03-01'
+      source: EIA.gov
+      value: 1253.2
   hydro storage:
     - datetime: '2023-10-01'
       source: EIA.gov
@@ -44,6 +47,9 @@ capacity:
     - datetime: '2023-10-01'
       source: EIA.gov
       value: 17.0
+    - datetime: '2023-12-01'
+      source: EIA.gov
+      value: 18.5
   unknown:
     - datetime: '2023-10-01'
       source: EIA.gov

--- a/config/zones/US-CENT-SWPP.yaml
+++ b/config/zones/US-CENT-SWPP.yaml
@@ -8,6 +8,9 @@ capacity:
     - datetime: '2023-10-01'
       source: EIA.gov
       value: 26.9
+    - datetime: '2023-12-01'
+      source: EIA.gov
+      value: 25.7
   biomass:
     - datetime: '2023-10-01'
       source: EIA.gov
@@ -20,6 +23,12 @@ capacity:
     - datetime: '2023-10-01'
       source: EIA.gov
       value: 34966.3
+    - datetime: '2023-12-01'
+      source: EIA.gov
+      value: 34976.7
+    - datetime: '2024-03-01'
+      source: EIA.gov
+      value: 34947.2
   geothermal:
     - datetime: '2023-10-01'
       source: EIA.gov
@@ -40,10 +49,22 @@ capacity:
     - datetime: '2023-10-01'
       source: EIA.gov
       value: 2053.6
+    - datetime: '2023-12-01'
+      source: EIA.gov
+      value: 2047.3
+    - datetime: '2024-03-01'
+      source: EIA.gov
+      value: 2085.5
   solar:
     - datetime: '2023-10-01'
       source: EIA.gov
       value: 588.6
+    - datetime: '2023-12-01'
+      source: EIA.gov
+      value: 596.9
+    - datetime: '2024-03-01'
+      source: EIA.gov
+      value: 606.9
   unknown:
     - datetime: '2023-10-01'
       source: EIA.gov
@@ -52,6 +73,12 @@ capacity:
     - datetime: '2023-10-01'
       source: EIA.gov
       value: 31745.7
+    - datetime: '2023-12-01'
+      source: EIA.gov
+      value: 32688.6
+    - datetime: '2024-03-01'
+      source: EIA.gov
+      value: 33089.0
 comment: Southwest Power Pool
 contributors:
   - systemcatch

--- a/config/zones/US-FLA-FMPP.yaml
+++ b/config/zones/US-FLA-FMPP.yaml
@@ -40,6 +40,9 @@ capacity:
     - datetime: '2023-10-01'
       source: EIA.gov
       value: 93.8
+    - datetime: '2024-03-01'
+      source: EIA.gov
+      value: 87.8
   solar:
     - datetime: '2023-10-01'
       source: EIA.gov

--- a/config/zones/US-FLA-FPC.yaml
+++ b/config/zones/US-FLA-FPC.yaml
@@ -8,10 +8,16 @@ capacity:
     - datetime: '2023-10-01'
       source: EIA.gov
       value: 47.6
+    - datetime: '2023-12-01'
+      source: EIA.gov
+      value: 50.1
   biomass:
     - datetime: '2023-10-01'
       source: EIA.gov
       value: 257.2
+    - datetime: '2024-03-01'
+      source: EIA.gov
+      value: 184.2
   coal:
     - datetime: '2023-10-01'
       source: EIA.gov
@@ -20,6 +26,9 @@ capacity:
     - datetime: '2023-10-01'
       source: EIA.gov
       value: 10751.1
+    - datetime: '2024-03-01'
+      source: EIA.gov
+      value: 10774.1
   geothermal:
     - datetime: '2023-10-01'
       source: EIA.gov
@@ -44,6 +53,9 @@ capacity:
     - datetime: '2023-10-01'
       source: EIA.gov
       value: 1261.0
+    - datetime: '2024-03-01'
+      source: EIA.gov
+      value: 1414.8
   unknown:
     - datetime: '2023-10-01'
       source: EIA.gov

--- a/config/zones/US-FLA-FPL.yaml
+++ b/config/zones/US-FLA-FPL.yaml
@@ -44,6 +44,9 @@ capacity:
     - datetime: '2023-10-01'
       source: EIA.gov
       value: 4584.8
+    - datetime: '2024-03-01'
+      source: EIA.gov
+      value: 6223.8
   unknown:
     - datetime: '2023-10-01'
       source: EIA.gov

--- a/config/zones/US-FLA-HST.yaml
+++ b/config/zones/US-FLA-HST.yaml
@@ -20,6 +20,9 @@ capacity:
     - datetime: '2023-10-01'
       source: EIA.gov
       value: 35.6
+    - datetime: '2023-12-01'
+      source: EIA.gov
+      value: 33.6
   geothermal:
     - datetime: '2023-10-01'
       source: EIA.gov
@@ -40,6 +43,9 @@ capacity:
     - datetime: '2023-10-01'
       source: EIA.gov
       value: 0.0
+    - datetime: '2023-12-01'
+      source: EIA.gov
+      value: 2.0
   solar:
     - datetime: '2023-10-01'
       source: EIA.gov

--- a/config/zones/US-FLA-SEC.yaml
+++ b/config/zones/US-FLA-SEC.yaml
@@ -16,6 +16,9 @@ capacity:
     - datetime: '2023-10-01'
       source: EIA.gov
       value: 1429.2
+    - datetime: '2024-03-01'
+      source: EIA.gov
+      value: 714.6
   gas:
     - datetime: '2023-10-01'
       source: EIA.gov

--- a/config/zones/US-FLA-TEC.yaml
+++ b/config/zones/US-FLA-TEC.yaml
@@ -44,6 +44,9 @@ capacity:
     - datetime: '2023-10-01'
       source: EIA.gov
       value: 1029.4
+    - datetime: '2023-12-01'
+      source: EIA.gov
+      value: 1258.9
   unknown:
     - datetime: '2023-10-01'
       source: EIA.gov

--- a/config/zones/US-MIDA-PJM.yaml
+++ b/config/zones/US-MIDA-PJM.yaml
@@ -8,18 +8,39 @@ capacity:
     - datetime: '2023-10-01'
       source: EIA.gov
       value: 316.1
+    - datetime: '2023-12-01'
+      source: EIA.gov
+      value: 336.1
+    - datetime: '2024-03-01'
+      source: EIA.gov
+      value: 362.1
   biomass:
     - datetime: '2023-10-01'
       source: EIA.gov
       value: 2140.3
+    - datetime: '2023-12-01'
+      source: EIA.gov
+      value: 2133.5
+    - datetime: '2024-03-01'
+      source: EIA.gov
+      value: 2118.6
   coal:
     - datetime: '2023-10-01'
       source: EIA.gov
       value: 41332.1
+    - datetime: '2024-03-01'
+      source: EIA.gov
+      value: 37334.8
   gas:
     - datetime: '2023-10-01'
       source: EIA.gov
       value: 103431.3
+    - datetime: '2023-12-01'
+      source: EIA.gov
+      value: 103416.7
+    - datetime: '2024-03-01'
+      source: EIA.gov
+      value: 105136.5
   geothermal:
     - datetime: '2023-10-01'
       source: EIA.gov
@@ -40,10 +61,22 @@ capacity:
     - datetime: '2023-10-01'
       source: EIA.gov
       value: 4990.7
+    - datetime: '2023-12-01'
+      source: EIA.gov
+      value: 4980.8
+    - datetime: '2024-03-01'
+      source: EIA.gov
+      value: 5319.6
   solar:
     - datetime: '2023-10-01'
       source: EIA.gov
       value: 8720.7
+    - datetime: '2023-12-01'
+      source: EIA.gov
+      value: 10280.5
+    - datetime: '2024-03-01'
+      source: EIA.gov
+      value: 11474.2
   unknown:
     - datetime: '2023-10-01'
       source: EIA.gov
@@ -52,6 +85,12 @@ capacity:
     - datetime: '2023-10-01'
       source: EIA.gov
       value: 11168.6
+    - datetime: '2023-12-01'
+      source: EIA.gov
+      value: 11182.6
+    - datetime: '2024-03-01'
+      source: EIA.gov
+      value: 11270.6
 comment: Pjm Interconnection, Llc
 contributors:
   - systemcatch

--- a/config/zones/US-MIDW-AECI.yaml
+++ b/config/zones/US-MIDW-AECI.yaml
@@ -40,10 +40,16 @@ capacity:
     - datetime: '2023-10-01'
       source: EIA.gov
       value: 44.3
+    - datetime: '2023-12-01'
+      source: EIA.gov
+      value: 97.5
   solar:
     - datetime: '2023-10-01'
       source: EIA.gov
       value: 4.0
+    - datetime: '2024-03-01'
+      source: EIA.gov
+      value: 1.5
   unknown:
     - datetime: '2023-10-01'
       source: EIA.gov

--- a/config/zones/US-MIDW-LGEE.yaml
+++ b/config/zones/US-MIDW-LGEE.yaml
@@ -44,6 +44,9 @@ capacity:
     - datetime: '2023-10-01'
       source: EIA.gov
       value: 15.1
+    - datetime: '2024-03-01'
+      source: EIA.gov
+      value: 18.1
   unknown:
     - datetime: '2023-10-01'
       source: EIA.gov

--- a/config/zones/US-MIDW-MISO.yaml
+++ b/config/zones/US-MIDW-MISO.yaml
@@ -8,18 +8,39 @@ capacity:
     - datetime: '2023-10-01'
       source: EIA.gov
       value: 82.0
+    - datetime: '2024-03-01'
+      source: EIA.gov
+      value: 81.5
   biomass:
     - datetime: '2023-10-01'
       source: EIA.gov
       value: 2285.1
+    - datetime: '2023-12-01'
+      source: EIA.gov
+      value: 2282.4
+    - datetime: '2024-03-01'
+      source: EIA.gov
+      value: 2281.8
   coal:
     - datetime: '2023-10-01'
       source: EIA.gov
       value: 50924.4
+    - datetime: '2023-12-01'
+      source: EIA.gov
+      value: 50159.1
+    - datetime: '2024-03-01'
+      source: EIA.gov
+      value: 50124.0
   gas:
     - datetime: '2023-10-01'
       source: EIA.gov
       value: 83093.1
+    - datetime: '2023-12-01'
+      source: EIA.gov
+      value: 82979.7
+    - datetime: '2024-03-01'
+      source: EIA.gov
+      value: 82306.0
   geothermal:
     - datetime: '2023-10-01'
       source: EIA.gov
@@ -28,6 +49,12 @@ capacity:
     - datetime: '2023-10-01'
       source: EIA.gov
       value: 2456.9
+    - datetime: '2023-12-01'
+      source: EIA.gov
+      value: 2452.9
+    - datetime: '2024-03-01'
+      source: EIA.gov
+      value: 2451.3
   hydro storage:
     - datetime: '2023-10-01'
       source: EIA.gov
@@ -40,18 +67,39 @@ capacity:
     - datetime: '2023-10-01'
       source: EIA.gov
       value: 4108.2
+    - datetime: '2023-12-01'
+      source: EIA.gov
+      value: 4128.3
+    - datetime: '2024-03-01'
+      source: EIA.gov
+      value: 4100.3
   solar:
     - datetime: '2023-10-01'
       source: EIA.gov
       value: 5665.8
+    - datetime: '2023-12-01'
+      source: EIA.gov
+      value: 7191.8
+    - datetime: '2024-03-01'
+      source: EIA.gov
+      value: 7364.8
   unknown:
     - datetime: '2023-10-01'
       source: EIA.gov
       value: 487.5
+    - datetime: '2024-03-01'
+      source: EIA.gov
+      value: 512.8
   wind:
     - datetime: '2023-10-01'
       source: EIA.gov
       value: 30866.3
+    - datetime: '2023-12-01'
+      source: EIA.gov
+      value: 31239.7
+    - datetime: '2024-03-01'
+      source: EIA.gov
+      value: 31237.2
 comment: Midcontinent Independent Transmission System Operator, Inc..
 contributors:
   - systemcatch

--- a/config/zones/US-NE-ISNE.yaml
+++ b/config/zones/US-NE-ISNE.yaml
@@ -8,10 +8,16 @@ capacity:
     - datetime: '2023-10-01'
       source: EIA.gov
       value: 332.3
+    - datetime: '2024-03-01'
+      source: EIA.gov
+      value: 368.2
   biomass:
     - datetime: '2023-10-01'
       source: EIA.gov
       value: 1281.3
+    - datetime: '2024-03-01'
+      source: EIA.gov
+      value: 1247.5
   coal:
     - datetime: '2023-10-01'
       source: EIA.gov
@@ -20,6 +26,12 @@ capacity:
     - datetime: '2023-10-01'
       source: EIA.gov
       value: 18600.2
+    - datetime: '2023-12-01'
+      source: EIA.gov
+      value: 18599.1
+    - datetime: '2024-03-01'
+      source: EIA.gov
+      value: 18618.4
   geothermal:
     - datetime: '2023-10-01'
       source: EIA.gov
@@ -28,22 +40,46 @@ capacity:
     - datetime: '2023-10-01'
       source: EIA.gov
       value: 1905.9
+    - datetime: '2023-12-01'
+      source: EIA.gov
+      value: 1903.9
+    - datetime: '2024-03-01'
+      source: EIA.gov
+      value: 1897.9
   hydro storage:
     - datetime: '2023-10-01'
       source: EIA.gov
       value: 1499.0
+    - datetime: '2023-12-01'
+      source: EIA.gov
+      value: 1532.0
   nuclear:
     - datetime: '2023-10-01'
       source: EIA.gov
       value: 3404.9
+    - datetime: '2024-03-01'
+      source: EIA.gov
+      value: 3501.9
   oil:
     - datetime: '2023-10-01'
       source: EIA.gov
       value: 5886.3
+    - datetime: '2023-12-01'
+      source: EIA.gov
+      value: 5861.3
+    - datetime: '2024-03-01'
+      source: EIA.gov
+      value: 5867.9
   solar:
     - datetime: '2023-10-01'
       source: EIA.gov
       value: 2394.8
+    - datetime: '2023-12-01'
+      source: EIA.gov
+      value: 2590.3
+    - datetime: '2024-03-01'
+      source: EIA.gov
+      value: 2804.2
   unknown:
     - datetime: '2023-10-01'
       source: EIA.gov

--- a/config/zones/US-NW-BPAT.yaml
+++ b/config/zones/US-NW-BPAT.yaml
@@ -12,6 +12,9 @@ capacity:
     - datetime: '2023-10-01'
       source: EIA.gov
       value: 303.4
+    - datetime: '2024-03-01'
+      source: EIA.gov
+      value: 293.6
   coal:
     - datetime: '2023-10-01'
       source: EIA.gov
@@ -20,6 +23,9 @@ capacity:
     - datetime: '2023-10-01'
       source: EIA.gov
       value: 2271.7
+    - datetime: '2024-03-01'
+      source: EIA.gov
+      value: 2167.0
   geothermal:
     - datetime: '2023-10-01'
       source: EIA.gov
@@ -28,6 +34,12 @@ capacity:
     - datetime: '2023-10-01'
       source: EIA.gov
       value: 19577.9
+    - datetime: '2023-12-01'
+      source: EIA.gov
+      value: 19737.6
+    - datetime: '2024-03-01'
+      source: EIA.gov
+      value: 19752.0
   hydro storage:
     - datetime: '2023-10-01'
       source: EIA.gov

--- a/config/zones/US-NW-CHPD.yaml
+++ b/config/zones/US-NW-CHPD.yaml
@@ -28,6 +28,9 @@ capacity:
     - datetime: '2023-10-01'
       source: EIA.gov
       value: 1664.2
+    - datetime: '2023-12-01'
+      source: EIA.gov
+      value: 1601.5
   hydro storage:
     - datetime: '2023-10-01'
       source: EIA.gov

--- a/config/zones/US-NW-GRID.yaml
+++ b/config/zones/US-NW-GRID.yaml
@@ -16,6 +16,9 @@ capacity:
     - datetime: '2023-10-01'
       source: EIA.gov
       value: 729.9
+    - datetime: '2023-12-01'
+      source: EIA.gov
+      value: 0.0
   gas:
     - datetime: '2023-10-01'
       source: EIA.gov

--- a/config/zones/US-NW-IPCO.yaml
+++ b/config/zones/US-NW-IPCO.yaml
@@ -20,6 +20,9 @@ capacity:
     - datetime: '2023-10-01'
       source: EIA.gov
       value: 776.6
+    - datetime: '2023-12-01'
+      source: EIA.gov
+      value: 779.1
   geothermal:
     - datetime: '2023-10-01'
       source: EIA.gov
@@ -28,6 +31,9 @@ capacity:
     - datetime: '2023-10-01'
       source: EIA.gov
       value: 1827.8
+    - datetime: '2024-03-01'
+      source: EIA.gov
+      value: 1766.2
   hydro storage:
     - datetime: '2023-10-01'
       source: EIA.gov

--- a/config/zones/US-NW-NEVP.yaml
+++ b/config/zones/US-NW-NEVP.yaml
@@ -8,6 +8,12 @@ capacity:
     - datetime: '2023-10-01'
       source: EIA.gov
       value: 175.0
+    - datetime: '2023-12-01'
+      source: EIA.gov
+      value: 470.0
+    - datetime: '2024-03-01'
+      source: EIA.gov
+      value: 850.0
   biomass:
     - datetime: '2023-10-01'
       source: EIA.gov
@@ -24,6 +30,12 @@ capacity:
     - datetime: '2023-10-01'
       source: EIA.gov
       value: 859.7
+    - datetime: '2023-12-01'
+      source: EIA.gov
+      value: 856.7
+    - datetime: '2024-03-01'
+      source: EIA.gov
+      value: 872.7
   hydro:
     - datetime: '2023-10-01'
       source: EIA.gov
@@ -44,6 +56,12 @@ capacity:
     - datetime: '2023-10-01'
       source: EIA.gov
       value: 2795.8
+    - datetime: '2023-12-01'
+      source: EIA.gov
+      value: 2996.8
+    - datetime: '2024-03-01'
+      source: EIA.gov
+      value: 3710.8
   unknown:
     - datetime: '2023-10-01'
       source: EIA.gov

--- a/config/zones/US-NW-NWMT.yaml
+++ b/config/zones/US-NW-NWMT.yaml
@@ -16,6 +16,9 @@ capacity:
     - datetime: '2023-10-01'
       source: EIA.gov
       value: 1814.7
+    - datetime: '2024-03-01'
+      source: EIA.gov
+      value: 1810.7
   gas:
     - datetime: '2023-10-01'
       source: EIA.gov
@@ -28,6 +31,9 @@ capacity:
     - datetime: '2023-10-01'
       source: EIA.gov
       value: 649.7
+    - datetime: '2024-03-01'
+      source: EIA.gov
+      value: 666.1
   hydro storage:
     - datetime: '2023-10-01'
       source: EIA.gov
@@ -52,6 +58,12 @@ capacity:
     - datetime: '2023-10-01'
       source: EIA.gov
       value: 452.9
+    - datetime: '2023-12-01'
+      source: EIA.gov
+      value: 555.7
+    - datetime: '2024-03-01'
+      source: EIA.gov
+      value: 763.6
 comment: Northwestern Energy (Nwmt)
 contributors:
   - systemcatch

--- a/config/zones/US-NW-PACE.yaml
+++ b/config/zones/US-NW-PACE.yaml
@@ -12,18 +12,36 @@ capacity:
     - datetime: '2023-10-01'
       source: EIA.gov
       value: 15.3
+    - datetime: '2024-03-01'
+      source: EIA.gov
+      value: 12.1
   coal:
     - datetime: '2023-10-01'
       source: EIA.gov
       value: 7447.5
+    - datetime: '2023-12-01'
+      source: EIA.gov
+      value: 7096.9
+    - datetime: '2024-03-01'
+      source: EIA.gov
+      value: 6991.9
   gas:
     - datetime: '2023-10-01'
       source: EIA.gov
       value: 3776.5
+    - datetime: '2023-12-01'
+      source: EIA.gov
+      value: 3706.9
+    - datetime: '2024-03-01'
+      source: EIA.gov
+      value: 3439.4
   geothermal:
     - datetime: '2023-10-01'
       source: EIA.gov
       value: 83.8
+    - datetime: '2024-03-01'
+      source: EIA.gov
+      value: 77.1
   hydro:
     - datetime: '2023-10-01'
       source: EIA.gov
@@ -44,6 +62,9 @@ capacity:
     - datetime: '2023-10-01'
       source: EIA.gov
       value: 1717.9
+    - datetime: '2024-03-01'
+      source: EIA.gov
+      value: 1997.9
   unknown:
     - datetime: '2023-10-01'
       source: EIA.gov
@@ -52,6 +73,9 @@ capacity:
     - datetime: '2023-10-01'
       source: EIA.gov
       value: 3451.6
+    - datetime: '2024-03-01'
+      source: EIA.gov
+      value: 3603.2
 comment: Pacificorp - East
 contributors:
   - systemcatch

--- a/config/zones/US-NW-PACW.yaml
+++ b/config/zones/US-NW-PACW.yaml
@@ -12,6 +12,9 @@ capacity:
     - datetime: '2023-10-01'
       source: EIA.gov
       value: 115.5
+    - datetime: '2024-03-01'
+      source: EIA.gov
+      value: 118.7
   coal:
     - datetime: '2023-10-01'
       source: EIA.gov
@@ -44,6 +47,9 @@ capacity:
     - datetime: '2023-10-01'
       source: EIA.gov
       value: 408.4
+    - datetime: '2024-03-01'
+      source: EIA.gov
+      value: 463.4
   unknown:
     - datetime: '2023-10-01'
       source: EIA.gov

--- a/config/zones/US-NW-PGE.yaml
+++ b/config/zones/US-NW-PGE.yaml
@@ -44,6 +44,9 @@ capacity:
     - datetime: '2023-10-01'
       source: EIA.gov
       value: 165.0
+    - datetime: '2024-03-01'
+      source: EIA.gov
+      value: 170.9
   unknown:
     - datetime: '2023-10-01'
       source: EIA.gov

--- a/config/zones/US-NW-PSCO.yaml
+++ b/config/zones/US-NW-PSCO.yaml
@@ -20,6 +20,9 @@ capacity:
     - datetime: '2023-10-01'
       source: EIA.gov
       value: 6430.0
+    - datetime: '2024-03-01'
+      source: EIA.gov
+      value: 6870.0
   geothermal:
     - datetime: '2023-10-01'
       source: EIA.gov
@@ -28,6 +31,9 @@ capacity:
     - datetime: '2023-10-01'
       source: EIA.gov
       value: 53.9
+    - datetime: '2024-03-01'
+      source: EIA.gov
+      value: 48.9
   hydro storage:
     - datetime: '2023-10-01'
       source: EIA.gov
@@ -44,6 +50,12 @@ capacity:
     - datetime: '2023-10-01'
       source: EIA.gov
       value: 1671.4
+    - datetime: '2023-12-01'
+      source: EIA.gov
+      value: 1927.4
+    - datetime: '2024-03-01'
+      source: EIA.gov
+      value: 1941.4
   unknown:
     - datetime: '2023-10-01'
       source: EIA.gov
@@ -52,6 +64,12 @@ capacity:
     - datetime: '2023-10-01'
       source: EIA.gov
       value: 4490.8
+    - datetime: '2023-12-01'
+      source: EIA.gov
+      value: 4692.3
+    - datetime: '2024-03-01'
+      source: EIA.gov
+      value: 4662.6
 comment: Public Service Company Of Colorado
 contributors:
   - systemcatch

--- a/config/zones/US-NW-SCL.yaml
+++ b/config/zones/US-NW-SCL.yaml
@@ -20,6 +20,9 @@ capacity:
     - datetime: '2023-10-01'
       source: EIA.gov
       value: 0.0
+    - datetime: '2023-12-01'
+      source: EIA.gov
+      value: 3.0
   geothermal:
     - datetime: '2023-10-01'
       source: EIA.gov
@@ -28,6 +31,9 @@ capacity:
     - datetime: '2023-10-01'
       source: EIA.gov
       value: 2005.1
+    - datetime: '2024-03-01'
+      source: EIA.gov
+      value: 1816.7
   hydro storage:
     - datetime: '2023-10-01'
       source: EIA.gov

--- a/config/zones/US-NW-TPWR.yaml
+++ b/config/zones/US-NW-TPWR.yaml
@@ -12,6 +12,9 @@ capacity:
     - datetime: '2023-10-01'
       source: EIA.gov
       value: 64.0
+    - datetime: '2023-12-01'
+      source: EIA.gov
+      value: 0.0
   coal:
     - datetime: '2023-10-01'
       source: EIA.gov

--- a/config/zones/US-NW-WACM.yaml
+++ b/config/zones/US-NW-WACM.yaml
@@ -8,6 +8,9 @@ capacity:
     - datetime: '2023-10-01'
       source: EIA.gov
       value: 10.3
+    - datetime: '2024-03-01'
+      source: EIA.gov
+      value: 6.3
   biomass:
     - datetime: '2023-10-01'
       source: EIA.gov
@@ -20,6 +23,12 @@ capacity:
     - datetime: '2023-10-01'
       source: EIA.gov
       value: 2026.8
+    - datetime: '2023-12-01'
+      source: EIA.gov
+      value: 2023.8
+    - datetime: '2024-03-01'
+      source: EIA.gov
+      value: 1585.3
   geothermal:
     - datetime: '2023-10-01'
       source: EIA.gov
@@ -44,14 +53,23 @@ capacity:
     - datetime: '2023-10-01'
       source: EIA.gov
       value: 243.9
+    - datetime: '2024-03-01'
+      source: EIA.gov
+      value: 259.3
   unknown:
     - datetime: '2023-10-01'
       source: EIA.gov
       value: 10.6
+    - datetime: '2024-03-01'
+      source: EIA.gov
+      value: 12.4
   wind:
     - datetime: '2023-10-01'
       source: EIA.gov
       value: 1236.9
+    - datetime: '2023-12-01'
+      source: EIA.gov
+      value: 1342.6
 comment: Western Area Power Administration - Rocky Mountain Region
 contributors:
   - systemcatch

--- a/config/zones/US-NW-WAUW.yaml
+++ b/config/zones/US-NW-WAUW.yaml
@@ -28,6 +28,9 @@ capacity:
     - datetime: '2023-10-01'
       source: EIA.gov
       value: 950.2
+    - datetime: '2024-03-01'
+      source: EIA.gov
+      value: 952.8
   hydro storage:
     - datetime: '2023-10-01'
       source: EIA.gov

--- a/config/zones/US-NY-NYIS.yaml
+++ b/config/zones/US-NY-NYIS.yaml
@@ -8,10 +8,16 @@ capacity:
     - datetime: '2023-10-01'
       source: EIA.gov
       value: 217.5
+    - datetime: '2024-03-01'
+      source: EIA.gov
+      value: 221.3
   biomass:
     - datetime: '2023-10-01'
       source: EIA.gov
       value: 506.9
+    - datetime: '2024-03-01'
+      source: EIA.gov
+      value: 451.4
   coal:
     - datetime: '2023-10-01'
       source: EIA.gov
@@ -20,6 +26,12 @@ capacity:
     - datetime: '2023-10-01'
       source: EIA.gov
       value: 25158.1
+    - datetime: '2023-12-01'
+      source: EIA.gov
+      value: 25779.1
+    - datetime: '2024-03-01'
+      source: EIA.gov
+      value: 25777.0
   geothermal:
     - datetime: '2023-10-01'
       source: EIA.gov
@@ -28,6 +40,9 @@ capacity:
     - datetime: '2023-10-01'
       source: EIA.gov
       value: 4617.3
+    - datetime: '2024-03-01'
+      source: EIA.gov
+      value: 4604.4
   hydro storage:
     - datetime: '2023-10-01'
       source: EIA.gov
@@ -40,10 +55,19 @@ capacity:
     - datetime: '2023-10-01'
       source: EIA.gov
       value: 4065.4
+    - datetime: '2023-12-01'
+      source: EIA.gov
+      value: 3444.4
   solar:
     - datetime: '2023-10-01'
       source: EIA.gov
       value: 1446.4
+    - datetime: '2023-12-01'
+      source: EIA.gov
+      value: 1487.0
+    - datetime: '2024-03-01'
+      source: EIA.gov
+      value: 1614.7
   unknown:
     - datetime: '2023-10-01'
       source: EIA.gov
@@ -52,6 +76,9 @@ capacity:
     - datetime: '2023-10-01'
       source: EIA.gov
       value: 2526.3
+    - datetime: '2023-12-01'
+      source: EIA.gov
+      value: 2745.6
 comment: New York Independent System Operator
 contributors:
   - systemcatch

--- a/config/zones/US-SE-SEPA.yaml
+++ b/config/zones/US-SE-SEPA.yaml
@@ -32,6 +32,9 @@ capacity:
     - datetime: '2023-10-01'
       source: EIA.gov
       value: 246.0
+    - datetime: '2024-03-01'
+      source: EIA.gov
+      value: 164.0
   nuclear:
     - datetime: '2023-10-01'
       source: EIA.gov

--- a/config/zones/US-SE-SOCO.yaml
+++ b/config/zones/US-SE-SOCO.yaml
@@ -8,10 +8,19 @@ capacity:
     - datetime: '2023-10-01'
       source: EIA.gov
       value: 82.7
+    - datetime: '2024-03-01'
+      source: EIA.gov
+      value: 83.7
   biomass:
     - datetime: '2023-10-01'
       source: EIA.gov
       value: 1929.4
+    - datetime: '2023-12-01'
+      source: EIA.gov
+      value: 1916.4
+    - datetime: '2024-03-01'
+      source: EIA.gov
+      value: 1821.5
   coal:
     - datetime: '2023-10-01'
       source: EIA.gov
@@ -20,6 +29,12 @@ capacity:
     - datetime: '2023-10-01'
       source: EIA.gov
       value: 37762.7
+    - datetime: '2023-12-01'
+      source: EIA.gov
+      value: 38536.7
+    - datetime: '2024-03-01'
+      source: EIA.gov
+      value: 38570.5
   geothermal:
     - datetime: '2023-10-01'
       source: EIA.gov
@@ -47,6 +62,12 @@ capacity:
     - datetime: '2023-10-01'
       source: EIA.gov
       value: 4650.2
+    - datetime: '2023-12-01'
+      source: EIA.gov
+      value: 4885.2
+    - datetime: '2024-03-01'
+      source: EIA.gov
+      value: 4893.6
   unknown:
     - datetime: '2023-10-01'
       source: EIA.gov

--- a/config/zones/US-SW-AZPS.yaml
+++ b/config/zones/US-SW-AZPS.yaml
@@ -44,6 +44,9 @@ capacity:
     - datetime: '2023-10-01'
       source: EIA.gov
       value: 831.7
+    - datetime: '2024-03-01'
+      source: EIA.gov
+      value: 831.3
   unknown:
     - datetime: '2023-10-01'
       source: EIA.gov

--- a/config/zones/US-SW-EPE.yaml
+++ b/config/zones/US-SW-EPE.yaml
@@ -20,6 +20,9 @@ capacity:
     - datetime: '2023-10-01'
       source: EIA.gov
       value: 1915.9
+    - datetime: '2023-12-01'
+      source: EIA.gov
+      value: 2143.7
   geothermal:
     - datetime: '2023-10-01'
       source: EIA.gov

--- a/config/zones/US-SW-PNM.yaml
+++ b/config/zones/US-SW-PNM.yaml
@@ -12,14 +12,23 @@ capacity:
     - datetime: '2023-10-01'
       source: EIA.gov
       value: 4.4
+    - datetime: '2024-03-01'
+      source: EIA.gov
+      value: 3.3
   coal:
     - datetime: '2023-10-01'
       source: EIA.gov
       value: 516.3
+    - datetime: '2023-12-01'
+      source: EIA.gov
+      value: 0.0
   gas:
     - datetime: '2023-10-01'
       source: EIA.gov
       value: 1732.7
+    - datetime: '2024-03-01'
+      source: EIA.gov
+      value: 1733.8
   geothermal:
     - datetime: '2023-10-01'
       source: EIA.gov
@@ -44,6 +53,9 @@ capacity:
     - datetime: '2023-10-01'
       source: EIA.gov
       value: 596.3
+    - datetime: '2024-03-01'
+      source: EIA.gov
+      value: 896.3
   unknown:
     - datetime: '2023-10-01'
       source: EIA.gov

--- a/config/zones/US-SW-SRP.yaml
+++ b/config/zones/US-SW-SRP.yaml
@@ -44,6 +44,12 @@ capacity:
     - datetime: '2023-10-01'
       source: EIA.gov
       value: 559.8
+    - datetime: '2023-12-01'
+      source: EIA.gov
+      value: 819.8
+    - datetime: '2024-03-01'
+      source: EIA.gov
+      value: 941.8
   unknown:
     - datetime: '2023-10-01'
       source: EIA.gov

--- a/config/zones/US-SW-TEPC.yaml
+++ b/config/zones/US-SW-TEPC.yaml
@@ -8,6 +8,9 @@ capacity:
     - datetime: '2023-10-01'
       source: EIA.gov
       value: 50.0
+    - datetime: '2023-12-01'
+      source: EIA.gov
+      value: 70.0
   biomass:
     - datetime: '2023-10-01'
       source: EIA.gov
@@ -20,6 +23,9 @@ capacity:
     - datetime: '2023-10-01'
       source: EIA.gov
       value: 1530.7
+    - datetime: '2024-03-01'
+      source: EIA.gov
+      value: 1530.2
   geothermal:
     - datetime: '2023-10-01'
       source: EIA.gov
@@ -44,6 +50,9 @@ capacity:
     - datetime: '2023-10-01'
       source: EIA.gov
       value: 474.0
+    - datetime: '2023-12-01'
+      source: EIA.gov
+      value: 494.0
   unknown:
     - datetime: '2023-10-01'
       source: EIA.gov

--- a/config/zones/US-SW-WALC.yaml
+++ b/config/zones/US-SW-WALC.yaml
@@ -8,6 +8,9 @@ capacity:
     - datetime: '2023-10-01'
       source: EIA.gov
       value: 90.0
+    - datetime: '2023-12-01'
+      source: EIA.gov
+      value: 105.0
   biomass:
     - datetime: '2023-10-01'
       source: EIA.gov
@@ -44,6 +47,9 @@ capacity:
     - datetime: '2023-10-01'
       source: EIA.gov
       value: 323.1
+    - datetime: '2023-12-01'
+      source: EIA.gov
+      value: 340.7
   unknown:
     - datetime: '2023-10-01'
       source: EIA.gov

--- a/config/zones/US-TEN-TVA.yaml
+++ b/config/zones/US-TEN-TVA.yaml
@@ -20,6 +20,12 @@ capacity:
     - datetime: '2023-10-01'
       source: EIA.gov
       value: 17137.0
+    - datetime: '2023-12-01'
+      source: EIA.gov
+      value: 17187.0
+    - datetime: '2024-03-01'
+      source: EIA.gov
+      value: 17880.6
   geothermal:
     - datetime: '2023-10-01'
       source: EIA.gov
@@ -44,6 +50,12 @@ capacity:
     - datetime: '2023-10-01'
       source: EIA.gov
       value: 867.5
+    - datetime: '2023-12-01'
+      source: EIA.gov
+      value: 919.7
+    - datetime: '2024-03-01'
+      source: EIA.gov
+      value: 934.4
   unknown:
     - datetime: '2023-10-01'
       source: EIA.gov

--- a/config/zones/US-TEX-ERCO.yaml
+++ b/config/zones/US-TEX-ERCO.yaml
@@ -8,10 +8,19 @@ capacity:
     - datetime: '2023-10-01'
       source: EIA.gov
       value: 3166.3
+    - datetime: '2023-12-01'
+      source: EIA.gov
+      value: 3416.3
+    - datetime: '2024-03-01'
+      source: EIA.gov
+      value: 3899.8
   biomass:
     - datetime: '2023-10-01'
       source: EIA.gov
       value: 170.1
+    - datetime: '2024-03-01'
+      source: EIA.gov
+      value: 160.5
   coal:
     - datetime: '2023-10-01'
       source: EIA.gov
@@ -20,6 +29,12 @@ capacity:
     - datetime: '2023-10-01'
       source: EIA.gov
       value: 65837.7
+    - datetime: '2023-12-01'
+      source: EIA.gov
+      value: 65817.7
+    - datetime: '2024-03-01'
+      source: EIA.gov
+      value: 65761.6
   geothermal:
     - datetime: '2023-10-01'
       source: EIA.gov
@@ -28,6 +43,9 @@ capacity:
     - datetime: '2023-10-01'
       source: EIA.gov
       value: 558.0
+    - datetime: '2023-12-01'
+      source: EIA.gov
+      value: 550.4
   hydro storage:
     - datetime: '2023-10-01'
       source: EIA.gov
@@ -44,6 +62,12 @@ capacity:
     - datetime: '2023-10-01'
       source: EIA.gov
       value: 13478.1
+    - datetime: '2023-12-01'
+      source: EIA.gov
+      value: 15456.5
+    - datetime: '2024-03-01'
+      source: EIA.gov
+      value: 16850.2
   unknown:
     - datetime: '2023-10-01'
       source: EIA.gov
@@ -52,6 +76,12 @@ capacity:
     - datetime: '2023-10-01'
       source: EIA.gov
       value: 37042.2
+    - datetime: '2023-12-01'
+      source: EIA.gov
+      value: 37266.1
+    - datetime: '2024-03-01'
+      source: EIA.gov
+      value: 37732.5
 comment: Electric Reliability Council Of Texas, Inc.
 contributors:
   - systemcatch


### PR DESCRIPTION
## Issue

Capacities for EIA zones were out of date.

## Description

This PR includes capacity updates from March 2024.

### Double check

- [ ] I have tested my parser changes locally with `poetry run test_parser "zone_key"`
- [ ] I have run `pnpx prettier@2 --write .` and `poetry run format` in the top level directory to format my changes.
