### PR TITLE
fix(translation): Update color blind mode location in FAQ answer for EN and ID language 

### DIFF
--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -374,7 +374,7 @@
     "mapNuclearColors-question": "Why are nuclear-powered countries shown as green on the map?",
     "mapNuclearColors-answer": "Nuclear energy production has a very low carbon intensity (<a href=\"https://en.wikipedia.org/wiki/Life-cycle_greenhouse-gas_emissions_of_energy_sources#2014_IPCC.2C_Global_warming_potential_of_selected_electricity_sources\" target=\"_blank\" >source</a>), and nuclear-powered countries are therefore shown as green on the map. This does not mean that there are not other environmental challenges associated with nuclear energy (as is also the case with other forms of energy production), but these challenges are unrelated to the emissions of greenhouse gases and are therefore outside the scope of this map.",
     "mapColorBlind-question": "I am color blind. How can I read your map?",
-    "mapColorBlind-answer": "You can change the colours displayed in the map by enabling the “color blind mode” setting. It is located below the select language button in the map control on desktop and in the settings tab on the mobile app."
+    "mapColorBlind-answer": "You can change the colours displayed in the map by enabling the “color blind mode” setting. It is located on right side of the app on desktop and in the settings panel on the mobile app."
   },
   "mapAreas": {
     "groupName": "Areas in the map",

--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -374,7 +374,7 @@
     "mapNuclearColors-question": "Why are nuclear-powered countries shown as green on the map?",
     "mapNuclearColors-answer": "Nuclear energy production has a very low carbon intensity (<a href=\"https://en.wikipedia.org/wiki/Life-cycle_greenhouse-gas_emissions_of_energy_sources#2014_IPCC.2C_Global_warming_potential_of_selected_electricity_sources\" target=\"_blank\" >source</a>), and nuclear-powered countries are therefore shown as green on the map. This does not mean that there are not other environmental challenges associated with nuclear energy (as is also the case with other forms of energy production), but these challenges are unrelated to the emissions of greenhouse gases and are therefore outside the scope of this map.",
     "mapColorBlind-question": "I am color blind. How can I read your map?",
-    "mapColorBlind-answer": "You can change the colours displayed in the map by enabling the “color blind mode” setting. It is located on the bottom of the left panel on desktop and in the information tab on the mobile app."
+    "mapColorBlind-answer": "You can change the colours displayed in the map by enabling the “color blind mode” setting. It is located below the select language button in the map control on desktop and in the settings tab on the mobile app."
   },
   "mapAreas": {
     "groupName": "Areas in the map",

--- a/web/src/locales/id.json
+++ b/web/src/locales/id.json
@@ -124,7 +124,7 @@
     "mapNuclearColors-question": "Mengapa negara dengan energi nuklir berwarna hijau pada peta?",
     "mapNuclearColors-answer": "Produksi energi nuklir menghasilkan intensitas Karbon yang rendah (<a href=\"https://en.wikipedia.org/wiki/Life-cycle_greenhouse-gas_emissions_of_energy_sources#2014_IPCC.2C_Global_warming_potential_of_selected_electricity_sources\"  target=\"_blank\" >sumber</a>), dan negara-negara bertenaga nuklir ditampilkan sebagai hijau di peta. Ini tidak berarti bahwa tidak ada tantangan lingkungan lain yang terkait dengan energi nuklir (seperti halnya dengan bentuk-bentuk lain dari produksi energi), tetapi tantangan-tantangan ini tidak terkait dengan emisi gas rumah kaca dan karena itu berada di luar lingkup peta ini.",
     "mapColorBlind-question": "Saya buta warna. Bagaimana saya membaca peta Anda?",
-    "mapColorBlind-answer": "Anda dapat mengubah warna yang ditampilkan di peta dengan mengaktifkan pengaturan “mode buta warna”. Pengaturan ini terletak di bawah tombol ganti bahasa pada pengaturan map di desktop dan di tab pengaturan di aplikasi seluler."
+    "mapColorBlind-answer": "Anda dapat mengubah warna yang ditampilkan di peta dengan mengaktifkan pengaturan “mode buta warna”. Pengaturan ini terletak pada sebelah kanan aplikasi di desktop dan di panel pengaturan pada aplikasi seluler."
   },
   "mapAreas": {
     "groupName": "Area dalam peta",

--- a/web/src/locales/id.json
+++ b/web/src/locales/id.json
@@ -57,7 +57,7 @@
   "legends": {
     "windpotential": "Potensi kekuatan angin",
     "solarpotential": "Potensi kekuatan matahari",
-    "colorblindmode": "mode color blind",
+    "colorblindmode": "mode buta warna",
     "carbonintensity": "Intensitas Karbon"
   },
   "tooltips": {
@@ -124,7 +124,7 @@
     "mapNuclearColors-question": "Mengapa negara dengan energi nuklir berwarna hijau pada peta?",
     "mapNuclearColors-answer": "Produksi energi nuklir menghasilkan intensitas Karbon yang rendah (<a href=\"https://en.wikipedia.org/wiki/Life-cycle_greenhouse-gas_emissions_of_energy_sources#2014_IPCC.2C_Global_warming_potential_of_selected_electricity_sources\"  target=\"_blank\" >sumber</a>), dan negara-negara bertenaga nuklir ditampilkan sebagai hijau di peta. Ini tidak berarti bahwa tidak ada tantangan lingkungan lain yang terkait dengan energi nuklir (seperti halnya dengan bentuk-bentuk lain dari produksi energi), tetapi tantangan-tantangan ini tidak terkait dengan emisi gas rumah kaca dan karena itu berada di luar lingkup peta ini.",
     "mapColorBlind-question": "Saya buta warna. Bagaimana saya membaca peta Anda?",
-    "mapColorBlind-answer": "Anda dapat mengubah warna yang ditampilkan di peta dengan mengaktifkan pengaturan “mode color-blind”. Terletak di bagian bawah panel kiri di desktop dan di tab informasi di aplikasi seluler."
+    "mapColorBlind-answer": "Anda dapat mengubah warna yang ditampilkan di peta dengan mengaktifkan pengaturan “mode buta warna”. Pengaturan ini terletak di bawah tombol ganti bahasa pada pengaturan map di desktop dan di tab pengaturan di aplikasi seluler."
   },
   "mapAreas": {
     "groupName": "Area dalam peta",


### PR DESCRIPTION
## Issue
Closes #6780 
Note: We need to update translations for other language as well, so we may need to create issue for other languages or not close this one yet 🙇 

## Description
This PR changes  the answer in FAQ section for color blind question. The location of color blind mode is updated to map control in desktop and settings tab in mobile

### Preview
EN language: 
![image](https://github.com/electricitymaps/electricitymaps-contrib/assets/89449388/b837d835-93b7-4be2-ade7-1f7d2d93f54d)

ID language:
![image](https://github.com/electricitymaps/electricitymaps-contrib/assets/89449388/d0010c92-aa1c-4d37-a47e-f04c93180866)


### Double check

- [ ] I have tested my parser changes locally with `poetry run test_parser "zone_key"`
- [x] I have run `pnpx prettier@2 --write .` and `poetry run format` in the top level directory to format my changes.
