### PR TITLE
bug(web): update timeslider on hour change

### DIFF
--- a/web/src/api/getState.ts
+++ b/web/src/api/getState.ts
@@ -5,7 +5,7 @@ import type { GridState } from 'types';
 import { TimeAverages } from 'utils/constants';
 import { timeAverageAtom } from 'utils/state/atoms';
 
-import { cacheBuster, getBasePath, getHeaders, QUERY_KEYS } from './helpers';
+import { cacheBuster, getBasePath, QUERY_KEYS } from './helpers';
 
 const getState = async (timeAverage: string): Promise<GridState> => {
   const path: URL = new URL(`v8/state/${timeAverage}`, getBasePath());

--- a/web/src/features/time/TimeController.tsx
+++ b/web/src/features/time/TimeController.tsx
@@ -25,7 +25,8 @@ export default function TimeController({ className }: { className?: string }) {
   // or as Date objects. In this case datetimes are easier to work with
   const datetimes = useMemo(
     () => (data ? Object.keys(data.data?.datetimes).map((d) => new Date(d)) : undefined),
-    [data]
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- is loading is used to trigger the re-memoization on hour change
+    [data, isLoading]
   );
 
   useEffect(() => {


### PR DESCRIPTION
## Issue
The timeslider was not updating with the changing hours

## Description
This PR adds the isLoading variable to the useMemo dependency array that sets the list of datetimes used in the timeslider.

P.S. removed random unused import