### PR TITLE
bug(web): map overlays blocking touch events on mobile

### DIFF
--- a/web/src/components/MapOverlays.tsx
+++ b/web/src/components/MapOverlays.tsx
@@ -12,7 +12,7 @@ export default function MapOverlays() {
   const surveyEnabled = useFeatureFlag('feedback-micro-survey') && !hasSeenSurveyCard;
 
   return (
-    <div className="fixed bottom-4 right-4 z-20 hidden flex-col items-end space-y-3 sm:flex">
+    <div className="pointer-events-none fixed bottom-4 right-4 z-20 hidden flex-col items-end space-y-3 sm:flex">
       <Suspense>
         <FeatureFlagsManager />
       </Suspense>

--- a/web/src/components/MapOverlays.tsx
+++ b/web/src/components/MapOverlays.tsx
@@ -12,7 +12,7 @@ export default function MapOverlays() {
   const surveyEnabled = useFeatureFlag('feedback-micro-survey') && !hasSeenSurveyCard;
 
   return (
-    <div className="fixed bottom-4 right-4 z-20 flex flex-col items-end space-y-3">
+    <div className="fixed bottom-4 right-4 z-20 hidden flex-col items-end space-y-3 sm:flex">
       <Suspense>
         <FeatureFlagsManager />
       </Suspense>

--- a/web/src/components/app-survey/SurveyCard.tsx
+++ b/web/src/components/app-survey/SurveyCard.tsx
@@ -40,7 +40,7 @@ async function postSurveyResponse({
 export default function SurveyCard() {
   const { t } = useTranslation();
   return (
-    <div className="invisible  z-20  sm:visible ">
+    <div className="pointer-events-auto invisible  z-20  sm:visible ">
       <FeedbackCard
         surveyReference="Map Survey"
         postSurveyResponse={postSurveyResponse}

--- a/web/src/features/feature-flags/FeatureFlagsManager.tsx
+++ b/web/src/features/feature-flags/FeatureFlagsManager.tsx
@@ -67,7 +67,7 @@ export default function FeatureFlagsManager() {
   }
 
   return (
-    <div className="invisible flex w-[224px] flex-col rounded bg-white/90 px-4 py-4 shadow-lg backdrop-blur-sm sm:visible dark:bg-gray-800">
+    <div className="pointer-events-auto invisible flex w-[224px] flex-col rounded bg-white/90 px-4 py-4 shadow-lg backdrop-blur-sm sm:visible dark:bg-gray-800">
       <Content features={features} />
     </div>
   );


### PR DESCRIPTION
## Issue

Empty map overlay component is blocking touch events on smaller devices

## Description

This PR hides the component on smaller devices