### PR TITLE
bug(web): prevent translation causing crashing on edge browser

### DIFF
--- a/web/src/components/Button.tsx
+++ b/web/src/components/Button.tsx
@@ -53,6 +53,7 @@ export function Button({
         type={componentType}
         onClick={onClick}
         target="_blank"
+        // Used to prevent browser translation crashes on edge, see #6809
         translate="no"
       >
         {icon}

--- a/web/src/components/Button.tsx
+++ b/web/src/components/Button.tsx
@@ -53,6 +53,7 @@ export function Button({
         type={componentType}
         onClick={onClick}
         target="_blank"
+        translate="no"
       >
         {icon}
         {children}

--- a/web/src/features/charts/tooltips/BreakdownChartTooltip.tsx
+++ b/web/src/features/charts/tooltips/BreakdownChartTooltip.tsx
@@ -191,7 +191,7 @@ export function BreakdownChartTooltipContent({
       )}
 
       {!displayByEmissions && (
-        <>
+        <div translate="no">
           <MetricRatio
             value={usage}
             total={totalElectricity}
@@ -226,7 +226,7 @@ export function BreakdownChartTooltipContent({
             label={t('ofCO2eq')}
             useTotalUnit
           />
-        </>
+        </div>
       )}
       {!displayByEmissions && (Number.isFinite(co2Intensity) || usage !== 0) && (
         <>

--- a/web/src/features/charts/tooltips/BreakdownChartTooltip.tsx
+++ b/web/src/features/charts/tooltips/BreakdownChartTooltip.tsx
@@ -191,6 +191,7 @@ export function BreakdownChartTooltipContent({
       )}
 
       {!displayByEmissions && (
+        // Used to prevent browser translation crashes on edge, see #6809
         <div translate="no">
           <MetricRatio
             value={usage}


### PR DESCRIPTION
## Issue

We've seen quite a few crashes from people using built in translation on edge browsers.

Related to: #5331

[Sentry issues](https://electricitymaps.sentry.io/issues/5038059282/events/1ed35f6c76f040cbb5aa2090963c9b72/?referrer=user-feedback)

## Description

This PR prevents translation on limited elements that are used in dynamic dom elements that can cause crashes.

## More info
[React issue](https://github.com/facebook/react/issues/11538)