### PR TITLE
fix(parser-validation): Remove parser validation on US-SE-SEPA

### DIFF
--- a/parsers/EIA.py
+++ b/parsers/EIA.py
@@ -383,7 +383,6 @@ FILTER_INCOMPLETE_DATA_BYPASSED_MODES = {
     "US-MIDW-MISO": ["biomass", "geothermal", "oil"],
     "US-TEN-TVA": ["biomass", "geothermal", "oil"],
     "US-SE-SOCO": ["biomass", "geothermal", "oil"],
-    "US-SE-SEPA": ["biomass", "geothermal", "oil"],
     "US-FLA-FPL": ["biomass", "geothermal", "oil"],
 }
 


### PR DESCRIPTION
## Issue

The backend validation is now active, so we should start relying less on parser validation which might discard a point. As a starter we disable it for US-SE-SEPA as right now we discard all datapoints because there's no solar but actually this zone should almost never have solar.
