### PR TITLE
fix(config): Update expected production parser delays for some zones

### DIFF
--- a/config/zones/AU-NT.yaml
+++ b/config/zones/AU-NT.yaml
@@ -13,10 +13,11 @@ contributors:
 delays:
   consumption: 30
   price: 30
-  production: 30
+  production: 111
+disclaimer: The Northern Territory power grid is not connected to the (Australian)
+  National Electricity Market or Western Australia's grid.
 parsers:
   consumption: NTESMO.fetch_consumption
   price: NTESMO.fetch_price
   production: NTESMO.fetch_production
-disclaimer: The Northern Territory power grid is not connected to the (Australian) National Electricity Market or Western Australia's grid.
 timezone: Australia/Darwin

--- a/config/zones/BA.yaml
+++ b/config/zones/BA.yaml
@@ -27,6 +27,8 @@ capacity:
 contributors:
   - corradio
   - nessie2013
+delays:
+  production: 4
 emissionFactors:
   direct:
     battery discharge:

--- a/config/zones/US-CENT-SPA.yaml
+++ b/config/zones/US-CENT-SPA.yaml
@@ -66,7 +66,7 @@ contributors:
 delays:
   consumption: 30
   consumptionForecast: 30
-  production: 30
+  production: 33
 disclaimer: Data for real-time consumption and generation mix is estimated. Real-time
   exchanges are not available.
 emissionFactors:

--- a/config/zones/US-FLA-HST.yaml
+++ b/config/zones/US-FLA-HST.yaml
@@ -66,7 +66,7 @@ contributors:
 delays:
   consumption: 30
   consumptionForecast: 30
-  production: 30
+  production: 41
 emissionFactors:
   direct: {}
   lifecycle:

--- a/config/zones/US-SE-SEPA.yaml
+++ b/config/zones/US-SE-SEPA.yaml
@@ -61,7 +61,7 @@ contributors:
   - robertahunt
   - KabelWlan
 delays:
-  production: 30
+  production: 118
 disclaimer: Data for real-time consumption and generation mix is estimated. Real-time
   exchanges are not available.
 emissionFactors:


### PR DESCRIPTION
## Issue

Our production parsers have varying delays across zones but this is not fully captured in the config files at the moment.

## Description

Step-by-step (according to parser availability monitoring), we will update the expected delays on demand. @VIKTORVAV99, for context, the update is computed as outlined in https://github.com/electricitymaps/electricitymaps/pull/5200

### Double check

- [ ] I have tested my parser changes locally with `poetry run test_parser "zone_key"`
- [x] I have run `pnpx prettier@2 --write .` and `poetry run format` in the top level directory to format my changes.
