### PR TITLE
fix(GB->NO-NO2): change GB->NO-NO2 to use ENTSO-E

### DIFF
--- a/config/exchanges/GB_NO-NO2.yaml
+++ b/config/exchanges/GB_NO-NO2.yaml
@@ -5,5 +5,6 @@ lonlat:
   - 2.44819
   - 57.266334
 parsers:
-  exchange: ELEXON.fetch_exchange
+  exchange: ENTSOE.fetch_exchange
+  exchangeForecast: ENTSOE.fetch_exchange_forecast
 rotation: 50


### PR DESCRIPTION
## Issue

Seems like the flows are reversed right now.
## Description

Switches parsers to ENTSO-E to fix the above issue and get more data while we look into the core issue in the other parser.

### Double check

- [x] I have tested my parser changes locally with `poetry run test_parser "zone_key"`
- [x] I have run `pnpx prettier@2 --write .` and `poetry run format` in the top level directory to format my changes.
