### PR TITLE
fix(config): Update expected production parser delays for US zones

### DIFF
--- a/config/zones/US-AK-SEAPA.yaml
+++ b/config/zones/US-AK-SEAPA.yaml
@@ -5,6 +5,8 @@ bounding_box:
     - 57.32198154784774
 contributors:
   - wrma6
+delays:
+  production: 2
 parsers:
   production: SEAPA.fetch_production
 timezone: America/Anchorage

--- a/config/zones/US-CAL-BANC.yaml
+++ b/config/zones/US-CAL-BANC.yaml
@@ -63,7 +63,7 @@ contributors:
 delays:
   consumption: 30
   consumptionForecast: 30
-  production: 30
+  production: 32
 disclaimer: Data for real-time consumption and generation mix is estimated. Real-time
   exchanges are not available.
 emissionFactors:

--- a/config/zones/US-CAL-CISO.yaml
+++ b/config/zones/US-CAL-CISO.yaml
@@ -102,6 +102,8 @@ contributors:
   - systemcatch
   - robertahunt
   - KabelWlan
+delays:
+  production: 2
 emissionFactors:
   direct:
     battery discharge:

--- a/config/zones/US-CAL-IID.yaml
+++ b/config/zones/US-CAL-IID.yaml
@@ -63,7 +63,7 @@ contributors:
 delays:
   consumption: 30
   consumptionForecast: 30
-  production: 30
+  production: 31
 disclaimer: Data for real-time consumption and generation mix is estimated. Real-time
   exchanges are not available.
 emissionFactors:

--- a/config/zones/US-CAL-LDWP.yaml
+++ b/config/zones/US-CAL-LDWP.yaml
@@ -66,7 +66,7 @@ contributors:
 delays:
   consumption: 30
   consumptionForecast: 30
-  production: 30
+  production: 31
 disclaimer: Data for real-time consumption and generation mix is estimated. Real-time
   exchanges are not available.
 emissionFactors:

--- a/config/zones/US-CAL-TIDC.yaml
+++ b/config/zones/US-CAL-TIDC.yaml
@@ -60,7 +60,7 @@ contributors:
 delays:
   consumption: 30
   consumptionForecast: 30
-  production: 30
+  production: 31
 disclaimer: Data for real-time consumption and generation mix is estimated. Real-time
   exchanges are not available.
 emissionFactors:

--- a/config/zones/US-CAR-CPLE.yaml
+++ b/config/zones/US-CAR-CPLE.yaml
@@ -75,7 +75,7 @@ contributors:
 delays:
   consumption: 30
   consumptionForecast: 30
-  production: 30
+  production: 35
 disclaimer: Data for real-time consumption and generation mix is estimated. Real-time
   exchanges are not available.
 emissionFactors:

--- a/config/zones/US-CAR-CPLW.yaml
+++ b/config/zones/US-CAR-CPLW.yaml
@@ -65,7 +65,7 @@ contributors:
 delays:
   consumption: 30
   consumptionForecast: 30
-  production: 30
+  production: 34
 disclaimer: Data for real-time consumption and generation mix is estimated. Real-time
   exchanges are not available.
 emissionFactors:

--- a/config/zones/US-CAR-DUK.yaml
+++ b/config/zones/US-CAR-DUK.yaml
@@ -72,7 +72,7 @@ contributors:
 delays:
   consumption: 30
   consumptionForecast: 30
-  production: 30
+  production: 34
 disclaimer: Data for real-time consumption and generation mix is estimated. Real-time
   exchanges are not available.
 emissionFactors:

--- a/config/zones/US-CAR-SC.yaml
+++ b/config/zones/US-CAR-SC.yaml
@@ -63,7 +63,7 @@ contributors:
 delays:
   consumption: 30
   consumptionForecast: 30
-  production: 30
+  production: 70
 disclaimer: Data for real-time consumption and generation mix is estimated. Real-time
   exchanges are not available. This zone includes a third of the nuclear related electricity
   production from the balancing authority South Carolina Electric & Gas Company. Read

--- a/config/zones/US-CAR-SCEG.yaml
+++ b/config/zones/US-CAR-SCEG.yaml
@@ -63,12 +63,11 @@ contributors:
 delays:
   consumption: 30
   consumptionForecast: 30
-  production: 30
-disclaimer: Data for real-time consumption and generation mix is estimated.
-  Real-time exchanges are not available. A third of the nuclear-related
-  electricity production is attributed to the balancing authority
-  South Carolina Public Service Authority (US-CAR-SC) due to
-  an agreement between the two balancing authorities. Read more
+  production: 34
+disclaimer: Data for real-time consumption and generation mix is estimated. Real-time
+  exchanges are not available. A third of the nuclear-related electricity production
+  is attributed to the balancing authority South Carolina Public Service Authority
+  (US-CAR-SC) due to an agreement between the two balancing authorities. Read more
   on the zone definition wiki page.
 emissionFactors:
   direct:

--- a/config/zones/US-CAR-YAD.yaml
+++ b/config/zones/US-CAR-YAD.yaml
@@ -58,7 +58,7 @@ contributors:
   - robertahunt
   - KabelWlan
 delays:
-  production: 30
+  production: 35
 disclaimer: Data for real-time consumption and generation mix is estimated. Real-time
   exchanges are not available.
 emissionFactors:

--- a/config/zones/US-CENT-SWPP.yaml
+++ b/config/zones/US-CENT-SWPP.yaml
@@ -84,6 +84,8 @@ contributors:
   - systemcatch
   - robertahunt
   - KabelWlan
+delays:
+  production: 2
 emissionFactors:
   direct:
     battery discharge:

--- a/config/zones/US-FLA-FMPP.yaml
+++ b/config/zones/US-FLA-FMPP.yaml
@@ -63,7 +63,7 @@ contributors:
 delays:
   consumption: 30
   consumptionForecast: 30
-  production: 30
+  production: 34
 disclaimer: Data for real-time consumption and generation mix is estimated. Real-time
   exchanges are not available.
 emissionFactors:

--- a/config/zones/US-FLA-FPC.yaml
+++ b/config/zones/US-FLA-FPC.yaml
@@ -72,7 +72,7 @@ contributors:
 delays:
   consumption: 30
   consumptionForecast: 30
-  production: 30
+  production: 34
 disclaimer: Data for real-time consumption and generation mix is estimated. Real-time
   exchanges are not available.
 emissionFactors:

--- a/config/zones/US-FLA-FPL.yaml
+++ b/config/zones/US-FLA-FPL.yaml
@@ -63,7 +63,7 @@ contributors:
 delays:
   consumption: 30
   consumptionForecast: 30
-  production: 30
+  production: 36
 disclaimer: Data for real-time consumption and generation mix is estimated. Real-time
   exchanges are not available.
 emissionFactors:

--- a/config/zones/US-FLA-GVL.yaml
+++ b/config/zones/US-FLA-GVL.yaml
@@ -60,7 +60,7 @@ contributors:
 delays:
   consumption: 30
   consumptionForecast: 30
-  production: 30
+  production: 34
 disclaimer: Data for real-time consumption and generation mix is estimated. Real-time
   exchanges are not available.
 emissionFactors:

--- a/config/zones/US-FLA-HST.yaml
+++ b/config/zones/US-FLA-HST.yaml
@@ -66,7 +66,7 @@ contributors:
 delays:
   consumption: 30
   consumptionForecast: 30
-  production: 41
+  production: 37
 emissionFactors:
   direct: {}
   lifecycle:

--- a/config/zones/US-FLA-JEA.yaml
+++ b/config/zones/US-FLA-JEA.yaml
@@ -59,7 +59,7 @@ contributors:
 delays:
   consumption: 30
   consumptionForecast: 30
-  production: 30
+  production: 95
 disclaimer: Data for real-time consumption and generation mix is estimated. Real-time
   exchanges are not available.
 emissionFactors:

--- a/config/zones/US-FLA-SEC.yaml
+++ b/config/zones/US-FLA-SEC.yaml
@@ -63,7 +63,7 @@ contributors:
 delays:
   consumption: 30
   consumptionForecast: 30
-  production: 30
+  production: 35
 disclaimer: Data for real-time consumption and generation mix is estimated. Real-time
   exchanges are not available.
 emissionFactors:

--- a/config/zones/US-FLA-TAL.yaml
+++ b/config/zones/US-FLA-TAL.yaml
@@ -60,7 +60,7 @@ contributors:
 delays:
   consumption: 30
   consumptionForecast: 30
-  production: 30
+  production: 34
 disclaimer: Data for real-time consumption and generation mix is estimated. Real-time
   exchanges are not available.
 emissionFactors:

--- a/config/zones/US-FLA-TEC.yaml
+++ b/config/zones/US-FLA-TEC.yaml
@@ -64,7 +64,7 @@ contributors:
 delays:
   consumption: 30
   consumptionForecast: 30
-  production: 30
+  production: 35
 disclaimer: Data for real-time consumption and generation mix is estimated. Real-time
   exchanges are not available.
 emissionFactors:

--- a/config/zones/US-MIDA-PJM.yaml
+++ b/config/zones/US-MIDA-PJM.yaml
@@ -96,6 +96,8 @@ contributors:
   - systemcatch
   - robertahunt
   - KabelWlan
+delays:
+  production: 5
 emissionFactors:
   direct:
     battery discharge:

--- a/config/zones/US-MIDW-AECI.yaml
+++ b/config/zones/US-MIDW-AECI.yaml
@@ -66,7 +66,7 @@ contributors:
 delays:
   consumption: 30
   consumptionForecast: 30
-  production: 30
+  production: 33
 disclaimer: Data for real-time consumption and generation mix is estimated. Real-time
   exchanges are not available.
 emissionFactors:

--- a/config/zones/US-MIDW-LGEE.yaml
+++ b/config/zones/US-MIDW-LGEE.yaml
@@ -63,7 +63,7 @@ contributors:
 delays:
   consumption: 30
   consumptionForecast: 30
-  production: 30
+  production: 34
 disclaimer: Data for real-time consumption and generation mix is estimated. Real-time
   exchanges are not available.
 emissionFactors:

--- a/config/zones/US-MIDW-MISO.yaml
+++ b/config/zones/US-MIDW-MISO.yaml
@@ -108,7 +108,7 @@ contributors:
 delays:
   consumption: 30
   consumptionForecast: 30
-  production: 30
+  production: 34
 disclaimer: Data for real-time consumption and generation mix is estimated. Real-time
   exchanges are not available.
 emissionFactors:

--- a/config/zones/US-NE-ISNE.yaml
+++ b/config/zones/US-NE-ISNE.yaml
@@ -93,6 +93,8 @@ contributors:
   - systemcatch
   - robertahunt
   - KabelWlan
+delays:
+  production: 2
 emissionFactors:
   direct:
     battery discharge:

--- a/config/zones/US-NW-AVA.yaml
+++ b/config/zones/US-NW-AVA.yaml
@@ -60,7 +60,7 @@ contributors:
 delays:
   consumption: 30
   consumptionForecast: 30
-  production: 30
+  production: 32
 disclaimer: Data for real-time consumption and generation mix is estimated. Real-time
   exchanges are not available.
 emissionFactors:

--- a/config/zones/US-NW-BPAT.yaml
+++ b/config/zones/US-NW-BPAT.yaml
@@ -72,7 +72,7 @@ contributors:
 delays:
   consumption: 30
   consumptionForecast: 30
-  production: 30
+  production: 31
 disclaimer: Data for real-time consumption and generation mix is estimated. Real-time
   exchanges are not available. This zone includes all wind related electricity production
   from the generation-only balancing authority Avangrid Renewables, LLC. Read more

--- a/config/zones/US-NW-CHPD.yaml
+++ b/config/zones/US-NW-CHPD.yaml
@@ -63,7 +63,7 @@ contributors:
 delays:
   consumption: 30
   consumptionForecast: 30
-  production: 30
+  production: 32
 disclaimer: Data for real-time consumption and generation mix is estimated. Real-time
   exchanges are not available.
 emissionFactors:

--- a/config/zones/US-NW-DOPD.yaml
+++ b/config/zones/US-NW-DOPD.yaml
@@ -60,7 +60,7 @@ contributors:
 delays:
   consumption: 30
   consumptionForecast: 30
-  production: 30
+  production: 32
 disclaimer: Data for real-time consumption and generation mix is estimated. Real-time
   exchanges are not available.
 emissionFactors:

--- a/config/zones/US-NW-GCPD.yaml
+++ b/config/zones/US-NW-GCPD.yaml
@@ -60,7 +60,7 @@ contributors:
 delays:
   consumption: 30
   consumptionForecast: 30
-  production: 30
+  production: 32
 disclaimer: Data for real-time consumption and generation mix is estimated. Real-time
   exchanges are not available.
 emissionFactors:

--- a/config/zones/US-NW-GRID.yaml
+++ b/config/zones/US-NW-GRID.yaml
@@ -60,7 +60,7 @@ contributors:
   - systemcatch
   - robertahunt
 delays:
-  production: 30
+  production: 32
 disclaimer: Data for real-time consumption and generation mix is estimated. Real-time
   exchanges are not available.
 emissionFactors:

--- a/config/zones/US-NW-IPCO.yaml
+++ b/config/zones/US-NW-IPCO.yaml
@@ -66,7 +66,7 @@ contributors:
 delays:
   consumption: 30
   consumptionForecast: 30
-  production: 30
+  production: 32
 disclaimer: Data for real-time consumption and generation mix is estimated. Real-time
   exchanges are not available.
 emissionFactors:

--- a/config/zones/US-NW-NEVP.yaml
+++ b/config/zones/US-NW-NEVP.yaml
@@ -78,7 +78,7 @@ contributors:
 delays:
   consumption: 30
   consumptionForecast: 30
-  production: 30
+  production: 32
 disclaimer: Data for real-time consumption and generation mix is estimated. Real-time
   exchanges are not available.
 emissionFactors:

--- a/config/zones/US-NW-NWMT.yaml
+++ b/config/zones/US-NW-NWMT.yaml
@@ -72,7 +72,7 @@ contributors:
 delays:
   consumption: 30
   consumptionForecast: 30
-  production: 30
+  production: 32
 disclaimer: Data for real-time consumption and generation mix is estimated. Real-time
   exchanges are not available. This zone includes all electricity production from
   the generation-only balancing authorities NaturEner Power Watch, LLC and NaturEner

--- a/config/zones/US-NW-PACE.yaml
+++ b/config/zones/US-NW-PACE.yaml
@@ -84,7 +84,7 @@ contributors:
 delays:
   consumption: 30
   consumptionForecast: 30
-  production: 30
+  production: 34
 disclaimer: Data for real-time consumption and generation mix is estimated. Real-time
   exchanges are not available. This zone includes all gas related electricity production
   from the generation-only balancing authority Avangrid Renewables, LLC. Read more

--- a/config/zones/US-NW-PACW.yaml
+++ b/config/zones/US-NW-PACW.yaml
@@ -66,7 +66,7 @@ contributors:
 delays:
   consumption: 30
   consumptionForecast: 30
-  production: 30
+  production: 32
 disclaimer: Data for real-time consumption and generation mix is estimated. Real-time
   exchanges are not available.
 emissionFactors:

--- a/config/zones/US-NW-PGE.yaml
+++ b/config/zones/US-NW-PGE.yaml
@@ -63,7 +63,7 @@ contributors:
 delays:
   consumption: 30
   consumptionForecast: 30
-  production: 30
+  production: 33
 disclaimer: Data for real-time consumption and generation mix is estimated. Real-time
   exchanges are not available.
 emissionFactors:

--- a/config/zones/US-NW-PSCO.yaml
+++ b/config/zones/US-NW-PSCO.yaml
@@ -78,7 +78,7 @@ contributors:
 delays:
   consumption: 30
   consumptionForecast: 30
-  production: 30
+  production: 32
 disclaimer: Data for real-time consumption and generation mix is estimated. Real-time
   exchanges are not available.
 emissionFactors:

--- a/config/zones/US-NW-PSEI.yaml
+++ b/config/zones/US-NW-PSEI.yaml
@@ -61,7 +61,7 @@ contributors:
 delays:
   consumption: 30
   consumptionForecast: 30
-  production: 30
+  production: 32
 disclaimer: Data for real-time consumption and generation mix is estimated. Real-time
   exchanges are not available.
 emissionFactors:
@@ -261,10 +261,10 @@ parsers:
 sources:
   IPCC 2014:
     link: https://www.ipcc.ch/site/assets/uploads/2018/02/ipcc_wg3_ar5_annex-iii.pdf#page=7
+  PSE 2023 IRP:
+    link: https://www.pse.com/en/IRP/Past-IRPs/2023-IRP
   eGrid 2020:
     link: https://drive.google.com/file/d/1_FAAuTtIdMuORZKsqHnd9vMNHlQgYarh/view?usp=sharing
   eGrid 2021:
     link: ' https://drive.google.com/file/d/1_FAAuTtIdMuORZKsqHnd9vMNHlQgYarh/view?usp=sharing'
-  PSE 2023 IRP:
-    link: https://www.pse.com/en/IRP/Past-IRPs/2023-IRP
 timezone: US/Pacific

--- a/config/zones/US-NW-SCL.yaml
+++ b/config/zones/US-NW-SCL.yaml
@@ -66,7 +66,7 @@ contributors:
 delays:
   consumption: 30
   consumptionForecast: 30
-  production: 30
+  production: 32
 disclaimer: Data for real-time consumption and generation mix is estimated. Real-time
   exchanges are not available.
 emissionFactors:

--- a/config/zones/US-NW-TPWR.yaml
+++ b/config/zones/US-NW-TPWR.yaml
@@ -63,7 +63,7 @@ contributors:
 delays:
   consumption: 30
   consumptionForecast: 30
-  production: 30
+  production: 32
 disclaimer: Data for real-time consumption and generation mix is estimated. Real-time
   exchanges are not available.
 emissionFactors:

--- a/config/zones/US-NW-WACM.yaml
+++ b/config/zones/US-NW-WACM.yaml
@@ -78,7 +78,7 @@ contributors:
 delays:
   consumption: 30
   consumptionForecast: 30
-  production: 30
+  production: 32
 disclaimer: Data for real-time consumption and generation mix is estimated. Real-time
   exchanges are not available.
 emissionFactors:

--- a/config/zones/US-NW-WAUW.yaml
+++ b/config/zones/US-NW-WAUW.yaml
@@ -63,7 +63,7 @@ contributors:
 delays:
   consumption: 30
   consumptionForecast: 30
-  production: 30
+  production: 32
 disclaimer: Data for real-time consumption and generation mix is estimated. Real-time
   exchanges are not available.
 emissionFactors:

--- a/config/zones/US-NY-NYIS.yaml
+++ b/config/zones/US-NY-NYIS.yaml
@@ -85,6 +85,8 @@ contributors:
   - robertahunt
   - KabelWlan
   - brandongalbraith
+delays:
+  production: 2
 emissionFactors:
   direct:
     battery discharge:

--- a/config/zones/US-SE-SEPA.yaml
+++ b/config/zones/US-SE-SEPA.yaml
@@ -61,7 +61,7 @@ contributors:
   - robertahunt
   - KabelWlan
 delays:
-  production: 118
+  production: 85
 disclaimer: Data for real-time consumption and generation mix is estimated. Real-time
   exchanges are not available.
 emissionFactors:

--- a/config/zones/US-SE-SOCO.yaml
+++ b/config/zones/US-SE-SOCO.yaml
@@ -85,7 +85,7 @@ contributors:
 delays:
   consumption: 30
   consumptionForecast: 30
-  production: 30
+  production: 34
 disclaimer: Data for real-time consumption and generation mix is estimated. Real-time
   exchanges are not available.
 emissionFactors:

--- a/config/zones/US-SW-AZPS.yaml
+++ b/config/zones/US-SW-AZPS.yaml
@@ -63,7 +63,7 @@ contributors:
 delays:
   consumption: 30
   consumptionForecast: 30
-  production: 30
+  production: 32
 disclaimer: Data for real-time consumption and generation mix is estimated. Real-time
   exchanges are not available.
 emissionFactors:

--- a/config/zones/US-SW-EPE.yaml
+++ b/config/zones/US-SW-EPE.yaml
@@ -63,7 +63,7 @@ contributors:
 delays:
   consumption: 30
   consumptionForecast: 30
-  production: 30
+  production: 31
 disclaimer: Data for real-time consumption and generation mix is estimated. Real-time
   exchanges are not available.
 emissionFactors:

--- a/config/zones/US-SW-PNM.yaml
+++ b/config/zones/US-SW-PNM.yaml
@@ -73,7 +73,7 @@ contributors:
 delays:
   consumption: 30
   consumptionForecast: 30
-  production: 30
+  production: 32
 disclaimer: Data for real-time consumption and generation mix is estimated. Real-time
   exchanges are not available.
 emissionFactors:

--- a/config/zones/US-SW-SRP.yaml
+++ b/config/zones/US-SW-SRP.yaml
@@ -66,7 +66,7 @@ contributors:
 delays:
   consumption: 30
   consumptionForecast: 30
-  production: 30
+  production: 31
 disclaimer: Data for real-time consumption and generation mix is estimated. Real-time
   exchanges are not available. This zone includes all electricity production from
   the generation-only balancing authorities Arlington Valley, LLC - AVBA and New Harquahala

--- a/config/zones/US-SW-TEPC.yaml
+++ b/config/zones/US-SW-TEPC.yaml
@@ -69,7 +69,7 @@ contributors:
 delays:
   consumption: 30
   consumptionForecast: 30
-  production: 30
+  production: 32
 disclaimer: Data for real-time consumption and generation mix is estimated. Real-time
   exchanges are not available.
 emissionFactors:

--- a/config/zones/US-SW-WALC.yaml
+++ b/config/zones/US-SW-WALC.yaml
@@ -66,7 +66,7 @@ contributors:
 delays:
   consumption: 30
   consumptionForecast: 30
-  production: 30
+  production: 31
 disclaimer: Data for real-time consumption and generation mix is estimated. Real-time
   exchanges are not available. This zone includes all electricity production from
   the generation-only balancing authority Griffith Energy, LLC. Read more on the zone

--- a/config/zones/US-TEN-TVA.yaml
+++ b/config/zones/US-TEN-TVA.yaml
@@ -72,7 +72,7 @@ contributors:
 delays:
   consumption: 30
   consumptionForecast: 30
-  production: 30
+  production: 33
 disclaimer: Data for real-time consumption and generation mix is estimated. Real-time
   exchanges are not available.
 emissionFactors:

--- a/config/zones/US-TEX-ERCO.yaml
+++ b/config/zones/US-TEX-ERCO.yaml
@@ -90,7 +90,7 @@ contributors:
 delays:
   consumption: 30
   consumptionForecast: 30
-  production: 30
+  production: 33
 disclaimer: Data for real-time consumption and generation mix is estimated. Real-time
   exchanges are not available.
 emissionFactors:


### PR DESCRIPTION
## Issue

Our production parsers have varying delays across zones but this is not fully captured in the config files at the moment.

## Description
This is the second step of updating expected delays. For context, the update is computed as outlined in https://github.com/electricitymaps/electricitymaps/pull/5200.
