### PR TITLE
Turn exchange arrows gray for zones with an outage

### DIFF
--- a/web/src/features/exchanges/ExchangeTooltip.tsx
+++ b/web/src/features/exchanges/ExchangeTooltip.tsx
@@ -44,10 +44,12 @@ export default function ExchangeTooltip({
       </div>
       {t('tooltips.carbonintensityexport')}:
       <div className="pt-1">
-        {co2intensity > 0 && (
+        {co2intensity > 0 ? (
           <div className="inline-flex items-center gap-x-1">
             <CarbonIntensityDisplay withSquare co2Intensity={co2intensity} />
           </div>
+        ) : (
+          <p className="text-gray-400">{t('tooltips.temporarilyUnavailable')}</p>
         )}
       </div>
     </div>

--- a/web/src/hooks/arrows.test.ts
+++ b/web/src/hooks/arrows.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import { filterExchanges } from './arrows';
+import { filterExchanges, shouldHideExchangeIntensity } from './arrows';
 
 const mockExchangesToExcludeZoneView = ['exchange1', 'exchange2', 'exchange4'];
 
@@ -123,5 +123,17 @@ describe('filterExchanges', () => {
         )
       ).toThrow(TypeError);
     });
+  });
+});
+
+describe('shouldHideExchangeIntensity', () => {
+  it('should hide exported intensity if zone has an outage', () => {
+    expect(shouldHideExchangeIntensity('zone1->zone2', ['zone2'], -10)).toBe(true); // zone2 is exporting
+    expect(shouldHideExchangeIntensity('zone2->zone1', ['zone2'], 10)).toBe(true); // zone2 is exporting
+    expect(shouldHideExchangeIntensity('zone1->zone2', ['zone2'], 10)).toBe(false); // zone2 is importing
+  });
+  it('should not hide intensity of zones are not having an outage', () => {
+    expect(shouldHideExchangeIntensity('zone1->zone2', [], 10)).toBe(false);
+    expect(shouldHideExchangeIntensity('zone1->zone2', ['zone3'], -10)).toBe(false);
   });
 });

--- a/web/src/hooks/arrows.ts
+++ b/web/src/hooks/arrows.ts
@@ -11,6 +11,10 @@ import exchangesToExclude from '../../config/excluded_aggregated_exchanges.json'
 const exchangesConfig: Record<string, any> = exchangesConfigJSON;
 const { exchangesToExcludeZoneView, exchangesToExcludeCountryView } = exchangesToExclude;
 
+/**
+ * Determines if the carbon intensity of an exchange should be hidden due to a temporary zone outage.
+ * By not passing on carbon intensity, we are able to still show a grey arrow with the power value.
+ */
 function shouldHideExchangeIntensity(
   exchange: string,
   zonesWithOutages: string[],
@@ -18,6 +22,8 @@ function shouldHideExchangeIntensity(
 ) {
   const [zone1, zone2] = exchange.split('->');
 
+  // Check if the exchange is from a zone with an outage and the power is flowing out of the zone
+  // and not in. We only want to hide the intensity being exported by the zone.
   return (
     (zonesWithOutages.includes(zone1) && value > 0) ||
     (zonesWithOutages.includes(zone2) && value < 0)

--- a/web/src/hooks/arrows.ts
+++ b/web/src/hooks/arrows.ts
@@ -15,7 +15,7 @@ const { exchangesToExcludeZoneView, exchangesToExcludeCountryView } = exchangesT
  * Determines if the carbon intensity of an exchange should be hidden due to a temporary zone outage.
  * By not passing on carbon intensity, we are able to still show a grey arrow with the power value.
  */
-function shouldHideExchangeIntensity(
+export function shouldHideExchangeIntensity(
   exchange: string,
   zonesWithOutages: string[],
   value: number

--- a/web/src/hooks/arrows.ts
+++ b/web/src/hooks/arrows.ts
@@ -11,6 +11,19 @@ import exchangesToExclude from '../../config/excluded_aggregated_exchanges.json'
 const exchangesConfig: Record<string, any> = exchangesConfigJSON;
 const { exchangesToExcludeZoneView, exchangesToExcludeCountryView } = exchangesToExclude;
 
+function shouldHideExchangeIntensity(
+  exchange: string,
+  zonesWithOutages: string[],
+  value: number
+) {
+  const [zone1, zone2] = exchange.split('->');
+
+  return (
+    (zonesWithOutages.includes(zone1) && value > 0) ||
+    (zonesWithOutages.includes(zone2) && value < 0)
+  );
+}
+
 export function filterExchanges(
   exchanges: Record<string, StateExchangeData>,
   exclusionArrayZones: string[],
@@ -40,6 +53,16 @@ export function useExchangeArrowsData(): ExchangeArrowData[] {
   const [viewMode] = useAtom(spatialAggregateAtom);
   const { data } = useGetState();
 
+  // Find outages in state data and hide exports from those zones
+  const zonesWithOutages = useMemo(() => {
+    const zoneData = data?.data?.datetimes?.[selectedDatetime?.datetimeString]?.z;
+    return zoneData
+      ? Object.entries(zoneData)
+          .filter(([_, value]) => value.o)
+          .map(([zone]) => zone)
+      : [];
+  }, [data, selectedDatetime]);
+
   const exchangesToUse: { [key: string]: StateExchangeData } = useMemo(() => {
     const exchanges = data?.data?.datetimes?.[selectedDatetime?.datetimeString]?.e;
 
@@ -60,12 +83,14 @@ export function useExchangeArrowsData(): ExchangeArrowData[] {
 
   const currentExchanges: ExchangeArrowData[] = useMemo(() => {
     return Object.entries(exchangesToUse).map(([key, value]) => ({
-      co2intensity: value.ci,
+      co2intensity: shouldHideExchangeIntensity(key, zonesWithOutages, value.f)
+        ? Number.NaN
+        : value.ci,
       netFlow: value.f,
       ...exchangesConfig[key],
       key,
     }));
-  }, [exchangesToUse]);
+  }, [exchangesToUse, zonesWithOutages]);
 
   return currentExchanges;
 }

--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -291,6 +291,7 @@
     "changeTheme": "Change theme",
     "noParserInfo": "No data available",
     "temporaryDataOutage": "Live data temporarily unavailable",
+    "temporarilyUnavailable": "Temporarily unavailable",
     "production": "production",
     "consumption": "consumption",
     "cpinfo": "<b>consumption</b> takes imports and exports into account, <b>production</b> ignores them",


### PR DESCRIPTION
## Issue

It feels weird seeing colorful arrows with a carbon-intensity value, when the zone is grayed out due to an outage.

## Description

This turns the export arrows of a zone with an ongoing outage gray.

We do however still want to include the estimated exchange in the zone details, as the estimated values are used in the flowtracing algorithms and as such we want to make sure they are available.

### Preview
![Screenshot 2024-06-14 at 15 34 07](https://github.com/electricitymaps/electricitymaps-contrib/assets/3296643/f32bb863-92d6-4f7d-9bf5-7341b4638453)

![Screenshot 2024-06-14 at 15 34 18](https://github.com/electricitymaps/electricitymaps-contrib/assets/3296643/b838cfe9-8172-4132-a6f9-08bd404cba20)
