### PR TITLE
perf(manual-chunking): Remove `country-flag-icons` from manual chunking

### DIFF
--- a/web/vite.config.cts
+++ b/web/vite.config.cts
@@ -11,7 +11,6 @@ import tsconfigPaths from 'vite-tsconfig-paths';
 const manualChunkMap = {
   '@sentry': 'sentry',
   '@radix-ui': 'radix',
-  'country-flag-icons': 'flags',
   recharts: 'recharts',
   'world.json': 'world',
   'usa_states.json': 'config',


### PR DESCRIPTION
## Description

Since this is now only imported into the Flag component we no longer need to add it as a manual chunk, this improve performance by budding it directly where it's used (together with the Flag component) and removes a lot of import links that was included in half the bundles for some reason.

Should yield a very minor performance boost when it comes to http downloads and first visits to the app.

### Double check

- [x] I have run `pnpx prettier@2 --write .` and `poetry run format` in the top level directory to format my changes.
