### PR TITLE
Hide zones with insufficient data from the map

### DIFF
--- a/config/zones/BH.yaml
+++ b/config/zones/BH.yaml
@@ -1,3 +1,5 @@
+aggregates_displayed:
+  - none # We are not showing this zone due to lack of data
 bounding_box:
   - - 49.94890384200005
     - 25.289536851000037

--- a/config/zones/HK.yaml
+++ b/config/zones/HK.yaml
@@ -1,5 +1,5 @@
 aggregates_displayed:
-  - yearly
+  - none # We are not showing this zone due to lack of data
 bounding_box:
   - - 113.337331576
     - 21.677069403000075

--- a/config/zones/HK.yaml
+++ b/config/zones/HK.yaml
@@ -1,5 +1,5 @@
 aggregates_displayed:
-  - none # We are not showing this zone due to lack of data
+  - yearly
 bounding_box:
   - - 113.337331576
     - 21.677069403000075

--- a/config/zones/KW.yaml
+++ b/config/zones/KW.yaml
@@ -1,3 +1,5 @@
+aggregates_displayed:
+  - none # We are not showing this zone due to lack of data
 bounding_box:
   - - 46.155
     - 28.3985

--- a/config/zones/MX-BC.yaml
+++ b/config/zones/MX-BC.yaml
@@ -1,3 +1,5 @@
+aggregates_displayed:
+  - none # We are not showing this zone due to lack of data
 bounding_box:
   - - -118.86880422899992
     - 22.37215511800008

--- a/config/zones/MX-BCS.yaml
+++ b/config/zones/MX-BCS.yaml
@@ -1,3 +1,5 @@
+aggregates_displayed:
+  - none # We are not showing this zone due to lack of data
 bounding_box:
   - - -118.86880422899992
     - 22.37215511800008

--- a/config/zones/MX-CE.yaml
+++ b/config/zones/MX-CE.yaml
@@ -1,3 +1,5 @@
+aggregates_displayed:
+  - none # We are not showing this zone due to lack of data
 bounding_box:
   - - -100.01069047658422
     - 17.392189846084534

--- a/config/zones/MX-NE.yaml
+++ b/config/zones/MX-NE.yaml
@@ -1,3 +1,5 @@
+aggregates_displayed:
+  - none # We are not showing this zone due to lack of data
 bounding_box:
   - - -101.71565100768782
     - 21.719780991999187

--- a/config/zones/MX-NO.yaml
+++ b/config/zones/MX-NO.yaml
@@ -1,3 +1,5 @@
+aggregates_displayed:
+  - none # We are not showing this zone due to lack of data
 bounding_box:
   - - -109.65359025758431
     - 21.8191030954315

--- a/config/zones/MX-NW.yaml
+++ b/config/zones/MX-NW.yaml
@@ -1,3 +1,5 @@
+aggregates_displayed:
+  - none # We are not showing this zone due to lack of data
 bounding_box:
   - - -115.53974260094026
     - 21.9489659687045

--- a/config/zones/MX-OC.yaml
+++ b/config/zones/MX-OC.yaml
@@ -1,3 +1,5 @@
+aggregates_displayed:
+  - none # We are not showing this zone due to lack of data
 bounding_box:
   - - -115.29857337099992
     - 17.415988111000047

--- a/config/zones/MX-OR.yaml
+++ b/config/zones/MX-OR.yaml
@@ -1,3 +1,5 @@
+aggregates_displayed:
+  - none # We are not showing this zone due to lack of data
 bounding_box:
   - - -102.67957149932522
     - 14.046279476000095

--- a/config/zones/MX-PN.yaml
+++ b/config/zones/MX-PN.yaml
@@ -1,3 +1,5 @@
+aggregates_displayed:
+  - none # We are not showing this zone due to lack of data
 bounding_box:
   - - -92.98614402599992
     - 17.301963603000004

--- a/config/zones/MX.yaml
+++ b/config/zones/MX.yaml
@@ -1,3 +1,5 @@
+aggregates_displayed:
+  - none # We are not showing this zone due to lack of data
 bounding_box:
   - - -117.12776
     - 14.5388286402

--- a/config/zones/TH.yaml
+++ b/config/zones/TH.yaml
@@ -1,3 +1,5 @@
+aggregates_displayed:
+  - none # We are not showing this zone due to lack of data
 bounding_box:
   - - 96.85140100100011
     - 5.129890035000059

--- a/web/src/features/panels/zone/NoInformationMessage.tsx
+++ b/web/src/features/panels/zone/NoInformationMessage.tsx
@@ -13,11 +13,18 @@ const translations = {
     name: 'country-panel.aggregationDisabled',
     object: {},
   },
+  [ZoneDataStatus.FULLY_DISABLED]: {
+    name: 'country-panel.fullyDisabled',
+    object: {
+      link: 'https://github.com/electricitymaps/electricitymaps-contrib',
+    },
+  },
 };
 
 type PossibleStatusTypes =
   | ZoneDataStatus.NO_INFORMATION
-  | ZoneDataStatus.AGGREGATE_DISABLED;
+  | ZoneDataStatus.AGGREGATE_DISABLED
+  | ZoneDataStatus.FULLY_DISABLED;
 export default function NoInformationMessage({ status }: { status: ZoneDataStatus }) {
   const { t } = useTranslation();
 

--- a/web/src/features/panels/zone/ZoneDetails.tsx
+++ b/web/src/features/panels/zone/ZoneDetails.tsx
@@ -187,9 +187,11 @@ function ZoneDetailsContent({
   }
 
   if (
-    [ZoneDataStatus.NO_INFORMATION, ZoneDataStatus.AGGREGATE_DISABLED].includes(
-      zoneDataStatus
-    )
+    [
+      ZoneDataStatus.NO_INFORMATION,
+      ZoneDataStatus.AGGREGATE_DISABLED,
+      ZoneDataStatus.FULLY_DISABLED,
+    ].includes(zoneDataStatus)
   ) {
     return <NoInformationMessage status={zoneDataStatus} />;
   }

--- a/web/src/features/panels/zone/util.ts
+++ b/web/src/features/panels/zone/util.ts
@@ -20,6 +20,7 @@ export const getHasSubZones = (zoneId?: string) => {
 
 export enum ZoneDataStatus {
   AGGREGATE_DISABLED = 'aggregate_disabled',
+  FULLY_DISABLED = 'fully_disabled',
   NO_INFORMATION = 'no_information',
   NO_REAL_TIME_DATA = 'dark',
   AVAILABLE = 'available',
@@ -44,8 +45,6 @@ export const getZoneDataStatus = (
   // If there is no config for the zone, we assume we do not have any data
   const zoneConfig = config.zones[zoneId];
   if (!zoneConfig) {
-    console.log(zoneConfig);
-
     return ZoneDataStatus.NO_INFORMATION;
   }
 
@@ -53,6 +52,9 @@ export const getZoneDataStatus = (
     config.zones[zoneId].aggregates_displayed &&
     !config.zones[zoneId].aggregates_displayed.includes(timeAverage)
   ) {
+    if (config.zones[zoneId].aggregates_displayed[0] === 'none') {
+      return ZoneDataStatus.FULLY_DISABLED;
+    }
     return ZoneDataStatus.AGGREGATE_DISABLED;
   }
 

--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -88,6 +88,7 @@
     "helpUs": "Help us identify the problem by taking a look at the <a href=\"{{link}}\" target=\"_blank\">runtime logs</a> or contact the data provider.",
     "noParserInfo": "We do not yet have any information about this area.<br/> Want to help fix this? You can contribute by <a href=\"{{link}}\" target=\"_blank\">adding area data</a>.",
     "aggregationDisabled": "Data is not available for the selected time period due to missing granular breakdown. Try a broader time period.",
+    "fullyDisabled": "The data we have available for this zone is insufficient and therefore not shown. If you are aware of data sources for this area, please <a href=\"{{link}}\" target=\"_blank\">let us know</a>.",
     "now": "Now",
     "by-source": {
       "emissions": "Carbon emissions by source",


### PR DESCRIPTION
## Issue

We have some zones that are always showing the same carbon intensity for every single hour of the year. This means we are showing potentially quite wrong data (Thailand as example has an average of 550g co2/kWh for 2023 according to [Our World in Data](https://ourworldindata.org/grapher/carbon-intensity-electricity?tab=chart&time=2017..latest&country=~THA) vs our 409g CO2/kWh).

## Description

This PR hides certain zones from the map to avoid showing incorrect colors and numbers on the map.
I decided to reuse the `aggregates_displayed` property in zone configurations to avoid introducing more new ways of doing things. To make changes minimal I added a "none" entry for the zones, but an alternative implementation (which requires a bit more work) would be to return an empty array instead (`aggregates_displayed: []`).

**Zones hidden:**
- All subzones in Mexico
- Thailand
- Kuwait
- Bahrain


### Preview

![Screenshot 2024-06-18 at 22 48 17](https://github.com/electricitymaps/electricitymaps-contrib/assets/3296643/2761b8a5-aed8-4e45-881c-ddd0c918fb4e)


### Double check

- [x] I have tested my parser changes locally with `poetry run test_parser "zone_key"`
- [x] I have run `pnpx prettier@2 --write .` and `poetry run format` in the top level directory to format my changes.
