### PR TITLE
feat(hack): in app storage buster

### DIFF
--- a/web/src/features/feature-flags/FeatureFlagsManager.tsx
+++ b/web/src/features/feature-flags/FeatureFlagsManager.tsx
@@ -7,6 +7,11 @@ import { useSearchParams } from 'react-router-dom';
 import { useFeatureFlags } from './api';
 import { FeatureFlags } from './types';
 
+function handleClearLocalStorage() {
+  localStorage.clear();
+  location.reload();
+}
+
 function Content({ features }: { features: FeatureFlags }) {
   const queryClient = useQueryClient();
   const mutation = useMutation({
@@ -34,23 +39,31 @@ function Content({ features }: { features: FeatureFlags }) {
   });
 
   return (
-    <div>
+    <div className="flex flex-col">
       <p className="pb-1 font-poppins text-sm text-gray-600">Feature Flags</p>
-      {Object.entries(features).map(([key, value]) => (
-        <div className="flex w-full items-center justify-between text-sm" key={key}>
-          <label className="pr-8" htmlFor={key}>
-            {key}
-          </label>
-          <Switch.Root
-            className="relative h-[20px] w-[38px] cursor-default rounded-full bg-gray-300 outline-none data-[state=checked]:bg-brand-green"
-            id={key}
-            defaultChecked={Boolean(value)}
-            onCheckedChange={() => mutation.mutate(key)}
-          >
-            <Switch.Thumb className="block h-[16px] w-[16px] translate-x-0.5 rounded-full bg-white transition-transform duration-100 will-change-transform data-[state=checked]:translate-x-[19px]" />
-          </Switch.Root>
-        </div>
-      ))}
+      <div>
+        {Object.entries(features).map(([key, value]) => (
+          <div className="flex w-full items-center justify-between text-sm" key={key}>
+            <label className="pr-8" htmlFor={key}>
+              {key}
+            </label>
+            <Switch.Root
+              className="relative h-[20px] w-[38px] cursor-default rounded-full bg-gray-300 outline-none data-[state=checked]:bg-brand-green"
+              id={key}
+              defaultChecked={Boolean(value)}
+              onCheckedChange={() => mutation.mutate(key)}
+            >
+              <Switch.Thumb className="block h-[16px] w-[16px] translate-x-0.5 rounded-full bg-white transition-transform duration-100 will-change-transform data-[state=checked]:translate-x-[19px]" />
+            </Switch.Root>
+          </div>
+        ))}
+      </div>
+      <button
+        className="mt-2 self-end rounded  bg-green-900 p-1 text-xs text-white"
+        onClick={handleClearLocalStorage}
+      >
+        Clear Local Storage
+      </button>
     </div>
   );
 }


### PR DESCRIPTION
## Issue
The dev process on feature flagged stuff can be quite slow to delete local storage keys

## Description
This PR adds a new button to the featureflags manager (find with the ff query param, `app.el...com/map?ff`)

The button clears all local storage and reloads the page.