### PR TITLE
Remove US-CENT-SPA from fossil production requirement

### DIFF
--- a/parsers/lib/quality.py
+++ b/parsers/lib/quality.py
@@ -139,6 +139,7 @@ def validate_production(obj: dict[str, Any], zone_key: ZoneKey) -> None:
             "AU-TAS",
             "DK-BHM",
             "US-CAR-YAD",
+            "US-CENT-SPA",
             "US-NW-SCL",
             "US-NW-CHPD",
             "US-NW-WWA",


### PR DESCRIPTION
## Issue

US-CENT-SPA is a zone which only has hydro production. However, so far, we have required that the parser reports one of the fossil production technologies, leading to the parser to fail recently (previously they had reported unknown: 0).

## Description
In the PR, we add the zone to the list of fossil-free production.

### Double check

- [ ] I have tested my parser changes locally with `poetry run test_parser "zone_key"`
- [ ] I have run `pnpx prettier@2 --write .` and `poetry run format` in the top level directory to format my changes.
