### PR TITLE
perf: Move CSS import to `main.tsx`

### DIFF
--- a/web/src/features/map/Map.tsx
+++ b/web/src/features/map/Map.tsx
@@ -1,5 +1,3 @@
-import 'maplibre-gl/dist/maplibre-gl.css';
-
 import useGetState from 'api/getState';
 import ExchangeLayer from 'features/exchanges/ExchangeLayer';
 import ZoomControls from 'features/map-controls/ZoomControls';

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -1,5 +1,6 @@
 // Init CSS
 import 'react-spring-bottom-sheet/dist/style.css';
+import 'maplibre-gl/dist/maplibre-gl.css';
 import './index.css';
 
 import * as Sentry from '@sentry/react';


### PR DESCRIPTION
## Issue

Since we didn't import the CSS in the same place as the other CSS files it created a separate bundle at build time. And since CSS is render blocking both where needed for the map to render.

## Description

Moves the CSS import to our `main.tsx` where our other CSS imports are so they end up in the same bundle.

### Preview
On master:
```
dist/assets/MapWrapper-05820bd7.css               63.75 kB │ gzip:   9.07 kB
dist/assets/index-cfaab156.css                    76.15 kB │ gzip:  13.26 kB
```
On this branch:
```
dist/assets/index-4f5ad7ed.css                   139.90 kB │ gzip:  22.25 kB
```

### Double check

- [x] I have run `pnpx prettier@2 --write .` and `poetry run format` in the top level directory to format my changes.
