### PR TITLE
ENTE parser: refactor to use event classes

### DIFF
--- a/parsers/test/snapshots/snap_test_ENTE.py
+++ b/parsers/test/snapshots/snap_test_ENTE.py
@@ -11,9 +11,14 @@ snapshots["TestENTE::test_fetch_exchange 1"] = {
     "source": "enteoperador.org",
 }
 
-snapshots["TestENTE::test_fetch_production 1"] = {
-    "datetime": "2024-04-03T08:00:00-06:00",
-    "production": {"unknown": 1460.3},
-    "source": "enteoperador.org",
-    "zoneKey": "HN",
-}
+snapshots["TestENTE::test_fetch_production 1"] = [
+    {
+        "correctedModes": [],
+        "datetime": "2024-04-03T08:00:00-06:00",
+        "production": {"unknown": 1460.3},
+        "source": "enteoperador.org",
+        "sourceType": "measured",
+        "storage": {},
+        "zoneKey": "HN",
+    }
+]

--- a/parsers/test/snapshots/snap_test_ENTE.py
+++ b/parsers/test/snapshots/snap_test_ENTE.py
@@ -4,12 +4,15 @@ from snapshottest import Snapshot
 
 snapshots = Snapshot()
 
-snapshots["TestENTE::test_fetch_exchange 1"] = {
-    "datetime": "2024-04-03T08:37:00-06:00",
-    "netFlow": -7.5,
-    "sortedZoneKeys": "CR->NI",
-    "source": "enteoperador.org",
-}
+snapshots["TestENTE::test_fetch_exchange 1"] = [
+    {
+        "datetime": "2024-04-03T08:37:00-06:00",
+        "netFlow": -7.5,
+        "sortedZoneKeys": "CR->NI",
+        "source": "enteoperador.org",
+        "sourceType": "measured",
+    }
+]
 
 snapshots["TestENTE::test_fetch_production 1"] = [
     {

--- a/parsers/test/test_ENTE.py
+++ b/parsers/test/test_ENTE.py
@@ -34,12 +34,16 @@ class TestENTE(TestCase):
         )
 
         self.assertMatchSnapshot(
-            {
-                "datetime": exchange["datetime"].isoformat(),
-                "sortedZoneKeys": exchange["sortedZoneKeys"],
-                "netFlow": exchange["netFlow"],
-                "source": exchange["source"],
-            }
+            [
+                {
+                    "datetime": element["datetime"].isoformat(),
+                    "netFlow": element["netFlow"],
+                    "source": element["source"],
+                    "sortedZoneKeys": element["sortedZoneKeys"],
+                    "sourceType": element["sourceType"].value,
+                }
+                for element in exchange
+            ]
         )
 
     def test_fetch_exchange_raises_exception_on_exchange_not_implemented(self):

--- a/parsers/test/test_ENTE.py
+++ b/parsers/test/test_ENTE.py
@@ -61,10 +61,16 @@ class TestENTE(TestCase):
         )
 
         self.assertMatchSnapshot(
-            {
-                "datetime": production["datetime"].isoformat(),
-                "zoneKey": production["zoneKey"],
-                "production": production["production"],
-                "source": production["source"],
-            }
+            [
+                {
+                    "datetime": element["datetime"].isoformat(),
+                    "zoneKey": element["zoneKey"],
+                    "production": element["production"],
+                    "storage": element["storage"],
+                    "source": element["source"],
+                    "sourceType": element["sourceType"].value,
+                    "correctedModes": element["correctedModes"],
+                }
+                for element in production
+            ]
         )


### PR DESCRIPTION
## Issue

#6011

## Description

This PR refactors the ENTE parser to use event classes, as described in the issue.

### Preview

### Double check

- [ ] I have tested my parser changes locally with `poetry run test_parser "zone_key"`
- [ ] I have run `pnpx prettier@2 --write .` and `poetry run format` in the top level directory to format my changes.
