### PR TITLE
Update Solar and Wind capacity for Portugal

### DIFF
--- a/config/zones/PT.yaml
+++ b/config/zones/PT.yaml
@@ -64,6 +64,9 @@ capacity:
     - datetime: '2024-01-01'
       source: entsoe.eu
       value: 1811.0
+    - datetime: '2024-03-01'
+      source: ren.pt
+      value: 2744.0
     - datetime: '2024-07-01'
       source: ren.pt
       value: 3129.0
@@ -79,6 +82,9 @@ capacity:
       source: entsoe.eu
       value: 5358.0
     - datetime: '2024-03-01'
+      source: ren.pt
+      value: 5374.0
+    - datetime: '2024-07-01'
       source: ren.pt
       value: 5380.0
 contributors:


### PR DESCRIPTION
Solar and wind figures have been updated as per the most recent REN data.
