### PR TITLE
feat: Update selectedDatetimeIndexAtom to use a Date object and use derived Atom for string format

### DIFF
--- a/web/src/components/TimeDisplay.tsx
+++ b/web/src/components/TimeDisplay.tsx
@@ -1,4 +1,4 @@
-import { useAtomValue } from 'jotai/react';
+import { useAtomValue } from 'jotai';
 import { useTranslation } from 'react-i18next';
 import { formatDate } from 'utils/formatting';
 import { selectedDatetimeIndexAtom, timeAverageAtom } from 'utils/state/atoms';

--- a/web/src/components/TimeDisplay.tsx
+++ b/web/src/components/TimeDisplay.tsx
@@ -1,14 +1,16 @@
-import { useAtom } from 'jotai';
+import { useAtomValue } from 'jotai/react';
 import { useTranslation } from 'react-i18next';
 import { formatDate } from 'utils/formatting';
 import { selectedDatetimeIndexAtom, timeAverageAtom } from 'utils/state/atoms';
 
 export function TimeDisplay({ className }: { className?: string }) {
   const { i18n } = useTranslation();
-  const [timeAverage] = useAtom(timeAverageAtom);
-  const [selectedDatetime] = useAtom(selectedDatetimeIndexAtom);
+  const timeAverage = useAtomValue(timeAverageAtom);
+  const selectedDatetime = useAtomValue(selectedDatetimeIndexAtom);
 
-  const date = new Date(selectedDatetime.datetimeString);
-
-  return <p className={className}>{formatDate(date, i18n.language, timeAverage)}</p>;
+  return (
+    <p className={className}>
+      {formatDate(selectedDatetime.datetime, i18n.language, timeAverage)}
+    </p>
+  );
 }

--- a/web/src/components/TimeSlider.tsx
+++ b/web/src/components/TimeSlider.tsx
@@ -2,7 +2,7 @@ import * as SliderPrimitive from '@radix-ui/react-slider';
 import { scaleLinear } from 'd3-scale';
 import { useNightTimes } from 'hooks/nightTimes';
 import { useDarkMode } from 'hooks/theme';
-import { useAtom } from 'jotai/react';
+import { useAtom } from 'jotai';
 import trackEvent from 'utils/analytics';
 import { TimeAverages } from 'utils/constants';
 import { useGetZoneFromPath } from 'utils/helpers';

--- a/web/src/features/charts/hooks/useBarElectricityBreakdownChartData.ts
+++ b/web/src/features/charts/hooks/useBarElectricityBreakdownChartData.ts
@@ -1,5 +1,5 @@
 import useGetZone from 'api/getZone';
-import { useAtomValue } from 'jotai/react';
+import { useAtomValue } from 'jotai';
 import { useParams } from 'react-router-dom';
 import { Mode, SpatialAggregate } from 'utils/constants';
 import {

--- a/web/src/features/charts/hooks/useBarElectricityBreakdownChartData.ts
+++ b/web/src/features/charts/hooks/useBarElectricityBreakdownChartData.ts
@@ -1,10 +1,10 @@
 import useGetZone from 'api/getZone';
-import { useAtom } from 'jotai';
+import { useAtomValue } from 'jotai/react';
 import { useParams } from 'react-router-dom';
 import { Mode, SpatialAggregate } from 'utils/constants';
 import {
   productionConsumptionAtom,
-  selectedDatetimeIndexAtom,
+  selectedDatetimeStringAtom,
   spatialAggregateAtom,
 } from 'utils/state/atoms';
 
@@ -21,17 +21,17 @@ export default function useBarBreakdownChartData() {
   // TODO: Create hook for using "current" selectedTimeIndex of data instead
   const { data: zoneData, isLoading } = useGetZone();
   const { zoneId } = useParams();
-  const [viewMode] = useAtom(spatialAggregateAtom);
-  const [selectedDatetime] = useAtom(selectedDatetimeIndexAtom);
-  const [mixMode] = useAtom(productionConsumptionAtom);
+  const viewMode = useAtomValue(spatialAggregateAtom);
+  const selectedDatetimeString = useAtomValue(selectedDatetimeStringAtom);
+  const mixMode = useAtomValue(productionConsumptionAtom);
   const isCountryView = viewMode === SpatialAggregate.COUNTRY;
-  const currentData = zoneData?.zoneStates?.[selectedDatetime.datetimeString];
+  const currentData = zoneData?.zoneStates?.[selectedDatetimeString];
   const isConsumption = mixMode === Mode.CONSUMPTION;
   if (isLoading) {
     return { isLoading };
   }
 
-  if (!zoneId || !zoneData || !selectedDatetime.datetimeString || !currentData) {
+  if (!zoneId || !zoneData || !selectedDatetimeString || !currentData) {
     return {
       height: DEFAULT_BAR_PX_HEIGHT,
       zoneDetails: undefined,

--- a/web/src/features/map/Map.cy.tsx
+++ b/web/src/features/map/Map.cy.tsx
@@ -158,7 +158,7 @@ describe('Map Component', () => {
           [
             selectedDatetimeIndexAtom,
             {
-              datetimeString: '2022-12-05T08:00:00Z',
+              datetime: new Date('2022-12-05T08:00:00+00:00'),
               index: 0,
             },
           ],

--- a/web/src/features/map/MapMovement.cy.tsx
+++ b/web/src/features/map/MapMovement.cy.tsx
@@ -37,7 +37,7 @@ describe('Map Component', () => {
           [
             selectedDatetimeIndexAtom,
             {
-              datetimeString: '2024-05-01T17:00:00Z',
+              datetime: new Date('2024-05-01T17:00:00+00:00'),
               index: 0,
             },
           ],

--- a/web/src/features/map/MapTooltip.tsx
+++ b/web/src/features/map/MapTooltip.tsx
@@ -6,7 +6,7 @@ import EstimationBadge from 'components/EstimationBadge';
 import OutageBadge from 'components/OutageBadge';
 import { getSafeTooltipPosition } from 'components/tooltips/utilities';
 import { ZoneName } from 'components/ZoneName';
-import { useAtom } from 'jotai';
+import { useAtomValue } from 'jotai';
 import { useTranslation } from 'react-i18next';
 import { StateZoneData } from 'types';
 import { Mode } from 'utils/constants';
@@ -15,6 +15,7 @@ import { getCarbonIntensity, getFossilFuelRatio, getRenewableRatio } from 'utils
 import {
   productionConsumptionAtom,
   selectedDatetimeIndexAtom,
+  selectedDatetimeStringAtom,
   timeAverageAtom,
 } from 'utils/state/atoms';
 
@@ -33,7 +34,7 @@ export function TooltipInner({
 
   const { t } = useTranslation();
 
-  const [currentMode] = useAtom(productionConsumptionAtom);
+  const currentMode = useAtomValue(productionConsumptionAtom);
   const isConsumption = currentMode === Mode.CONSUMPTION;
   const intensity = getCarbonIntensity(zoneData, isConsumption);
   const fossilFuelPercentage = getFossilFuelRatio(zoneData, isConsumption);
@@ -94,11 +95,12 @@ function DataValidityBadge({
 }
 
 export default function MapTooltip() {
-  const [mousePosition] = useAtom(mousePositionAtom);
-  const [hoveredZone] = useAtom(hoveredZoneAtom);
-  const [selectedDatetime] = useAtom(selectedDatetimeIndexAtom);
-  const [timeAverage] = useAtom(timeAverageAtom);
-  const [isMapMoving] = useAtom(mapMovingAtom);
+  const mousePosition = useAtomValue(mousePositionAtom);
+  const hoveredZone = useAtomValue(hoveredZoneAtom);
+  const selectedDatetime = useAtomValue(selectedDatetimeIndexAtom);
+  const selectedDatetimeString = useAtomValue(selectedDatetimeStringAtom);
+  const timeAverage = useAtomValue(timeAverageAtom);
+  const isMapMoving = useAtomValue(mapMovingAtom);
   const { i18n, t } = useTranslation();
   const { data } = useGetState();
 
@@ -108,18 +110,13 @@ export default function MapTooltip() {
 
   const { x, y } = mousePosition;
   const zoneData =
-    data?.data?.datetimes[selectedDatetime.datetimeString]?.z[hoveredZone.zoneId] ??
-    undefined;
+    data?.data?.datetimes[selectedDatetimeString]?.z[hoveredZone.zoneId] ?? undefined;
 
   const screenWidth = window.innerWidth;
   const tooltipWithDataPositon = getSafeTooltipPosition(x, y, screenWidth, 361, 170);
   const emptyTooltipPosition = getSafeTooltipPosition(x, y, screenWidth, 176, 70);
 
-  const formattedDate = formatDate(
-    new Date(selectedDatetime.datetimeString),
-    i18n.language,
-    timeAverage
-  );
+  const formattedDate = formatDate(selectedDatetime.datetime, i18n.language, timeAverage);
 
   if (zoneData) {
     return (

--- a/web/src/features/panels/ranking-panel/RankingPanel.tsx
+++ b/web/src/features/panels/ranking-panel/RankingPanel.tsx
@@ -1,11 +1,10 @@
 import useGetState from 'api/getState';
 import { useCo2ColorScale } from 'hooks/theme';
-import { useAtom, useAtomValue } from 'jotai';
+import { useAtomValue } from 'jotai';
 import { ReactElement, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import {
   productionConsumptionAtom,
-  selectedDatetimeIndexAtom,
   selectedDatetimeStringAtom,
   spatialAggregateAtom,
 } from 'utils/state/atoms';

--- a/web/src/features/panels/ranking-panel/RankingPanel.tsx
+++ b/web/src/features/panels/ranking-panel/RankingPanel.tsx
@@ -1,11 +1,12 @@
 import useGetState from 'api/getState';
 import { useCo2ColorScale } from 'hooks/theme';
-import { useAtom } from 'jotai';
+import { useAtom, useAtomValue } from 'jotai';
 import { ReactElement, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import {
   productionConsumptionAtom,
   selectedDatetimeIndexAtom,
+  selectedDatetimeStringAtom,
   spatialAggregateAtom,
 } from 'utils/state/atoms';
 
@@ -18,10 +19,10 @@ import { VirtualizedZoneList } from './ZoneList';
 export default function RankingPanel(): ReactElement {
   const { t } = useTranslation();
   const getCo2colorScale = useCo2ColorScale();
-  const [selectedDatetime] = useAtom(selectedDatetimeIndexAtom);
+  const selectedDatetimeString = useAtomValue(selectedDatetimeStringAtom);
   const [searchTerm, setSearchTerm] = useState('');
-  const [electricityMode] = useAtom(productionConsumptionAtom);
-  const [spatialAggregation] = useAtom(spatialAggregateAtom);
+  const electricityMode = useAtomValue(productionConsumptionAtom);
+  const spatialAggregation = useAtomValue(spatialAggregateAtom);
   const inputHandler = (inputEvent: React.ChangeEvent<HTMLInputElement>) => {
     const { target } = inputEvent;
 
@@ -36,7 +37,7 @@ export default function RankingPanel(): ReactElement {
     data,
     getCo2colorScale,
     'asc',
-    selectedDatetime.datetimeString,
+    selectedDatetimeString,
     electricityMode,
     spatialAggregation
   );

--- a/web/src/features/panels/zone/ZoneDetails.tsx
+++ b/web/src/features/panels/zone/ZoneDetails.tsx
@@ -2,7 +2,7 @@ import useGetZone from 'api/getZone';
 import { Button } from 'components/Button';
 import LoadingSpinner from 'components/LoadingSpinner';
 import BarBreakdownChart from 'features/charts/bar-breakdown/BarBreakdownChart';
-import { useAtom } from 'jotai';
+import { useAtomValue, useSetAtom } from 'jotai';
 import { useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
 import { MdOutlineCloudDownload } from 'react-icons/md';
@@ -11,7 +11,7 @@ import { ZoneMessage } from 'types';
 import { EstimationMethods, SpatialAggregate, TimeAverages } from 'utils/constants';
 import {
   displayByEmissionsAtom,
-  selectedDatetimeIndexAtom,
+  selectedDatetimeStringAtom,
   spatialAggregateAtom,
   timeAverageAtom,
 } from 'utils/state/atoms';
@@ -29,10 +29,10 @@ import ZoneHeaderTitle from './ZoneHeaderTitle';
 
 export default function ZoneDetails(): JSX.Element {
   const { zoneId } = useParams();
-  const [timeAverage] = useAtom(timeAverageAtom);
-  const [displayByEmissions] = useAtom(displayByEmissionsAtom);
-  const [_, setViewMode] = useAtom(spatialAggregateAtom);
-  const [selectedDatetime] = useAtom(selectedDatetimeIndexAtom);
+  const timeAverage = useAtomValue(timeAverageAtom);
+  const displayByEmissions = useAtomValue(displayByEmissionsAtom);
+  const setViewMode = useSetAtom(spatialAggregateAtom);
+  const selectedDatetimeString = useAtomValue(selectedDatetimeStringAtom);
   const { data, isError, isLoading } = useGetZone();
   const { t } = useTranslation();
   const isMobile = !useBreakpoint('sm');
@@ -68,7 +68,7 @@ export default function ZoneDetails(): JSX.Element {
 
   const datetimes = Object.keys(data?.zoneStates || {})?.map((key) => new Date(key));
 
-  const selectedData = data?.zoneStates[selectedDatetime.datetimeString];
+  const selectedData = data?.zoneStates[selectedDatetimeString];
   const { estimationMethod, estimatedPercentage } = selectedData || {};
   const zoneMessage = data?.zoneMessage;
   const cardType = getCardType({ estimationMethod, zoneMessage, timeAverage });

--- a/web/src/features/panels/zone/ZoneHeaderGauges.tsx
+++ b/web/src/features/panels/zone/ZoneHeaderGauges.tsx
@@ -1,11 +1,11 @@
 import CarbonIntensitySquare from 'components/CarbonIntensitySquare';
 import { CircularGauge } from 'components/CircularGauge';
-import { useAtom } from 'jotai';
+import { useAtomValue } from 'jotai';
 import { useTranslation } from 'react-i18next';
 import { ZoneDetails } from 'types';
 import { Mode } from 'utils/constants';
 import { getCarbonIntensity, getFossilFuelRatio, getRenewableRatio } from 'utils/helpers';
-import { productionConsumptionAtom, selectedDatetimeIndexAtom } from 'utils/state/atoms';
+import { productionConsumptionAtom, selectedDatetimeStringAtom } from 'utils/state/atoms';
 
 function LowCarbonTooltip() {
   const { t } = useTranslation();
@@ -21,10 +21,10 @@ function LowCarbonTooltip() {
 
 export function ZoneHeaderGauges({ data }: { data?: ZoneDetails }) {
   const { t } = useTranslation();
-  const [currentMode] = useAtom(productionConsumptionAtom);
-  const [selectedDatetime] = useAtom(selectedDatetimeIndexAtom);
+  const currentMode = useAtomValue(productionConsumptionAtom);
+  const selectedDatetimeString = useAtomValue(selectedDatetimeStringAtom);
   const isConsumption = currentMode === Mode.CONSUMPTION;
-  const selectedData = data?.zoneStates[selectedDatetime.datetimeString];
+  const selectedData = data?.zoneStates[selectedDatetimeString];
 
   const {
     co2intensity,

--- a/web/src/features/time/TimeController.tsx
+++ b/web/src/features/time/TimeController.tsx
@@ -5,7 +5,6 @@ import { useAtom } from 'jotai';
 import { useEffect, useMemo, useState } from 'react';
 import trackEvent from 'utils/analytics';
 import { TimeAverages } from 'utils/constants';
-import { dateToDatetimeString } from 'utils/helpers';
 import { selectedDatetimeIndexAtom, timeAverageAtom } from 'utils/state/atoms';
 
 import TimeAxis from './TimeAxis';
@@ -36,7 +35,7 @@ export default function TimeController({ className }: { className?: string }) {
       setNumberOfEntries(datetimes.length - 1);
       // Reset the selected datetime when data changes
       setSelectedDatetime({
-        datetimeString: dateToDatetimeString(datetimes.at(-1) as Date),
+        datetime: datetimes.at(-1) as Date,
         index: datetimes.length - 1,
       });
     }
@@ -48,7 +47,7 @@ export default function TimeController({ className }: { className?: string }) {
       return;
     }
     setSelectedDatetime({
-      datetimeString: dateToDatetimeString(datetimes[index]),
+      datetime: datetimes[index],
       index,
     });
   };
@@ -56,7 +55,7 @@ export default function TimeController({ className }: { className?: string }) {
   const onToggleGroupClick = (timeAverage: TimeAverages) => {
     // Set time slider to latest value before switching aggregate to avoid flickering
     setSelectedDatetime({
-      datetimeString: selectedDatetime.datetimeString,
+      datetime: selectedDatetime.datetime,
       index: numberOfEntries,
     });
     setTimeAverage(timeAverage);

--- a/web/src/features/time/TimeHeader.tsx
+++ b/web/src/features/time/TimeHeader.tsx
@@ -1,5 +1,5 @@
 import useGetState from 'api/getState';
-import { useAtom } from 'jotai';
+import { useAtom, useAtomValue } from 'jotai';
 import { useTranslation } from 'react-i18next';
 import { formatDate } from 'utils/formatting';
 import { selectedDatetimeIndexAtom, timeAverageAtom } from 'utils/state/atoms';
@@ -9,15 +9,11 @@ type TimeHeaderProps = {
 };
 export default function TimeHeader({ className }: TimeHeaderProps) {
   const { t, i18n } = useTranslation();
-  const [timeAverage] = useAtom(timeAverageAtom);
-  const [selectedDatetime] = useAtom(selectedDatetimeIndexAtom);
+  const timeAverage = useAtomValue(timeAverageAtom);
+  const selectedDatetime = useAtomValue(selectedDatetimeIndexAtom);
   const { isLoading } = useGetState();
 
-  const date = formatDate(
-    new Date(selectedDatetime.datetimeString),
-    i18n.language,
-    timeAverage
-  );
+  const date = formatDate(selectedDatetime.datetime, i18n.language, timeAverage);
 
   return (
     <div

--- a/web/src/features/time/TimeHeader.tsx
+++ b/web/src/features/time/TimeHeader.tsx
@@ -1,5 +1,5 @@
 import useGetState from 'api/getState';
-import { useAtom, useAtomValue } from 'jotai';
+import { useAtomValue } from 'jotai';
 import { useTranslation } from 'react-i18next';
 import { formatDate } from 'utils/formatting';
 import { selectedDatetimeIndexAtom, timeAverageAtom } from 'utils/state/atoms';

--- a/web/src/hooks/arrows.ts
+++ b/web/src/hooks/arrows.ts
@@ -1,9 +1,9 @@
 import useGetState from 'api/getState';
-import { useAtom } from 'jotai';
+import { useAtomValue } from 'jotai';
 import { useMemo } from 'react';
 import { ExchangeArrowData, StateExchangeData } from 'types';
 import { SpatialAggregate } from 'utils/constants';
-import { selectedDatetimeIndexAtom, spatialAggregateAtom } from 'utils/state/atoms';
+import { selectedDatetimeStringAtom, spatialAggregateAtom } from 'utils/state/atoms';
 
 import exchangesConfigJSON from '../../config/exchanges.json'; // do something globally
 import exchangesToExclude from '../../config/excluded_aggregated_exchanges.json'; // do something globally
@@ -55,22 +55,22 @@ export function filterExchanges(
 }
 
 export function useExchangeArrowsData(): ExchangeArrowData[] {
-  const [selectedDatetime] = useAtom(selectedDatetimeIndexAtom);
-  const [viewMode] = useAtom(spatialAggregateAtom);
+  const selectedDatetimeString = useAtomValue(selectedDatetimeStringAtom);
+  const viewMode = useAtomValue(spatialAggregateAtom);
   const { data } = useGetState();
 
   // Find outages in state data and hide exports from those zones
   const zonesWithOutages = useMemo(() => {
-    const zoneData = data?.data?.datetimes?.[selectedDatetime?.datetimeString]?.z;
+    const zoneData = data?.data?.datetimes?.[selectedDatetimeString]?.z;
     return zoneData
       ? Object.entries(zoneData)
           .filter(([_, value]) => value.o)
           .map(([zone]) => zone)
       : [];
-  }, [data, selectedDatetime]);
+  }, [data?.data?.datetimes, selectedDatetimeString]);
 
   const exchangesToUse: { [key: string]: StateExchangeData } = useMemo(() => {
-    const exchanges = data?.data?.datetimes?.[selectedDatetime?.datetimeString]?.e;
+    const exchanges = data?.data?.datetimes?.[selectedDatetimeString]?.e;
 
     if (!exchanges) {
       return {};
@@ -85,7 +85,7 @@ export function useExchangeArrowsData(): ExchangeArrowData[] {
     return viewMode === SpatialAggregate.COUNTRY
       ? countryViewExchanges
       : zoneViewExchanges;
-  }, [data, selectedDatetime, viewMode]);
+  }, [data?.data?.datetimes, selectedDatetimeString, viewMode]);
 
   const currentExchanges: ExchangeArrowData[] = useMemo(() => {
     return Object.entries(exchangesToUse).map(([key, value]) => ({

--- a/web/src/hooks/arrows.ts
+++ b/web/src/hooks/arrows.ts
@@ -67,7 +67,7 @@ export function useExchangeArrowsData(): ExchangeArrowData[] {
           .filter(([_, value]) => value.o)
           .map(([zone]) => zone)
       : [];
-  }, [data?.data?.datetimes, selectedDatetimeString]);
+  }, [data, selectedDatetimeString]);
 
   const exchangesToUse: { [key: string]: StateExchangeData } = useMemo(() => {
     const exchanges = data?.data?.datetimes?.[selectedDatetimeString]?.e;
@@ -85,7 +85,7 @@ export function useExchangeArrowsData(): ExchangeArrowData[] {
     return viewMode === SpatialAggregate.COUNTRY
       ? countryViewExchanges
       : zoneViewExchanges;
-  }, [data?.data?.datetimes, selectedDatetimeString, viewMode]);
+  }, [data, selectedDatetimeString, viewMode]);
 
   const currentExchanges: ExchangeArrowData[] = useMemo(() => {
     return Object.entries(exchangesToUse).map(([key, value]) => ({

--- a/web/src/utils/state/atoms.ts
+++ b/web/src/utils/state/atoms.ts
@@ -1,5 +1,6 @@
 import { atom } from 'jotai';
 import { atomWithStorage } from 'jotai/utils';
+import { dateToDatetimeString } from 'utils/helpers';
 
 import {
   Mode,
@@ -15,7 +16,12 @@ import {
 export const timeAverageAtom = atom(TimeAverages.HOURLY);
 
 // TODO: consider another initial value
-export const selectedDatetimeIndexAtom = atom({ datetimeString: '', index: 0 });
+export const selectedDatetimeIndexAtom = atom({ datetime: new Date(), index: 0 });
+
+export const selectedDatetimeStringAtom = atom((get) => {
+  const { datetime } = get(selectedDatetimeIndexAtom);
+  return dateToDatetimeString(datetime);
+});
 
 export const spatialAggregateAtom = atomWithStorage(
   'country-mode',


### PR DESCRIPTION
## Description

The selectedDatetimeIndexAtom in the atoms.ts file was updated to store the datetime as a Date object instead of a datetimeString. This change was made to improve consistency, simplify the code, reduce code duplication and increase the performance of the app.

To still be able to use the string value for the areas that require it I created a derived atom that takes the datetime from the index atom and returns it in a string format.

This change allows Vite to further optimise our bundles reducing the amount of preached bundles by 2 from 75 to 73 entries while also lowering the overall code size by 1kb.

### Double check

- [x] I have run `pnpx prettier@2 --write .` and `poetry run format` in the top level directory to format my changes.
