### PR TITLE
fix: add missing exchange between DK and NL

### DIFF
--- a/config/exchanges/DK_NL.yaml
+++ b/config/exchanges/DK_NL.yaml
@@ -1,0 +1,7 @@
+capacity:
+  - -700
+  - 700
+lonlat:
+  - 7.4
+  - 54.5
+rotation: -150


### PR DESCRIPTION
## Issue

We where missing a exchange confix for the aggregated exchange between DK and NL.

## Description

Adds the exchange config with the same location, rotation and capacity as the exchange between DK-DK1 and NL.

### Double check

- [ x] I have run `pnpx prettier@2 --write .` and `poetry run format` in the top level directory to format my changes.
