### PR TITLE
feat(web): Add tooltip to production source legends in BreakdownChart

### DIFF
--- a/web/src/features/charts/ProductionSourceLegendList.tsx
+++ b/web/src/features/charts/ProductionSourceLegendList.tsx
@@ -61,9 +61,9 @@ function ProductionSourceTooltip({
 function ProductionSourceTooltipInner({ sources }: { sources: ElectricityModeType[] }) {
   return (
     <div className="flex flex-col gap-1.5">
-      {sources.map((source, index) => (
+      {sources.map((source) => (
         <div key={source} className="flex flex-row gap-2">
-          <ProductionSourceLegend key={index} electricityType={source} />
+          <ProductionSourceLegend key={source} electricityType={source} />
           <div className="text-xs font-medium">{source}</div>
         </div>
       ))}

--- a/web/src/features/charts/ProductionSourceLegendList.tsx
+++ b/web/src/features/charts/ProductionSourceLegendList.tsx
@@ -20,8 +20,8 @@ export default function ProductionSourceLegendList({
       tooltipContent={<ProductionSourceTooltip sources={sources} isMobile={isMobile} />}
       tooltipClassName={
         isMobile
-          ? 'bg-transparent shadow-none border-transparent dark:bg-transparent items-center flex flex-col p-0'
-          : 'rounded-2xl min-w-44 dark:bg-gray-900/80 dark:border-1 dark:border-gray-700 mx-5 backdrop-blur bg-white/80'
+          ? 'bg-transparent shadow-none border-transparent dark:bg-transparent items-center flex flex-col p-0 mb-2'
+          : 'rounded-2xl min-w-44 dark:bg-gray-900/80 dark:border-1 dark:border-gray-700 mx-5 backdrop-blur bg-white/80 mb-2'
       }
       side="bottom"
       isMobile={isMobile}
@@ -46,14 +46,7 @@ function ProductionSourceTooltip({
     return (
       <>
         <div className="dark:border-1 relative h-auto min-w-44 rounded-2xl border bg-white/80 p-4 text-left text-sm shadow-md backdrop-blur dark:border-gray-700 dark:bg-gray-900/80">
-          <div className="flex flex-col gap-1.5">
-            {sources.map((source, index) => (
-              <div key={source} className="flex flex-row gap-2">
-                <ProductionSourceLegend key={index} electricityType={source} />
-                <div className="text-xs font-medium">{source}</div>
-              </div>
-            ))}
-          </div>
+          <ProductionSourceTooltipInner sources={sources} />
         </div>
         <button className="p-auto pointer-events-auto mt-2 flex h-10 w-10 items-center justify-center self-center rounded-full border bg-white text-black shadow-md">
           <HiXMark size="24" />
@@ -62,6 +55,10 @@ function ProductionSourceTooltip({
     );
   }
 
+  return <ProductionSourceTooltipInner sources={sources} />;
+}
+
+function ProductionSourceTooltipInner({ sources }: { sources: ElectricityModeType[] }) {
   return (
     <div className="flex flex-col gap-1.5">
       {sources.map((source, index) => (

--- a/web/src/features/charts/ProductionSourceLegendList.tsx
+++ b/web/src/features/charts/ProductionSourceLegendList.tsx
@@ -21,8 +21,8 @@ export default function ProductionSourceLegendList({
       tooltipContent={<ProductionSourceTooltip sources={sources} isMobile={isMobile} />}
       tooltipClassName={
         isMobile
-          ? 'absolute h-full min-w-44 rounded-none border-0 p-0 text-left text-lg shadow-none dark:border-white dark:bg-gray-900'
-          : 'rounded-xl min-w-44 dark:bg-gray-900 dark:border-1 dark:border-gray-700'
+          ? ''
+          : 'rounded-2xl min-w-44 dark:bg-gray-900 dark:border-1 dark:border-gray-700 mx-5'
       }
       side="bottom"
       isMobile={isMobile}
@@ -46,7 +46,7 @@ function ProductionSourceTooltip({
   if (isMobile) {
     return (
       <Portal.Root className="pointer-events-none absolute left-0 top-0 z-50 flex h-full w-full flex-col content-center items-center justify-center bg-black/20 pb-40">
-        <div className="dark:border-1 relative mx-6 h-auto min-w-64 rounded-xl border bg-zinc-50 p-4 text-left text-sm opacity-80 shadow-md dark:border-gray-700 dark:bg-gray-900">
+        <div className="dark:border-1 relative mx-6 h-auto min-w-64 rounded-2xl border bg-zinc-50 p-4 text-left text-sm opacity-80 shadow-md dark:border-gray-700 dark:bg-gray-900">
           <div className="flex flex-col gap-1.5">
             {sources.map((source, index) => (
               <div key={source} className="flex flex-row gap-2">

--- a/web/src/features/charts/ProductionSourceLegendList.tsx
+++ b/web/src/features/charts/ProductionSourceLegendList.tsx
@@ -1,5 +1,9 @@
+import * as Portal from '@radix-ui/react-portal';
+import TooltipWrapper from 'components/tooltips/TooltipWrapper';
+import { HiXMark } from 'react-icons/hi2';
 import { twMerge } from 'tailwind-merge';
 import { ElectricityModeType } from 'types';
+import { useIsMobile } from 'utils/styling';
 
 import ProductionSourceLegend from './ProductionSourceLegend';
 
@@ -10,10 +14,62 @@ export default function ProductionSourceLegendList({
   sources: ElectricityModeType[];
   className?: string;
 }) {
+  const isMobile = useIsMobile();
+
   return (
-    <div className={twMerge('flex flex-row gap-1.5 py-1', className)}>
+    <TooltipWrapper
+      tooltipContent={<ProductionSourceTooltip sources={sources} isMobile={isMobile} />}
+      tooltipClassName={
+        isMobile
+          ? 'absolute h-full min-w-44 rounded-none border-0 p-0 text-left text-lg shadow-none dark:border-white dark:bg-gray-900'
+          : 'rounded-xl min-w-44 dark:bg-gray-900 dark:border-1 dark:border-gray-700'
+      }
+      side="bottom"
+      isMobile={isMobile}
+    >
+      <div className={twMerge('flex w-fit flex-row gap-1.5 py-1', className)}>
+        {sources.map((source, index) => (
+          <ProductionSourceLegend key={index} electricityType={source} />
+        ))}
+      </div>
+    </TooltipWrapper>
+  );
+}
+
+function ProductionSourceTooltip({
+  sources,
+  isMobile,
+}: {
+  sources: ElectricityModeType[];
+  isMobile: boolean;
+}) {
+  if (isMobile) {
+    return (
+      <Portal.Root className="pointer-events-none absolute left-0 top-0 z-50 flex h-full w-full flex-col content-center items-center justify-center bg-black/20 pb-40">
+        <div className="dark:border-1 relative mx-6 h-auto min-w-64 rounded-xl border bg-zinc-50 p-4 text-left text-sm opacity-80 shadow-md dark:border-gray-700 dark:bg-gray-900">
+          <div className="flex flex-col gap-1.5">
+            {sources.map((source, index) => (
+              <div key={source} className="flex flex-row gap-2">
+                <ProductionSourceLegend key={index} electricityType={source} />
+                <div className="text-xs font-medium">{source}</div>
+              </div>
+            ))}
+          </div>
+        </div>
+        <button className="p-auto pointer-events-auto mt-2 flex h-10 w-10 items-center justify-center self-center rounded-full border bg-zinc-50 text-black shadow-md">
+          <HiXMark size="24" />
+        </button>
+      </Portal.Root>
+    );
+  }
+
+  return (
+    <div className="flex flex-col gap-1.5">
       {sources.map((source, index) => (
-        <ProductionSourceLegend key={index} electricityType={source} />
+        <div key={source} className="flex flex-row gap-2">
+          <ProductionSourceLegend key={index} electricityType={source} />
+          <div className="text-xs font-medium">{source}</div>
+        </div>
       ))}
     </div>
   );

--- a/web/src/features/charts/ProductionSourceLegendList.tsx
+++ b/web/src/features/charts/ProductionSourceLegendList.tsx
@@ -1,4 +1,3 @@
-import * as Portal from '@radix-ui/react-portal';
 import TooltipWrapper from 'components/tooltips/TooltipWrapper';
 import { HiXMark } from 'react-icons/hi2';
 import { twMerge } from 'tailwind-merge';

--- a/web/src/features/charts/ProductionSourceLegendList.tsx
+++ b/web/src/features/charts/ProductionSourceLegendList.tsx
@@ -21,8 +21,8 @@ export default function ProductionSourceLegendList({
       tooltipContent={<ProductionSourceTooltip sources={sources} isMobile={isMobile} />}
       tooltipClassName={
         isMobile
-          ? ''
-          : 'rounded-2xl min-w-44 dark:bg-gray-900 dark:border-1 dark:border-gray-700 mx-5'
+          ? 'bg-transparent shadow-none border-transparent dark:bg-transparent items-center flex flex-col p-0'
+          : 'rounded-2xl min-w-44 dark:bg-gray-900/80 dark:border-1 dark:border-gray-700 mx-5 backdrop-blur bg-white/80'
       }
       side="bottom"
       isMobile={isMobile}
@@ -45,8 +45,8 @@ function ProductionSourceTooltip({
 }) {
   if (isMobile) {
     return (
-      <Portal.Root className="pointer-events-none absolute left-0 top-0 z-50 flex h-full w-full flex-col content-center items-center justify-center bg-black/20 pb-40">
-        <div className="dark:border-1 relative mx-6 h-auto min-w-64 rounded-2xl border bg-zinc-50 p-4 text-left text-sm opacity-80 shadow-md dark:border-gray-700 dark:bg-gray-900">
+      <>
+        <div className="dark:border-1 relative h-auto min-w-44 rounded-2xl border bg-white/80 p-4 text-left text-sm shadow-md backdrop-blur dark:border-gray-700 dark:bg-gray-900/80">
           <div className="flex flex-col gap-1.5">
             {sources.map((source, index) => (
               <div key={source} className="flex flex-row gap-2">
@@ -56,10 +56,10 @@ function ProductionSourceTooltip({
             ))}
           </div>
         </div>
-        <button className="p-auto pointer-events-auto mt-2 flex h-10 w-10 items-center justify-center self-center rounded-full border bg-zinc-50 text-black shadow-md">
+        <button className="p-auto pointer-events-auto mt-2 flex h-10 w-10 items-center justify-center self-center rounded-full border bg-white text-black shadow-md">
           <HiXMark size="24" />
         </button>
-      </Portal.Root>
+      </>
     );
   }
 


### PR DESCRIPTION
## Issue

<!-- If you want to close an issue automatically when your PR is merged, write "Closes X" where X is the PR number. For example: Closes #000 -->
[AVO-234](https://linear.app/electricitymaps/issue/AVO-234/origin-of-electricity-add-legend-tooltip-for-sources)

## Description

<!-- Explains the goal of this PR -->
This PR adds a tooltip to the production source legend list in the BreakdownChart.

### Preview
<img width="418" alt="image" src="https://github.com/electricitymaps/electricitymaps-contrib/assets/95029552/6ef12ca2-6e2c-4993-9c38-83db6054dc60">
<img width="419" alt="image" src="https://github.com/electricitymaps/electricitymaps-contrib/assets/95029552/e75c84e3-73e0-4114-9b9e-c0ab60ee51fc">

Mobile:
<img width="373" alt="image" src="https://github.com/electricitymaps/electricitymaps-contrib/assets/95029552/702e0d81-cd2d-4b9e-889a-c56e5cd1f5b0">
<img width="371" alt="image" src="https://github.com/electricitymaps/electricitymaps-contrib/assets/95029552/9af40eec-6978-4bd6-a04b-7998e31a7d3e">

<!-- Please add screenshots and/or gif that shows visual changes (if applicable) -->

### Double check

- [ ] I have tested my parser changes locally with `poetry run test_parser "zone_key"`
- [x] I have run `pnpx prettier@2 --write .` and `poetry run format` in the top level directory to format my changes.
