### PR TITLE
fix: Fix github icon color on outage message

### DIFF
--- a/web/src/features/panels/zone/EstimationCard.tsx
+++ b/web/src/features/panels/zone/EstimationCard.tsx
@@ -6,7 +6,7 @@ import { useGetEstimationTranslation } from 'hooks/getEstimationTranslation';
 import { useAtom } from 'jotai';
 import { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { FaGithub } from 'react-icons/fa';
+import { FaGithub } from 'react-icons/fa6';
 import { ZoneMessage } from 'types';
 import trackEvent from 'utils/analytics';
 import { EstimationMethods } from 'utils/constants';

--- a/web/src/features/panels/zone/EstimationCard.tsx
+++ b/web/src/features/panels/zone/EstimationCard.tsx
@@ -6,6 +6,7 @@ import { useGetEstimationTranslation } from 'hooks/getEstimationTranslation';
 import { useAtom } from 'jotai';
 import { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
+import { FaGithub } from 'react-icons/fa';
 import { ZoneMessage } from 'types';
 import trackEvent from 'utils/analytics';
 import { EstimationMethods } from 'utils/constants';
@@ -296,19 +297,11 @@ function ZoneMessageBlock({ zoneMessage }: { zoneMessage?: ZoneMessage }) {
       {zoneMessage?.issue && zoneMessage.issue != 'None' && (
         <span className="mt-1 inline-flex">
           <a
-            className="inline-flex text-sm font-semibold text-black underline dark:text-white"
+            className="inline-flex items-center gap-1 text-sm font-semibold text-black underline dark:text-white"
             href={`https://github.com/electricitymaps/electricitymaps-contrib/issues/${zoneMessage.issue}`}
           >
             <span className="pl-1 underline">{t('estimation-card.outage-details')}</span>
-            <svg
-              xmlns="http://www.w3.org/2000/svg"
-              width="18"
-              height="18"
-              viewBox="0 0 24 24"
-              className="ml-1"
-            >
-              <path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z" />
-            </svg>
+            <FaGithub />
           </a>
         </span>
       )}

--- a/web/src/features/panels/zone/EstimationCard.tsx
+++ b/web/src/features/panels/zone/EstimationCard.tsx
@@ -301,7 +301,7 @@ function ZoneMessageBlock({ zoneMessage }: { zoneMessage?: ZoneMessage }) {
             href={`https://github.com/electricitymaps/electricitymaps-contrib/issues/${zoneMessage.issue}`}
           >
             <span className="pl-1 underline">{t('estimation-card.outage-details')}</span>
-            <FaGithub />
+            <FaGithub size={18} />
           </a>
         </span>
       )}


### PR DESCRIPTION
## Issue

Fixes: #6967

## Description

Changes the icon to use the FaGithub icon from font awesome and aligns it with the text.

- [x] I have run `pnpx prettier@2 --write .` and `poetry run format` in the top level directory to format my changes.
