### PR TITLE
perf: Add useCallbacks and isHourly derived atom

### DIFF
--- a/web/src/api/getState.ts
+++ b/web/src/api/getState.ts
@@ -1,9 +1,8 @@
 import type { UseQueryResult } from '@tanstack/react-query';
 import { useQuery } from '@tanstack/react-query';
-import { useAtom } from 'jotai';
+import { useAtom, useAtomValue } from 'jotai';
 import type { GridState } from 'types';
-import { TimeAverages } from 'utils/constants';
-import { timeAverageAtom } from 'utils/state/atoms';
+import { isHourlyAtom, timeAverageAtom } from 'utils/state/atoms';
 
 import { cacheBuster, getBasePath, QUERY_KEYS } from './helpers';
 
@@ -23,20 +22,19 @@ const getState = async (timeAverage: string): Promise<GridState> => {
 
 const useGetState = (): UseQueryResult<GridState> => {
   const [timeAverage] = useAtom(timeAverageAtom);
+  const isHourly = useAtomValue(isHourlyAtom);
 
   // First fetch last hour only
   const last_hour = useQuery<GridState>({
     queryKey: [QUERY_KEYS.STATE, { aggregate: 'last_hour' }],
     queryFn: async () => getState('last_hour'),
-    enabled: timeAverage === TimeAverages.HOURLY,
+    enabled: isHourly,
   });
 
   const hourZeroWasSuccessful = Boolean(last_hour.isLoading === false && last_hour.data);
 
   const shouldFetchFullState =
-    timeAverage !== TimeAverages.HOURLY ||
-    hourZeroWasSuccessful ||
-    last_hour.isError === true;
+    !isHourly || hourZeroWasSuccessful || last_hour.isError === true;
 
   // Then fetch the rest of the data
   const all_data = useQuery<GridState>({
@@ -46,7 +44,7 @@ const useGetState = (): UseQueryResult<GridState> => {
     // The query should not execute until the last_hour query is done
     enabled: shouldFetchFullState,
   });
-  return (all_data.data || timeAverage != 'hourly' ? all_data : last_hour) ?? {};
+  return (all_data.data || !isHourly ? all_data : last_hour) ?? {};
 };
 
 export default useGetState;

--- a/web/src/components/TimeSlider.tsx
+++ b/web/src/components/TimeSlider.tsx
@@ -2,11 +2,11 @@ import * as SliderPrimitive from '@radix-ui/react-slider';
 import { scaleLinear } from 'd3-scale';
 import { useNightTimes } from 'hooks/nightTimes';
 import { useDarkMode } from 'hooks/theme';
-import { useAtom } from 'jotai';
+import { useAtom, useAtomValue } from 'jotai';
 import trackEvent from 'utils/analytics';
 import { TimeAverages } from 'utils/constants';
 import { useGetZoneFromPath } from 'utils/helpers';
-import { timeAverageAtom } from 'utils/state/atoms';
+import { isHourlyAtom, timeAverageAtom } from 'utils/state/atoms';
 
 type NightTimeSet = number[];
 type ThumbIconPath =
@@ -149,8 +149,8 @@ export function TimeSliderWithNight(props: TimeSliderProps) {
 
 function TimeSlider(props: TimeSliderProps) {
   const zoneId = useGetZoneFromPath();
-  const [timeAverage] = useAtom(timeAverageAtom);
-  const showNightTime = zoneId && timeAverage === TimeAverages.HOURLY;
+  const isHourly = useAtomValue(isHourlyAtom);
+  const showNightTime = zoneId && isHourly;
 
   return showNightTime ? (
     <TimeSliderWithNight {...props} />

--- a/web/src/features/charts/BreakdownChart.tsx
+++ b/web/src/features/charts/BreakdownChart.tsx
@@ -4,12 +4,13 @@ import Divider from 'features/panels/zone/Divider';
 import { CircleBoltIcon } from 'icons/circleBoltIcon';
 import { IndustryIcon } from 'icons/industryIcon';
 import { WindTurbineIcon } from 'icons/windTurbineIcon';
+import { useAtomValue } from 'jotai';
 import { useTranslation } from 'react-i18next';
 import { ElectricityModeType } from 'types';
 import trackEvent from 'utils/analytics';
 import { Mode, TimeAverages, TrackEvent } from 'utils/constants';
 import { formatCo2 } from 'utils/formatting';
-import { dataSourcesCollapsedBreakdown } from 'utils/state/atoms';
+import { dataSourcesCollapsedBreakdown, isHourlyAtom } from 'utils/state/atoms';
 
 import { ChartTitle } from './ChartTitle';
 import { DataSources } from './DataSources';
@@ -42,13 +43,13 @@ function BreakdownChart({
     emissionFactorSourcesToProductionSources,
   } = useZoneDataSources();
   const { t } = useTranslation();
+  const isHourly = useAtomValue(isHourlyAtom);
 
   if (!data) {
     return null;
   }
 
-  const isBreakdownGraphOverlayEnabled =
-    mixMode === Mode.CONSUMPTION && timeAverage !== TimeAverages.HOURLY;
+  const isBreakdownGraphOverlayEnabled = mixMode === Mode.CONSUMPTION && !isHourly;
 
   const { chartData, valueAxisLabel, layerFill, layerKeys } = data;
 

--- a/web/src/features/charts/bar-breakdown/BarBreakdownChart.tsx
+++ b/web/src/features/charts/bar-breakdown/BarBreakdownChart.tsx
@@ -5,7 +5,7 @@ import Divider from 'features/panels/zone/Divider';
 import { IndustryIcon } from 'icons/industryIcon';
 import { UtilityPoleIcon } from 'icons/utilityPoleIcon';
 import { WindTurbineIcon } from 'icons/windTurbineIcon';
-import { useAtom } from 'jotai';
+import { useAtom, useAtomValue } from 'jotai';
 import React, { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { HiXMark } from 'react-icons/hi2';
@@ -16,8 +16,8 @@ import { TrackEvent } from 'utils/constants';
 import {
   dataSourcesCollapsedBarBreakdown,
   displayByEmissionsAtom,
+  isHourlyAtom,
   productionConsumptionAtom,
-  timeAverageAtom,
 } from 'utils/state/atoms';
 import { useBreakpoint } from 'utils/styling';
 
@@ -59,7 +59,7 @@ function BarBreakdownChart({
   const { ref, width: observerWidth = 0 } = useResizeObserver<HTMLDivElement>();
   const { t } = useTranslation();
   const isBiggerThanMobile = useBreakpoint('sm');
-  const [timeAverage] = useAtom(timeAverageAtom);
+  const isHourly = useAtomValue(isHourlyAtom);
   const [mixMode] = useAtom(productionConsumptionAtom);
   const width = observerWidth + X_PADDING;
 
@@ -129,13 +129,7 @@ function BarBreakdownChart({
       <BySource
         hasEstimationPill={hasEstimationPill}
         estimatedPercentage={currentZoneDetail.estimatedPercentage}
-        unit={determineUnit(
-          displayByEmissions,
-          currentZoneDetail,
-          mixMode,
-          timeAverage,
-          t
-        )}
+        unit={determineUnit(displayByEmissions, currentZoneDetail, mixMode, isHourly, t)}
         estimationMethod={currentZoneDetail.estimationMethod}
       />
       {tooltipData && (

--- a/web/src/features/charts/bar-breakdown/BarElectricityBreakdownChart.tsx
+++ b/web/src/features/charts/bar-breakdown/BarElectricityBreakdownChart.tsx
@@ -2,13 +2,13 @@ import { CountryFlag } from 'components/Flag';
 import { max as d3Max, min as d3Min } from 'd3-array';
 import { scaleLinear } from 'd3-scale';
 import { useCo2ColorScale } from 'hooks/theme';
-import { useAtom } from 'jotai';
+import { useAtomValue } from 'jotai';
 import { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { ElectricityModeType, ZoneDetail, ZoneDetails, ZoneKey } from 'types';
-import { modeColor, TimeAverages } from 'utils/constants';
+import { modeColor } from 'utils/constants';
 import { formatEnergy, formatPower } from 'utils/formatting';
-import { timeAverageAtom } from 'utils/state/atoms';
+import { isHourlyAtom } from 'utils/state/atoms';
 
 import ProductionSourceLegend from '../ProductionSourceLegend';
 import { LABEL_MAX_WIDTH, PADDING_X } from './constants';
@@ -63,8 +63,7 @@ function BarElectricityBreakdownChart({
     productionData.length,
     exchangeData
   );
-  const [timeAverage] = useAtom(timeAverageAtom);
-  const isHourly = timeAverage === TimeAverages.HOURLY;
+  const isHourly = useAtomValue(isHourlyAtom);
 
   // Use the whole history to determine the min/max values in order to avoid
   // graph jumping while sliding through the time range.

--- a/web/src/features/charts/graphUtils.ts
+++ b/web/src/features/charts/graphUtils.ts
@@ -6,7 +6,7 @@ import { scaleTime } from 'd3-scale';
 import { pointer } from 'd3-selection';
 import { TFunction } from 'i18next';
 import { ElectricityStorageType, GenerationType, Maybe, ZoneDetail } from 'types';
-import { EstimationMethods, Mode, modeOrder, TimeAverages } from 'utils/constants';
+import { EstimationMethods, Mode, modeOrder } from 'utils/constants';
 import { formatCo2, formatEnergy, formatPower } from 'utils/formatting';
 
 import { AreaGraphElement } from './types';
@@ -120,7 +120,7 @@ export function determineUnit(
   displayByEmissions: boolean,
   currentZoneDetail: ZoneDetail,
   mixMode: Mode,
-  timeAverage: TimeAverages,
+  isHourly: boolean,
   t: TFunction
 ) {
   if (displayByEmissions) {
@@ -131,7 +131,7 @@ export function determineUnit(
     );
   }
 
-  return timeAverage === TimeAverages.HOURLY
+  return isHourly
     ? getUnit(formatPower(getTotalElectricityAvailable(currentZoneDetail, mixMode)))
     : getUnit(formatEnergy(getTotalElectricityAvailable(currentZoneDetail, mixMode)));
 }

--- a/web/src/features/charts/tooltips/BreakdownChartTooltip.tsx
+++ b/web/src/features/charts/tooltips/BreakdownChartTooltip.tsx
@@ -2,7 +2,7 @@ import { CarbonIntensityDisplay } from 'components/CarbonIntensityDisplay';
 import { CountryFlag } from 'components/Flag';
 import { MetricRatio } from 'components/MetricRatio';
 import { useCo2ColorScale } from 'hooks/theme';
-import { useAtom } from 'jotai';
+import { useAtom, useAtomValue } from 'jotai';
 import { renderToString } from 'react-dom/server';
 import { useTranslation } from 'react-i18next';
 import { getZoneName } from 'translation/translation';
@@ -11,6 +11,7 @@ import { EstimationMethods, Mode, modeColor, TimeAverages } from 'utils/constant
 import { formatCo2, formatEnergy, formatPower } from 'utils/formatting';
 import {
   displayByEmissionsAtom,
+  isHourlyAtom,
   productionConsumptionAtom,
   timeAverageAtom,
 } from 'utils/state/atoms';
@@ -140,6 +141,7 @@ export function BreakdownChartTooltipContent({
 }: BreakdownChartTooltipContentProperties) {
   const { t } = useTranslation();
   const co2ColorScale = useCo2ColorScale();
+  const isHourly = useAtomValue(isHourlyAtom);
   // Dynamically generate the translated headline HTML based on the exchange or generation type
   const percentageUsage = displayByEmissions
     ? getRatioPercent(emissions, totalEmissions)
@@ -200,10 +202,10 @@ export function BreakdownChartTooltipContent({
           <MetricRatio
             value={usage}
             total={totalElectricity}
-            format={timeAverage === TimeAverages.HOURLY ? formatPower : formatEnergy}
+            format={isHourly ? formatPower : formatEnergy}
           />
           <br />
-          {timeAverage === TimeAverages.HOURLY && (
+          {isHourly && (
             <>
               <br />
               {t('tooltips.utilizing')} <b>{getRatioPercent(usage, capacity)} %</b>{' '}

--- a/web/src/features/charts/tooltips/NetExchangeChartTooltip.tsx
+++ b/web/src/features/charts/tooltips/NetExchangeChartTooltip.tsx
@@ -1,9 +1,8 @@
-import { useAtom } from 'jotai';
+import { useAtom, useAtomValue } from 'jotai';
 import { useTranslation } from 'react-i18next';
-import { TimeAverages } from 'utils/constants';
 import { formatCo2, scalePower } from 'utils/formatting';
 import { getNetExchange, round } from 'utils/helpers';
-import { displayByEmissionsAtom, timeAverageAtom } from 'utils/state/atoms';
+import { displayByEmissionsAtom, isHourlyAtom, timeAverageAtom } from 'utils/state/atoms';
 
 import { InnerAreaGraphTooltipProps } from '../types';
 import AreaGraphToolTipHeader from './AreaGraphTooltipHeader';
@@ -13,13 +12,13 @@ export default function NetExchangeChartTooltip({
 }: InnerAreaGraphTooltipProps) {
   const [timeAverage] = useAtom(timeAverageAtom);
   const [displayByEmissions] = useAtom(displayByEmissionsAtom);
+  const isHourly = useAtomValue(isHourlyAtom);
   const { t } = useTranslation();
 
   if (!zoneDetail) {
     return null;
   }
 
-  const isHourly = timeAverage === TimeAverages.HOURLY;
   const { stateDatetime } = zoneDetail;
 
   const netExchange = getNetExchange(zoneDetail, displayByEmissions);

--- a/web/src/features/exchanges/ExchangeTooltip.tsx
+++ b/web/src/features/exchanges/ExchangeTooltip.tsx
@@ -1,12 +1,11 @@
 import { CarbonIntensityDisplay } from 'components/CarbonIntensityDisplay';
 import { ZoneName } from 'components/ZoneName';
-import { useAtom } from 'jotai';
+import { useAtomValue } from 'jotai';
 import type { ReactElement } from 'react';
 import { useTranslation } from 'react-i18next';
 import { ExchangeArrowData } from 'types';
-import { TimeAverages } from 'utils/constants';
 import { formatEnergy, formatPower } from 'utils/formatting';
-import { timeAverageAtom } from 'utils/state/atoms';
+import { isHourlyAtom } from 'utils/state/atoms';
 
 interface ExchangeTooltipProperties {
   exchangeData: ExchangeArrowData;
@@ -17,15 +16,14 @@ export default function ExchangeTooltip({
   exchangeData,
   isMobile,
 }: ExchangeTooltipProperties): ReactElement {
+  const { t } = useTranslation();
+  const isHourly = useAtomValue(isHourlyAtom);
   const { key, netFlow, co2intensity } = exchangeData;
 
-  const { t } = useTranslation();
   const isExporting = netFlow > 0;
   const roundedNetFlow = Math.abs(Math.round(netFlow));
   const zoneFrom = key.split('->')[isExporting ? 0 : 1];
   const zoneTo = key.split('->')[isExporting ? 1 : 0];
-  const [timeAverage] = useAtom(timeAverageAtom);
-  const isHourly = timeAverage === TimeAverages.HOURLY;
 
   const divClass = `${isMobile ? 'flex-col' : 'flex'} items-center pb-2`;
   return (

--- a/web/src/features/map-controls/MapControls.tsx
+++ b/web/src/features/map-controls/MapControls.tsx
@@ -1,6 +1,6 @@
 import { Button } from 'components/Button';
 import { isInfoModalOpenAtom, isSettingsModalOpenAtom } from 'features/modals/modalAtoms';
-import { useAtom, useSetAtom } from 'jotai';
+import { useAtom, useAtomValue, useSetAtom } from 'jotai';
 import { useTransition } from 'react';
 import { useTranslation } from 'react-i18next';
 import { FiWind } from 'react-icons/fi';
@@ -8,14 +8,14 @@ import { HiOutlineEyeOff, HiOutlineSun } from 'react-icons/hi';
 import { HiCog6Tooth, HiOutlineInformationCircle } from 'react-icons/hi2';
 import { MoonLoader } from 'react-spinners';
 import trackEvent from 'utils/analytics';
-import { ThemeOptions, TimeAverages, ToggleOptions } from 'utils/constants';
+import { ThemeOptions, ToggleOptions } from 'utils/constants';
 import {
   colorblindModeAtom,
+  isHourlyAtom,
   selectedDatetimeIndexAtom,
   solarLayerEnabledAtom,
   solarLayerLoadingAtom,
   themeAtom,
-  timeAverageAtom,
   windLayerAtom,
   windLayerLoadingAtom,
 } from 'utils/state/atoms';
@@ -121,14 +121,13 @@ function WeatherButton({ type }: { type: 'wind' | 'solar' }) {
 
 function DesktopMapControls() {
   const { t } = useTranslation();
-  const [timeAverage] = useAtom(timeAverageAtom);
+  const isHourly = useAtomValue(isHourlyAtom);
   const [selectedDatetime] = useAtom(selectedDatetimeIndexAtom);
   const [isColorblindModeEnabled, setIsColorblindModeEnabled] =
     useAtom(colorblindModeAtom);
 
   // We are currently only supporting and fetching weather data for the latest hourly value
-  const areWeatherLayersAllowed =
-    selectedDatetime.index === 24 && timeAverage === TimeAverages.HOURLY;
+  const areWeatherLayersAllowed = selectedDatetime.index === 24 && isHourly;
 
   const handleColorblindModeToggle = () => {
     setIsColorblindModeEnabled(!isColorblindModeEnabled);

--- a/web/src/features/modals/SettingsModal.tsx
+++ b/web/src/features/modals/SettingsModal.tsx
@@ -5,15 +5,15 @@ import { LanguageSelector } from 'features/map-controls/LanguageSelector';
 import { weatherButtonMap } from 'features/map-controls/MapControls';
 import SpatialAggregatesToggle from 'features/map-controls/SpatialAggregatesToggle';
 import ThemeSelector from 'features/map-controls/ThemeSelector';
-import { useAtom } from 'jotai';
+import { useAtom, useAtomValue } from 'jotai';
 import { useTranslation } from 'react-i18next';
 import { HiOutlineEyeOff } from 'react-icons/hi';
 import { MoonLoader } from 'react-spinners';
-import { TimeAverages, ToggleOptions } from 'utils/constants';
+import { ToggleOptions } from 'utils/constants';
 import {
   colorblindModeAtom,
+  isHourlyAtom,
   selectedDatetimeIndexAtom,
-  timeAverageAtom,
 } from 'utils/state/atoms';
 
 import { isSettingsModalOpenAtom } from './modalAtoms';
@@ -68,14 +68,13 @@ function WeatherToggleButton({
 }
 
 export function SettingsModalContent() {
-  const [timeAverage] = useAtom(timeAverageAtom);
+  const isHourly = useAtomValue(isHourlyAtom);
   const [selectedDatetime] = useAtom(selectedDatetimeIndexAtom);
   const [isColorblindModeEnabled, setIsColorblindModeEnabled] =
     useAtom(colorblindModeAtom);
 
   // We are currently only supporting and fetching weather data for the latest hourly value
-  const areWeatherLayersAllowed =
-    selectedDatetime.index === 24 && timeAverage === TimeAverages.HOURLY;
+  const areWeatherLayersAllowed = selectedDatetime.index === 24 && isHourly;
 
   const { t } = useTranslation();
   return (

--- a/web/src/features/panels/zone/ZoneDetails.tsx
+++ b/web/src/features/panels/zone/ZoneDetails.tsx
@@ -8,9 +8,10 @@ import { useTranslation } from 'react-i18next';
 import { MdOutlineCloudDownload } from 'react-icons/md';
 import { Navigate, useParams } from 'react-router-dom';
 import { ZoneMessage } from 'types';
-import { EstimationMethods, SpatialAggregate, TimeAverages } from 'utils/constants';
+import { EstimationMethods, SpatialAggregate } from 'utils/constants';
 import {
   displayByEmissionsAtom,
+  isHourlyAtom,
   selectedDatetimeStringAtom,
   spatialAggregateAtom,
   timeAverageAtom,
@@ -35,6 +36,7 @@ export default function ZoneDetails(): JSX.Element {
   const selectedDatetimeString = useAtomValue(selectedDatetimeStringAtom);
   const { data, isError, isLoading } = useGetZone();
   const { t } = useTranslation();
+  const isHourly = useAtomValue(isHourlyAtom);
   const isMobile = !useBreakpoint('sm');
 
   const hasSubZones = getHasSubZones(zoneId);
@@ -71,7 +73,7 @@ export default function ZoneDetails(): JSX.Element {
   const selectedData = data?.zoneStates[selectedDatetimeString];
   const { estimationMethod, estimatedPercentage } = selectedData || {};
   const zoneMessage = data?.zoneMessage;
-  const cardType = getCardType({ estimationMethod, zoneMessage, timeAverage });
+  const cardType = getCardType({ estimationMethod, zoneMessage, isHourly });
   const hasEstimationPill = Boolean(estimationMethod) || Boolean(estimatedPercentage);
 
   return (
@@ -137,11 +139,11 @@ export default function ZoneDetails(): JSX.Element {
 function getCardType({
   estimationMethod,
   zoneMessage,
-  timeAverage,
+  isHourly,
 }: {
   estimationMethod?: EstimationMethods;
   zoneMessage?: ZoneMessage;
-  timeAverage: TimeAverages;
+  isHourly: boolean;
 }): 'estimated' | 'aggregated' | 'outage' | 'none' {
   if (
     (zoneMessage !== undefined &&
@@ -151,7 +153,7 @@ function getCardType({
   ) {
     return 'outage';
   }
-  if (timeAverage !== TimeAverages.HOURLY) {
+  if (!isHourly) {
     return 'aggregated';
   }
   if (estimationMethod) {

--- a/web/src/features/time/TimeController.tsx
+++ b/web/src/features/time/TimeController.tsx
@@ -1,17 +1,22 @@
 import useGetState from 'api/getState';
 import TimeAverageToggle from 'components/TimeAverageToggle';
 import TimeSlider from 'components/TimeSlider';
-import { useAtom } from 'jotai';
+import { useAtom, useAtomValue } from 'jotai';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import trackEvent from 'utils/analytics';
 import { TimeAverages } from 'utils/constants';
-import { selectedDatetimeIndexAtom, timeAverageAtom } from 'utils/state/atoms';
+import {
+  isHourlyAtom,
+  selectedDatetimeIndexAtom,
+  timeAverageAtom,
+} from 'utils/state/atoms';
 
 import TimeAxis from './TimeAxis';
 import TimeHeader from './TimeHeader';
 
 export default function TimeController({ className }: { className?: string }) {
   const [timeAverage, setTimeAverage] = useAtom(timeAverageAtom);
+  const isHourly = useAtomValue(isHourlyAtom);
   const [selectedDatetime, setSelectedDatetime] = useAtom(selectedDatetimeIndexAtom);
   const [numberOfEntries, setNumberOfEntries] = useState(0);
   const { data, isLoading: dataLoading } = useGetState();
@@ -89,7 +94,7 @@ export default function TimeController({ className }: { className?: string }) {
         isLoading={isLoading}
         className="h-[22px] w-full overflow-visible"
         transform={`translate(12, 0)`}
-        isLiveDisplay={timeAverage === TimeAverages.HOURLY}
+        isLiveDisplay={isHourly}
       />
     </div>
   );

--- a/web/src/features/time/TimeController.tsx
+++ b/web/src/features/time/TimeController.tsx
@@ -2,7 +2,7 @@ import useGetState from 'api/getState';
 import TimeAverageToggle from 'components/TimeAverageToggle';
 import TimeSlider from 'components/TimeSlider';
 import { useAtom } from 'jotai';
-import { useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import trackEvent from 'utils/analytics';
 import { TimeAverages } from 'utils/constants';
 import { selectedDatetimeIndexAtom, timeAverageAtom } from 'utils/state/atoms';
@@ -41,26 +41,32 @@ export default function TimeController({ className }: { className?: string }) {
     }
   }, [data, datetimes, setSelectedDatetime]);
 
-  const onTimeSliderChange = (index: number) => {
-    // TODO: Does this work properly missing values?
-    if (!datetimes) {
-      return;
-    }
-    setSelectedDatetime({
-      datetime: datetimes[index],
-      index,
-    });
-  };
+  const onTimeSliderChange = useCallback(
+    (index: number) => {
+      // TODO: Does this work properly missing values?
+      if (!datetimes) {
+        return;
+      }
+      setSelectedDatetime({
+        datetime: datetimes[index],
+        index,
+      });
+    },
+    [datetimes, setSelectedDatetime]
+  );
 
-  const onToggleGroupClick = (timeAverage: TimeAverages) => {
-    // Set time slider to latest value before switching aggregate to avoid flickering
-    setSelectedDatetime({
-      datetime: selectedDatetime.datetime,
-      index: numberOfEntries,
-    });
-    setTimeAverage(timeAverage);
-    trackEvent('Time Aggregate Button Clicked', { timeAverage });
-  };
+  const onToggleGroupClick = useCallback(
+    (timeAverage: TimeAverages) => {
+      // Set time slider to latest value before switching aggregate to avoid flickering
+      setSelectedDatetime({
+        datetime: selectedDatetime.datetime,
+        index: numberOfEntries,
+      });
+      setTimeAverage(timeAverage);
+      trackEvent('Time Aggregate Button Clicked', { timeAverage });
+    },
+    [selectedDatetime.datetime, numberOfEntries, setSelectedDatetime, setTimeAverage]
+  );
 
   return (
     <div className={className}>

--- a/web/src/utils/state/atoms.ts
+++ b/web/src/utils/state/atoms.ts
@@ -14,6 +14,7 @@ import {
 // TODO: Make some of these atoms also sync with URL (see atomWithCustomStorage.ts)
 
 export const timeAverageAtom = atom(TimeAverages.HOURLY);
+export const isHourlyAtom = atom((get) => get(timeAverageAtom) === TimeAverages.HOURLY);
 
 // TODO: consider another initial value
 export const selectedDatetimeIndexAtom = atom({ datetime: new Date(), index: 0 });


### PR DESCRIPTION
## Description
This PR does two things:

1. Wraps two component callbacks in useCallback so they are not re-created on every render.
2. Creates and uses a derived atom of `isHourly`.

### Double check

- [x] I have run `pnpx prettier@2 --write .` and `poetry run format` in the top level directory to format my changes.
