### PR TITLE
perf: use derived atoms for solar and wind state

### DIFF
--- a/web/src/components/legend/LegendContainer.tsx
+++ b/web/src/components/legend/LegendContainer.tsx
@@ -1,25 +1,14 @@
-import { useAtom } from 'jotai';
+import { useAtomValue } from 'jotai';
 import type { ReactElement } from 'react';
-import { ToggleOptions } from 'utils/constants';
-import {
-  selectedDatetimeIndexAtom,
-  solarLayerEnabledAtom,
-  windLayerAtom,
-} from 'utils/state/atoms';
+import { isSolarLayerEnabledAtom, isWindLayerEnabledAtom } from 'utils/state/atoms';
 
 import Co2Legend from './Co2Legend';
 import SolarLegend from './SolarLegend';
 import WindLegend from './WindLegend';
 
 export default function LegendContainer(): ReactElement {
-  const [solarLayerToggle] = useAtom(solarLayerEnabledAtom);
-  const [windLayerToggle] = useAtom(windLayerAtom);
-  const [selectedDatetime] = useAtom(selectedDatetimeIndexAtom);
-
-  const isSolarLayerEnabled =
-    solarLayerToggle === ToggleOptions.ON && selectedDatetime.index === 24;
-  const isWindLayerEnabled =
-    windLayerToggle === ToggleOptions.ON && selectedDatetime.index === 24;
+  const isSolarLayerEnabled = useAtomValue(isSolarLayerEnabledAtom);
+  const isWindLayerEnabled = useAtomValue(isWindLayerEnabledAtom);
 
   return (
     <div className="invisible  flex w-[224px] flex-col rounded bg-white/90 px-1 py-2 shadow-xl backdrop-blur-sm sm:visible dark:bg-gray-800">

--- a/web/src/features/map-controls/MapControls.tsx
+++ b/web/src/features/map-controls/MapControls.tsx
@@ -12,7 +12,7 @@ import { ThemeOptions, TimeAverages, ToggleOptions } from 'utils/constants';
 import {
   colorblindModeAtom,
   selectedDatetimeIndexAtom,
-  solarLayerEnabledAtom,
+  solarLayerAtom,
   solarLayerLoadingAtom,
   themeAtom,
   timeAverageAtom,
@@ -66,7 +66,7 @@ export const weatherButtonMap = {
   solar: {
     icon: HiOutlineSun,
     iconSize: 21,
-    enabledAtom: solarLayerEnabledAtom,
+    enabledAtom: solarLayerAtom,
     loadingAtom: solarLayerLoadingAtom,
   },
 };

--- a/web/src/features/weather-layers/solar/SolarLayer.tsx
+++ b/web/src/features/weather-layers/solar/SolarLayer.tsx
@@ -1,12 +1,7 @@
 import { useGetSolar } from 'api/getWeatherData';
-import { useAtom, useSetAtom } from 'jotai';
+import { useAtomValue, useSetAtom } from 'jotai';
 import { useEffect, useMemo, useRef, useState } from 'react';
-import { ToggleOptions } from 'utils/constants';
-import {
-  selectedDatetimeIndexAtom,
-  solarLayerEnabledAtom,
-  solarLayerLoadingAtom,
-} from 'utils/state/atoms';
+import { isSolarLayerEnabledAtom, solarLayerLoadingAtom } from 'utils/state/atoms';
 
 import { stackBlurImageOpacity } from './stackBlurImageOpacity';
 import {
@@ -33,12 +28,9 @@ function convertYToLat(yMax: number, y: number): number {
 }
 
 export default function SolarLayer({ map }: { map?: maplibregl.Map }) {
-  const [selectedDatetime] = useAtom(selectedDatetimeIndexAtom);
-  const [solarLayerToggle] = useAtom(solarLayerEnabledAtom);
   const setIsLoadingSolarLayer = useSetAtom(solarLayerLoadingAtom);
+  const isSolarLayerEnabled = useAtomValue(isSolarLayerEnabledAtom);
 
-  const isSolarLayerEnabled =
-    solarLayerToggle === ToggleOptions.ON && selectedDatetime.index === 24;
   const { data: solarDataArray, isSuccess } = useGetSolar({
     enabled: isSolarLayerEnabled,
   });

--- a/web/src/features/weather-layers/wind-layer/WindLayer.tsx
+++ b/web/src/features/weather-layers/wind-layer/WindLayer.tsx
@@ -1,14 +1,9 @@
 import { GfsForecastResponse, useGetWind } from 'api/getWeatherData';
 import { mapMovingAtom } from 'features/map/mapAtoms';
-import { useAtom, useSetAtom } from 'jotai';
+import { useAtom, useAtomValue, useSetAtom } from 'jotai';
 import { useEffect, useMemo, useRef, useState } from 'react';
 import useResizeObserver from 'use-resize-observer';
-import { ToggleOptions } from 'utils/constants';
-import {
-  selectedDatetimeIndexAtom,
-  windLayerAtom,
-  windLayerLoadingAtom,
-} from 'utils/state/atoms';
+import { isWindLayerEnabledAtom, windLayerLoadingAtom } from 'utils/state/atoms';
 
 import { Windy } from './windy';
 
@@ -48,11 +43,8 @@ export default function WindLayer({ map }: { map?: maplibregl.Map }) {
     };
   }, [map, width, height]);
 
-  const [selectedDatetime] = useAtom(selectedDatetimeIndexAtom);
-  const [windLayerToggle] = useAtom(windLayerAtom);
   const setIsLoadingWindLayer = useSetAtom(windLayerLoadingAtom);
-  const isWindLayerEnabled =
-    windLayerToggle === ToggleOptions.ON && selectedDatetime.index === 24;
+  const isWindLayerEnabled = useAtomValue(isWindLayerEnabledAtom);
   const { data: windData, isSuccess } = useGetWind({ enabled: isWindLayerEnabled });
   const isVisible = isSuccess && !isMapMoving && isWindLayerEnabled;
 

--- a/web/src/utils/state/atoms.ts
+++ b/web/src/utils/state/atoms.ts
@@ -29,8 +29,19 @@ export const spatialAggregateAtom = atomWithStorage(
 );
 export const productionConsumptionAtom = atomWithStorage('mode', Mode.CONSUMPTION);
 
-export const solarLayerEnabledAtom = atomWithStorage('solar', ToggleOptions.OFF);
+export const solarLayerAtom = atomWithStorage('solar', ToggleOptions.OFF);
+export const isSolarLayerEnabledAtom = atom(
+  (get) =>
+    get(solarLayerAtom) === ToggleOptions.ON &&
+    get(selectedDatetimeIndexAtom).index === 24
+);
+
 export const windLayerAtom = atomWithStorage('wind', ToggleOptions.OFF);
+export const isWindLayerEnabledAtom = atom(
+  (get) =>
+    get(windLayerAtom) === ToggleOptions.ON && get(selectedDatetimeIndexAtom).index === 24
+);
+
 export const solarLayerLoadingAtom = atom(false);
 export const windLayerLoadingAtom = atom(false);
 

--- a/web/src/utils/state/atoms.ts
+++ b/web/src/utils/state/atoms.ts
@@ -33,6 +33,7 @@ export const productionConsumptionAtom = atomWithStorage('mode', Mode.CONSUMPTIO
 export const solarLayerAtom = atomWithStorage('solar', ToggleOptions.OFF);
 export const isSolarLayerEnabledAtom = atom(
   (get) =>
+    get(isHourlyAtom) &&
     get(solarLayerAtom) === ToggleOptions.ON &&
     get(selectedDatetimeIndexAtom).index === 24
 );
@@ -40,7 +41,9 @@ export const isSolarLayerEnabledAtom = atom(
 export const windLayerAtom = atomWithStorage('wind', ToggleOptions.OFF);
 export const isWindLayerEnabledAtom = atom(
   (get) =>
-    get(windLayerAtom) === ToggleOptions.ON && get(selectedDatetimeIndexAtom).index === 24
+    get(isHourlyAtom) &&
+    get(windLayerAtom) === ToggleOptions.ON &&
+    get(selectedDatetimeIndexAtom).index === 24
 );
 
 export const solarLayerLoadingAtom = atom(false);


### PR DESCRIPTION
## Description

Uses derived atoms for the wind and solar enabled state to reduce code duplication and minimise unneeded imports.

### Double check
- [x] I have run `pnpx prettier@2 --write .` and `poetry run format` in the top level directory to format my changes.
