### PR TITLE
revert: use reseaux parser again

### DIFF
--- a/config/zones/FR.yaml
+++ b/config/zones/FR.yaml
@@ -362,7 +362,7 @@ parsers:
   consumptionForecast: ENTSOE.fetch_consumption_forecast
   generationForecast: ENTSOE.fetch_generation_forecast
   price: ENTSOE.fetch_price
-  production: ENTSOE.fetch_production
+  production: FR.fetch_production
   productionCapacity: ENTSOE.fetch_production_capacity
   productionPerModeForecast: ENTSOE.fetch_wind_solar_forecasts
 region: Europe


### PR DESCRIPTION
fixes GMM-86

https://github.com/electricitymaps/electricitymaps-contrib/pull/6733 switched the parser for FR to ENTSOE because the reseaux parser was down. It seems to be working again, so we can revert.

I will backfill after this has been merged.

```
>poetry run python test_parser.py 'FR'
Parser result:
[{'correctedModes': [],
  'datetime': datetime.datetime(2024, 7, 14, 11, 0, tzinfo=zoneinfo.ZoneInfo(key='Europe/Paris')),
  'production': {'biomass': 848.0,
                 'coal': 0.0,
                 'gas': 494.0,
                 'hydro': 6518.0,
                 'nuclear': 27048.0,
                 'oil': 123.0,
                 'solar': 7201.0,
                 'wind': 511.0},
  'source': 'opendata.reseaux-energies.fr',
  'sourceType': <EventSourceType.measured: 'measured'>,
  'storage': {'battery': 4.0, 'hydro': 1678.0},
  'zoneKey': 'FR'},
 {'correctedModes': [],
  'datetime': datetime.datetime(2024, 7, 14, 11, 30, tzinfo=zoneinfo.ZoneInfo(key='Europe/Paris')),
  'production': {'biomass': 845.5,
                 'coal': 0.0,
                 'gas': 496.5,
                 'hydro': 6534.5,
                 'nuclear': 26652.0,
                 'oil': 123.5,
                 'solar': 7252.5,
                 'wind': 511.0},
  'source': 'opendata.reseaux-energies.fr',
  'sourceType': <EventSourceType.measured: 'measured'>,
  'storage': {'battery': 4.0, 'hydro': 1785.5},
  'zoneKey': 'FR'},
 {'correctedModes': [],
  'datetime': datetime.datetime(2024, 7, 14, 12, 0, tzinfo=zoneinfo.ZoneInfo(key='Europe/Paris')),
  'production': {'biomass': 846.5,
                 'coal': 0.0,
                 'gas': 492.0,
                 'hydro': 6629.0,
                 'nuclear': 26539.5,
                 'oil': 123.5,
                 'solar': 7588.5,
                 'wind': 502.0},
  'source': 'opendata.reseaux-energies.fr',
  'sourceType': <EventSourceType.measured: 'measured'>,
  'storage': {'battery': 6.0, 'hydro': 1918.5},
  'zoneKey': 'FR'},
 {'correctedModes': [],
  'datetime': datetime.datetime(2024, 7, 14, 12, 30, tzinfo=zoneinfo.ZoneInfo(key='Europe/Paris')),
  'production': {'biomass': 839.5,
                 'coal': 0.0,
                 'gas': 494.0,
                 'hydro': 6678.5,
                 'nuclear': 26676.5,
                 'oil': 123.0,
                 'solar': 7990.5,
                 'wind': 518.5},
  'source': 'opendata.reseaux-energies.fr',
  'sourceType': <EventSourceType.measured: 'measured'>,
  'storage': {'battery': 8.5, 'hydro': 1807.5},
  'zoneKey': 'FR'},
 {'correctedModes': [],
  'datetime': datetime.datetime(2024, 7, 14, 13, 0, tzinfo=zoneinfo.ZoneInfo(key='Europe/Paris')),
  'production': {'biomass': 844.5,
                 'coal': 0.0,
                 'gas': 496.5,
                 'hydro': 6656.0,
                 'nuclear': 26581.5,
                 'oil': 123.0,
                 'solar': 8139.0,
                 'wind': 546.5},
  'source': 'opendata.reseaux-energies.fr',
  'sourceType': <EventSourceType.measured: 'measured'>,
  'storage': {'battery': 8.0, 'hydro': 1699.0},
  'zoneKey': 'FR'},
 {'correctedModes': [],
  'datetime': datetime.datetime(2024, 7, 14, 13, 30, tzinfo=zoneinfo.ZoneInfo(key='Europe/Paris')),
  'production': {'biomass': 840.5,
                 'coal': 0.0,
                 'gas': 495.5,
                 'hydro': 6590.5,
                 'nuclear': 25651.0,
                 'oil': 123.0,
                 'solar': 8170.5,
                 'wind': 558.5},
  'source': 'opendata.reseaux-energies.fr',
  'sourceType': <EventSourceType.measured: 'measured'>,
  'storage': {'battery': 7.5, 'hydro': 1713.0},
  'zoneKey': 'FR'},
 {'correctedModes': [],
  'datetime': datetime.datetime(2024, 7, 14, 14, 0, tzinfo=zoneinfo.ZoneInfo(key='Europe/Paris')),
  'production': {'biomass': 844.5,
                 'coal': 0.0,
                 'gas': 497.0,
                 'hydro': 6578.5,
                 'nuclear': 25909.5,
                 'oil': 124.0,
                 'solar': 8430.0,
                 'wind': 591.5},
  'source': 'opendata.reseaux-energies.fr',
  'sourceType': <EventSourceType.measured: 'measured'>,
  'storage': {'battery': 7.5, 'hydro': 1811.0},
  'zoneKey': 'FR'},
 {'correctedModes': [],
  'datetime': datetime.datetime(2024, 7, 14, 14, 30, tzinfo=zoneinfo.ZoneInfo(key='Europe/Paris')),
  'production': {'biomass': 841.5,
                 'coal': 0.0,
                 'gas': 497.5,
                 'hydro': 6623.0,
                 'nuclear': 26276.0,
                 'oil': 124.0,
                 'solar': 8322.5,
                 'wind': 539.0},
  'source': 'opendata.reseaux-energies.fr',
  'sourceType': <EventSourceType.measured: 'measured'>,
  'storage': {'battery': 6.0, 'hydro': 1920.5},
  'zoneKey': 'FR'},
 {'correctedModes': [],
  'datetime': datetime.datetime(2024, 7, 14, 15, 0, tzinfo=zoneinfo.ZoneInfo(key='Europe/Paris')),
  'production': {'biomass': 845.0,
                 'coal': 0.0,
                 'gas': 491.0,
                 'hydro': 6663.0,
                 'nuclear': 26716.0,
                 'oil': 124.0,
                 'solar': 8182.0,
                 'wind': 508.5},
  'source': 'opendata.reseaux-energies.fr',
  'sourceType': <EventSourceType.measured: 'measured'>,
  'storage': {'battery': -1.0, 'hydro': 1792.0},
  'zoneKey': 'FR'},
 {'correctedModes': [],
  'datetime': datetime.datetime(2024, 7, 14, 15, 30, tzinfo=zoneinfo.ZoneInfo(key='Europe/Paris')),
  'production': {'biomass': 844.0,
                 'coal': 0.0,
                 'gas': 492.5,
                 'hydro': 6675.5,
                 'nuclear': 27535.0,
                 'oil': 124.0,
                 'solar': 8022.0,
                 'wind': 571.0},
  'source': 'opendata.reseaux-energies.fr',
  'sourceType': <EventSourceType.measured: 'measured'>,
  'storage': {'battery': -2.5, 'hydro': 1602.0},
  'zoneKey': 'FR'},
 {'correctedModes': [],
  'datetime': datetime.datetime(2024, 7, 14, 16, 0, tzinfo=zoneinfo.ZoneInfo(key='Europe/Paris')),
  'production': {'biomass': 836.0,
                 'coal': 0.0,
                 'gas': 493.5,
                 'hydro': 6629.0,
                 'nuclear': 29113.5,
                 'oil': 124.0,
                 'solar': 7701.0,
                 'wind': 537.0},
  'source': 'opendata.reseaux-energies.fr',
  'sourceType': <EventSourceType.measured: 'measured'>,
  'storage': {'battery': 1.0, 'hydro': 1379.5},
  'zoneKey': 'FR'},
 {'correctedModes': [],
  'datetime': datetime.datetime(2024, 7, 14, 16, 30, tzinfo=zoneinfo.ZoneInfo(key='Europe/Paris')),
  'production': {'biomass': 837.5,
                 'coal': 0.0,
                 'gas': 491.0,
                 'hydro': 7098.0,
                 'nuclear': 30869.5,
                 'oil': 124.0,
                 'solar': 6911.5,
                 'wind': 505.0},
  'source': 'opendata.reseaux-energies.fr',
  'sourceType': <EventSourceType.measured: 'measured'>,
  'storage': {'battery': 4.0, 'hydro': 1135.5},
  'zoneKey': 'FR'},
 {'correctedModes': [],
  'datetime': datetime.datetime(2024, 7, 14, 17, 0, tzinfo=zoneinfo.ZoneInfo(key='Europe/Paris')),
  'production': {'biomass': 835.5,
                 'coal': 0.0,
                 'gas': 494.0,
                 'hydro': 7089.0,
                 'nuclear': 32074.0,
                 'oil': 124.0,
                 'solar': 7468.5,
                 'wind': 680.0},
  'source': 'opendata.reseaux-energies.fr',
  'sourceType': <EventSourceType.measured: 'measured'>,
  'storage': {'battery': 5.0, 'hydro': 1057.5},
  'zoneKey': 'FR'},
 {'correctedModes': [],
  'datetime': datetime.datetime(2024, 7, 14, 17, 30, tzinfo=zoneinfo.ZoneInfo(key='Europe/Paris')),
  'production': {'biomass': 835.5,
                 'coal': 0.0,
                 'gas': 492.0,
                 'hydro': 7313.0,
                 'nuclear': 33805.5,
                 'oil': 124.0,
                 'solar': 7961.0,
                 'wind': 889.5},
  'source': 'opendata.reseaux-energies.fr',
  'sourceType': <EventSourceType.measured: 'measured'>,
  'storage': {'battery': 3.5, 'hydro': 876.5},
  'zoneKey': 'FR'},
 {'correctedModes': [],
  'datetime': datetime.datetime(2024, 7, 14, 18, 0, tzinfo=zoneinfo.ZoneInfo(key='Europe/Paris')),
  'production': {'biomass': 825.5,
                 'coal': 0.0,
                 'gas': 489.5,
                 'hydro': 7357.0,
                 'nuclear': 35183.0,
                 'oil': 124.0,
                 'solar': 6880.5,
                 'wind': 919.5},
  'source': 'opendata.reseaux-energies.fr',
  'sourceType': <EventSourceType.measured: 'measured'>,
  'storage': {'battery': 4.0, 'hydro': 711.5},
  'zoneKey': 'FR'},
 {'correctedModes': [],
  'datetime': datetime.datetime(2024, 7, 14, 18, 30, tzinfo=zoneinfo.ZoneInfo(key='Europe/Paris')),
  'production': {'biomass': 834.0,
                 'coal': 0.0,
                 'gas': 490.5,
                 'hydro': 7697.0,
                 'nuclear': 36344.0,
                 'oil': 124.0,
                 'solar': 5562.5,
                 'wind': 951.0},
  'source': 'opendata.reseaux-energies.fr',
  'sourceType': <EventSourceType.measured: 'measured'>,
  'storage': {'battery': 2.0, 'hydro': 427.5},
  'zoneKey': 'FR'},
 {'correctedModes': [],
  'datetime': datetime.datetime(2024, 7, 14, 19, 0, tzinfo=zoneinfo.ZoneInfo(key='Europe/Paris')),
  'production': {'biomass': 836.0,
                 'coal': 0.0,
                 'gas': 489.0,
                 'hydro': 7766.5,
                 'nuclear': 37127.0,
                 'oil': 124.0,
                 'solar': 4053.5,
                 'wind': 925.0},
  'source': 'opendata.reseaux-energies.fr',
  'sourceType': <EventSourceType.measured: 'measured'>,
  'storage': {'battery': -1.0, 'hydro': -201.5},
  'zoneKey': 'FR'},
 {'correctedModes': [],
  'datetime': datetime.datetime(2024, 7, 14, 19, 30, tzinfo=zoneinfo.ZoneInfo(key='Europe/Paris')),
  'production': {'biomass': 829.0,
                 'coal': 0.0,
                 'gas': 487.0,
                 'hydro': 7842.0,
                 'nuclear': 38154.5,
                 'oil': 123.5,
                 'solar': 2701.0,
                 'wind': 865.5},
  'source': 'opendata.reseaux-energies.fr',
  'sourceType': <EventSourceType.measured: 'measured'>,
  'storage': {'battery': -2.0, 'hydro': -981.5},
  'zoneKey': 'FR'},
 {'correctedModes': [],
  'datetime': datetime.datetime(2024, 7, 14, 20, 0, tzinfo=zoneinfo.ZoneInfo(key='Europe/Paris')),
  'production': {'biomass': 829.0,
                 'coal': 0.0,
                 'gas': 491.0,
                 'hydro': 8289.5,
                 'nuclear': 38410.0,
                 'oil': 124.0,
                 'solar': 1647.0,
                 'wind': 842.5},
  'source': 'opendata.reseaux-energies.fr',
  'sourceType': <EventSourceType.measured: 'measured'>,
  'storage': {'battery': -1.0, 'hydro': -1962.0},
  'zoneKey': 'FR'},
 {'correctedModes': [],
  'datetime': datetime.datetime(2024, 7, 14, 20, 30, tzinfo=zoneinfo.ZoneInfo(key='Europe/Paris')),
  'production': {'biomass': 834.0,
                 'coal': 0.0,
                 'gas': 491.0,
                 'hydro': 8644.5,
                 'nuclear': 38898.0,
                 'oil': 124.0,
                 'solar': 966.5,
                 'wind': 813.0},
  'source': 'opendata.reseaux-energies.fr',
  'sourceType': <EventSourceType.measured: 'measured'>,
  'storage': {'battery': 2.0, 'hydro': -2849.5},
  'zoneKey': 'FR'},
 {'correctedModes': [],
  'datetime': datetime.datetime(2024, 7, 14, 21, 0, tzinfo=zoneinfo.ZoneInfo(key='Europe/Paris')),
  'production': {'biomass': 838.0,
                 'coal': 0.0,
                 'gas': 509.0,
                 'hydro': 8690.5,
                 'nuclear': 38991.5,
                 'oil': 124.0,
                 'solar': 493.0,
                 'wind': 780.0},
  'source': 'opendata.reseaux-energies.fr',
  'sourceType': <EventSourceType.measured: 'measured'>,
  'storage': {'battery': -1.5, 'hydro': -2698.5},
  'zoneKey': 'FR'},
 {'correctedModes': [],
  'datetime': datetime.datetime(2024, 7, 14, 21, 30, tzinfo=zoneinfo.ZoneInfo(key='Europe/Paris')),
  'production': {'biomass': 833.0,
                 'coal': 0.0,
                 'gas': 501.5,
                 'hydro': 8693.5,
                 'nuclear': 39120.5,
                 'oil': 123.0,
                 'solar': 340.5,
                 'wind': 793.5},
  'source': 'opendata.reseaux-energies.fr',
  'sourceType': <EventSourceType.measured: 'measured'>,
  'storage': {'battery': -2.0, 'hydro': -2481.0},
  'zoneKey': 'FR'},
 {'correctedModes': [],
  'datetime': datetime.datetime(2024, 7, 14, 22, 0, tzinfo=zoneinfo.ZoneInfo(key='Europe/Paris')),
  'production': {'biomass': 832.5,
                 'coal': 0.0,
                 'gas': 501.0,
                 'hydro': 8759.5,
                 'nuclear': 39120.0,
                 'oil': 124.0,
                 'solar': 259.0,
                 'wind': 808.0},
  'source': 'opendata.reseaux-energies.fr',
  'sourceType': <EventSourceType.measured: 'measured'>,
  'storage': {'battery': -3.5, 'hydro': -2603.0},
  'zoneKey': 'FR'},
 {'correctedModes': [],
  'datetime': datetime.datetime(2024, 7, 14, 22, 30, tzinfo=zoneinfo.ZoneInfo(key='Europe/Paris')),
  'production': {'biomass': 827.0,
                 'coal': 0.0,
                 'gas': 500.0,
                 'hydro': 8879.0,
                 'nuclear': 39176.0,
                 'oil': 124.0,
                 'solar': 128.5,
                 'wind': 816.5},
  'source': 'opendata.reseaux-energies.fr',
  'sourceType': <EventSourceType.measured: 'measured'>,
  'storage': {'battery': -3.0, 'hydro': -2401.5},
  'zoneKey': 'FR'},
 {'correctedModes': [],
  'datetime': datetime.datetime(2024, 7, 14, 23, 0, tzinfo=zoneinfo.ZoneInfo(key='Europe/Paris')),
  'production': {'biomass': 823.5,
                 'coal': 0.0,
                 'gas': 503.5,
                 'hydro': 8726.0,
                 'nuclear': 39173.5,
                 'oil': 124.0,
                 'solar': 0.0,
                 'wind': 840.0},
  'source': 'opendata.reseaux-energies.fr',
  'sourceType': <EventSourceType.measured: 'measured'>,
  'storage': {'battery': 0.5, 'hydro': -2452.5},
  'zoneKey': 'FR'},
 {'correctedModes': [],
  'datetime': datetime.datetime(2024, 7, 14, 23, 30, tzinfo=zoneinfo.ZoneInfo(key='Europe/Paris')),
  'production': {'biomass': 825.0,
                 'coal': 0.0,
                 'gas': 496.0,
                 'hydro': 8336.5,
                 'nuclear': 39209.5,
                 'oil': 123.5,
                 'solar': 0.0,
                 'wind': 886.0},
  'source': 'opendata.reseaux-energies.fr',
  'sourceType': <EventSourceType.measured: 'measured'>,
  'storage': {'battery': 1.5, 'hydro': -2430.5},
  'zoneKey': 'FR'},
 {'correctedModes': [],
  'datetime': datetime.datetime(2024, 7, 15, 0, 0, tzinfo=zoneinfo.ZoneInfo(key='Europe/Paris')),
  'production': {'biomass': 833.5,
                 'coal': 0.0,
                 'gas': 475.5,
                 'hydro': 8664.0,
                 'nuclear': 39241.0,
                 'oil': 124.0,
                 'solar': 0.0,
                 'wind': 922.5},
  'source': 'opendata.reseaux-energies.fr',
  'sourceType': <EventSourceType.measured: 'measured'>,
  'storage': {'battery': 2.0, 'hydro': -2125.5},
  'zoneKey': 'FR'},
 {'correctedModes': [],
  'datetime': datetime.datetime(2024, 7, 15, 0, 30, tzinfo=zoneinfo.ZoneInfo(key='Europe/Paris')),
  'production': {'biomass': 831.0,
                 'coal': 0.0,
                 'gas': 494.0,
                 'hydro': 8082.5,
                 'nuclear': 39204.5,
                 'oil': 124.0,
                 'solar': 0.0,
                 'wind': 972.5},
  'source': 'opendata.reseaux-energies.fr',
  'sourceType': <EventSourceType.measured: 'measured'>,
  'storage': {'battery': 5.0, 'hydro': -1894.5},
  'zoneKey': 'FR'},
 {'correctedModes': [],
  'datetime': datetime.datetime(2024, 7, 15, 1, 0, tzinfo=zoneinfo.ZoneInfo(key='Europe/Paris')),
  'production': {'biomass': 835.5,
                 'coal': 0.0,
                 'gas': 458.5,
                 'hydro': 7596.5,
                 'nuclear': 39146.5,
                 'oil': 123.5,
                 'solar': 0.0,
                 'wind': 1018.5},
  'source': 'opendata.reseaux-energies.fr',
  'sourceType': <EventSourceType.measured: 'measured'>,
  'storage': {'battery': 5.5, 'hydro': -1518.5},
  'zoneKey': 'FR'},
 {'correctedModes': [],
  'datetime': datetime.datetime(2024, 7, 15, 1, 30, tzinfo=zoneinfo.ZoneInfo(key='Europe/Paris')),
  'production': {'biomass': 838.0,
                 'coal': 0.0,
                 'gas': 449.5,
                 'hydro': 7551.5,
                 'nuclear': 39123.0,
                 'oil': 123.0,
                 'solar': 0.0,
                 'wind': 1070.5},
  'source': 'opendata.reseaux-energies.fr',
  'sourceType': <EventSourceType.measured: 'measured'>,
  'storage': {'battery': 6.5, 'hydro': -1409.5},
  'zoneKey': 'FR'},
 {'correctedModes': [],
  'datetime': datetime.datetime(2024, 7, 15, 2, 0, tzinfo=zoneinfo.ZoneInfo(key='Europe/Paris')),
  'production': {'biomass': 841.0,
                 'coal': 0.0,
                 'gas': 450.0,
                 'hydro': 7541.0,
                 'nuclear': 39210.5,
                 'oil': 124.0,
                 'solar': 0.0,
                 'wind': 1199.0},
  'source': 'opendata.reseaux-energies.fr',
  'sourceType': <EventSourceType.measured: 'measured'>,
  'storage': {'battery': 2.0, 'hydro': -1449.5},
  'zoneKey': 'FR'},
 {'correctedModes': [],
  'datetime': datetime.datetime(2024, 7, 15, 2, 30, tzinfo=zoneinfo.ZoneInfo(key='Europe/Paris')),
  'production': {'biomass': 844.0,
                 'coal': 0.0,
                 'gas': 451.0,
                 'hydro': 7460.0,
                 'nuclear': 39084.5,
                 'oil': 123.0,
                 'solar': 0.0,
                 'wind': 1307.0},
  'source': 'opendata.reseaux-energies.fr',
  'sourceType': <EventSourceType.measured: 'measured'>,
  'storage': {'battery': 3.0, 'hydro': -743.0},
  'zoneKey': 'FR'},
 {'correctedModes': [],
  'datetime': datetime.datetime(2024, 7, 15, 3, 0, tzinfo=zoneinfo.ZoneInfo(key='Europe/Paris')),
  'production': {'biomass': 841.0,
                 'coal': 0.0,
                 'gas': 450.5,
                 'hydro': 7470.5,
                 'nuclear': 39128.5,
                 'oil': 124.0,
                 'solar': 0.0,
                 'wind': 1393.0},
  'source': 'opendata.reseaux-energies.fr',
  'sourceType': <EventSourceType.measured: 'measured'>,
  'storage': {'battery': 3.5, 'hydro': -458.5},
  'zoneKey': 'FR'},
 {'correctedModes': [],
  'datetime': datetime.datetime(2024, 7, 15, 3, 30, tzinfo=zoneinfo.ZoneInfo(key='Europe/Paris')),
  'production': {'biomass': 845.0,
                 'coal': 0.0,
                 'gas': 449.0,
                 'hydro': 7610.5,
                 'nuclear': 39051.5,
                 'oil': 123.5,
                 'solar': 0.0,
                 'wind': 1473.5},
  'source': 'opendata.reseaux-energies.fr',
  'sourceType': <EventSourceType.measured: 'measured'>,
  'storage': {'battery': 6.0, 'hydro': -214.5},
  'zoneKey': 'FR'},
 {'correctedModes': [],
  'datetime': datetime.datetime(2024, 7, 15, 4, 0, tzinfo=zoneinfo.ZoneInfo(key='Europe/Paris')),
  'production': {'biomass': 846.5,
                 'coal': 0.0,
                 'gas': 450.5,
                 'hydro': 7446.0,
                 'nuclear': 39093.0,
                 'oil': 123.5,
                 'solar': 0.0,
                 'wind': 1552.5},
  'source': 'opendata.reseaux-energies.fr',
  'sourceType': <EventSourceType.measured: 'measured'>,
  'storage': {'battery': 4.5, 'hydro': 138.5},
  'zoneKey': 'FR'},
 {'correctedModes': [],
  'datetime': datetime.datetime(2024, 7, 15, 4, 30, tzinfo=zoneinfo.ZoneInfo(key='Europe/Paris')),
  'production': {'biomass': 833.0,
                 'coal': 0.0,
                 'gas': 450.0,
                 'hydro': 7395.5,
                 'nuclear': 39173.5,
                 'oil': 124.0,
                 'solar': 0.0,
                 'wind': 1749.0},
  'source': 'opendata.reseaux-energies.fr',
  'sourceType': <EventSourceType.measured: 'measured'>,
  'storage': {'battery': 3.5, 'hydro': 242.5},
  'zoneKey': 'FR'},
 {'correctedModes': [],
  'datetime': datetime.datetime(2024, 7, 15, 5, 0, tzinfo=zoneinfo.ZoneInfo(key='Europe/Paris')),
  'production': {'biomass': 828.5,
                 'coal': 0.0,
                 'gas': 447.5,
                 'hydro': 7255.5,
                 'nuclear': 39105.0,
                 'oil': 123.5,
                 'solar': 0.0,
                 'wind': 2109.0},
  'source': 'opendata.reseaux-energies.fr',
  'sourceType': <EventSourceType.measured: 'measured'>,
  'storage': {'battery': 6.0, 'hydro': -67.5},
  'zoneKey': 'FR'},
 {'correctedModes': [],
  'datetime': datetime.datetime(2024, 7, 15, 5, 30, tzinfo=zoneinfo.ZoneInfo(key='Europe/Paris')),
  'production': {'biomass': 835.5,
                 'coal': 0.0,
                 'gas': 445.5,
                 'hydro': 7211.0,
                 'nuclear': 39042.0,
                 'oil': 124.0,
                 'solar': 128.5,
                 'wind': 2576.5},
  'source': 'opendata.reseaux-energies.fr',
  'sourceType': <EventSourceType.measured: 'measured'>,
  'storage': {'battery': 7.0, 'hydro': -479.0},
  'zoneKey': 'FR'},
 {'correctedModes': [],
  'datetime': datetime.datetime(2024, 7, 15, 6, 0, tzinfo=zoneinfo.ZoneInfo(key='Europe/Paris')),
  'production': {'biomass': 836.0,
                 'coal': 0.0,
                 'gas': 440.5,
                 'hydro': 7269.0,
                 'nuclear': 39291.0,
                 'oil': 124.0,
                 'solar': 303.0,
                 'wind': 2899.0},
  'source': 'opendata.reseaux-energies.fr',
  'sourceType': <EventSourceType.measured: 'measured'>,
  'storage': {'battery': 6.0, 'hydro': -744.0},
  'zoneKey': 'FR'},
 {'correctedModes': [],
  'datetime': datetime.datetime(2024, 7, 15, 6, 30, tzinfo=zoneinfo.ZoneInfo(key='Europe/Paris')),
  'production': {'biomass': 835.0,
                 'coal': 0.0,
                 'gas': 438.5,
                 'hydro': 7498.5,
                 'nuclear': 39362.0,
                 'oil': 124.0,
                 'solar': 500.0,
                 'wind': 3357.0},
  'source': 'opendata.reseaux-energies.fr',
  'sourceType': <EventSourceType.measured: 'measured'>,
  'storage': {'battery': 3.0, 'hydro': -950.0},
  'zoneKey': 'FR'},
 {'correctedModes': [],
  'datetime': datetime.datetime(2024, 7, 15, 7, 0, tzinfo=zoneinfo.ZoneInfo(key='Europe/Paris')),
  'production': {'biomass': 833.0,
                 'coal': 0.0,
                 'gas': 440.5,
                 'hydro': 7678.0,
                 'nuclear': 39377.5,
                 'oil': 124.0,
                 'solar': 842.5,
                 'wind': 3661.5},
  'source': 'opendata.reseaux-energies.fr',
  'sourceType': <EventSourceType.measured: 'measured'>,
  'storage': {'battery': 2.0, 'hydro': -1259.0},
  'zoneKey': 'FR'},
 {'correctedModes': [],
  'datetime': datetime.datetime(2024, 7, 15, 7, 30, tzinfo=zoneinfo.ZoneInfo(key='Europe/Paris')),
  'production': {'biomass': 831.0,
                 'coal': 0.0,
                 'gas': 444.0,
                 'hydro': 7813.5,
                 'nuclear': 39426.0,
                 'oil': 124.0,
                 'solar': 1581.5,
                 'wind': 3852.0},
  'source': 'opendata.reseaux-energies.fr',
  'sourceType': <EventSourceType.measured: 'measured'>,
  'storage': {'battery': 2.5, 'hydro': -1616.0},
  'zoneKey': 'FR'},
 {'correctedModes': [],
  'datetime': datetime.datetime(2024, 7, 15, 8, 0, tzinfo=zoneinfo.ZoneInfo(key='Europe/Paris')),
  'production': {'biomass': 823.0,
                 'coal': 0.0,
                 'gas': 443.5,
                 'hydro': 7902.0,
                 'nuclear': 39401.0,
                 'oil': 124.0,
                 'solar': 2609.0,
                 'wind': 4039.0},
  'source': 'opendata.reseaux-energies.fr',
  'sourceType': <EventSourceType.measured: 'measured'>,
  'storage': {'battery': -13.0, 'hydro': -1918.5},
  'zoneKey': 'FR'},
 {'correctedModes': [],
  'datetime': datetime.datetime(2024, 7, 15, 8, 30, tzinfo=zoneinfo.ZoneInfo(key='Europe/Paris')),
  'production': {'biomass': 819.5,
                 'coal': 0.0,
                 'gas': 443.5,
                 'hydro': 7818.0,
                 'nuclear': 39322.0,
                 'oil': 124.0,
                 'solar': 3925.5,
                 'wind': 3379.0},
  'source': 'opendata.reseaux-energies.fr',
  'sourceType': <EventSourceType.measured: 'measured'>,
  'storage': {'battery': 2.5, 'hydro': -1951.5},
  'zoneKey': 'FR'},
 {'correctedModes': [],
  'datetime': datetime.datetime(2024, 7, 15, 9, 0, tzinfo=zoneinfo.ZoneInfo(key='Europe/Paris')),
  'production': {'biomass': 816.5,
                 'coal': 0.0,
                 'gas': 442.5,
                 'hydro': 7514.0,
                 'nuclear': 39317.5,
                 'oil': 124.0,
                 'solar': 4999.5,
                 'wind': 2848.0},
  'source': 'opendata.reseaux-energies.fr',
  'sourceType': <EventSourceType.measured: 'measured'>,
  'storage': {'battery': 0.5, 'hydro': -1932.0},
  'zoneKey': 'FR'},
 {'correctedModes': [],
  'datetime': datetime.datetime(2024, 7, 15, 9, 30, tzinfo=zoneinfo.ZoneInfo(key='Europe/Paris')),
  'production': {'biomass': 820.5,
                 'coal': 0.0,
                 'gas': 444.0,
                 'hydro': 7176.5,
                 'nuclear': 39270.0,
                 'oil': 123.5,
                 'solar': 6190.0,
                 'wind': 2707.0},
  'source': 'opendata.reseaux-energies.fr',
  'sourceType': <EventSourceType.measured: 'measured'>,
  'storage': {'battery': 2.5, 'hydro': -1737.5},
  'zoneKey': 'FR'},
 {'correctedModes': [],
  'datetime': datetime.datetime(2024, 7, 15, 10, 0, tzinfo=zoneinfo.ZoneInfo(key='Europe/Paris')),
  'production': {'biomass': 817.0,
                 'coal': 0.0,
                 'gas': 442.0,
                 'hydro': 7002.5,
                 'nuclear': 39204.5,
                 'oil': 124.0,
                 'solar': 7310.5,
                 'wind': 2677.0},
  'source': 'opendata.reseaux-energies.fr',
  'sourceType': <EventSourceType.measured: 'measured'>,
  'storage': {'battery': 11.5, 'hydro': -940.0},
  'zoneKey': 'FR'},
 {'correctedModes': [],
  'datetime': datetime.datetime(2024, 7, 15, 10, 30, tzinfo=zoneinfo.ZoneInfo(key='Europe/Paris')),
  'production': {'biomass': 808.5,
                 'coal': 0.0,
                 'gas': 440.5,
                 'hydro': 6580.0,
                 'nuclear': 38724.5,
                 'oil': 123.5,
                 'solar': 7943.0,
                 'wind': 2924.5},
  'source': 'opendata.reseaux-energies.fr',
  'sourceType': <EventSourceType.measured: 'measured'>,
  'storage': {'battery': 40.0, 'hydro': -107.0},
  'zoneKey': 'FR'}]
---------------------
took 0.70s
min returned datetime: 2024-07-14 09:00:00+00:00 UTC
max returned datetime: 2024-07-15 08:30:00+00:00 UTC  -- OK, <2h from now :) (now=2024-07-15T09:09:01+00:00 UTC)
```