### PR TITLE
feat(config): add tag in zones config for generation only zones

### DIFF
--- a/config/zones/US-CAR-YAD.yaml
+++ b/config/zones/US-CAR-YAD.yaml
@@ -205,3 +205,4 @@ sources:
   IPCC 2014:
     link: https://www.ipcc.ch/site/assets/uploads/2018/02/ipcc_wg3_ar5_annex-iii.pdf#page=7
 timezone: US/Eastern
+generation_only: true

--- a/config/zones/US-NW-GRID.yaml
+++ b/config/zones/US-NW-GRID.yaml
@@ -296,3 +296,4 @@ sources:
   eGrid 2021:
     link: ' https://drive.google.com/file/d/1_FAAuTtIdMuORZKsqHnd9vMNHlQgYarh/view?usp=sharing'
 timezone: US/Pacific
+generation_only: true

--- a/config/zones/US-SE-SEPA.yaml
+++ b/config/zones/US-SE-SEPA.yaml
@@ -202,3 +202,4 @@ sources:
   IPCC 2014:
     link: https://www.ipcc.ch/site/assets/uploads/2018/02/ipcc_wg3_ar5_annex-iii.pdf#page=7
 timezone: US/Eastern
+generation_only: true

--- a/electricitymap/contrib/config/model.py
+++ b/electricitymap/contrib/config/model.py
@@ -131,6 +131,7 @@ class Zone(StrictBaseModelWithAlias):
     parsers: Parsers = Parsers()
     price_displayed: bool | None
     aggregates_displayed: list[str] | None
+    generation_only: bool | None
     sub_zone_names: list[ZoneKey] | None = Field(None, alias="subZoneNames")
     timezone: str | None
     key: ZoneKey  # This is not part of zones/{zone_key}.yaml, but added here to enable self referencing


### PR DESCRIPTION
fixes GMM-94

Adds a tag to generation only zones to allow identification in the backend. These zones should be handled differently as they don't have any consumption.

source: https://www.eia.gov/electricity/gridmonitor/about


