### PR TITLE
Revert "parser validation - add function to filter out events with total production of 0 MW"

### DIFF
--- a/electricitymap/contrib/lib/models/event_lists.py
+++ b/electricitymap/contrib/lib/models/event_lists.py
@@ -365,31 +365,6 @@ class ProductionBreakdownList(AggregatableEventList):
         return updated_production_breakdowns
 
     @staticmethod
-    def filter_only_zero_production(
-        breakdowns: "ProductionBreakdownList",
-    ) -> "ProductionBreakdownList":
-        """
-        TODO: Remove once the internal outlier detection is able to handle this.
-        A method to filter out production breakdowns with a total production of 0 MW."""
-        production_events = ProductionBreakdownList(breakdowns.logger)
-        for event in breakdowns.events:
-            if event.production is not None and not any(
-                v for _mode, v in event.production
-            ):
-                production_events.logger.warning(
-                    f"Discarded production event for {event.zoneKey} at {event.datetime} because all production values are 0 or None."
-                )
-                continue
-            production_events.append(
-                zoneKey=event.zoneKey,
-                datetime=event.datetime,
-                production=event.production,
-                storage=event.storage,
-                source=event.source,
-            )
-        return production_events
-
-    @staticmethod
     def filter_expected_modes(
         breakdowns: "ProductionBreakdownList",
         strict_storage: bool = False,

--- a/electricitymap/contrib/lib/tests/test_event_lists.py
+++ b/electricitymap/contrib/lib/tests/test_event_lists.py
@@ -1085,39 +1085,6 @@ class TestProductionBreakdownList(unittest.TestCase):
         )
         assert len(output) == 1
 
-    def test_filter_only_zero_production(self):
-        production_list = ProductionBreakdownList(logging.Logger("test"))
-        production_list.append(
-            ZoneKey("US-NW-PGE"),
-            datetime=datetime(2023, 1, 1, tzinfo=timezone.utc),
-            production=ProductionMix(
-                wind=0,
-                coal=0,
-                solar=0,
-                gas=0,
-                unknown=0,
-                hydro=0,
-                oil=0,
-            ),
-            source="trust.me",
-        )
-        production_list.append(
-            ZoneKey("US-NW-PGE"),
-            datetime=datetime(2023, 1, 1, tzinfo=timezone.utc),
-            production=ProductionMix(
-                wind=0,
-                coal=0,
-                solar=10,
-                gas=0,
-                unknown=0,
-                hydro=0,
-                oil=0,
-            ),
-            source="trust.me",
-        )
-        output = ProductionBreakdownList.filter_only_zero_production(production_list)
-        assert len(output) == 1
-
 
 class TestTotalProductionList(unittest.TestCase):
     def test_total_production_list(self):

--- a/parsers/EIA.py
+++ b/parsers/EIA.py
@@ -601,9 +601,6 @@ def fetch_production_mix(
         events = ProductionBreakdownList.filter_expected_modes(
             events, by_passed_modes=FILTER_INCOMPLETE_DATA_BYPASSED_MODES[zone_key]
         )
-
-    # filter events with a total_production of 0
-    events = ProductionBreakdownList.filter_only_zero_production(events)
     return events.to_list()
 
 

--- a/parsers/PE.py
+++ b/parsers/PE.py
@@ -76,10 +76,7 @@ def fetch_production(
     production_events = ProductionBreakdownList.merge_production_breakdowns(
         all_production_breakdowns, logger
     )
-    filtered_production_events = ProductionBreakdownList.filter_only_zero_production(
-        production_events
-    )
-    filtered_production_events = filtered_production_events.to_list()
+    production_events = production_events.to_list()
 
     # Drop last datapoints if it "looks" incomplete.
     # The last hour often only contains data from some power plants
@@ -90,7 +87,7 @@ def fetch_production(
     # TODO: remove this in the future, when this is automatically detected by QA layer
 
     total_production_per_datapoint = [
-        sum(d["production"].values()) for d in filtered_production_events
+        sum(d["production"].values()) for d in production_events
     ]
     mean_production = sum(total_production_per_datapoint) / len(
         total_production_per_datapoint
@@ -102,5 +99,5 @@ def fetch_production(
         logger.warning(
             "Dropping last datapoint as it is probably incomplete. Total production is less than 90% of the mean."
         )
-        filtered_production_events = filtered_production_events[:-1]
-    return filtered_production_events
+        production_events = production_events[:-1]
+    return production_events


### PR DESCRIPTION
Reverts electricitymaps/electricitymaps-contrib#6533

We have now added this rule to our backend QA pipeline, so we can remove this from the parser validation. 