### PR TITLE
Add missing space to frontend structure tree

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -94,7 +94,7 @@ mobileapp
 ├── android
 ├── assets
 ├── icons
-└──ios
+└── ios
 web
 ├── config
 ├── cypress


### PR DESCRIPTION
## Issue

Cosmetic: There is a space missing in front of the iOS folder in the front-end description tree outlining the front end folder structure in CONTRIBUTING.md.

## Description

Make the structure look visually appealing by adding the space.

### Preview

Self-explanatory, I hope.

### Double check

I have not run any test scripts since I just added a space to an .md file.
