### PR TITLE
fix: remove generation only zones from ranking

### DIFF
--- a/web/src/features/panels/ranking-panel/getRankingPanelData.ts
+++ b/web/src/features/panels/ranking-panel/getRankingPanelData.ts
@@ -3,7 +3,7 @@ import type { GridState, ZoneKey } from 'types';
 import { SpatialAggregate } from 'utils/constants';
 import { getCO2IntensityByMode } from 'utils/helpers';
 
-import { getHasSubZones } from '../zone/util';
+import { getHasSubZones, isGenerationOnlyZone } from '../zone/util';
 import { ZoneRowType } from './ZoneList';
 
 function filterZonesBySpatialAggregation(
@@ -63,7 +63,8 @@ export const getRankedState = (
     .filter(
       (zone) =>
         Boolean(zone.co2intensity) &&
-        filterZonesBySpatialAggregation(zone.zoneId, spatialAggregation)
+        filterZonesBySpatialAggregation(zone.zoneId, spatialAggregation) &&
+        !isGenerationOnlyZone(zone.zoneId)
     );
 
   const orderedZones =

--- a/web/src/features/panels/zone/util.ts
+++ b/web/src/features/panels/zone/util.ts
@@ -94,3 +94,6 @@ export function showEstimationFeedbackCard(
   }
   return false;
 }
+
+export const isGenerationOnlyZone = (zoneId: string) =>
+  config.zones[zoneId]?.generation_only;

--- a/web/src/features/panels/zone/util.ts
+++ b/web/src/features/panels/zone/util.ts
@@ -95,5 +95,5 @@ export function showEstimationFeedbackCard(
   return false;
 }
 
-export const isGenerationOnlyZone = (zoneId: string) =>
-  config.zones[zoneId]?.generation_only;
+export const isGenerationOnlyZone = (zoneId: string): boolean =>
+  config.zones[zoneId]?.generation_only ?? false;


### PR DESCRIPTION
## Issue

We are currently showing zones in the ranking that we don't have on the map in staging.

## Description
This checks if it's a generation only zone and hides it from the ranking if it is to match the map.

### Double check
- [x] I have run `pnpx prettier@2 --write .` and `poetry run format` in the top level directory to format my changes.
