### PR TITLE
fix: Fix Thailand's electricity price calculation

### DIFF
--- a/parsers/TH.py
+++ b/parsers/TH.py
@@ -20,7 +20,9 @@ from parsers.lib.exceptions import ParserException
 
 EGAT_GENERATION_URL = "https://www.sothailand.com/sysgen/ws/sysgen"
 EGAT_URL = "www.egat.co.th"
-MEA_BASEPRICE_URL = "https://www.mea.or.th/en/our-services/tariff-calculation/other/-yosbxMGAjzp0"
+MEA_BASEPRICE_URL = (
+    "https://www.mea.or.th/en/our-services/tariff-calculation/other/-yosbxMGAjzp0"
+)
 MEA_FT_URL = "https://www.mea.or.th/our-services/tariff-calculation/ft/bG2m6iSUN"
 MEA_URL = "www.mea.or.th"
 TZ = ZoneInfo("Asia/Bangkok")

--- a/parsers/TH.py
+++ b/parsers/TH.py
@@ -20,8 +20,8 @@ from parsers.lib.exceptions import ParserException
 
 EGAT_GENERATION_URL = "https://www.sothailand.com/sysgen/ws/sysgen"
 EGAT_URL = "www.egat.co.th"
-MEA_BASEPRICE_URL = "https://www.mea.or.th/en/profile/109/111"
-MEA_FT_URL = "https://www.mea.or.th/content/detail/2985/2987/474"
+MEA_BASEPRICE_URL = "https://www.mea.or.th/en/our-services/tariff-calculation/other/-yosbxMGAjzp0"
+MEA_FT_URL = "https://www.mea.or.th/our-services/tariff-calculation/ft/bG2m6iSUN"
 MEA_URL = "www.mea.or.th"
 TZ = ZoneInfo("Asia/Bangkok")
 
@@ -201,7 +201,7 @@ def fetch_price(
         )
 
     unit_price_table = soup_base.find_all("table")[1]
-    price_base = unit_price_table.find_all("td")[19].text
+    price_base = unit_price_table.find_all("td")[8].text
 
     # Available Ft pricing history dated back as far as September 2535 B.E. (1992 C.E.)
     # `price_ft` slot's is 0+(month number), additional +13 is needed if that slot is " "
@@ -216,7 +216,7 @@ def fetch_price(
             zone_key=zone_key,
         )
 
-    ft_rate_table = soup_ft.find_all("table")[1]
+    ft_rate_table = soup_ft.find_all("table")[0]
     curr_ft_month = _as_localtime(datetime.now()).month
     price_ft = ft_rate_table.find_all("td")[curr_ft_month].text
 


### PR DESCRIPTION
## Fix Thailand's electricity price calculation

<!-- If you want to close an issue automatically when your PR is merged, write "Closes X" where X is the PR number. For example: Closes #000 -->

## Description

From #6510 , this fixes Thailand's electricity pricing calculation to account for `Metropolitan Electrical Authority (การไฟฟ้านครหลวง)`'s recent website overhauls.

### Preview

<!-- Please add screenshots and/or gif that shows visual changes (if applicable) -->
![image](https://github.com/user-attachments/assets/464691f5-27f5-4c6a-b21c-e8bee16d8408)

Electricity Rate as of Jul 2024
- [Base Price](https://www.mea.or.th/en/our-services/tariff-calculation/other/-yosbxMGAjzp0) = 4.4217 THB/KWh
- [Ft Rate](https://www.mea.or.th/our-services/tariff-calculation/ft/bG2m6iSUN) = 0.3972 THB/KWh

Actual Electricity Price = ( 4.4217 + 0.3972 ) * 1,000 = 4,818.90 THB per MWh which matches the result shown in the screenshot above.

### Double check

- [x] I have tested my parser changes locally with `poetry run test_parser "zone_key"`
- [x] I have run `pnpx prettier@2 --write .` and `poetry run format` in the top level directory to format my changes.
