### PR TITLE
feat: add lucide-react and change X icon

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -82,6 +82,7 @@
     "i18next-resources-to-backend": "^1.2.1",
     "jotai": "^2.8.4",
     "js-yaml": "^4.1.0",
+    "lucide-react": "^0.414.0",
     "maplibre-gl": "^3.6.2",
     "react": "18.3.1",
     "react-dom": "18.3.1",

--- a/web/pnpm-lock.yaml
+++ b/web/pnpm-lock.yaml
@@ -110,6 +110,9 @@ importers:
       js-yaml:
         specifier: ^4.1.0
         version: 4.1.0
+      lucide-react:
+        specifier: ^0.414.0
+        version: 0.414.0(react@18.3.1)
       maplibre-gl:
         specifier: ^3.6.2
         version: 3.6.2
@@ -6345,6 +6348,11 @@ packages:
   lru-cache@5.1.1:
     resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
 
+  lucide-react@0.414.0:
+    resolution: {integrity: sha512-Krr/MHg9AWoJc52qx8hyJ64X9++JNfS1wjaJviLM1EP/68VNB7Tv0VMldLCB1aUe6Ka9QxURPhQm/eB6cqOM3A==}
+    peerDependencies:
+      react: ^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
   lz-string@1.5.0:
     resolution: {integrity: sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==}
     hasBin: true
@@ -11193,7 +11201,7 @@ snapshots:
 
   '@react-three/fiber@8.16.1(react-dom@18.3.1(react@18.3.1))(react-native@0.73.6(@babel/core@7.24.7)(@babel/preset-env@7.24.7(@babel/core@7.24.7))(react@18.3.1))(react@18.3.1)(three@0.163.0)':
     dependencies:
-      '@babel/runtime': 7.24.7
+      '@babel/runtime': 7.24.8
       '@types/react-reconciler': 0.26.7
       '@types/webxr': 0.5.19
       base64-js: 1.5.1
@@ -16582,6 +16590,10 @@ snapshots:
     dependencies:
       yallist: 3.1.1
 
+  lucide-react@0.414.0(react@18.3.1):
+    dependencies:
+      react: 18.3.1
+
   lz-string@1.5.0: {}
 
   magic-string@0.25.9:
@@ -16739,7 +16751,7 @@ snapshots:
 
   metro-runtime@0.80.9:
     dependencies:
-      '@babel/runtime': 7.24.7
+      '@babel/runtime': 7.24.8
 
   metro-source-map@0.80.9:
     dependencies:

--- a/web/src/components/Modal.tsx
+++ b/web/src/components/Modal.tsx
@@ -1,5 +1,5 @@
 import * as Dialog from '@radix-ui/react-dialog';
-import { HiXMark } from 'react-icons/hi2';
+import { X } from 'lucide-react'
 
 interface ModalProps {
   isOpen: boolean;
@@ -40,7 +40,7 @@ export default function Modal({
             aria-label="Close"
             data-test-id="close-modal-button"
           >
-            <HiXMark size="18" />
+            <X size="18" />
           </Dialog.Close>
           <div
             className={fullWidth ? 'p-0' : 'px-2 py-3 sm:p-[25px_55px] md:px-2 md:py-4'}

--- a/web/src/components/Modal.tsx
+++ b/web/src/components/Modal.tsx
@@ -1,5 +1,5 @@
 import * as Dialog from '@radix-ui/react-dialog';
-import { X } from 'lucide-react'
+import { X } from 'lucide-react';
 
 interface ModalProps {
   isOpen: boolean;

--- a/web/src/components/Toast.tsx
+++ b/web/src/components/Toast.tsx
@@ -1,5 +1,5 @@
 import * as ToastPrimitive from '@radix-ui/react-toast';
-import { X } from 'lucide-react'
+import { X } from 'lucide-react';
 import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 

--- a/web/src/components/Toast.tsx
+++ b/web/src/components/Toast.tsx
@@ -1,7 +1,7 @@
 import * as ToastPrimitive from '@radix-ui/react-toast';
+import { X } from 'lucide-react'
 import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { HiXMark } from 'react-icons/hi2';
 
 import { Button } from './Button';
 
@@ -70,7 +70,7 @@ function Toast({
             onClick={handleToastClose}
             aria-label={toastCloseText ?? t('misc.dismiss')}
           >
-            <HiXMark className="h-4 w-4" />
+            <X />
           </ToastPrimitive.Close>
         </div>
       </ToastPrimitive.Root>

--- a/web/src/components/app-survey/FeedbackCard.tsx
+++ b/web/src/components/app-survey/FeedbackCard.tsx
@@ -1,6 +1,7 @@
 import * as ToggleGroupPrimitive from '@radix-ui/react-toggle-group';
 import Pill from 'components/Pill';
 import { useAtom, useSetAtom } from 'jotai';
+import { X } from 'lucide-react';
 import {
   ChangeEvent,
   Dispatch,
@@ -10,7 +11,6 @@ import {
   useState,
 } from 'react';
 import { useTranslation } from 'react-i18next';
-import { HiXMark } from 'react-icons/hi2';
 import { hasSeenSurveyCardAtom, userLocationAtom } from 'utils/state/atoms';
 import { useIsMobile } from 'utils/styling';
 
@@ -108,7 +108,7 @@ export default function FeedbackCard({
           </h2>
         </div>
         <button data-test-id="close-button" onClick={handleClose}>
-          <HiXMark />
+          <X />
         </button>
       </div>
       <div>

--- a/web/src/components/modals/OnboardingModalInner.tsx
+++ b/web/src/components/modals/OnboardingModalInner.tsx
@@ -1,7 +1,8 @@
 import { TFunction } from 'i18next';
+import { X } from 'lucide-react';
 import { ReactElement, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { HiCheck, HiChevronLeft, HiChevronRight, HiXMark } from 'react-icons/hi2';
+import { HiCheck, HiChevronLeft, HiChevronRight } from 'react-icons/hi2';
 
 export interface Page {
   headerImage: { pathname: string };
@@ -90,7 +91,7 @@ function Modal({
               onClick={onDismiss}
               data-test-id="close-modal"
             >
-              <HiXMark size="28" />
+              <X size="28" />
             </button>
           </div>
           <div

--- a/web/src/features/charts/DataSources.tsx
+++ b/web/src/features/charts/DataSources.tsx
@@ -2,8 +2,8 @@ import * as Portal from '@radix-ui/react-portal';
 import { Link } from 'components/Link';
 import TooltipWrapper from 'components/tooltips/TooltipWrapper';
 import { TFunction } from 'i18next';
+import { X } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
-import { HiXMark } from 'react-icons/hi2';
 import { IoInformationCircleOutline } from 'react-icons/io5';
 import { ElectricityModeType } from 'types';
 import { sourceLinkMapping } from 'utils/constants';
@@ -95,7 +95,7 @@ function EmissionFactorTooltip({ t }: { t: TFunction<'translation', undefined> }
         {t('country-panel.emissionFactorDataSourcesTooltip')}
       </div>
       <button className="p-auto pointer-events-auto mt-2 flex h-10 w-10 items-center justify-center self-center rounded-full border bg-zinc-50 text-black shadow-md">
-        <HiXMark size="24" />
+        <X />
       </button>
     </Portal.Root>
   );

--- a/web/src/features/charts/ProductionSourceLegendList.tsx
+++ b/web/src/features/charts/ProductionSourceLegendList.tsx
@@ -1,5 +1,5 @@
 import TooltipWrapper from 'components/tooltips/TooltipWrapper';
-import { HiXMark } from 'react-icons/hi2';
+import { X } from 'lucide-react';
 import { twMerge } from 'tailwind-merge';
 import { ElectricityModeType } from 'types';
 import { useIsMobile } from 'utils/styling';
@@ -49,7 +49,7 @@ function ProductionSourceTooltip({
           <ProductionSourceTooltipInner sources={sources} />
         </div>
         <button className="p-auto pointer-events-auto mt-2 flex h-10 w-10 items-center justify-center self-center rounded-full border bg-white text-black shadow-md">
-          <HiXMark size="24" />
+          <X />
         </button>
       </>
     );

--- a/web/src/features/charts/bar-breakdown/BarBreakdownChart.tsx
+++ b/web/src/features/charts/bar-breakdown/BarBreakdownChart.tsx
@@ -6,9 +6,9 @@ import { IndustryIcon } from 'icons/industryIcon';
 import { UtilityPoleIcon } from 'icons/utilityPoleIcon';
 import { WindTurbineIcon } from 'icons/windTurbineIcon';
 import { useAtom, useAtomValue } from 'jotai';
+import { X } from 'lucide-react';
 import React, { useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { HiXMark } from 'react-icons/hi2';
 import { ElectricityModeType, ZoneDetail, ZoneKey } from 'types';
 import useResizeObserver from 'use-resize-observer';
 import trackEvent from 'utils/analytics';
@@ -147,7 +147,7 @@ function BarBreakdownChart({
               hasEstimationPill={hasEstimationPill}
             />
             <button className="p-auto pointer-events-auto flex h-8 w-8 items-center justify-center rounded-full bg-white shadow sm:hidden dark:bg-gray-800">
-              <HiXMark size="24" />
+              <X />
             </button>
           </div>
         </Portal.Root>

--- a/web/src/features/charts/tooltips/AreaGraphTooltip.tsx
+++ b/web/src/features/charts/tooltips/AreaGraphTooltip.tsx
@@ -1,6 +1,6 @@
 import * as Portal from '@radix-ui/react-portal';
+import { X } from 'lucide-react';
 import type { ReactElement } from 'react';
-import { HiXMark } from 'react-icons/hi2';
 import { ZoneDetail } from 'types';
 
 import { getOffsetTooltipPosition } from '../../../components/tooltips/utilities';
@@ -53,7 +53,7 @@ export default function AreaGraphTooltip({
       >
         {children({ zoneDetail, selectedLayerKey })}
         <button className="p-auto pointer-events-auto flex h-8 w-8 items-center justify-center rounded-full bg-white shadow sm:hidden dark:bg-gray-800">
-          <HiXMark size="24" />
+          <X />
         </button>
       </div>
     </Portal.Root>

--- a/web/src/features/modals/AnnouncementModal.tsx
+++ b/web/src/features/modals/AnnouncementModal.tsx
@@ -2,8 +2,8 @@ import { Link } from 'components/Link';
 import { SourceColorAnnouncementImage } from 'icons/announcementSourceColorImage';
 import { useAtom } from 'jotai';
 import { atomWithStorage } from 'jotai/utils';
+import { X } from 'lucide-react';
 import { useEffect, useState } from 'react';
-import { HiXMark } from 'react-icons/hi2';
 import { useSearchParams } from 'react-router-dom';
 import { hasOnboardingBeenSeenAtom } from 'utils/state/atoms';
 
@@ -89,7 +89,7 @@ export default function AnnouncementModal() {
         onClick={handleDismiss}
         className="p-auto pointer-events-auto mt-2 flex h-10 w-10 items-center justify-center self-center rounded-full border border-neutral-200 bg-zinc-50 text-black shadow-md dark:border-gray-700 dark:bg-gray-900 dark:text-white"
       >
-        <HiXMark size="24" />
+        <X />
       </button>
     </div>
   );


### PR DESCRIPTION
## Description
Since we agreed to change to Lucide icons I have added it to our dependencies and changed the X (close) icon to ensure it's working (it looks identical as far as I can tell).

### Double check

- [x] I have run `pnpx prettier@2 --write .` and `poetry run format` in the top level directory to format my changes.
