### PR TITLE
feat(web): always show BarBreakdownAxisLegend

### DIFF
--- a/web/src/features/charts/bar-breakdown/BarBreakdownChart.tsx
+++ b/web/src/features/charts/bar-breakdown/BarBreakdownChart.tsx
@@ -32,7 +32,6 @@ import BarElectricityBreakdownChart from './BarElectricityBreakdownChart';
 import BySource from './elements/BySource';
 import CapacityLegend from './elements/CapacityLegend';
 import EmptyBarBreakdownChart from './EmptyBarBreakdownChart';
-import { hasNegativeDataValues } from './utils';
 
 const X_PADDING = 20;
 
@@ -130,8 +129,6 @@ function BarBreakdownChart({
     showCapacitySources || showPowerSources || showEmissionSources
   );
 
-  const hasNegativeValuesInData = hasNegativeDataValues(productionData, exchangeData);
-
   return (
     <div
       className="mt-4 rounded-2xl border border-neutral-200 px-4 pb-2 text-sm dark:border-gray-700"
@@ -195,7 +192,6 @@ function BarBreakdownChart({
           height={height}
           isMobile={false}
           graphUnit={graphUnit}
-          hasNegativeValuesInData={hasNegativeValuesInData}
         />
       )}
       {showDataSourceAccordion && (

--- a/web/src/features/charts/bar-breakdown/BarElectricityBreakdownChart.tsx
+++ b/web/src/features/charts/bar-breakdown/BarElectricityBreakdownChart.tsx
@@ -33,7 +33,6 @@ interface BarElectricityBreakdownChartProps {
   ) => void;
   onExchangeRowMouseOut: () => void;
   graphUnit: string | undefined;
-  hasNegativeValuesInData: boolean;
 }
 
 function BarElectricityBreakdownChart({
@@ -49,7 +48,6 @@ function BarElectricityBreakdownChart({
   onExchangeRowMouseOut,
   width,
   graphUnit,
-  hasNegativeValuesInData,
 }: BarElectricityBreakdownChartProps) {
   const co2ColorScale = useCo2ColorScale();
   const { productionY, exchangeHeight } = getDataBlockPositions(
@@ -114,7 +112,6 @@ function BarElectricityBreakdownChart({
         onProductionRowMouseOver={onProductionRowMouseOver}
         onProductionRowMouseOut={onProductionRowMouseOut}
         isMobile={isMobile}
-        hasNegativeValuesInData={hasNegativeValuesInData}
       />
       <BarElectricityExchangeChart
         height={exchangeHeight + EXCHANGE_PADDING}

--- a/web/src/features/charts/bar-breakdown/BarElectricityProductionChart.tsx
+++ b/web/src/features/charts/bar-breakdown/BarElectricityProductionChart.tsx
@@ -21,7 +21,6 @@ export function BarElectricityProductionChart({
   onProductionRowMouseOver,
   onProductionRowMouseOut,
   isMobile,
-  hasNegativeValuesInData,
 }: {
   powerScale: ScaleLinear<number, number, never>;
   height: number;
@@ -37,7 +36,6 @@ export function BarElectricityProductionChart({
   ) => void;
   onProductionRowMouseOut: () => void;
   isMobile: boolean;
-  hasNegativeValuesInData: boolean;
 }) {
   const { t } = useTranslation();
   return (
@@ -46,7 +44,6 @@ export function BarElectricityProductionChart({
         formatTick={formatTick}
         height={height}
         scale={powerScale}
-        hasNegativeValuesInData={hasNegativeValuesInData}
         axisLegendText={{
           left: t('country-panel.graph-legends.stored'),
           right: t('country-panel.graph-legends.produced'),

--- a/web/src/features/charts/bar-breakdown/elements/Axis.tsx
+++ b/web/src/features/charts/bar-breakdown/elements/Axis.tsx
@@ -8,16 +8,9 @@ type Props = {
   scale: ScaleLinear<number, number, never>;
   formatTick: (tick: number) => string | number;
   axisLegendText?: { left: string; right: string };
-  hasNegativeValuesInData?: boolean;
 };
 
-export default function Axis({
-  formatTick,
-  height,
-  scale,
-  axisLegendText,
-  hasNegativeValuesInData = true,
-}: Props) {
+export default function Axis({ formatTick, height, scale, axisLegendText }: Props) {
   const axisTicks = scale.ticks(SCALE_TICKS);
 
   return (
@@ -51,7 +44,7 @@ export default function Axis({
           >
             {formatTick(t)}
           </text>
-          {axisLegendText && t == 0 && hasNegativeValuesInData && (
+          {axisLegendText && t == 0 && (
             <BarBreakdownAxisLegend height={height} legendText={axisLegendText} />
           )}
         </g>

--- a/web/src/features/charts/bar-breakdown/elements/BarBreakdownAxisLegend.tsx
+++ b/web/src/features/charts/bar-breakdown/elements/BarBreakdownAxisLegend.tsx
@@ -21,7 +21,7 @@ export default function BarBreakdownAxisLegend({
       <text
         fill="rgba(115, 115, 115, 1)"
         fontSize={'0.7rem'}
-        y={height - X_AXIS_HEIGHT + 10}
+        y={height - X_AXIS_HEIGHT + 12}
         x={-18}
         textAnchor="end"
       >
@@ -30,17 +30,17 @@ export default function BarBreakdownAxisLegend({
       <FaArrowLeft
         className="text-neutral-300 dark:text-gray-700"
         x={-15}
-        y={height - X_AXIS_HEIGHT + 2}
+        y={height - X_AXIS_HEIGHT + 3}
       />
       <FaArrowRight
         className="text-neutral-300 dark:text-gray-700"
         x={5}
-        y={height - X_AXIS_HEIGHT + 2}
+        y={height - X_AXIS_HEIGHT + 3}
       />
       <text
         fill="rgba(115, 115, 115, 1)"
         fontSize={'0.7rem'}
-        y={height - X_AXIS_HEIGHT + 10}
+        y={height - X_AXIS_HEIGHT + 12}
         x={18}
         textAnchor="start"
       >

--- a/web/src/features/charts/bar-breakdown/utils.ts
+++ b/web/src/features/charts/bar-breakdown/utils.ts
@@ -192,21 +192,3 @@ export const getExchangesToDisplay = (
     (exchangeZoneKey) => !exchangeZoneKeysToRemove.has(exchangeZoneKey)
   );
 };
-
-export const hasNegativeDataValues = (
-  productionData: ProductionDataType[],
-  exchangeData: ExchangeDataType[]
-) => {
-  for (const d of productionData) {
-    if ((d.isStorage && (d.capacity ?? 0) > 0) || (d.storage ?? 0) > 0) {
-      return true;
-    }
-  }
-  for (const d of exchangeData) {
-    if (d.exchange < 0 || d.exchangeCapacityRange[0] < 0) {
-      return true;
-    }
-  }
-
-  return false;
-};


### PR DESCRIPTION
## Issue

<!-- If you want to close an issue automatically when your PR is merged, write "Closes X" where X is the PR number. For example: Closes #000 -->
[AVO-434](https://linear.app/electricitymaps/issue/AVO-434/always-show-barbreakdownaxislegend)

## Description

<!-- Explains the goal of this PR -->
This PR changes removes the logic for when the BarBreakdownAxisLegend is shown, so that it is always there. It also moves the legend a tiny bit down.

### Preview

<!-- Please add screenshots and/or gif that shows visual changes (if applicable) -->
Before:
<img width="423" alt="image" src="https://github.com/user-attachments/assets/330f6633-1d7e-4dab-ad69-d500c477d221">

After:
<img width="423" alt="image" src="https://github.com/user-attachments/assets/84d9aeae-224b-428c-9918-4d705b1f1d4b">



### Double check

- [ ] I have tested my parser changes locally with `poetry run test_parser "zone_key"`
- [x] I have run `pnpx prettier@2 --write .` and `poetry run format` in the top level directory to format my changes.
