### PR TITLE
feat(web): add co2 legend to carbon intensity graph

### DIFF
--- a/web/src/features/charts/CarbonChart.tsx
+++ b/web/src/features/charts/CarbonChart.tsx
@@ -1,5 +1,7 @@
 import Accordion from 'components/Accordion';
+import HorizontalColorbar from 'components/legend/ColorBar';
 import Divider from 'features/panels/zone/Divider';
+import { useCo2ColorScale } from 'hooks/theme';
 import { IndustryIcon } from 'icons/industryIcon';
 import { WindTurbineIcon } from 'icons/windTurbineIcon';
 import { useTranslation } from 'react-i18next';
@@ -30,6 +32,7 @@ function CarbonChart({ datetimes, timeAverage }: CarbonChartProps) {
     emissionFactorSourcesToProductionSources,
   } = useZoneDataSources();
   const { t } = useTranslation();
+  const co2ColorScale = useCo2ColorScale();
 
   if (isLoading || isError || !data) {
     return null;
@@ -64,6 +67,9 @@ function CarbonChart({ datetimes, timeAverage }: CarbonChartProps) {
         selectedTimeAggregate={timeAverage}
         tooltip={CarbonChartTooltip}
       />
+      <div className="pb-1 pt-2">
+        <HorizontalColorbar colorScale={co2ColorScale} ticksCount={6} id={'co2'} />
+      </div>
       <Divider />
       <Accordion
         onOpen={() => {


### PR DESCRIPTION
## Issue

<!-- If you want to close an issue automatically when your PR is merged, write "Closes X" where X is the PR number. For example: Closes #000 -->
[AVO-221](https://linear.app/electricitymaps/issue/AVO-221/carbon-intensity-add-ci-legend)

## Description

<!-- Explains the goal of this PR -->
This PR adds the CO2 intensity legend to the carbon intensity graph.

### Preview

<!-- Please add screenshots and/or gif that shows visual changes (if applicable) -->
<img width="385" alt="image" src="https://github.com/user-attachments/assets/26c2e7a6-85be-4705-818e-a4152e93a183">
<img width="388" alt="image" src="https://github.com/user-attachments/assets/129b21c8-75bc-40d8-8e1d-74825eda3323">


### Double check

- [ ] I have tested my parser changes locally with `poetry run test_parser "zone_key"`
- [x] I have run `pnpx prettier@2 --write .` and `poetry run format` in the top level directory to format my changes.
