### PR TITLE
refactor(web): change styling of exchange tooltips to match the other map tooltips

### DIFF
--- a/web/src/features/exchanges/ExchangeArrow.tsx
+++ b/web/src/features/exchanges/ExchangeArrow.tsx
@@ -60,7 +60,8 @@ function ExchangeArrow({
   };
 
   // Setting the top position from the arrow tooltip preventing overflowing to top.
-  let tooltipClassName = 'max-h-[256px] max-w-[512px] md:flex';
+  let tooltipClassName =
+    'max-h-[256px] max-w-[512px] md:flex rounded-2xl border-neutral-200 bg-white dark:bg-gray-900 dark:border-gray-700 dark:border';
   if (!isMobile) {
     tooltipClassName += transform.y - 76 < headerHeight ? ' top-[76px]' : ' top-[-76px]';
   }


### PR DESCRIPTION
## Issue

<!-- If you want to close an issue automatically when your PR is merged, write "Closes X" where X is the PR number. For example: Closes #000 -->
[AVO-431](https://linear.app/electricitymaps/issue/AVO-431/unify-exchange-tooltip)

## Description

<!-- Explains the goal of this PR -->
This PR changes the styling of the exchange tooltips to match the other map tooltips

### Preview

<!-- Please add screenshots and/or gif that shows visual changes (if applicable) -->
<img width="557" alt="image" src="https://github.com/user-attachments/assets/5a3a534b-a941-4fc9-923d-b4204ebe62e2">
<img width="394" alt="image" src="https://github.com/user-attachments/assets/0bfcb8ed-4cd4-476f-abd6-960b2a607889">


### Double check

- [ ] I have tested my parser changes locally with `poetry run test_parser "zone_key"`
- [x] I have run `pnpx prettier@2 --write .` and `poetry run format` in the top level directory to format my changes.
