### PR TITLE
fix(JP-TK): update url and parsing

### DIFF
--- a/parsers/JP.py
+++ b/parsers/JP.py
@@ -160,7 +160,7 @@ def fetch_consumption_df(
     consumption_url = {
         "JP-HKD": f"http://denkiyoho.hepco.co.jp/area/data/juyo_01_{datestamp}.csv",
         "JP-TH": f"https://setsuden.nw.tohoku-epco.co.jp/common/demand/juyo_02_{datestamp}.csv",
-        "JP-TK": "http://www.tepco.co.jp/forecast/html/images/juyo-d-j.csv",
+        "JP-TK": "https://www.tepco.co.jp/forecast/html/images/juyo-d1-j.csv",
         "JP-HR": f"http://www.rikuden.co.jp/nw/denki-yoho/csv/juyo_05_{datestamp}.csv",
         "JP-CB": "https://powergrid.chuden.co.jp/denki_yoho_content_data/juyo_cepco003.csv",
         "JP-KN": "https://www.kansai-td.co.jp/yamasou/juyo1_kansai.csv",
@@ -184,6 +184,8 @@ def fetch_consumption_df(
 
     if zone_key in ["JP-TH"]:
         df.columns = ["Date", "Time", "cons", "solar", "wind"]
+    elif zone_key in ["JP-TK"]:
+        df.columns = ["Date", "Time", "cons", "solar", "solar_pct"]
     else:
         df.columns = ["Date", "Time", "cons", "solar"]
     # Convert 万kW to MW


### PR DESCRIPTION
## Description

Updates the URL and parsing. They have added a new column with the solar% 

### Preview

```sh
> poetry run python test_parser.py 'JP-TK'

Parser result:
[{'capacity': {'wind': 440},
  'datetime': datetime.datetime(2024, 8, 2, 0, 5, tzinfo=tzfile('/usr/share/zoneinfo/Asia/Tokyo')),
  'production': {'biomass': None,
                 'coal': None,
                 'gas': None,
                 'geothermal': None,
                 'hydro': None,
                 'nuclear': None,
                 'oil': None,
                 'solar': 0.0,
                 'unknown': 27371.0,
                 'wind': None},
  'source': 'occtonet.or.jp, www.tepco.co.jp',
  'zoneKey': 'JP-TK'},
 {'capacity': {'wind': 440},
  'datetime': datetime.datetime(2024, 8, 2, 0, 10, tzinfo=tzfile('/usr/share/zoneinfo/Asia/Tokyo')),
  'production': {'biomass': None,
                 'coal': None,
                 'gas': None,
                 'geothermal': None,
                 'hydro': None,
                 'nuclear': None,
                 'oil': None,
                 'solar': 0.0,
                 'unknown': 27046.0,
                 'wind': None},
  'source': 'occtonet.or.jp, www.tepco.co.jp',
  'zoneKey': 'JP-TK'},
 {'capacity': {'wind': 440},
  'datetime': datetime.datetime(2024, 8, 2, 0, 15, tzinfo=tzfile('/usr/share/zoneinfo/Asia/Tokyo')),
  'production': {'biomass': None,
                 'coal': None,
                 'gas': None,
                 'geothermal': None,
                 'hydro': None,
                 'nuclear': None,
                 'oil': None,
                 'solar': 0.0,
                 'unknown': 26580.0,
                 'wind': None},
  'source': 'occtonet.or.jp, www.tepco.co.jp',
  'zoneKey': 'JP-TK'},
 {'capacity': {'wind': 440},
  'datetime': datetime.datetime(2024, 8, 2, 0, 20, tzinfo=tzfile('/usr/share/zoneinfo/Asia/Tokyo')),
  'production': {'biomass': None,
                 'coal': None,
                 'gas': None,
                 'geothermal': None,
                 'hydro': None,
                 'nuclear': None,
                 'oil': None,
                 'solar': 0.0,
                 'unknown': 26588.0,
                 'wind': None},
  'source': 'occtonet.or.jp, www.tepco.co.jp',
  'zoneKey': 'JP-TK'},
 {'capacity': {'wind': 440},
  'datetime': datetime.datetime(2024, 8, 2, 0, 25, tzinfo=tzfile('/usr/share/zoneinfo/Asia/Tokyo')),
  'production': {'biomass': None,
                 'coal': None,
                 'gas': None,
                 'geothermal': None,
                 'hydro': None,
                 'nuclear': None,
                 'oil': None,
                 'solar': 0.0,
                 'unknown': 26275.0,
                 'wind': None},
  'source': 'occtonet.or.jp, www.tepco.co.jp',
  'zoneKey': 'JP-TK'},
 {'capacity': {'wind': 440},
  'datetime': datetime.datetime(2024, 8, 2, 0, 30, tzinfo=tzfile('/usr/share/zoneinfo/Asia/Tokyo')),
  'production': {'biomass': None,
                 'coal': None,
                 'gas': None,
                 'geothermal': None,
                 'hydro': None,
                 'nuclear': None,
                 'oil': None,
                 'solar': 0.0,
                 'unknown': 26127.0,
                 'wind': None},
  'source': 'occtonet.or.jp, www.tepco.co.jp',
  'zoneKey': 'JP-TK'},
 {'capacity': {'wind': 440},
  'datetime': datetime.datetime(2024, 8, 2, 0, 35, tzinfo=tzfile('/usr/share/zoneinfo/Asia/Tokyo')),
  'production': {'biomass': None,
                 'coal': None,
                 'gas': None,
                 'geothermal': None,
                 'hydro': None,
                 'nuclear': None,
                 'oil': None,
                 'solar': 0.0,
                 'unknown': 25581.0,
                 'wind': None},
  'source': 'occtonet.or.jp, www.tepco.co.jp',
  'zoneKey': 'JP-TK'},
 {'capacity': {'wind': 440},
  'datetime': datetime.datetime(2024, 8, 2, 0, 40, tzinfo=tzfile('/usr/share/zoneinfo/Asia/Tokyo')),
  'production': {'biomass': None,
                 'coal': None,
                 'gas': None,
                 'geothermal': None,
                 'hydro': None,
                 'nuclear': None,
                 'oil': None,
                 'solar': 0.0,
                 'unknown': 25424.0,
                 'wind': None},
  'source': 'occtonet.or.jp, www.tepco.co.jp',
  'zoneKey': 'JP-TK'},
 {'capacity': {'wind': 440},
  'datetime': datetime.datetime(2024, 8, 2, 0, 45, tzinfo=tzfile('/usr/share/zoneinfo/Asia/Tokyo')),
  'production': {'biomass': None,
                 'coal': None,
                 'gas': None,
                 'geothermal': None,
                 'hydro': None,
                 'nuclear': None,
                 'oil': None,
                 'solar': 0.0,
                 'unknown': 25257.0,
                 'wind': None},
  'source': 'occtonet.or.jp, www.tepco.co.jp',
  'zoneKey': 'JP-TK'},
 {'capacity': {'wind': 440},
  'datetime': datetime.datetime(2024, 8, 2, 0, 50, tzinfo=tzfile('/usr/share/zoneinfo/Asia/Tokyo')),
  'production': {'biomass': None,
                 'coal': None,
                 'gas': None,
                 'geothermal': None,
                 'hydro': None,
                 'nuclear': None,
                 'oil': None,
                 'solar': 0.0,
                 'unknown': 24921.0,
                 'wind': None},
  'source': 'occtonet.or.jp, www.tepco.co.jp',
  'zoneKey': 'JP-TK'},
 {'capacity': {'wind': 440},
  'datetime': datetime.datetime(2024, 8, 2, 0, 55, tzinfo=tzfile('/usr/share/zoneinfo/Asia/Tokyo')),
  'production': {'biomass': None,
                 'coal': None,
                 'gas': None,
                 'geothermal': None,
                 'hydro': None,
                 'nuclear': None,
                 'oil': None,
                 'solar': 0.0,
                 'unknown': 25092.0,
                 'wind': None},
  'source': 'occtonet.or.jp, www.tepco.co.jp',
  'zoneKey': 'JP-TK'},
 {'capacity': {'wind': 440},
  'datetime': datetime.datetime(2024, 8, 2, 1, 0, tzinfo=tzfile('/usr/share/zoneinfo/Asia/Tokyo')),
  'production': {'biomass': None,
                 'coal': None,
                 'gas': None,
                 'geothermal': None,
                 'hydro': None,
                 'nuclear': None,
                 'oil': None,
                 'solar': 0.0,
                 'unknown': 24995.0,
                 'wind': None},
  'source': 'occtonet.or.jp, www.tepco.co.jp',
  'zoneKey': 'JP-TK'},
 {'capacity': {'wind': 440},
  'datetime': datetime.datetime(2024, 8, 2, 1, 5, tzinfo=tzfile('/usr/share/zoneinfo/Asia/Tokyo')),
  'production': {'biomass': None,
                 'coal': None,
                 'gas': None,
                 'geothermal': None,
                 'hydro': None,
                 'nuclear': None,
                 'oil': None,
                 'solar': 0.0,
                 'unknown': 25124.0,
                 'wind': None},
  'source': 'occtonet.or.jp, www.tepco.co.jp',
  'zoneKey': 'JP-TK'},
 {'capacity': {'wind': 440},
  'datetime': datetime.datetime(2024, 8, 2, 1, 10, tzinfo=tzfile('/usr/share/zoneinfo/Asia/Tokyo')),
  'production': {'biomass': None,
                 'coal': None,
                 'gas': None,
                 'geothermal': None,
                 'hydro': None,
                 'nuclear': None,
                 'oil': None,
                 'solar': 0.0,
                 'unknown': 24774.0,
                 'wind': None},
  'source': 'occtonet.or.jp, www.tepco.co.jp',
  'zoneKey': 'JP-TK'},
 {'capacity': {'wind': 440},
  'datetime': datetime.datetime(2024, 8, 2, 1, 15, tzinfo=tzfile('/usr/share/zoneinfo/Asia/Tokyo')),
  'production': {'biomass': None,
                 'coal': None,
                 'gas': None,
                 'geothermal': None,
                 'hydro': None,
                 'nuclear': None,
                 'oil': None,
                 'solar': 0.0,
                 'unknown': 24634.0,
                 'wind': None},
  'source': 'occtonet.or.jp, www.tepco.co.jp',
  'zoneKey': 'JP-TK'},
 {'capacity': {'wind': 440},
  'datetime': datetime.datetime(2024, 8, 2, 1, 20, tzinfo=tzfile('/usr/share/zoneinfo/Asia/Tokyo')),
  'production': {'biomass': None,
                 'coal': None,
                 'gas': None,
                 'geothermal': None,
                 'hydro': None,
                 'nuclear': None,
                 'oil': None,
                 'solar': 0.0,
                 'unknown': 24339.0,
                 'wind': None},
  'source': 'occtonet.or.jp, www.tepco.co.jp',
  'zoneKey': 'JP-TK'},
 {'capacity': {'wind': 440},
  'datetime': datetime.datetime(2024, 8, 2, 1, 25, tzinfo=tzfile('/usr/share/zoneinfo/Asia/Tokyo')),
  'production': {'biomass': None,
                 'coal': None,
                 'gas': None,
                 'geothermal': None,
                 'hydro': None,
                 'nuclear': None,
                 'oil': None,
                 'solar': 0.0,
                 'unknown': 24221.0,
                 'wind': None},
  'source': 'occtonet.or.jp, www.tepco.co.jp',
  'zoneKey': 'JP-TK'},
 {'capacity': {'wind': 440},
  'datetime': datetime.datetime(2024, 8, 2, 1, 30, tzinfo=tzfile('/usr/share/zoneinfo/Asia/Tokyo')),
  'production': {'biomass': None,
                 'coal': None,
                 'gas': None,
                 'geothermal': None,
                 'hydro': None,
                 'nuclear': None,
                 'oil': None,
                 'solar': 0.0,
                 'unknown': 24236.0,
                 'wind': None},
  'source': 'occtonet.or.jp, www.tepco.co.jp',
  'zoneKey': 'JP-TK'},
 {'capacity': {'wind': 440},
  'datetime': datetime.datetime(2024, 8, 2, 1, 35, tzinfo=tzfile('/usr/share/zoneinfo/Asia/Tokyo')),
  'production': {'biomass': None,
                 'coal': None,
                 'gas': None,
                 'geothermal': None,
                 'hydro': None,
                 'nuclear': None,
                 'oil': None,
                 'solar': 0.0,
                 'unknown': 24229.0,
                 'wind': None},
  'source': 'occtonet.or.jp, www.tepco.co.jp',
  'zoneKey': 'JP-TK'},
 {'capacity': {'wind': 440},
  'datetime': datetime.datetime(2024, 8, 2, 1, 40, tzinfo=tzfile('/usr/share/zoneinfo/Asia/Tokyo')),
  'production': {'biomass': None,
                 'coal': None,
                 'gas': None,
                 'geothermal': None,
                 'hydro': None,
                 'nuclear': None,
                 'oil': None,
                 'solar': 0.0,
                 'unknown': 23917.0,
                 'wind': None},
  'source': 'occtonet.or.jp, www.tepco.co.jp',
  'zoneKey': 'JP-TK'},
 {'capacity': {'wind': 440},
  'datetime': datetime.datetime(2024, 8, 2, 1, 45, tzinfo=tzfile('/usr/share/zoneinfo/Asia/Tokyo')),
  'production': {'biomass': None,
                 'coal': None,
                 'gas': None,
                 'geothermal': None,
                 'hydro': None,
                 'nuclear': None,
                 'oil': None,
                 'solar': 0.0,
                 'unknown': 23781.0,
                 'wind': None},
  'source': 'occtonet.or.jp, www.tepco.co.jp',
  'zoneKey': 'JP-TK'},
 {'capacity': {'wind': 440},
  'datetime': datetime.datetime(2024, 8, 2, 1, 50, tzinfo=tzfile('/usr/share/zoneinfo/Asia/Tokyo')),
  'production': {'biomass': None,
                 'coal': None,
                 'gas': None,
                 'geothermal': None,
                 'hydro': None,
                 'nuclear': None,
                 'oil': None,
                 'solar': 0.0,
                 'unknown': 23667.0,
                 'wind': None},
  'source': 'occtonet.or.jp, www.tepco.co.jp',
  'zoneKey': 'JP-TK'},
 {'capacity': {'wind': 440},
  'datetime': datetime.datetime(2024, 8, 2, 1, 55, tzinfo=tzfile('/usr/share/zoneinfo/Asia/Tokyo')),
  'production': {'biomass': None,
                 'coal': None,
                 'gas': None,
                 'geothermal': None,
                 'hydro': None,
                 'nuclear': None,
                 'oil': None,
                 'solar': 0.0,
                 'unknown': 23470.0,
                 'wind': None},
  'source': 'occtonet.or.jp, www.tepco.co.jp',
  'zoneKey': 'JP-TK'},
 {'capacity': {'wind': 440},
  'datetime': datetime.datetime(2024, 8, 2, 2, 0, tzinfo=tzfile('/usr/share/zoneinfo/Asia/Tokyo')),
  'production': {'biomass': None,
                 'coal': None,
                 'gas': None,
                 'geothermal': None,
                 'hydro': None,
                 'nuclear': None,
                 'oil': None,
                 'solar': 0.0,
                 'unknown': 23553.0,
                 'wind': None},
  'source': 'occtonet.or.jp, www.tepco.co.jp',
  'zoneKey': 'JP-TK'},
 {'capacity': {'wind': 440},
  'datetime': datetime.datetime(2024, 8, 2, 2, 5, tzinfo=tzfile('/usr/share/zoneinfo/Asia/Tokyo')),
  'production': {'biomass': None,
                 'coal': None,
                 'gas': None,
                 'geothermal': None,
                 'hydro': None,
                 'nuclear': None,
                 'oil': None,
                 'solar': 0.0,
                 'unknown': 23114.0,
                 'wind': None},
  'source': 'occtonet.or.jp, www.tepco.co.jp',
  'zoneKey': 'JP-TK'},
 {'capacity': {'wind': 440},
  'datetime': datetime.datetime(2024, 8, 2, 2, 10, tzinfo=tzfile('/usr/share/zoneinfo/Asia/Tokyo')),
  'production': {'biomass': None,
                 'coal': None,
                 'gas': None,
                 'geothermal': None,
                 'hydro': None,
                 'nuclear': None,
                 'oil': None,
                 'solar': 0.0,
                 'unknown': 23181.0,
                 'wind': None},
  'source': 'occtonet.or.jp, www.tepco.co.jp',
  'zoneKey': 'JP-TK'},
 {'capacity': {'wind': 440},
  'datetime': datetime.datetime(2024, 8, 2, 2, 15, tzinfo=tzfile('/usr/share/zoneinfo/Asia/Tokyo')),
  'production': {'biomass': None,
                 'coal': None,
                 'gas': None,
                 'geothermal': None,
                 'hydro': None,
                 'nuclear': None,
                 'oil': None,
                 'solar': 0.0,
                 'unknown': 23063.0,
                 'wind': None},
  'source': 'occtonet.or.jp, www.tepco.co.jp',
  'zoneKey': 'JP-TK'},
 {'capacity': {'wind': 440},
  'datetime': datetime.datetime(2024, 8, 2, 2, 20, tzinfo=tzfile('/usr/share/zoneinfo/Asia/Tokyo')),
  'production': {'biomass': None,
                 'coal': None,
                 'gas': None,
                 'geothermal': None,
                 'hydro': None,
                 'nuclear': None,
                 'oil': None,
                 'solar': 0.0,
                 'unknown': 22718.0,
                 'wind': None},
  'source': 'occtonet.or.jp, www.tepco.co.jp',
  'zoneKey': 'JP-TK'},
 {'capacity': {'wind': 440},
  'datetime': datetime.datetime(2024, 8, 2, 2, 25, tzinfo=tzfile('/usr/share/zoneinfo/Asia/Tokyo')),
  'production': {'biomass': None,
                 'coal': None,
                 'gas': None,
                 'geothermal': None,
                 'hydro': None,
                 'nuclear': None,
                 'oil': None,
                 'solar': 0.0,
                 'unknown': 23025.0,
                 'wind': None},
  'source': 'occtonet.or.jp, www.tepco.co.jp',
  'zoneKey': 'JP-TK'},
 {'capacity': {'wind': 440},
  'datetime': datetime.datetime(2024, 8, 2, 2, 30, tzinfo=tzfile('/usr/share/zoneinfo/Asia/Tokyo')),
  'production': {'biomass': None,
                 'coal': None,
                 'gas': None,
                 'geothermal': None,
                 'hydro': None,
                 'nuclear': None,
                 'oil': None,
                 'solar': 0.0,
                 'unknown': 22885.0,
                 'wind': None},
  'source': 'occtonet.or.jp, www.tepco.co.jp',
  'zoneKey': 'JP-TK'},
 {'capacity': {'wind': 440},
  'datetime': datetime.datetime(2024, 8, 2, 2, 35, tzinfo=tzfile('/usr/share/zoneinfo/Asia/Tokyo')),
  'production': {'biomass': None,
                 'coal': None,
                 'gas': None,
                 'geothermal': None,
                 'hydro': None,
                 'nuclear': None,
                 'oil': None,
                 'solar': 0.0,
                 'unknown': 23262.0,
                 'wind': None},
  'source': 'occtonet.or.jp, www.tepco.co.jp',
  'zoneKey': 'JP-TK'},
 {'capacity': {'wind': 440},
  'datetime': datetime.datetime(2024, 8, 2, 2, 40, tzinfo=tzfile('/usr/share/zoneinfo/Asia/Tokyo')),
  'production': {'biomass': None,
                 'coal': None,
                 'gas': None,
                 'geothermal': None,
                 'hydro': None,
                 'nuclear': None,
                 'oil': None,
                 'solar': 0.0,
                 'unknown': 23273.0,
                 'wind': None},
  'source': 'occtonet.or.jp, www.tepco.co.jp',
  'zoneKey': 'JP-TK'},
 {'capacity': {'wind': 440},
  'datetime': datetime.datetime(2024, 8, 2, 2, 45, tzinfo=tzfile('/usr/share/zoneinfo/Asia/Tokyo')),
  'production': {'biomass': None,
                 'coal': None,
                 'gas': None,
                 'geothermal': None,
                 'hydro': None,
                 'nuclear': None,
                 'oil': None,
                 'solar': 0.0,
                 'unknown': 23265.0,
                 'wind': None},
  'source': 'occtonet.or.jp, www.tepco.co.jp',
  'zoneKey': 'JP-TK'},
 {'capacity': {'wind': 440},
  'datetime': datetime.datetime(2024, 8, 2, 2, 50, tzinfo=tzfile('/usr/share/zoneinfo/Asia/Tokyo')),
  'production': {'biomass': None,
                 'coal': None,
                 'gas': None,
                 'geothermal': None,
                 'hydro': None,
                 'nuclear': None,
                 'oil': None,
                 'solar': 0.0,
                 'unknown': 23132.0,
                 'wind': None},
  'source': 'occtonet.or.jp, www.tepco.co.jp',
  'zoneKey': 'JP-TK'},
 {'capacity': {'wind': 440},
  'datetime': datetime.datetime(2024, 8, 2, 2, 55, tzinfo=tzfile('/usr/share/zoneinfo/Asia/Tokyo')),
  'production': {'biomass': None,
                 'coal': None,
                 'gas': None,
                 'geothermal': None,
                 'hydro': None,
                 'nuclear': None,
                 'oil': None,
                 'solar': 0.0,
                 'unknown': 23160.0,
                 'wind': None},
  'source': 'occtonet.or.jp, www.tepco.co.jp',
  'zoneKey': 'JP-TK'},
 {'capacity': {'wind': 440},
  'datetime': datetime.datetime(2024, 8, 2, 3, 0, tzinfo=tzfile('/usr/share/zoneinfo/Asia/Tokyo')),
  'production': {'biomass': None,
                 'coal': None,
                 'gas': None,
                 'geothermal': None,
                 'hydro': None,
                 'nuclear': None,
                 'oil': None,
                 'solar': 0.0,
                 'unknown': 23312.0,
                 'wind': None},
  'source': 'occtonet.or.jp, www.tepco.co.jp',
  'zoneKey': 'JP-TK'},
 {'capacity': {'wind': 440},
  'datetime': datetime.datetime(2024, 8, 2, 3, 5, tzinfo=tzfile('/usr/share/zoneinfo/Asia/Tokyo')),
  'production': {'biomass': None,
                 'coal': None,
                 'gas': None,
                 'geothermal': None,
                 'hydro': None,
                 'nuclear': None,
                 'oil': None,
                 'solar': 0.0,
                 'unknown': 23403.0,
                 'wind': None},
  'source': 'occtonet.or.jp, www.tepco.co.jp',
  'zoneKey': 'JP-TK'},
 {'capacity': {'wind': 440},
  'datetime': datetime.datetime(2024, 8, 2, 3, 10, tzinfo=tzfile('/usr/share/zoneinfo/Asia/Tokyo')),
  'production': {'biomass': None,
                 'coal': None,
                 'gas': None,
                 'geothermal': None,
                 'hydro': None,
                 'nuclear': None,
                 'oil': None,
                 'solar': 0.0,
                 'unknown': 23442.0,
                 'wind': None},
  'source': 'occtonet.or.jp, www.tepco.co.jp',
  'zoneKey': 'JP-TK'},
 {'capacity': {'wind': 440},
  'datetime': datetime.datetime(2024, 8, 2, 3, 15, tzinfo=tzfile('/usr/share/zoneinfo/Asia/Tokyo')),
  'production': {'biomass': None,
                 'coal': None,
                 'gas': None,
                 'geothermal': None,
                 'hydro': None,
                 'nuclear': None,
                 'oil': None,
                 'solar': 0.0,
                 'unknown': 23446.0,
                 'wind': None},
  'source': 'occtonet.or.jp, www.tepco.co.jp',
  'zoneKey': 'JP-TK'},
 {'capacity': {'wind': 440},
  'datetime': datetime.datetime(2024, 8, 2, 3, 20, tzinfo=tzfile('/usr/share/zoneinfo/Asia/Tokyo')),
  'production': {'biomass': None,
                 'coal': None,
                 'gas': None,
                 'geothermal': None,
                 'hydro': None,
                 'nuclear': None,
                 'oil': None,
                 'solar': 0.0,
                 'unknown': 23373.0,
                 'wind': None},
  'source': 'occtonet.or.jp, www.tepco.co.jp',
  'zoneKey': 'JP-TK'},
 {'capacity': {'wind': 440},
  'datetime': datetime.datetime(2024, 8, 2, 3, 25, tzinfo=tzfile('/usr/share/zoneinfo/Asia/Tokyo')),
  'production': {'biomass': None,
                 'coal': None,
                 'gas': None,
                 'geothermal': None,
                 'hydro': None,
                 'nuclear': None,
                 'oil': None,
                 'solar': 0.0,
                 'unknown': 23040.0,
                 'wind': None},
  'source': 'occtonet.or.jp, www.tepco.co.jp',
  'zoneKey': 'JP-TK'},
 {'capacity': {'wind': 440},
  'datetime': datetime.datetime(2024, 8, 2, 3, 30, tzinfo=tzfile('/usr/share/zoneinfo/Asia/Tokyo')),
  'production': {'biomass': None,
                 'coal': None,
                 'gas': None,
                 'geothermal': None,
                 'hydro': None,
                 'nuclear': None,
                 'oil': None,
                 'solar': 0.0,
                 'unknown': 23140.0,
                 'wind': None},
  'source': 'occtonet.or.jp, www.tepco.co.jp',
  'zoneKey': 'JP-TK'},
 {'capacity': {'wind': 440},
  'datetime': datetime.datetime(2024, 8, 2, 3, 35, tzinfo=tzfile('/usr/share/zoneinfo/Asia/Tokyo')),
  'production': {'biomass': None,
                 'coal': None,
                 'gas': None,
                 'geothermal': None,
                 'hydro': None,
                 'nuclear': None,
                 'oil': None,
                 'solar': 0.0,
                 'unknown': 23031.0,
                 'wind': None},
  'source': 'occtonet.or.jp, www.tepco.co.jp',
  'zoneKey': 'JP-TK'},
 {'capacity': {'wind': 440},
  'datetime': datetime.datetime(2024, 8, 2, 3, 40, tzinfo=tzfile('/usr/share/zoneinfo/Asia/Tokyo')),
  'production': {'biomass': None,
                 'coal': None,
                 'gas': None,
                 'geothermal': None,
                 'hydro': None,
                 'nuclear': None,
                 'oil': None,
                 'solar': 0.0,
                 'unknown': 22968.0,
                 'wind': None},
  'source': 'occtonet.or.jp, www.tepco.co.jp',
  'zoneKey': 'JP-TK'},
 {'capacity': {'wind': 440},
  'datetime': datetime.datetime(2024, 8, 2, 3, 45, tzinfo=tzfile('/usr/share/zoneinfo/Asia/Tokyo')),
  'production': {'biomass': None,
                 'coal': None,
                 'gas': None,
                 'geothermal': None,
                 'hydro': None,
                 'nuclear': None,
                 'oil': None,
                 'solar': 0.0,
                 'unknown': 22987.0,
                 'wind': None},
  'source': 'occtonet.or.jp, www.tepco.co.jp',
  'zoneKey': 'JP-TK'},
 {'capacity': {'wind': 440},
  'datetime': datetime.datetime(2024, 8, 2, 3, 50, tzinfo=tzfile('/usr/share/zoneinfo/Asia/Tokyo')),
  'production': {'biomass': None,
                 'coal': None,
                 'gas': None,
                 'geothermal': None,
                 'hydro': None,
                 'nuclear': None,
                 'oil': None,
                 'solar': 0.0,
                 'unknown': 22890.0,
                 'wind': None},
  'source': 'occtonet.or.jp, www.tepco.co.jp',
  'zoneKey': 'JP-TK'},
 {'capacity': {'wind': 440},
  'datetime': datetime.datetime(2024, 8, 2, 3, 55, tzinfo=tzfile('/usr/share/zoneinfo/Asia/Tokyo')),
  'production': {'biomass': None,
                 'coal': None,
                 'gas': None,
                 'geothermal': None,
                 'hydro': None,
                 'nuclear': None,
                 'oil': None,
                 'solar': 0.0,
                 'unknown': 22873.0,
                 'wind': None},
  'source': 'occtonet.or.jp, www.tepco.co.jp',
  'zoneKey': 'JP-TK'},
 {'capacity': {'wind': 440},
  'datetime': datetime.datetime(2024, 8, 2, 4, 0, tzinfo=tzfile('/usr/share/zoneinfo/Asia/Tokyo')),
  'production': {'biomass': None,
                 'coal': None,
                 'gas': None,
                 'geothermal': None,
                 'hydro': None,
                 'nuclear': None,
                 'oil': None,
                 'solar': 0.0,
                 'unknown': 22822.0,
                 'wind': None},
  'source': 'occtonet.or.jp, www.tepco.co.jp',
  'zoneKey': 'JP-TK'},
 {'capacity': {'wind': 440},
  'datetime': datetime.datetime(2024, 8, 2, 4, 5, tzinfo=tzfile('/usr/share/zoneinfo/Asia/Tokyo')),
  'production': {'biomass': None,
                 'coal': None,
                 'gas': None,
                 'geothermal': None,
                 'hydro': None,
                 'nuclear': None,
                 'oil': None,
                 'solar': 0.0,
                 'unknown': 23053.0,
                 'wind': None},
  'source': 'occtonet.or.jp, www.tepco.co.jp',
  'zoneKey': 'JP-TK'},
 {'capacity': {'wind': 440},
  'datetime': datetime.datetime(2024, 8, 2, 4, 10, tzinfo=tzfile('/usr/share/zoneinfo/Asia/Tokyo')),
  'production': {'biomass': None,
                 'coal': None,
                 'gas': None,
                 'geothermal': None,
                 'hydro': None,
                 'nuclear': None,
                 'oil': None,
                 'solar': 0.0,
                 'unknown': 23085.0,
                 'wind': None},
  'source': 'occtonet.or.jp, www.tepco.co.jp',
  'zoneKey': 'JP-TK'},
 {'capacity': {'wind': 440},
  'datetime': datetime.datetime(2024, 8, 2, 4, 15, tzinfo=tzfile('/usr/share/zoneinfo/Asia/Tokyo')),
  'production': {'biomass': None,
                 'coal': None,
                 'gas': None,
                 'geothermal': None,
                 'hydro': None,
                 'nuclear': None,
                 'oil': None,
                 'solar': 0.0,
                 'unknown': 23083.0,
                 'wind': None},
  'source': 'occtonet.or.jp, www.tepco.co.jp',
  'zoneKey': 'JP-TK'},
 {'capacity': {'wind': 440},
  'datetime': datetime.datetime(2024, 8, 2, 4, 20, tzinfo=tzfile('/usr/share/zoneinfo/Asia/Tokyo')),
  'production': {'biomass': None,
                 'coal': None,
                 'gas': None,
                 'geothermal': None,
                 'hydro': None,
                 'nuclear': None,
                 'oil': None,
                 'solar': 0.0,
                 'unknown': 22856.0,
                 'wind': None},
  'source': 'occtonet.or.jp, www.tepco.co.jp',
  'zoneKey': 'JP-TK'},
 {'capacity': {'wind': 440},
  'datetime': datetime.datetime(2024, 8, 2, 4, 25, tzinfo=tzfile('/usr/share/zoneinfo/Asia/Tokyo')),
  'production': {'biomass': None,
                 'coal': None,
                 'gas': None,
                 'geothermal': None,
                 'hydro': None,
                 'nuclear': None,
                 'oil': None,
                 'solar': 0.0,
                 'unknown': 22865.0,
                 'wind': None},
  'source': 'occtonet.or.jp, www.tepco.co.jp',
  'zoneKey': 'JP-TK'},
 {'capacity': {'wind': 440},
  'datetime': datetime.datetime(2024, 8, 2, 4, 30, tzinfo=tzfile('/usr/share/zoneinfo/Asia/Tokyo')),
  'production': {'biomass': None,
                 'coal': None,
                 'gas': None,
                 'geothermal': None,
                 'hydro': None,
                 'nuclear': None,
                 'oil': None,
                 'solar': 0.0,
                 'unknown': 22992.0,
                 'wind': None},
  'source': 'occtonet.or.jp, www.tepco.co.jp',
  'zoneKey': 'JP-TK'},
 {'capacity': {'wind': 440},
  'datetime': datetime.datetime(2024, 8, 2, 4, 35, tzinfo=tzfile('/usr/share/zoneinfo/Asia/Tokyo')),
  'production': {'biomass': None,
                 'coal': None,
                 'gas': None,
                 'geothermal': None,
                 'hydro': None,
                 'nuclear': None,
                 'oil': None,
                 'solar': 0.0,
                 'unknown': 22712.0,
                 'wind': None},
  'source': 'occtonet.or.jp, www.tepco.co.jp',
  'zoneKey': 'JP-TK'},
 {'capacity': {'wind': 440},
  'datetime': datetime.datetime(2024, 8, 2, 4, 40, tzinfo=tzfile('/usr/share/zoneinfo/Asia/Tokyo')),
  'production': {'biomass': None,
                 'coal': None,
                 'gas': None,
                 'geothermal': None,
                 'hydro': None,
                 'nuclear': None,
                 'oil': None,
                 'solar': 0.0,
                 'unknown': 22839.0,
                 'wind': None},
  'source': 'occtonet.or.jp, www.tepco.co.jp',
  'zoneKey': 'JP-TK'},
 {'capacity': {'wind': 440},
  'datetime': datetime.datetime(2024, 8, 2, 4, 45, tzinfo=tzfile('/usr/share/zoneinfo/Asia/Tokyo')),
  'production': {'biomass': None,
                 'coal': None,
                 'gas': None,
                 'geothermal': None,
                 'hydro': None,
                 'nuclear': None,
                 'oil': None,
                 'solar': 0.0,
                 'unknown': 22936.0,
                 'wind': None},
  'source': 'occtonet.or.jp, www.tepco.co.jp',
  'zoneKey': 'JP-TK'},
 {'capacity': {'wind': 440},
  'datetime': datetime.datetime(2024, 8, 2, 4, 50, tzinfo=tzfile('/usr/share/zoneinfo/Asia/Tokyo')),
  'production': {'biomass': None,
                 'coal': None,
                 'gas': None,
                 'geothermal': None,
                 'hydro': None,
                 'nuclear': None,
                 'oil': None,
                 'solar': 0.0,
                 'unknown': 22697.0,
                 'wind': None},
  'source': 'occtonet.or.jp, www.tepco.co.jp',
  'zoneKey': 'JP-TK'},
 {'capacity': {'wind': 440},
  'datetime': datetime.datetime(2024, 8, 2, 4, 55, tzinfo=tzfile('/usr/share/zoneinfo/Asia/Tokyo')),
  'production': {'biomass': None,
                 'coal': None,
                 'gas': None,
                 'geothermal': None,
                 'hydro': None,
                 'nuclear': None,
                 'oil': None,
                 'solar': 0.0,
                 'unknown': 22753.0,
                 'wind': None},
  'source': 'occtonet.or.jp, www.tepco.co.jp',
  'zoneKey': 'JP-TK'},
 {'capacity': {'wind': 440},
  'datetime': datetime.datetime(2024, 8, 2, 5, 0, tzinfo=tzfile('/usr/share/zoneinfo/Asia/Tokyo')),
  'production': {'biomass': None,
                 'coal': None,
                 'gas': None,
                 'geothermal': None,
                 'hydro': None,
                 'nuclear': None,
                 'oil': None,
                 'solar': 0.0,
                 'unknown': 22828.0,
                 'wind': None},
  'source': 'occtonet.or.jp, www.tepco.co.jp',
  'zoneKey': 'JP-TK'},
 {'capacity': {'wind': 440},
  'datetime': datetime.datetime(2024, 8, 2, 5, 5, tzinfo=tzfile('/usr/share/zoneinfo/Asia/Tokyo')),
  'production': {'biomass': None,
                 'coal': None,
                 'gas': None,
                 'geothermal': None,
                 'hydro': None,
                 'nuclear': None,
                 'oil': None,
                 'solar': 0.0,
                 'unknown': 23248.0,
                 'wind': None},
  'source': 'occtonet.or.jp, www.tepco.co.jp',
  'zoneKey': 'JP-TK'},
 {'capacity': {'wind': 440},
  'datetime': datetime.datetime(2024, 8, 2, 5, 10, tzinfo=tzfile('/usr/share/zoneinfo/Asia/Tokyo')),
  'production': {'biomass': None,
                 'coal': None,
                 'gas': None,
                 'geothermal': None,
                 'hydro': None,
                 'nuclear': None,
                 'oil': None,
                 'solar': 0.0,
                 'unknown': 23518.0,
                 'wind': None},
  'source': 'occtonet.or.jp, www.tepco.co.jp',
  'zoneKey': 'JP-TK'},
 {'capacity': {'wind': 440},
  'datetime': datetime.datetime(2024, 8, 2, 5, 15, tzinfo=tzfile('/usr/share/zoneinfo/Asia/Tokyo')),
  'production': {'biomass': None,
                 'coal': None,
                 'gas': None,
                 'geothermal': None,
                 'hydro': None,
                 'nuclear': None,
                 'oil': None,
                 'solar': 20.0,
                 'unknown': 23593.0,
                 'wind': None},
  'source': 'occtonet.or.jp, www.tepco.co.jp',
  'zoneKey': 'JP-TK'},
 {'capacity': {'wind': 440},
  'datetime': datetime.datetime(2024, 8, 2, 5, 20, tzinfo=tzfile('/usr/share/zoneinfo/Asia/Tokyo')),
  'production': {'biomass': None,
                 'coal': None,
                 'gas': None,
                 'geothermal': None,
                 'hydro': None,
                 'nuclear': None,
                 'oil': None,
                 'solar': 100.0,
                 'unknown': 23474.0,
                 'wind': None},
  'source': 'occtonet.or.jp, www.tepco.co.jp',
  'zoneKey': 'JP-TK'},
 {'capacity': {'wind': 440},
  'datetime': datetime.datetime(2024, 8, 2, 5, 25, tzinfo=tzfile('/usr/share/zoneinfo/Asia/Tokyo')),
  'production': {'biomass': None,
                 'coal': None,
                 'gas': None,
                 'geothermal': None,
                 'hydro': None,
                 'nuclear': None,
                 'oil': None,
                 'solar': 180.0,
                 'unknown': 23457.0,
                 'wind': None},
  'source': 'occtonet.or.jp, www.tepco.co.jp',
  'zoneKey': 'JP-TK'},
 {'capacity': {'wind': 440},
  'datetime': datetime.datetime(2024, 8, 2, 5, 30, tzinfo=tzfile('/usr/share/zoneinfo/Asia/Tokyo')),
  'production': {'biomass': None,
                 'coal': None,
                 'gas': None,
                 'geothermal': None,
                 'hydro': None,
                 'nuclear': None,
                 'oil': None,
                 'solar': 320.0,
                 'unknown': 23171.0,
                 'wind': None},
  'source': 'occtonet.or.jp, www.tepco.co.jp',
  'zoneKey': 'JP-TK'},
 {'capacity': {'wind': 440},
  'datetime': datetime.datetime(2024, 8, 2, 5, 35, tzinfo=tzfile('/usr/share/zoneinfo/Asia/Tokyo')),
  'production': {'biomass': None,
                 'coal': None,
                 'gas': None,
                 'geothermal': None,
                 'hydro': None,
                 'nuclear': None,
                 'oil': None,
                 'solar': 440.0,
                 'unknown': 23009.0,
                 'wind': None},
  'source': 'occtonet.or.jp, www.tepco.co.jp',
  'zoneKey': 'JP-TK'},
 {'capacity': {'wind': 440},
  'datetime': datetime.datetime(2024, 8, 2, 5, 40, tzinfo=tzfile('/usr/share/zoneinfo/Asia/Tokyo')),
  'production': {'biomass': None,
                 'coal': None,
                 'gas': None,
                 'geothermal': None,
                 'hydro': None,
                 'nuclear': None,
                 'oil': None,
                 'solar': 530.0,
                 'unknown': 23395.0,
                 'wind': None},
  'source': 'occtonet.or.jp, www.tepco.co.jp',
  'zoneKey': 'JP-TK'},
 {'capacity': {'wind': 440},
  'datetime': datetime.datetime(2024, 8, 2, 5, 45, tzinfo=tzfile('/usr/share/zoneinfo/Asia/Tokyo')),
  'production': {'biomass': None,
                 'coal': None,
                 'gas': None,
                 'geothermal': None,
                 'hydro': None,
                 'nuclear': None,
                 'oil': None,
                 'solar': 650.0,
                 'unknown': 23261.0,
                 'wind': None},
  'source': 'occtonet.or.jp, www.tepco.co.jp',
  'zoneKey': 'JP-TK'},
 {'capacity': {'wind': 440},
  'datetime': datetime.datetime(2024, 8, 2, 5, 50, tzinfo=tzfile('/usr/share/zoneinfo/Asia/Tokyo')),
  'production': {'biomass': None,
                 'coal': None,
                 'gas': None,
                 'geothermal': None,
                 'hydro': None,
                 'nuclear': None,
                 'oil': None,
                 'solar': 770.0,
                 'unknown': 23293.0,
                 'wind': None},
  'source': 'occtonet.or.jp, www.tepco.co.jp',
  'zoneKey': 'JP-TK'},
 {'capacity': {'wind': 440},
  'datetime': datetime.datetime(2024, 8, 2, 5, 55, tzinfo=tzfile('/usr/share/zoneinfo/Asia/Tokyo')),
  'production': {'biomass': None,
                 'coal': None,
                 'gas': None,
                 'geothermal': None,
                 'hydro': None,
                 'nuclear': None,
                 'oil': None,
                 'solar': 910.0,
                 'unknown': 23155.0,
                 'wind': None},
  'source': 'occtonet.or.jp, www.tepco.co.jp',
  'zoneKey': 'JP-TK'},
 {'capacity': {'wind': 440},
  'datetime': datetime.datetime(2024, 8, 2, 6, 0, tzinfo=tzfile('/usr/share/zoneinfo/Asia/Tokyo')),
  'production': {'biomass': None,
                 'coal': None,
                 'gas': None,
                 'geothermal': None,
                 'hydro': None,
                 'nuclear': None,
                 'oil': None,
                 'solar': 1050.0,
                 'unknown': 23214.0,
                 'wind': None},
  'source': 'occtonet.or.jp, www.tepco.co.jp',
  'zoneKey': 'JP-TK'},
 {'capacity': {'wind': 440},
  'datetime': datetime.datetime(2024, 8, 2, 6, 5, tzinfo=tzfile('/usr/share/zoneinfo/Asia/Tokyo')),
  'production': {'biomass': None,
                 'coal': None,
                 'gas': None,
                 'geothermal': None,
                 'hydro': None,
                 'nuclear': None,
                 'oil': None,
                 'solar': 1210.0,
                 'unknown': 23301.0,
                 'wind': None},
  'source': 'occtonet.or.jp, www.tepco.co.jp',
  'zoneKey': 'JP-TK'},
 {'capacity': {'wind': 440},
  'datetime': datetime.datetime(2024, 8, 2, 6, 10, tzinfo=tzfile('/usr/share/zoneinfo/Asia/Tokyo')),
  'production': {'biomass': None,
                 'coal': None,
                 'gas': None,
                 'geothermal': None,
                 'hydro': None,
                 'nuclear': None,
                 'oil': None,
                 'solar': 1380.0,
                 'unknown': 23152.0,
                 'wind': None},
  'source': 'occtonet.or.jp, www.tepco.co.jp',
  'zoneKey': 'JP-TK'},
 {'capacity': {'wind': 440},
  'datetime': datetime.datetime(2024, 8, 2, 6, 15, tzinfo=tzfile('/usr/share/zoneinfo/Asia/Tokyo')),
  'production': {'biomass': None,
                 'coal': None,
                 'gas': None,
                 'geothermal': None,
                 'hydro': None,
                 'nuclear': None,
                 'oil': None,
                 'solar': 1570.0,
                 'unknown': 23201.0,
                 'wind': None},
  'source': 'occtonet.or.jp, www.tepco.co.jp',
  'zoneKey': 'JP-TK'},
 {'capacity': {'wind': 440},
  'datetime': datetime.datetime(2024, 8, 2, 6, 20, tzinfo=tzfile('/usr/share/zoneinfo/Asia/Tokyo')),
  'production': {'biomass': None,
                 'coal': None,
                 'gas': None,
                 'geothermal': None,
                 'hydro': None,
                 'nuclear': None,
                 'oil': None,
                 'solar': 1770.0,
                 'unknown': 23137.0,
                 'wind': None},
  'source': 'occtonet.or.jp, www.tepco.co.jp',
  'zoneKey': 'JP-TK'},
 {'capacity': {'wind': 440},
  'datetime': datetime.datetime(2024, 8, 2, 6, 25, tzinfo=tzfile('/usr/share/zoneinfo/Asia/Tokyo')),
  'production': {'biomass': None,
                 'coal': None,
                 'gas': None,
                 'geothermal': None,
                 'hydro': None,
                 'nuclear': None,
                 'oil': None,
                 'solar': 2000.0,
                 'unknown': 23148.0,
                 'wind': None},
  'source': 'occtonet.or.jp, www.tepco.co.jp',
  'zoneKey': 'JP-TK'},
 {'capacity': {'wind': 440},
  'datetime': datetime.datetime(2024, 8, 2, 6, 30, tzinfo=tzfile('/usr/share/zoneinfo/Asia/Tokyo')),
  'production': {'biomass': None,
                 'coal': None,
                 'gas': None,
                 'geothermal': None,
                 'hydro': None,
                 'nuclear': None,
                 'oil': None,
                 'solar': 2230.0,
                 'unknown': 23381.0,
                 'wind': None},
  'source': 'occtonet.or.jp, www.tepco.co.jp',
  'zoneKey': 'JP-TK'},
 {'capacity': {'wind': 440},
  'datetime': datetime.datetime(2024, 8, 2, 6, 35, tzinfo=tzfile('/usr/share/zoneinfo/Asia/Tokyo')),
  'production': {'biomass': None,
                 'coal': None,
                 'gas': None,
                 'geothermal': None,
                 'hydro': None,
                 'nuclear': None,
                 'oil': None,
                 'solar': 2460.0,
                 'unknown': 23468.0,
                 'wind': None},
  'source': 'occtonet.or.jp, www.tepco.co.jp',
  'zoneKey': 'JP-TK'},
 {'capacity': {'wind': 440},
  'datetime': datetime.datetime(2024, 8, 2, 6, 40, tzinfo=tzfile('/usr/share/zoneinfo/Asia/Tokyo')),
  'production': {'biomass': None,
                 'coal': None,
                 'gas': None,
                 'geothermal': None,
                 'hydro': None,
                 'nuclear': None,
                 'oil': None,
                 'solar': 2680.0,
                 'unknown': 23495.0,
                 'wind': None},
  'source': 'occtonet.or.jp, www.tepco.co.jp',
  'zoneKey': 'JP-TK'},
 {'capacity': {'wind': 440},
  'datetime': datetime.datetime(2024, 8, 2, 6, 45, tzinfo=tzfile('/usr/share/zoneinfo/Asia/Tokyo')),
  'production': {'biomass': None,
                 'coal': None,
                 'gas': None,
                 'geothermal': None,
                 'hydro': None,
                 'nuclear': None,
                 'oil': None,
                 'solar': 2920.0,
                 'unknown': 23776.0,
                 'wind': None},
  'source': 'occtonet.or.jp, www.tepco.co.jp',
  'zoneKey': 'JP-TK'},
 {'capacity': {'wind': 440},
  'datetime': datetime.datetime(2024, 8, 2, 6, 50, tzinfo=tzfile('/usr/share/zoneinfo/Asia/Tokyo')),
  'production': {'biomass': None,
                 'coal': None,
                 'gas': None,
                 'geothermal': None,
                 'hydro': None,
                 'nuclear': None,
                 'oil': None,
                 'solar': 3150.0,
                 'unknown': 23854.0,
                 'wind': None},
  'source': 'occtonet.or.jp, www.tepco.co.jp',
  'zoneKey': 'JP-TK'},
 {'capacity': {'wind': 440},
  'datetime': datetime.datetime(2024, 8, 2, 6, 55, tzinfo=tzfile('/usr/share/zoneinfo/Asia/Tokyo')),
  'production': {'biomass': None,
                 'coal': None,
                 'gas': None,
                 'geothermal': None,
                 'hydro': None,
                 'nuclear': None,
                 'oil': None,
                 'solar': 3410.0,
                 'unknown': 23941.0,
                 'wind': None},
  'source': 'occtonet.or.jp, www.tepco.co.jp',
  'zoneKey': 'JP-TK'},
 {'capacity': {'wind': 440},
  'datetime': datetime.datetime(2024, 8, 2, 7, 0, tzinfo=tzfile('/usr/share/zoneinfo/Asia/Tokyo')),
  'production': {'biomass': None,
                 'coal': None,
                 'gas': None,
                 'geothermal': None,
                 'hydro': None,
                 'nuclear': None,
                 'oil': None,
                 'solar': 3660.0,
                 'unknown': 23907.0,
                 'wind': None},
  'source': 'occtonet.or.jp, www.tepco.co.jp',
  'zoneKey': 'JP-TK'},
 {'capacity': {'wind': 440},
  'datetime': datetime.datetime(2024, 8, 2, 7, 5, tzinfo=tzfile('/usr/share/zoneinfo/Asia/Tokyo')),
  'production': {'biomass': None,
                 'coal': None,
                 'gas': None,
                 'geothermal': None,
                 'hydro': None,
                 'nuclear': None,
                 'oil': None,
                 'solar': 3920.0,
                 'unknown': 24649.0,
                 'wind': None},
  'source': 'occtonet.or.jp, www.tepco.co.jp',
  'zoneKey': 'JP-TK'},
 {'capacity': {'wind': 440},
  'datetime': datetime.datetime(2024, 8, 2, 7, 10, tzinfo=tzfile('/usr/share/zoneinfo/Asia/Tokyo')),
  'production': {'biomass': None,
                 'coal': None,
                 'gas': None,
                 'geothermal': None,
                 'hydro': None,
                 'nuclear': None,
                 'oil': None,
                 'solar': 4170.0,
                 'unknown': 24600.0,
                 'wind': None},
  'source': 'occtonet.or.jp, www.tepco.co.jp',
  'zoneKey': 'JP-TK'},
 {'capacity': {'wind': 440},
  'datetime': datetime.datetime(2024, 8, 2, 7, 15, tzinfo=tzfile('/usr/share/zoneinfo/Asia/Tokyo')),
  'production': {'biomass': None,
                 'coal': None,
                 'gas': None,
                 'geothermal': None,
                 'hydro': None,
                 'nuclear': None,
                 'oil': None,
                 'solar': 4430.0,
                 'unknown': 24802.0,
                 'wind': None},
  'source': 'occtonet.or.jp, www.tepco.co.jp',
  'zoneKey': 'JP-TK'},
 {'capacity': {'wind': 440},
  'datetime': datetime.datetime(2024, 8, 2, 7, 20, tzinfo=tzfile('/usr/share/zoneinfo/Asia/Tokyo')),
  'production': {'biomass': None,
                 'coal': None,
                 'gas': None,
                 'geothermal': None,
                 'hydro': None,
                 'nuclear': None,
                 'oil': None,
                 'solar': 4670.0,
                 'unknown': 24849.0,
                 'wind': None},
  'source': 'occtonet.or.jp, www.tepco.co.jp',
  'zoneKey': 'JP-TK'},
 {'capacity': {'wind': 440},
  'datetime': datetime.datetime(2024, 8, 2, 7, 25, tzinfo=tzfile('/usr/share/zoneinfo/Asia/Tokyo')),
  'production': {'biomass': None,
                 'coal': None,
                 'gas': None,
                 'geothermal': None,
                 'hydro': None,
                 'nuclear': None,
                 'oil': None,
                 'solar': 4920.0,
                 'unknown': 25277.0,
                 'wind': None},
  'source': 'occtonet.or.jp, www.tepco.co.jp',
  'zoneKey': 'JP-TK'},
 {'capacity': {'wind': 440},
  'datetime': datetime.datetime(2024, 8, 2, 7, 30, tzinfo=tzfile('/usr/share/zoneinfo/Asia/Tokyo')),
  'production': {'biomass': None,
                 'coal': None,
                 'gas': None,
                 'geothermal': None,
                 'hydro': None,
                 'nuclear': None,
                 'oil': None,
                 'solar': 5170.0,
                 'unknown': 25029.0,
                 'wind': None},
  'source': 'occtonet.or.jp, www.tepco.co.jp',
  'zoneKey': 'JP-TK'},
 {'capacity': {'wind': 440},
  'datetime': datetime.datetime(2024, 8, 2, 7, 35, tzinfo=tzfile('/usr/share/zoneinfo/Asia/Tokyo')),
  'production': {'biomass': None,
                 'coal': None,
                 'gas': None,
                 'geothermal': None,
                 'hydro': None,
                 'nuclear': None,
                 'oil': None,
                 'solar': 5430.0,
                 'unknown': 26289.0,
                 'wind': None},
  'source': 'occtonet.or.jp, www.tepco.co.jp',
  'zoneKey': 'JP-TK'},
 {'capacity': {'wind': 440},
  'datetime': datetime.datetime(2024, 8, 2, 7, 40, tzinfo=tzfile('/usr/share/zoneinfo/Asia/Tokyo')),
  'production': {'biomass': None,
                 'coal': None,
                 'gas': None,
                 'geothermal': None,
                 'hydro': None,
                 'nuclear': None,
                 'oil': None,
                 'solar': 5690.0,
                 'unknown': 26035.0,
                 'wind': None},
  'source': 'occtonet.or.jp, www.tepco.co.jp',
  'zoneKey': 'JP-TK'},
 {'capacity': {'wind': 440},
  'datetime': datetime.datetime(2024, 8, 2, 7, 45, tzinfo=tzfile('/usr/share/zoneinfo/Asia/Tokyo')),
  'production': {'biomass': None,
                 'coal': None,
                 'gas': None,
                 'geothermal': None,
                 'hydro': None,
                 'nuclear': None,
                 'oil': None,
                 'solar': 5950.0,
                 'unknown': 26075.0,
                 'wind': None},
  'source': 'occtonet.or.jp, www.tepco.co.jp',
  'zoneKey': 'JP-TK'},
 {'capacity': {'wind': 440},
  'datetime': datetime.datetime(2024, 8, 2, 7, 50, tzinfo=tzfile('/usr/share/zoneinfo/Asia/Tokyo')),
  'production': {'biomass': None,
                 'coal': None,
                 'gas': None,
                 'geothermal': None,
                 'hydro': None,
                 'nuclear': None,
                 'oil': None,
                 'solar': 6180.0,
                 'unknown': 26515.0,
                 'wind': None},
  'source': 'occtonet.or.jp, www.tepco.co.jp',
  'zoneKey': 'JP-TK'},
 {'capacity': {'wind': 440},
  'datetime': datetime.datetime(2024, 8, 2, 7, 55, tzinfo=tzfile('/usr/share/zoneinfo/Asia/Tokyo')),
  'production': {'biomass': None,
                 'coal': None,
                 'gas': None,
                 'geothermal': None,
                 'hydro': None,
                 'nuclear': None,
                 'oil': None,
                 'solar': 6390.0,
                 'unknown': 26565.0,
                 'wind': None},
  'source': 'occtonet.or.jp, www.tepco.co.jp',
  'zoneKey': 'JP-TK'},
 {'capacity': {'wind': 440},
  'datetime': datetime.datetime(2024, 8, 2, 8, 0, tzinfo=tzfile('/usr/share/zoneinfo/Asia/Tokyo')),
  'production': {'biomass': None,
                 'coal': None,
                 'gas': None,
                 'geothermal': None,
                 'hydro': None,
                 'nuclear': None,
                 'oil': None,
                 'solar': 6610.0,
                 'unknown': 26675.0,
                 'wind': None},
  'source': 'occtonet.or.jp, www.tepco.co.jp',
  'zoneKey': 'JP-TK'},
 {'capacity': {'wind': 440},
  'datetime': datetime.datetime(2024, 8, 2, 8, 5, tzinfo=tzfile('/usr/share/zoneinfo/Asia/Tokyo')),
  'production': {'biomass': None,
                 'coal': None,
                 'gas': None,
                 'geothermal': None,
                 'hydro': None,
                 'nuclear': None,
                 'oil': None,
                 'solar': 6800.0,
                 'unknown': 26884.0,
                 'wind': None},
  'source': 'occtonet.or.jp, www.tepco.co.jp',
  'zoneKey': 'JP-TK'},
 {'capacity': {'wind': 440},
  'datetime': datetime.datetime(2024, 8, 2, 8, 10, tzinfo=tzfile('/usr/share/zoneinfo/Asia/Tokyo')),
  'production': {'biomass': None,
                 'coal': None,
                 'gas': None,
                 'geothermal': None,
                 'hydro': None,
                 'nuclear': None,
                 'oil': None,
                 'solar': 7000.0,
                 'unknown': 27297.0,
                 'wind': None},
  'source': 'occtonet.or.jp, www.tepco.co.jp',
  'zoneKey': 'JP-TK'},
 {'capacity': {'wind': 440},
  'datetime': datetime.datetime(2024, 8, 2, 8, 15, tzinfo=tzfile('/usr/share/zoneinfo/Asia/Tokyo')),
  'production': {'biomass': None,
                 'coal': None,
                 'gas': None,
                 'geothermal': None,
                 'hydro': None,
                 'nuclear': None,
                 'oil': None,
                 'solar': 7190.0,
                 'unknown': 27258.0,
                 'wind': None},
  'source': 'occtonet.or.jp, www.tepco.co.jp',
  'zoneKey': 'JP-TK'},
 {'capacity': {'wind': 440},
  'datetime': datetime.datetime(2024, 8, 2, 8, 20, tzinfo=tzfile('/usr/share/zoneinfo/Asia/Tokyo')),
  'production': {'biomass': None,
                 'coal': None,
                 'gas': None,
                 'geothermal': None,
                 'hydro': None,
                 'nuclear': None,
                 'oil': None,
                 'solar': 7350.0,
                 'unknown': 27247.0,
                 'wind': None},
  'source': 'occtonet.or.jp, www.tepco.co.jp',
  'zoneKey': 'JP-TK'},
 {'capacity': {'wind': 440},
  'datetime': datetime.datetime(2024, 8, 2, 8, 25, tzinfo=tzfile('/usr/share/zoneinfo/Asia/Tokyo')),
  'production': {'biomass': None,
                 'coal': None,
                 'gas': None,
                 'geothermal': None,
                 'hydro': None,
                 'nuclear': None,
                 'oil': None,
                 'solar': 7520.0,
                 'unknown': 27415.0,
                 'wind': None},
  'source': 'occtonet.or.jp, www.tepco.co.jp',
  'zoneKey': 'JP-TK'},
 {'capacity': {'wind': 440},
  'datetime': datetime.datetime(2024, 8, 2, 8, 30, tzinfo=tzfile('/usr/share/zoneinfo/Asia/Tokyo')),
  'production': {'biomass': None,
                 'coal': None,
                 'gas': None,
                 'geothermal': None,
                 'hydro': None,
                 'nuclear': None,
                 'oil': None,
                 'solar': 7720.0,
                 'unknown': 27510.0,
                 'wind': None},
  'source': 'occtonet.or.jp, www.tepco.co.jp',
  'zoneKey': 'JP-TK'},
 {'capacity': {'wind': 440},
  'datetime': datetime.datetime(2024, 8, 2, 8, 35, tzinfo=tzfile('/usr/share/zoneinfo/Asia/Tokyo')),
  'production': {'biomass': None,
                 'coal': None,
                 'gas': None,
                 'geothermal': None,
                 'hydro': None,
                 'nuclear': None,
                 'oil': None,
                 'solar': 7920.0,
                 'unknown': 28889.0,
                 'wind': None},
  'source': 'occtonet.or.jp, www.tepco.co.jp',
  'zoneKey': 'JP-TK'},
 {'capacity': {'wind': 440},
  'datetime': datetime.datetime(2024, 8, 2, 8, 40, tzinfo=tzfile('/usr/share/zoneinfo/Asia/Tokyo')),
  'production': {'biomass': None,
                 'coal': None,
                 'gas': None,
                 'geothermal': None,
                 'hydro': None,
                 'nuclear': None,
                 'oil': None,
                 'solar': 8130.0,
                 'unknown': 29359.0,
                 'wind': None},
  'source': 'occtonet.or.jp, www.tepco.co.jp',
  'zoneKey': 'JP-TK'},
 {'capacity': {'wind': 440},
  'datetime': datetime.datetime(2024, 8, 2, 8, 45, tzinfo=tzfile('/usr/share/zoneinfo/Asia/Tokyo')),
  'production': {'biomass': None,
                 'coal': None,
                 'gas': None,
                 'geothermal': None,
                 'hydro': None,
                 'nuclear': None,
                 'oil': None,
                 'solar': 8390.0,
                 'unknown': 29719.0,
                 'wind': None},
  'source': 'occtonet.or.jp, www.tepco.co.jp',
  'zoneKey': 'JP-TK'},
 {'capacity': {'wind': 440},
  'datetime': datetime.datetime(2024, 8, 2, 8, 50, tzinfo=tzfile('/usr/share/zoneinfo/Asia/Tokyo')),
  'production': {'biomass': None,
                 'coal': None,
                 'gas': None,
                 'geothermal': None,
                 'hydro': None,
                 'nuclear': None,
                 'oil': None,
                 'solar': 8630.0,
                 'unknown': 29999.0,
                 'wind': None},
  'source': 'occtonet.or.jp, www.tepco.co.jp',
  'zoneKey': 'JP-TK'},
 {'capacity': {'wind': 440},
  'datetime': datetime.datetime(2024, 8, 2, 8, 55, tzinfo=tzfile('/usr/share/zoneinfo/Asia/Tokyo')),
  'production': {'biomass': None,
                 'coal': None,
                 'gas': None,
                 'geothermal': None,
                 'hydro': None,
                 'nuclear': None,
                 'oil': None,
                 'solar': 8850.0,
                 'unknown': 30074.0,
                 'wind': None},
  'source': 'occtonet.or.jp, www.tepco.co.jp',
  'zoneKey': 'JP-TK'},
 {'capacity': {'wind': 440},
  'datetime': datetime.datetime(2024, 8, 2, 9, 0, tzinfo=tzfile('/usr/share/zoneinfo/Asia/Tokyo')),
  'production': {'biomass': None,
                 'coal': None,
                 'gas': None,
                 'geothermal': None,
                 'hydro': None,
                 'nuclear': None,
                 'oil': None,
                 'solar': 9050.0,
                 'unknown': 30414.0,
                 'wind': None},
  'source': 'occtonet.or.jp, www.tepco.co.jp',
  'zoneKey': 'JP-TK'},
 {'capacity': {'wind': 440},
  'datetime': datetime.datetime(2024, 8, 2, 9, 5, tzinfo=tzfile('/usr/share/zoneinfo/Asia/Tokyo')),
  'production': {'biomass': None,
                 'coal': None,
                 'gas': None,
                 'geothermal': None,
                 'hydro': None,
                 'nuclear': None,
                 'oil': None,
                 'solar': 9240.0,
                 'unknown': 31007.0,
                 'wind': None},
  'source': 'occtonet.or.jp, www.tepco.co.jp',
  'zoneKey': 'JP-TK'},
 {'capacity': {'wind': 440},
  'datetime': datetime.datetime(2024, 8, 2, 9, 10, tzinfo=tzfile('/usr/share/zoneinfo/Asia/Tokyo')),
  'production': {'biomass': None,
                 'coal': None,
                 'gas': None,
                 'geothermal': None,
                 'hydro': None,
                 'nuclear': None,
                 'oil': None,
                 'solar': 9430.0,
                 'unknown': 31339.0,
                 'wind': None},
  'source': 'occtonet.or.jp, www.tepco.co.jp',
  'zoneKey': 'JP-TK'},
 {'capacity': {'wind': 440},
  'datetime': datetime.datetime(2024, 8, 2, 9, 15, tzinfo=tzfile('/usr/share/zoneinfo/Asia/Tokyo')),
  'production': {'biomass': None,
                 'coal': None,
                 'gas': None,
                 'geothermal': None,
                 'hydro': None,
                 'nuclear': None,
                 'oil': None,
                 'solar': 9600.0,
                 'unknown': 31144.0,
                 'wind': None},
  'source': 'occtonet.or.jp, www.tepco.co.jp',
  'zoneKey': 'JP-TK'},
 {'capacity': {'wind': 440},
  'datetime': datetime.datetime(2024, 8, 2, 9, 20, tzinfo=tzfile('/usr/share/zoneinfo/Asia/Tokyo')),
  'production': {'biomass': None,
                 'coal': None,
                 'gas': None,
                 'geothermal': None,
                 'hydro': None,
                 'nuclear': None,
                 'oil': None,
                 'solar': 9800.0,
                 'unknown': 31377.0,
                 'wind': None},
  'source': 'occtonet.or.jp, www.tepco.co.jp',
  'zoneKey': 'JP-TK'},
 {'capacity': {'wind': 440},
  'datetime': datetime.datetime(2024, 8, 2, 9, 25, tzinfo=tzfile('/usr/share/zoneinfo/Asia/Tokyo')),
  'production': {'biomass': None,
                 'coal': None,
                 'gas': None,
                 'geothermal': None,
                 'hydro': None,
                 'nuclear': None,
                 'oil': None,
                 'solar': 10030.0,
                 'unknown': 31251.0,
                 'wind': None},
  'source': 'occtonet.or.jp, www.tepco.co.jp',
  'zoneKey': 'JP-TK'},
 {'capacity': {'wind': 440},
  'datetime': datetime.datetime(2024, 8, 2, 9, 30, tzinfo=tzfile('/usr/share/zoneinfo/Asia/Tokyo')),
  'production': {'biomass': None,
                 'coal': None,
                 'gas': None,
                 'geothermal': None,
                 'hydro': None,
                 'nuclear': None,
                 'oil': None,
                 'solar': 10210.0,
                 'unknown': 31401.0,
                 'wind': None},
  'source': 'occtonet.or.jp, www.tepco.co.jp',
  'zoneKey': 'JP-TK'},
 {'capacity': {'wind': 440},
  'datetime': datetime.datetime(2024, 8, 2, 9, 35, tzinfo=tzfile('/usr/share/zoneinfo/Asia/Tokyo')),
  'production': {'biomass': None,
                 'coal': None,
                 'gas': None,
                 'geothermal': None,
                 'hydro': None,
                 'nuclear': None,
                 'oil': None,
                 'solar': 10370.0,
                 'unknown': 32010.0,
                 'wind': None},
  'source': 'occtonet.or.jp, www.tepco.co.jp',
  'zoneKey': 'JP-TK'},
 {'capacity': {'wind': 440},
  'datetime': datetime.datetime(2024, 8, 2, 9, 40, tzinfo=tzfile('/usr/share/zoneinfo/Asia/Tokyo')),
  'production': {'biomass': None,
                 'coal': None,
                 'gas': None,
                 'geothermal': None,
                 'hydro': None,
                 'nuclear': None,
                 'oil': None,
                 'solar': 10500.0,
                 'unknown': 32187.0,
                 'wind': None},
  'source': 'occtonet.or.jp, www.tepco.co.jp',
  'zoneKey': 'JP-TK'},
 {'capacity': {'wind': 440},
  'datetime': datetime.datetime(2024, 8, 2, 9, 45, tzinfo=tzfile('/usr/share/zoneinfo/Asia/Tokyo')),
  'production': {'biomass': None,
                 'coal': None,
                 'gas': None,
                 'geothermal': None,
                 'hydro': None,
                 'nuclear': None,
                 'oil': None,
                 'solar': 10670.0,
                 'unknown': 32213.0,
                 'wind': None},
  'source': 'occtonet.or.jp, www.tepco.co.jp',
  'zoneKey': 'JP-TK'},
 {'capacity': {'wind': 440},
  'datetime': datetime.datetime(2024, 8, 2, 9, 50, tzinfo=tzfile('/usr/share/zoneinfo/Asia/Tokyo')),
  'production': {'biomass': None,
                 'coal': None,
                 'gas': None,
                 'geothermal': None,
                 'hydro': None,
                 'nuclear': None,
                 'oil': None,
                 'solar': 10850.0,
                 'unknown': 31955.0,
                 'wind': None},
  'source': 'occtonet.or.jp, www.tepco.co.jp',
  'zoneKey': 'JP-TK'},
 {'capacity': {'wind': 440},
  'datetime': datetime.datetime(2024, 8, 2, 9, 55, tzinfo=tzfile('/usr/share/zoneinfo/Asia/Tokyo')),
  'production': {'biomass': None,
                 'coal': None,
                 'gas': None,
                 'geothermal': None,
                 'hydro': None,
                 'nuclear': None,
                 'oil': None,
                 'solar': 10940.0,
                 'unknown': 31690.0,
                 'wind': None},
  'source': 'occtonet.or.jp, www.tepco.co.jp',
  'zoneKey': 'JP-TK'},
 {'capacity': {'wind': 440},
  'datetime': datetime.datetime(2024, 8, 2, 10, 0, tzinfo=tzfile('/usr/share/zoneinfo/Asia/Tokyo')),
  'production': {'biomass': None,
                 'coal': None,
                 'gas': None,
                 'geothermal': None,
                 'hydro': None,
                 'nuclear': None,
                 'oil': None,
                 'solar': 11080.0,
                 'unknown': 31264.0,
                 'wind': None},
  'source': 'occtonet.or.jp, www.tepco.co.jp',
  'zoneKey': 'JP-TK'},
 {'capacity': {'wind': 440},
  'datetime': datetime.datetime(2024, 8, 2, 10, 5, tzinfo=tzfile('/usr/share/zoneinfo/Asia/Tokyo')),
  'production': {'biomass': None,
                 'coal': None,
                 'gas': None,
                 'geothermal': None,
                 'hydro': None,
                 'nuclear': None,
                 'oil': None,
                 'solar': 11260.0,
                 'unknown': 31254.0,
                 'wind': None},
  'source': 'occtonet.or.jp, www.tepco.co.jp',
  'zoneKey': 'JP-TK'},
 {'capacity': {'wind': 440},
  'datetime': datetime.datetime(2024, 8, 2, 10, 10, tzinfo=tzfile('/usr/share/zoneinfo/Asia/Tokyo')),
  'production': {'biomass': None,
                 'coal': None,
                 'gas': None,
                 'geothermal': None,
                 'hydro': None,
                 'nuclear': None,
                 'oil': None,
                 'solar': 11410.0,
                 'unknown': 31366.0,
                 'wind': None},
  'source': 'occtonet.or.jp, www.tepco.co.jp',
  'zoneKey': 'JP-TK'},
 {'capacity': {'wind': 440},
  'datetime': datetime.datetime(2024, 8, 2, 10, 15, tzinfo=tzfile('/usr/share/zoneinfo/Asia/Tokyo')),
  'production': {'biomass': None,
                 'coal': None,
                 'gas': None,
                 'geothermal': None,
                 'hydro': None,
                 'nuclear': None,
                 'oil': None,
                 'solar': 11580.0,
                 'unknown': 31709.0,
                 'wind': None},
  'source': 'occtonet.or.jp, www.tepco.co.jp',
  'zoneKey': 'JP-TK'},
 {'capacity': {'wind': 440},
  'datetime': datetime.datetime(2024, 8, 2, 10, 20, tzinfo=tzfile('/usr/share/zoneinfo/Asia/Tokyo')),
  'production': {'biomass': None,
                 'coal': None,
                 'gas': None,
                 'geothermal': None,
                 'hydro': None,
                 'nuclear': None,
                 'oil': None,
                 'solar': 11680.0,
                 'unknown': 31759.0,
                 'wind': None},
  'source': 'occtonet.or.jp, www.tepco.co.jp',
  'zoneKey': 'JP-TK'},
 {'capacity': {'wind': 440},
  'datetime': datetime.datetime(2024, 8, 2, 10, 25, tzinfo=tzfile('/usr/share/zoneinfo/Asia/Tokyo')),
  'production': {'biomass': None,
                 'coal': None,
                 'gas': None,
                 'geothermal': None,
                 'hydro': None,
                 'nuclear': None,
                 'oil': None,
                 'solar': 11850.0,
                 'unknown': 31689.0,
                 'wind': None},
  'source': 'occtonet.or.jp, www.tepco.co.jp',
  'zoneKey': 'JP-TK'},
 {'capacity': {'wind': 440},
  'datetime': datetime.datetime(2024, 8, 2, 10, 30, tzinfo=tzfile('/usr/share/zoneinfo/Asia/Tokyo')),
  'production': {'biomass': None,
                 'coal': None,
                 'gas': None,
                 'geothermal': None,
                 'hydro': None,
                 'nuclear': None,
                 'oil': None,
                 'solar': 12000.0,
                 'unknown': 31789.0,
                 'wind': None},
  'source': 'occtonet.or.jp, www.tepco.co.jp',
  'zoneKey': 'JP-TK'},
 {'capacity': {'wind': 440},
  'datetime': datetime.datetime(2024, 8, 2, 10, 35, tzinfo=tzfile('/usr/share/zoneinfo/Asia/Tokyo')),
  'production': {'biomass': None,
                 'coal': None,
                 'gas': None,
                 'geothermal': None,
                 'hydro': None,
                 'nuclear': None,
                 'oil': None,
                 'solar': 12100.0,
                 'unknown': 31925.0,
                 'wind': None},
  'source': 'occtonet.or.jp, www.tepco.co.jp',
  'zoneKey': 'JP-TK'},
 {'capacity': {'wind': 440},
  'datetime': datetime.datetime(2024, 8, 2, 10, 40, tzinfo=tzfile('/usr/share/zoneinfo/Asia/Tokyo')),
  'production': {'biomass': None,
                 'coal': None,
                 'gas': None,
                 'geothermal': None,
                 'hydro': None,
                 'nuclear': None,
                 'oil': None,
                 'solar': 12170.0,
                 'unknown': 31948.0,
                 'wind': None},
  'source': 'occtonet.or.jp, www.tepco.co.jp',
  'zoneKey': 'JP-TK'},
 {'capacity': {'wind': 440},
  'datetime': datetime.datetime(2024, 8, 2, 10, 45, tzinfo=tzfile('/usr/share/zoneinfo/Asia/Tokyo')),
  'production': {'biomass': None,
                 'coal': None,
                 'gas': None,
                 'geothermal': None,
                 'hydro': None,
                 'nuclear': None,
                 'oil': None,
                 'solar': 12240.0,
                 'unknown': 31498.0,
                 'wind': None},
  'source': 'occtonet.or.jp, www.tepco.co.jp',
  'zoneKey': 'JP-TK'},
 {'capacity': {'wind': 440},
  'datetime': datetime.datetime(2024, 8, 2, 10, 50, tzinfo=tzfile('/usr/share/zoneinfo/Asia/Tokyo')),
  'production': {'biomass': None,
                 'coal': None,
                 'gas': None,
                 'geothermal': None,
                 'hydro': None,
                 'nuclear': None,
                 'oil': None,
                 'solar': 12310.0,
                 'unknown': 31280.0,
                 'wind': None},
  'source': 'occtonet.or.jp, www.tepco.co.jp',
  'zoneKey': 'JP-TK'},
 {'capacity': {'wind': 440},
  'datetime': datetime.datetime(2024, 8, 2, 10, 55, tzinfo=tzfile('/usr/share/zoneinfo/Asia/Tokyo')),
  'production': {'biomass': None,
                 'coal': None,
                 'gas': None,
                 'geothermal': None,
                 'hydro': None,
                 'nuclear': None,
                 'oil': None,
                 'solar': 12330.0,
                 'unknown': 31411.0,
                 'wind': None},
  'source': 'occtonet.or.jp, www.tepco.co.jp',
  'zoneKey': 'JP-TK'},
 {'capacity': {'wind': 440},
  'datetime': datetime.datetime(2024, 8, 2, 11, 0, tzinfo=tzfile('/usr/share/zoneinfo/Asia/Tokyo')),
  'production': {'biomass': None,
                 'coal': None,
                 'gas': None,
                 'geothermal': None,
                 'hydro': None,
                 'nuclear': None,
                 'oil': None,
                 'solar': 12420.0,
                 'unknown': 31526.0,
                 'wind': None},
  'source': 'occtonet.or.jp, www.tepco.co.jp',
  'zoneKey': 'JP-TK'},
 {'capacity': {'wind': 440},
  'datetime': datetime.datetime(2024, 8, 2, 11, 5, tzinfo=tzfile('/usr/share/zoneinfo/Asia/Tokyo')),
  'production': {'biomass': None,
                 'coal': None,
                 'gas': None,
                 'geothermal': None,
                 'hydro': None,
                 'nuclear': None,
                 'oil': None,
                 'solar': 12530.0,
                 'unknown': 31919.0,
                 'wind': None},
  'source': 'occtonet.or.jp, www.tepco.co.jp',
  'zoneKey': 'JP-TK'},
 {'capacity': {'wind': 440},
  'datetime': datetime.datetime(2024, 8, 2, 11, 10, tzinfo=tzfile('/usr/share/zoneinfo/Asia/Tokyo')),
  'production': {'biomass': None,
                 'coal': None,
                 'gas': None,
                 'geothermal': None,
                 'hydro': None,
                 'nuclear': None,
                 'oil': None,
                 'solar': 12640.0,
                 'unknown': 31847.0,
                 'wind': None},
  'source': 'occtonet.or.jp, www.tepco.co.jp',
  'zoneKey': 'JP-TK'},
 {'capacity': {'wind': 440},
  'datetime': datetime.datetime(2024, 8, 2, 11, 15, tzinfo=tzfile('/usr/share/zoneinfo/Asia/Tokyo')),
  'production': {'biomass': None,
                 'coal': None,
                 'gas': None,
                 'geothermal': None,
                 'hydro': None,
                 'nuclear': None,
                 'oil': None,
                 'solar': 12640.0,
                 'unknown': 31996.0,
                 'wind': None},
  'source': 'occtonet.or.jp, www.tepco.co.jp',
  'zoneKey': 'JP-TK'},
 {'capacity': {'wind': 440},
  'datetime': datetime.datetime(2024, 8, 2, 11, 20, tzinfo=tzfile('/usr/share/zoneinfo/Asia/Tokyo')),
  'production': {'biomass': None,
                 'coal': None,
                 'gas': None,
                 'geothermal': None,
                 'hydro': None,
                 'nuclear': None,
                 'oil': None,
                 'solar': 12710.0,
                 'unknown': 31883.0,
                 'wind': None},
  'source': 'occtonet.or.jp, www.tepco.co.jp',
  'zoneKey': 'JP-TK'},
 {'capacity': {'wind': 440},
  'datetime': datetime.datetime(2024, 8, 2, 11, 25, tzinfo=tzfile('/usr/share/zoneinfo/Asia/Tokyo')),
  'production': {'biomass': None,
                 'coal': None,
                 'gas': None,
                 'geothermal': None,
                 'hydro': None,
                 'nuclear': None,
                 'oil': None,
                 'solar': 12750.0,
                 'unknown': 32255.0,
                 'wind': None},
  'source': 'occtonet.or.jp, www.tepco.co.jp',
  'zoneKey': 'JP-TK'},
 {'capacity': {'wind': 440},
  'datetime': datetime.datetime(2024, 8, 2, 11, 30, tzinfo=tzfile('/usr/share/zoneinfo/Asia/Tokyo')),
  'production': {'biomass': None,
                 'coal': None,
                 'gas': None,
                 'geothermal': None,
                 'hydro': None,
                 'nuclear': None,
                 'oil': None,
                 'solar': 12850.0,
                 'unknown': 31919.0,
                 'wind': None},
  'source': 'occtonet.or.jp, www.tepco.co.jp',
  'zoneKey': 'JP-TK'},
 {'capacity': {'wind': 440},
  'datetime': datetime.datetime(2024, 8, 2, 11, 35, tzinfo=tzfile('/usr/share/zoneinfo/Asia/Tokyo')),
  'production': {'biomass': None,
                 'coal': None,
                 'gas': None,
                 'geothermal': None,
                 'hydro': None,
                 'nuclear': None,
                 'oil': None,
                 'solar': 12850.0,
                 'unknown': 32259.0,
                 'wind': None},
  'source': 'occtonet.or.jp, www.tepco.co.jp',
  'zoneKey': 'JP-TK'},
 {'capacity': {'wind': 440},
  'datetime': datetime.datetime(2024, 8, 2, 11, 40, tzinfo=tzfile('/usr/share/zoneinfo/Asia/Tokyo')),
  'production': {'biomass': None,
                 'coal': None,
                 'gas': None,
                 'geothermal': None,
                 'hydro': None,
                 'nuclear': None,
                 'oil': None,
                 'solar': 12910.0,
                 'unknown': 32380.0,
                 'wind': None},
  'source': 'occtonet.or.jp, www.tepco.co.jp',
  'zoneKey': 'JP-TK'},
 {'capacity': {'wind': 440},
  'datetime': datetime.datetime(2024, 8, 2, 11, 45, tzinfo=tzfile('/usr/share/zoneinfo/Asia/Tokyo')),
  'production': {'biomass': None,
                 'coal': None,
                 'gas': None,
                 'geothermal': None,
                 'hydro': None,
                 'nuclear': None,
                 'oil': None,
                 'solar': 12910.0,
                 'unknown': 32525.0,
                 'wind': None},
  'source': 'occtonet.or.jp, www.tepco.co.jp',
  'zoneKey': 'JP-TK'},
 {'capacity': {'wind': 440},
  'datetime': datetime.datetime(2024, 8, 2, 11, 50, tzinfo=tzfile('/usr/share/zoneinfo/Asia/Tokyo')),
  'production': {'biomass': None,
                 'coal': None,
                 'gas': None,
                 'geothermal': None,
                 'hydro': None,
                 'nuclear': None,
                 'oil': None,
                 'solar': 12930.0,
                 'unknown': 32692.0,
                 'wind': None},
  'source': 'occtonet.or.jp, www.tepco.co.jp',
  'zoneKey': 'JP-TK'},
 {'capacity': {'wind': 440},
  'datetime': datetime.datetime(2024, 8, 2, 11, 55, tzinfo=tzfile('/usr/share/zoneinfo/Asia/Tokyo')),
  'production': {'biomass': None,
                 'coal': None,
                 'gas': None,
                 'geothermal': None,
                 'hydro': None,
                 'nuclear': None,
                 'oil': None,
                 'solar': 12970.0,
                 'unknown': 32470.0,
                 'wind': None},
  'source': 'occtonet.or.jp, www.tepco.co.jp',
  'zoneKey': 'JP-TK'},
 {'capacity': {'wind': 440},
  'datetime': datetime.datetime(2024, 8, 2, 12, 0, tzinfo=tzfile('/usr/share/zoneinfo/Asia/Tokyo')),
  'production': {'biomass': None,
                 'coal': None,
                 'gas': None,
                 'geothermal': None,
                 'hydro': None,
                 'nuclear': None,
                 'oil': None,
                 'solar': 13000.0,
                 'unknown': 32397.0,
                 'wind': None},
  'source': 'occtonet.or.jp, www.tepco.co.jp',
  'zoneKey': 'JP-TK'},
 {'capacity': {'wind': 440},
  'datetime': datetime.datetime(2024, 8, 2, 12, 5, tzinfo=tzfile('/usr/share/zoneinfo/Asia/Tokyo')),
  'production': {'biomass': None,
                 'coal': None,
                 'gas': None,
                 'geothermal': None,
                 'hydro': None,
                 'nuclear': None,
                 'oil': None,
                 'solar': 13070.0,
                 'unknown': 32371.0,
                 'wind': None},
  'source': 'occtonet.or.jp, www.tepco.co.jp',
  'zoneKey': 'JP-TK'},
 {'capacity': {'wind': 440},
  'datetime': datetime.datetime(2024, 8, 2, 12, 10, tzinfo=tzfile('/usr/share/zoneinfo/Asia/Tokyo')),
  'production': {'biomass': None,
                 'coal': None,
                 'gas': None,
                 'geothermal': None,
                 'hydro': None,
                 'nuclear': None,
                 'oil': None,
                 'solar': 13140.0,
                 'unknown': 32589.0,
                 'wind': None},
  'source': 'occtonet.or.jp, www.tepco.co.jp',
  'zoneKey': 'JP-TK'},
 {'capacity': {'wind': 440},
  'datetime': datetime.datetime(2024, 8, 2, 12, 15, tzinfo=tzfile('/usr/share/zoneinfo/Asia/Tokyo')),
  'production': {'biomass': None,
                 'coal': None,
                 'gas': None,
                 'geothermal': None,
                 'hydro': None,
                 'nuclear': None,
                 'oil': None,
                 'solar': 13120.0,
                 'unknown': 32534.0,
                 'wind': None},
  'source': 'occtonet.or.jp, www.tepco.co.jp',
  'zoneKey': 'JP-TK'},
 {'capacity': {'wind': 440},
  'datetime': datetime.datetime(2024, 8, 2, 12, 20, tzinfo=tzfile('/usr/share/zoneinfo/Asia/Tokyo')),
  'production': {'biomass': None,
                 'coal': None,
                 'gas': None,
                 'geothermal': None,
                 'hydro': None,
                 'nuclear': None,
                 'oil': None,
                 'solar': 13060.0,
                 'unknown': 32382.0,
                 'wind': None},
  'source': 'occtonet.or.jp, www.tepco.co.jp',
  'zoneKey': 'JP-TK'},
 {'capacity': {'wind': 440},
  'datetime': datetime.datetime(2024, 8, 2, 12, 25, tzinfo=tzfile('/usr/share/zoneinfo/Asia/Tokyo')),
  'production': {'biomass': None,
                 'coal': None,
                 'gas': None,
                 'geothermal': None,
                 'hydro': None,
                 'nuclear': None,
                 'oil': None,
                 'solar': 13060.0,
                 'unknown': 32214.0,
                 'wind': None},
  'source': 'occtonet.or.jp, www.tepco.co.jp',
  'zoneKey': 'JP-TK'},
 {'capacity': {'wind': 440},
  'datetime': datetime.datetime(2024, 8, 2, 12, 30, tzinfo=tzfile('/usr/share/zoneinfo/Asia/Tokyo')),
  'production': {'biomass': None,
                 'coal': None,
                 'gas': None,
                 'geothermal': None,
                 'hydro': None,
                 'nuclear': None,
                 'oil': None,
                 'solar': 13030.0,
                 'unknown': 32192.0,
                 'wind': None},
  'source': 'occtonet.or.jp, www.tepco.co.jp',
  'zoneKey': 'JP-TK'},
 {'capacity': {'wind': 440},
  'datetime': datetime.datetime(2024, 8, 2, 12, 35, tzinfo=tzfile('/usr/share/zoneinfo/Asia/Tokyo')),
  'production': {'biomass': None,
                 'coal': None,
                 'gas': None,
                 'geothermal': None,
                 'hydro': None,
                 'nuclear': None,
                 'oil': None,
                 'solar': 13060.0,
                 'unknown': 31847.0,
                 'wind': None},
  'source': 'occtonet.or.jp, www.tepco.co.jp',
  'zoneKey': 'JP-TK'},
 {'capacity': {'wind': 440},
  'datetime': datetime.datetime(2024, 8, 2, 12, 40, tzinfo=tzfile('/usr/share/zoneinfo/Asia/Tokyo')),
  'production': {'biomass': None,
                 'coal': None,
                 'gas': None,
                 'geothermal': None,
                 'hydro': None,
                 'nuclear': None,
                 'oil': None,
                 'solar': 13030.0,
                 'unknown': 32103.0,
                 'wind': None},
  'source': 'occtonet.or.jp, www.tepco.co.jp',
  'zoneKey': 'JP-TK'},
 {'capacity': {'wind': 440},
  'datetime': datetime.datetime(2024, 8, 2, 12, 45, tzinfo=tzfile('/usr/share/zoneinfo/Asia/Tokyo')),
  'production': {'biomass': None,
                 'coal': None,
                 'gas': None,
                 'geothermal': None,
                 'hydro': None,
                 'nuclear': None,
                 'oil': None,
                 'solar': 12920.0,
                 'unknown': 32429.0,
                 'wind': None},
  'source': 'occtonet.or.jp, www.tepco.co.jp',
  'zoneKey': 'JP-TK'},
 {'capacity': {'wind': 440},
  'datetime': datetime.datetime(2024, 8, 2, 12, 50, tzinfo=tzfile('/usr/share/zoneinfo/Asia/Tokyo')),
  'production': {'biomass': None,
                 'coal': None,
                 'gas': None,
                 'geothermal': None,
                 'hydro': None,
                 'nuclear': None,
                 'oil': None,
                 'solar': 12880.0,
                 'unknown': 32570.0,
                 'wind': None},
  'source': 'occtonet.or.jp, www.tepco.co.jp',
  'zoneKey': 'JP-TK'},
 {'capacity': {'wind': 440},
  'datetime': datetime.datetime(2024, 8, 2, 12, 55, tzinfo=tzfile('/usr/share/zoneinfo/Asia/Tokyo')),
  'production': {'biomass': None,
                 'coal': None,
                 'gas': None,
                 'geothermal': None,
                 'hydro': None,
                 'nuclear': None,
                 'oil': None,
                 'solar': 12820.0,
                 'unknown': 32888.0,
                 'wind': None},
  'source': 'occtonet.or.jp, www.tepco.co.jp',
  'zoneKey': 'JP-TK'},
 {'capacity': {'wind': 440},
  'datetime': datetime.datetime(2024, 8, 2, 13, 0, tzinfo=tzfile('/usr/share/zoneinfo/Asia/Tokyo')),
  'production': {'biomass': None,
                 'coal': None,
                 'gas': None,
                 'geothermal': None,
                 'hydro': None,
                 'nuclear': None,
                 'oil': None,
                 'solar': 12730.0,
                 'unknown': 33365.0,
                 'wind': None},
  'source': 'occtonet.or.jp, www.tepco.co.jp',
  'zoneKey': 'JP-TK'},
 {'capacity': {'wind': 440},
  'datetime': datetime.datetime(2024, 8, 2, 13, 5, tzinfo=tzfile('/usr/share/zoneinfo/Asia/Tokyo')),
  'production': {'biomass': None,
                 'coal': None,
                 'gas': None,
                 'geothermal': None,
                 'hydro': None,
                 'nuclear': None,
                 'oil': None,
                 'solar': 12650.0,
                 'unknown': 34156.0,
                 'wind': None},
  'source': 'occtonet.or.jp, www.tepco.co.jp',
  'zoneKey': 'JP-TK'},
 {'capacity': {'wind': 440},
  'datetime': datetime.datetime(2024, 8, 2, 13, 10, tzinfo=tzfile('/usr/share/zoneinfo/Asia/Tokyo')),
  'production': {'biomass': None,
                 'coal': None,
                 'gas': None,
                 'geothermal': None,
                 'hydro': None,
                 'nuclear': None,
                 'oil': None,
                 'solar': 12590.0,
                 'unknown': 34562.0,
                 'wind': None},
  'source': 'occtonet.or.jp, www.tepco.co.jp',
  'zoneKey': 'JP-TK'},
 {'capacity': {'wind': 440},
  'datetime': datetime.datetime(2024, 8, 2, 13, 15, tzinfo=tzfile('/usr/share/zoneinfo/Asia/Tokyo')),
  'production': {'biomass': None,
                 'coal': None,
                 'gas': None,
                 'geothermal': None,
                 'hydro': None,
                 'nuclear': None,
                 'oil': None,
                 'solar': 12550.0,
                 'unknown': 34391.0,
                 'wind': None},
  'source': 'occtonet.or.jp, www.tepco.co.jp',
  'zoneKey': 'JP-TK'},
 {'capacity': {'wind': 440},
  'datetime': datetime.datetime(2024, 8, 2, 13, 20, tzinfo=tzfile('/usr/share/zoneinfo/Asia/Tokyo')),
  'production': {'biomass': None,
                 'coal': None,
                 'gas': None,
                 'geothermal': None,
                 'hydro': None,
                 'nuclear': None,
                 'oil': None,
                 'solar': 12460.0,
                 'unknown': 34534.0,
                 'wind': None},
  'source': 'occtonet.or.jp, www.tepco.co.jp',
  'zoneKey': 'JP-TK'},
 {'capacity': {'wind': 440},
  'datetime': datetime.datetime(2024, 8, 2, 13, 25, tzinfo=tzfile('/usr/share/zoneinfo/Asia/Tokyo')),
  'production': {'biomass': None,
                 'coal': None,
                 'gas': None,
                 'geothermal': None,
                 'hydro': None,
                 'nuclear': None,
                 'oil': None,
                 'solar': 12330.0,
                 'unknown': 34386.0,
                 'wind': None},
  'source': 'occtonet.or.jp, www.tepco.co.jp',
  'zoneKey': 'JP-TK'},
 {'capacity': {'wind': 440},
  'datetime': datetime.datetime(2024, 8, 2, 13, 30, tzinfo=tzfile('/usr/share/zoneinfo/Asia/Tokyo')),
  'production': {'biomass': None,
                 'coal': None,
                 'gas': None,
                 'geothermal': None,
                 'hydro': None,
                 'nuclear': None,
                 'oil': None,
                 'solar': 12210.0,
                 'unknown': 33852.0,
                 'wind': None},
  'source': 'occtonet.or.jp, www.tepco.co.jp',
  'zoneKey': 'JP-TK'},
 {'capacity': {'wind': 440},
  'datetime': datetime.datetime(2024, 8, 2, 13, 35, tzinfo=tzfile('/usr/share/zoneinfo/Asia/Tokyo')),
  'production': {'biomass': None,
                 'coal': None,
                 'gas': None,
                 'geothermal': None,
                 'hydro': None,
                 'nuclear': None,
                 'oil': None,
                 'solar': 12120.0,
                 'unknown': 35107.0,
                 'wind': None},
  'source': 'occtonet.or.jp, www.tepco.co.jp',
  'zoneKey': 'JP-TK'},
 {'capacity': {'wind': 440},
  'datetime': datetime.datetime(2024, 8, 2, 13, 40, tzinfo=tzfile('/usr/share/zoneinfo/Asia/Tokyo')),
  'production': {'biomass': None,
                 'coal': None,
                 'gas': None,
                 'geothermal': None,
                 'hydro': None,
                 'nuclear': None,
                 'oil': None,
                 'solar': 11970.0,
                 'unknown': 35421.0,
                 'wind': None},
  'source': 'occtonet.or.jp, www.tepco.co.jp',
  'zoneKey': 'JP-TK'},
 {'capacity': {'wind': 440},
  'datetime': datetime.datetime(2024, 8, 2, 13, 45, tzinfo=tzfile('/usr/share/zoneinfo/Asia/Tokyo')),
  'production': {'biomass': None,
                 'coal': None,
                 'gas': None,
                 'geothermal': None,
                 'hydro': None,
                 'nuclear': None,
                 'oil': None,
                 'solar': 11820.0,
                 'unknown': 35369.0,
                 'wind': None},
  'source': 'occtonet.or.jp, www.tepco.co.jp',
  'zoneKey': 'JP-TK'},
 {'capacity': {'wind': 440},
  'datetime': datetime.datetime(2024, 8, 2, 13, 50, tzinfo=tzfile('/usr/share/zoneinfo/Asia/Tokyo')),
  'production': {'biomass': None,
                 'coal': None,
                 'gas': None,
                 'geothermal': None,
                 'hydro': None,
                 'nuclear': None,
                 'oil': None,
                 'solar': 11690.0,
                 'unknown': 35540.0,
                 'wind': None},
  'source': 'occtonet.or.jp, www.tepco.co.jp',
  'zoneKey': 'JP-TK'},
 {'capacity': {'wind': 440},
  'datetime': datetime.datetime(2024, 8, 2, 13, 55, tzinfo=tzfile('/usr/share/zoneinfo/Asia/Tokyo')),
  'production': {'biomass': None,
                 'coal': None,
                 'gas': None,
                 'geothermal': None,
                 'hydro': None,
                 'nuclear': None,
                 'oil': None,
                 'solar': 11570.0,
                 'unknown': 35661.0,
                 'wind': None},
  'source': 'occtonet.or.jp, www.tepco.co.jp',
  'zoneKey': 'JP-TK'},
 {'capacity': {'wind': 440},
  'datetime': datetime.datetime(2024, 8, 2, 14, 0, tzinfo=tzfile('/usr/share/zoneinfo/Asia/Tokyo')),
  'production': {'biomass': None,
                 'coal': None,
                 'gas': None,
                 'geothermal': None,
                 'hydro': None,
                 'nuclear': None,
                 'oil': None,
                 'solar': 11420.0,
                 'unknown': 35991.0,
                 'wind': None},
  'source': 'occtonet.or.jp, www.tepco.co.jp',
  'zoneKey': 'JP-TK'},
 {'capacity': {'wind': 440},
  'datetime': datetime.datetime(2024, 8, 2, 14, 5, tzinfo=tzfile('/usr/share/zoneinfo/Asia/Tokyo')),
  'production': {'biomass': None,
                 'coal': None,
                 'gas': None,
                 'geothermal': None,
                 'hydro': None,
                 'nuclear': None,
                 'oil': None,
                 'solar': 11240.0,
                 'unknown': 36311.0,
                 'wind': None},
  'source': 'occtonet.or.jp, www.tepco.co.jp',
  'zoneKey': 'JP-TK'},
 {'capacity': {'wind': 440},
  'datetime': datetime.datetime(2024, 8, 2, 14, 10, tzinfo=tzfile('/usr/share/zoneinfo/Asia/Tokyo')),
  'production': {'biomass': None,
                 'coal': None,
                 'gas': None,
                 'geothermal': None,
                 'hydro': None,
                 'nuclear': None,
                 'oil': None,
                 'solar': 11110.0,
                 'unknown': 36351.0,
                 'wind': None},
  'source': 'occtonet.or.jp, www.tepco.co.jp',
  'zoneKey': 'JP-TK'},
 {'capacity': {'wind': 440},
  'datetime': datetime.datetime(2024, 8, 2, 14, 15, tzinfo=tzfile('/usr/share/zoneinfo/Asia/Tokyo')),
  'production': {'biomass': None,
                 'coal': None,
                 'gas': None,
                 'geothermal': None,
                 'hydro': None,
                 'nuclear': None,
                 'oil': None,
                 'solar': 10930.0,
                 'unknown': 36035.0,
                 'wind': None},
  'source': 'occtonet.or.jp, www.tepco.co.jp',
  'zoneKey': 'JP-TK'},
 {'capacity': {'wind': 440},
  'datetime': datetime.datetime(2024, 8, 2, 14, 20, tzinfo=tzfile('/usr/share/zoneinfo/Asia/Tokyo')),
  'production': {'biomass': None,
                 'coal': None,
                 'gas': None,
                 'geothermal': None,
                 'hydro': None,
                 'nuclear': None,
                 'oil': None,
                 'solar': 10800.0,
                 'unknown': 36700.0,
                 'wind': None},
  'source': 'occtonet.or.jp, www.tepco.co.jp',
  'zoneKey': 'JP-TK'},
 {'capacity': {'wind': 440},
  'datetime': datetime.datetime(2024, 8, 2, 14, 25, tzinfo=tzfile('/usr/share/zoneinfo/Asia/Tokyo')),
  'production': {'biomass': None,
                 'coal': None,
                 'gas': None,
                 'geothermal': None,
                 'hydro': None,
                 'nuclear': None,
                 'oil': None,
                 'solar': 10620.0,
                 'unknown': 36870.0,
                 'wind': None},
  'source': 'occtonet.or.jp, www.tepco.co.jp',
  'zoneKey': 'JP-TK'},
 {'capacity': {'wind': 440},
  'datetime': datetime.datetime(2024, 8, 2, 14, 30, tzinfo=tzfile('/usr/share/zoneinfo/Asia/Tokyo')),
  'production': {'biomass': None,
                 'coal': None,
                 'gas': None,
                 'geothermal': None,
                 'hydro': None,
                 'nuclear': None,
                 'oil': None,
                 'solar': 10420.0,
                 'unknown': 37114.0,
                 'wind': None},
  'source': 'occtonet.or.jp, www.tepco.co.jp',
  'zoneKey': 'JP-TK'},
 {'capacity': {'wind': 440},
  'datetime': datetime.datetime(2024, 8, 2, 14, 35, tzinfo=tzfile('/usr/share/zoneinfo/Asia/Tokyo')),
  'production': {'biomass': None,
                 'coal': None,
                 'gas': None,
                 'geothermal': None,
                 'hydro': None,
                 'nuclear': None,
                 'oil': None,
                 'solar': 10200.0,
                 'unknown': 37125.0,
                 'wind': None},
  'source': 'occtonet.or.jp, www.tepco.co.jp',
  'zoneKey': 'JP-TK'},
 {'capacity': {'wind': 440},
  'datetime': datetime.datetime(2024, 8, 2, 14, 40, tzinfo=tzfile('/usr/share/zoneinfo/Asia/Tokyo')),
  'production': {'biomass': None,
                 'coal': None,
                 'gas': None,
                 'geothermal': None,
                 'hydro': None,
                 'nuclear': None,
                 'oil': None,
                 'solar': 10010.0,
                 'unknown': 37323.0,
                 'wind': None},
  'source': 'occtonet.or.jp, www.tepco.co.jp',
  'zoneKey': 'JP-TK'},
 {'capacity': {'wind': 440},
  'datetime': datetime.datetime(2024, 8, 2, 14, 45, tzinfo=tzfile('/usr/share/zoneinfo/Asia/Tokyo')),
  'production': {'biomass': None,
                 'coal': None,
                 'gas': None,
                 'geothermal': None,
                 'hydro': None,
                 'nuclear': None,
                 'oil': None,
                 'solar': 9780.0,
                 'unknown': 37464.0,
                 'wind': None},
  'source': 'occtonet.or.jp, www.tepco.co.jp',
  'zoneKey': 'JP-TK'},
 {'capacity': {'wind': 440},
  'datetime': datetime.datetime(2024, 8, 2, 14, 50, tzinfo=tzfile('/usr/share/zoneinfo/Asia/Tokyo')),
  'production': {'biomass': None,
                 'coal': None,
                 'gas': None,
                 'geothermal': None,
                 'hydro': None,
                 'nuclear': None,
                 'oil': None,
                 'solar': 9600.0,
                 'unknown': 37535.0,
                 'wind': None},
  'source': 'occtonet.or.jp, www.tepco.co.jp',
  'zoneKey': 'JP-TK'},
 {'capacity': {'wind': 440},
  'datetime': datetime.datetime(2024, 8, 2, 14, 55, tzinfo=tzfile('/usr/share/zoneinfo/Asia/Tokyo')),
  'production': {'biomass': None,
                 'coal': None,
                 'gas': None,
                 'geothermal': None,
                 'hydro': None,
                 'nuclear': None,
                 'oil': None,
                 'solar': 9350.0,
                 'unknown': 37546.0,
                 'wind': None},
  'source': 'occtonet.or.jp, www.tepco.co.jp',
  'zoneKey': 'JP-TK'},
 {'capacity': {'wind': 440},
  'datetime': datetime.datetime(2024, 8, 2, 15, 0, tzinfo=tzfile('/usr/share/zoneinfo/Asia/Tokyo')),
  'production': {'biomass': None,
                 'coal': None,
                 'gas': None,
                 'geothermal': None,
                 'hydro': None,
                 'nuclear': None,
                 'oil': None,
                 'solar': 9130.0,
                 'unknown': 37935.0,
                 'wind': None},
  'source': 'occtonet.or.jp, www.tepco.co.jp',
  'zoneKey': 'JP-TK'},
 {'capacity': {'wind': 440},
  'datetime': datetime.datetime(2024, 8, 2, 15, 5, tzinfo=tzfile('/usr/share/zoneinfo/Asia/Tokyo')),
  'production': {'biomass': None,
                 'coal': None,
                 'gas': None,
                 'geothermal': None,
                 'hydro': None,
                 'nuclear': None,
                 'oil': None,
                 'solar': 8890.0,
                 'unknown': 38011.0,
                 'wind': None},
  'source': 'occtonet.or.jp, www.tepco.co.jp',
  'zoneKey': 'JP-TK'},
 {'capacity': {'wind': 440},
  'datetime': datetime.datetime(2024, 8, 2, 15, 10, tzinfo=tzfile('/usr/share/zoneinfo/Asia/Tokyo')),
  'production': {'biomass': None,
                 'coal': None,
                 'gas': None,
                 'geothermal': None,
                 'hydro': None,
                 'nuclear': None,
                 'oil': None,
                 'solar': 8640.0,
                 'unknown': 38479.0,
                 'wind': None},
  'source': 'occtonet.or.jp, www.tepco.co.jp',
  'zoneKey': 'JP-TK'},
 {'capacity': {'wind': 440},
  'datetime': datetime.datetime(2024, 8, 2, 15, 15, tzinfo=tzfile('/usr/share/zoneinfo/Asia/Tokyo')),
  'production': {'biomass': None,
                 'coal': None,
                 'gas': None,
                 'geothermal': None,
                 'hydro': None,
                 'nuclear': None,
                 'oil': None,
                 'solar': 8410.0,
                 'unknown': 38696.0,
                 'wind': None},
  'source': 'occtonet.or.jp, www.tepco.co.jp',
  'zoneKey': 'JP-TK'},
 {'capacity': {'wind': 440},
  'datetime': datetime.datetime(2024, 8, 2, 15, 20, tzinfo=tzfile('/usr/share/zoneinfo/Asia/Tokyo')),
  'production': {'biomass': None,
                 'coal': None,
                 'gas': None,
                 'geothermal': None,
                 'hydro': None,
                 'nuclear': None,
                 'oil': None,
                 'solar': 8150.0,
                 'unknown': 39210.0,
                 'wind': None},
  'source': 'occtonet.or.jp, www.tepco.co.jp',
  'zoneKey': 'JP-TK'},
 {'capacity': {'wind': 440},
  'datetime': datetime.datetime(2024, 8, 2, 15, 25, tzinfo=tzfile('/usr/share/zoneinfo/Asia/Tokyo')),
  'production': {'biomass': None,
                 'coal': None,
                 'gas': None,
                 'geothermal': None,
                 'hydro': None,
                 'nuclear': None,
                 'oil': None,
                 'solar': 7910.0,
                 'unknown': 39385.0,
                 'wind': None},
  'source': 'occtonet.or.jp, www.tepco.co.jp',
  'zoneKey': 'JP-TK'},
 {'capacity': {'wind': 440},
  'datetime': datetime.datetime(2024, 8, 2, 15, 30, tzinfo=tzfile('/usr/share/zoneinfo/Asia/Tokyo')),
  'production': {'biomass': None,
                 'coal': None,
                 'gas': None,
                 'geothermal': None,
                 'hydro': None,
                 'nuclear': None,
                 'oil': None,
                 'solar': 7650.0,
                 'unknown': 39457.0,
                 'wind': None},
  'source': 'occtonet.or.jp, www.tepco.co.jp',
  'zoneKey': 'JP-TK'},
 {'capacity': {'wind': 440},
  'datetime': datetime.datetime(2024, 8, 2, 15, 35, tzinfo=tzfile('/usr/share/zoneinfo/Asia/Tokyo')),
  'production': {'biomass': None,
                 'coal': None,
                 'gas': None,
                 'geothermal': None,
                 'hydro': None,
                 'nuclear': None,
                 'oil': None,
                 'solar': 7410.0,
                 'unknown': 39960.0,
                 'wind': None},
  'source': 'occtonet.or.jp, www.tepco.co.jp',
  'zoneKey': 'JP-TK'},
 {'capacity': {'wind': 440},
  'datetime': datetime.datetime(2024, 8, 2, 15, 40, tzinfo=tzfile('/usr/share/zoneinfo/Asia/Tokyo')),
  'production': {'biomass': None,
                 'coal': None,
                 'gas': None,
                 'geothermal': None,
                 'hydro': None,
                 'nuclear': None,
                 'oil': None,
                 'solar': 7150.0,
                 'unknown': 40188.0,
                 'wind': None},
  'source': 'occtonet.or.jp, www.tepco.co.jp',
  'zoneKey': 'JP-TK'},
 {'capacity': {'wind': 440},
  'datetime': datetime.datetime(2024, 8, 2, 15, 45, tzinfo=tzfile('/usr/share/zoneinfo/Asia/Tokyo')),
  'production': {'biomass': None,
                 'coal': None,
                 'gas': None,
                 'geothermal': None,
                 'hydro': None,
                 'nuclear': None,
                 'oil': None,
                 'solar': 6890.0,
                 'unknown': 40409.0,
                 'wind': None},
  'source': 'occtonet.or.jp, www.tepco.co.jp',
  'zoneKey': 'JP-TK'},
 {'capacity': {'wind': 440},
  'datetime': datetime.datetime(2024, 8, 2, 15, 50, tzinfo=tzfile('/usr/share/zoneinfo/Asia/Tokyo')),
  'production': {'biomass': None,
                 'coal': None,
                 'gas': None,
                 'geothermal': None,
                 'hydro': None,
                 'nuclear': None,
                 'oil': None,
                 'solar': 6610.0,
                 'unknown': 40670.0,
                 'wind': None},
  'source': 'occtonet.or.jp, www.tepco.co.jp',
  'zoneKey': 'JP-TK'},
 {'capacity': {'wind': 440},
  'datetime': datetime.datetime(2024, 8, 2, 15, 55, tzinfo=tzfile('/usr/share/zoneinfo/Asia/Tokyo')),
  'production': {'biomass': None,
                 'coal': None,
                 'gas': None,
                 'geothermal': None,
                 'hydro': None,
                 'nuclear': None,
                 'oil': None,
                 'solar': 6320.0,
                 'unknown': 40811.0,
                 'wind': None},
  'source': 'occtonet.or.jp, www.tepco.co.jp',
  'zoneKey': 'JP-TK'},
 {'capacity': {'wind': 440},
  'datetime': datetime.datetime(2024, 8, 2, 16, 0, tzinfo=tzfile('/usr/share/zoneinfo/Asia/Tokyo')),
  'production': {'biomass': None,
                 'coal': None,
                 'gas': None,
                 'geothermal': None,
                 'hydro': None,
                 'nuclear': None,
                 'oil': None,
                 'solar': 6050.0,
                 'unknown': 41187.0,
                 'wind': None},
  'source': 'occtonet.or.jp, www.tepco.co.jp',
  'zoneKey': 'JP-TK'},
 {'capacity': {'wind': 440},
  'datetime': datetime.datetime(2024, 8, 2, 16, 5, tzinfo=tzfile('/usr/share/zoneinfo/Asia/Tokyo')),
  'production': {'biomass': None,
                 'coal': None,
                 'gas': None,
                 'geothermal': None,
                 'hydro': None,
                 'nuclear': None,
                 'oil': None,
                 'solar': 5770.0,
                 'unknown': 41460.0,
                 'wind': None},
  'source': 'occtonet.or.jp, www.tepco.co.jp',
  'zoneKey': 'JP-TK'},
 {'capacity': {'wind': 440},
  'datetime': datetime.datetime(2024, 8, 2, 16, 10, tzinfo=tzfile('/usr/share/zoneinfo/Asia/Tokyo')),
  'production': {'biomass': None,
                 'coal': None,
                 'gas': None,
                 'geothermal': None,
                 'hydro': None,
                 'nuclear': None,
                 'oil': None,
                 'solar': 5460.0,
                 'unknown': 41695.0,
                 'wind': None},
  'source': 'occtonet.or.jp, www.tepco.co.jp',
  'zoneKey': 'JP-TK'},
 {'capacity': {'wind': 440},
  'datetime': datetime.datetime(2024, 8, 2, 16, 15, tzinfo=tzfile('/usr/share/zoneinfo/Asia/Tokyo')),
  'production': {'biomass': None,
                 'coal': None,
                 'gas': None,
                 'geothermal': None,
                 'hydro': None,
                 'nuclear': None,
                 'oil': None,
                 'solar': 5170.0,
                 'unknown': 41839.0,
                 'wind': None},
  'source': 'occtonet.or.jp, www.tepco.co.jp',
  'zoneKey': 'JP-TK'},
 {'capacity': {'wind': 440},
  'datetime': datetime.datetime(2024, 8, 2, 16, 20, tzinfo=tzfile('/usr/share/zoneinfo/Asia/Tokyo')),
  'production': {'biomass': None,
                 'coal': None,
                 'gas': None,
                 'geothermal': None,
                 'hydro': None,
                 'nuclear': None,
                 'oil': None,
                 'solar': 4910.0,
                 'unknown': 42084.0,
                 'wind': None},
  'source': 'occtonet.or.jp, www.tepco.co.jp',
  'zoneKey': 'JP-TK'},
 {'capacity': {'wind': 440},
  'datetime': datetime.datetime(2024, 8, 2, 16, 25, tzinfo=tzfile('/usr/share/zoneinfo/Asia/Tokyo')),
  'production': {'biomass': None,
                 'coal': None,
                 'gas': None,
                 'geothermal': None,
                 'hydro': None,
                 'nuclear': None,
                 'oil': None,
                 'solar': 4620.0,
                 'unknown': 42254.0,
                 'wind': None},
  'source': 'occtonet.or.jp, www.tepco.co.jp',
  'zoneKey': 'JP-TK'},
 {'capacity': {'wind': 440},
  'datetime': datetime.datetime(2024, 8, 2, 16, 30, tzinfo=tzfile('/usr/share/zoneinfo/Asia/Tokyo')),
  'production': {'biomass': None,
                 'coal': None,
                 'gas': None,
                 'geothermal': None,
                 'hydro': None,
                 'nuclear': None,
                 'oil': None,
                 'solar': 4350.0,
                 'unknown': 42327.0,
                 'wind': None},
  'source': 'occtonet.or.jp, www.tepco.co.jp',
  'zoneKey': 'JP-TK'},
 {'capacity': {'wind': 440},
  'datetime': datetime.datetime(2024, 8, 2, 16, 35, tzinfo=tzfile('/usr/share/zoneinfo/Asia/Tokyo')),
  'production': {'biomass': None,
                 'coal': None,
                 'gas': None,
                 'geothermal': None,
                 'hydro': None,
                 'nuclear': None,
                 'oil': None,
                 'solar': 4080.0,
                 'unknown': 42949.0,
                 'wind': None},
  'source': 'occtonet.or.jp, www.tepco.co.jp',
  'zoneKey': 'JP-TK'},
 {'capacity': {'wind': 440},
  'datetime': datetime.datetime(2024, 8, 2, 16, 40, tzinfo=tzfile('/usr/share/zoneinfo/Asia/Tokyo')),
  'production': {'biomass': None,
                 'coal': None,
                 'gas': None,
                 'geothermal': None,
                 'hydro': None,
                 'nuclear': None,
                 'oil': None,
                 'solar': 3820.0,
                 'unknown': 42980.0,
                 'wind': None},
  'source': 'occtonet.or.jp, www.tepco.co.jp',
  'zoneKey': 'JP-TK'},
 {'capacity': {'wind': 440},
  'datetime': datetime.datetime(2024, 8, 2, 16, 45, tzinfo=tzfile('/usr/share/zoneinfo/Asia/Tokyo')),
  'production': {'biomass': None,
                 'coal': None,
                 'gas': None,
                 'geothermal': None,
                 'hydro': None,
                 'nuclear': None,
                 'oil': None,
                 'solar': 3560.0,
                 'unknown': 43130.0,
                 'wind': None},
  'source': 'occtonet.or.jp, www.tepco.co.jp',
  'zoneKey': 'JP-TK'},
 {'capacity': {'wind': 440},
  'datetime': datetime.datetime(2024, 8, 2, 16, 50, tzinfo=tzfile('/usr/share/zoneinfo/Asia/Tokyo')),
  'production': {'biomass': None,
                 'coal': None,
                 'gas': None,
                 'geothermal': None,
                 'hydro': None,
                 'nuclear': None,
                 'oil': None,
                 'solar': 3290.0,
                 'unknown': 43150.0,
                 'wind': None},
  'source': 'occtonet.or.jp, www.tepco.co.jp',
  'zoneKey': 'JP-TK'},
 {'capacity': {'wind': 440},
  'datetime': datetime.datetime(2024, 8, 2, 16, 55, tzinfo=tzfile('/usr/share/zoneinfo/Asia/Tokyo')),
  'production': {'biomass': None,
                 'coal': None,
                 'gas': None,
                 'geothermal': None,
                 'hydro': None,
                 'nuclear': None,
                 'oil': None,
                 'solar': 3040.0,
                 'unknown': 43210.0,
                 'wind': None},
  'source': 'occtonet.or.jp, www.tepco.co.jp',
  'zoneKey': 'JP-TK'},
 {'capacity': {'wind': 440},
  'datetime': datetime.datetime(2024, 8, 2, 17, 0, tzinfo=tzfile('/usr/share/zoneinfo/Asia/Tokyo')),
  'production': {'biomass': None,
                 'coal': None,
                 'gas': None,
                 'geothermal': None,
                 'hydro': None,
                 'nuclear': None,
                 'oil': None,
                 'solar': 2800.0,
                 'unknown': 43331.0,
                 'wind': None},
  'source': 'occtonet.or.jp, www.tepco.co.jp',
  'zoneKey': 'JP-TK'},
 {'capacity': {'wind': 440},
  'datetime': datetime.datetime(2024, 8, 2, 17, 5, tzinfo=tzfile('/usr/share/zoneinfo/Asia/Tokyo')),
  'production': {'biomass': None,
                 'coal': None,
                 'gas': None,
                 'geothermal': None,
                 'hydro': None,
                 'nuclear': None,
                 'oil': None,
                 'solar': 2560.0,
                 'unknown': 43260.0,
                 'wind': None},
  'source': 'occtonet.or.jp, www.tepco.co.jp',
  'zoneKey': 'JP-TK'},
 {'capacity': {'wind': 440},
  'datetime': datetime.datetime(2024, 8, 2, 17, 10, tzinfo=tzfile('/usr/share/zoneinfo/Asia/Tokyo')),
  'production': {'biomass': None,
                 'coal': None,
                 'gas': None,
                 'geothermal': None,
                 'hydro': None,
                 'nuclear': None,
                 'oil': None,
                 'solar': 2330.0,
                 'unknown': 43290.0,
                 'wind': None},
  'source': 'occtonet.or.jp, www.tepco.co.jp',
  'zoneKey': 'JP-TK'},
 {'capacity': {'wind': 440},
  'datetime': datetime.datetime(2024, 8, 2, 17, 15, tzinfo=tzfile('/usr/share/zoneinfo/Asia/Tokyo')),
  'production': {'biomass': None,
                 'coal': None,
                 'gas': None,
                 'geothermal': None,
                 'hydro': None,
                 'nuclear': None,
                 'oil': None,
                 'solar': 2110.0,
                 'unknown': 43220.0,
                 'wind': None},
  'source': 'occtonet.or.jp, www.tepco.co.jp',
  'zoneKey': 'JP-TK'},
 {'capacity': {'wind': 440},
  'datetime': datetime.datetime(2024, 8, 2, 17, 20, tzinfo=tzfile('/usr/share/zoneinfo/Asia/Tokyo')),
  'production': {'biomass': None,
                 'coal': None,
                 'gas': None,
                 'geothermal': None,
                 'hydro': None,
                 'nuclear': None,
                 'oil': None,
                 'solar': 1890.0,
                 'unknown': 43130.0,
                 'wind': None},
  'source': 'occtonet.or.jp, www.tepco.co.jp',
  'zoneKey': 'JP-TK'},
 {'capacity': {'wind': 440},
  'datetime': datetime.datetime(2024, 8, 2, 17, 25, tzinfo=tzfile('/usr/share/zoneinfo/Asia/Tokyo')),
  'production': {'biomass': None,
                 'coal': None,
                 'gas': None,
                 'geothermal': None,
                 'hydro': None,
                 'nuclear': None,
                 'oil': None,
                 'solar': 1690.0,
                 'unknown': 43122.0,
                 'wind': None},
  'source': 'occtonet.or.jp, www.tepco.co.jp',
  'zoneKey': 'JP-TK'},
 {'capacity': {'wind': 440},
  'datetime': datetime.datetime(2024, 8, 2, 17, 30, tzinfo=tzfile('/usr/share/zoneinfo/Asia/Tokyo')),
  'production': {'biomass': None,
                 'coal': None,
                 'gas': None,
                 'geothermal': None,
                 'hydro': None,
                 'nuclear': None,
                 'oil': None,
                 'solar': 1510.0,
                 'unknown': 42990.0,
                 'wind': None},
  'source': 'occtonet.or.jp, www.tepco.co.jp',
  'zoneKey': 'JP-TK'},
 {'capacity': {'wind': 440},
  'datetime': datetime.datetime(2024, 8, 2, 17, 35, tzinfo=tzfile('/usr/share/zoneinfo/Asia/Tokyo')),
  'production': {'biomass': None,
                 'coal': None,
                 'gas': None,
                 'geothermal': None,
                 'hydro': None,
                 'nuclear': None,
                 'oil': None,
                 'solar': 1340.0,
                 'unknown': 42790.0,
                 'wind': None},
  'source': 'occtonet.or.jp, www.tepco.co.jp',
  'zoneKey': 'JP-TK'},
 {'capacity': {'wind': 440},
  'datetime': datetime.datetime(2024, 8, 2, 17, 40, tzinfo=tzfile('/usr/share/zoneinfo/Asia/Tokyo')),
  'production': {'biomass': None,
                 'coal': None,
                 'gas': None,
                 'geothermal': None,
                 'hydro': None,
                 'nuclear': None,
                 'oil': None,
                 'solar': 1180.0,
                 'unknown': 42780.0,
                 'wind': None},
  'source': 'occtonet.or.jp, www.tepco.co.jp',
  'zoneKey': 'JP-TK'},
 {'capacity': {'wind': 440},
  'datetime': datetime.datetime(2024, 8, 2, 17, 45, tzinfo=tzfile('/usr/share/zoneinfo/Asia/Tokyo')),
  'production': {'biomass': None,
                 'coal': None,
                 'gas': None,
                 'geothermal': None,
                 'hydro': None,
                 'nuclear': None,
                 'oil': None,
                 'solar': 1030.0,
                 'unknown': 42440.0,
                 'wind': None},
  'source': 'occtonet.or.jp, www.tepco.co.jp',
  'zoneKey': 'JP-TK'},
 {'capacity': {'wind': 440},
  'datetime': datetime.datetime(2024, 8, 2, 17, 50, tzinfo=tzfile('/usr/share/zoneinfo/Asia/Tokyo')),
  'production': {'biomass': None,
                 'coal': None,
                 'gas': None,
                 'geothermal': None,
                 'hydro': None,
                 'nuclear': None,
                 'oil': None,
                 'solar': 890.0,
                 'unknown': 42602.0,
                 'wind': None},
  'source': 'occtonet.or.jp, www.tepco.co.jp',
  'zoneKey': 'JP-TK'},
 {'capacity': {'wind': 440},
  'datetime': datetime.datetime(2024, 8, 2, 17, 55, tzinfo=tzfile('/usr/share/zoneinfo/Asia/Tokyo')),
  'production': {'biomass': None,
                 'coal': None,
                 'gas': None,
                 'geothermal': None,
                 'hydro': None,
                 'nuclear': None,
                 'oil': None,
                 'solar': 750.0,
                 'unknown': 42534.0,
                 'wind': None},
  'source': 'occtonet.or.jp, www.tepco.co.jp',
  'zoneKey': 'JP-TK'},
 {'capacity': {'wind': 440},
  'datetime': datetime.datetime(2024, 8, 2, 18, 0, tzinfo=tzfile('/usr/share/zoneinfo/Asia/Tokyo')),
  'production': {'biomass': None,
                 'coal': None,
                 'gas': None,
                 'geothermal': None,
                 'hydro': None,
                 'nuclear': None,
                 'oil': None,
                 'solar': 630.0,
                 'unknown': 42386.0,
                 'wind': None},
  'source': 'occtonet.or.jp, www.tepco.co.jp',
  'zoneKey': 'JP-TK'},
 {'capacity': {'wind': 440},
  'datetime': datetime.datetime(2024, 8, 2, 18, 5, tzinfo=tzfile('/usr/share/zoneinfo/Asia/Tokyo')),
  'production': {'biomass': None,
                 'coal': None,
                 'gas': None,
                 'geothermal': None,
                 'hydro': None,
                 'nuclear': None,
                 'oil': None,
                 'solar': 510.0,
                 'unknown': 42584.0,
                 'wind': None},
  'source': 'occtonet.or.jp, www.tepco.co.jp',
  'zoneKey': 'JP-TK'},
 {'capacity': {'wind': 440},
  'datetime': datetime.datetime(2024, 8, 2, 18, 10, tzinfo=tzfile('/usr/share/zoneinfo/Asia/Tokyo')),
  'production': {'biomass': None,
                 'coal': None,
                 'gas': None,
                 'geothermal': None,
                 'hydro': None,
                 'nuclear': None,
                 'oil': None,
                 'solar': 400.0,
                 'unknown': 42311.0,
                 'wind': None},
  'source': 'occtonet.or.jp, www.tepco.co.jp',
  'zoneKey': 'JP-TK'},
 {'capacity': {'wind': 440},
  'datetime': datetime.datetime(2024, 8, 2, 18, 15, tzinfo=tzfile('/usr/share/zoneinfo/Asia/Tokyo')),
  'production': {'biomass': None,
                 'coal': None,
                 'gas': None,
                 'geothermal': None,
                 'hydro': None,
                 'nuclear': None,
                 'oil': None,
                 'solar': 300.0,
                 'unknown': 42211.0,
                 'wind': None},
  'source': 'occtonet.or.jp, www.tepco.co.jp',
  'zoneKey': 'JP-TK'},
 {'capacity': {'wind': 440},
  'datetime': datetime.datetime(2024, 8, 2, 18, 20, tzinfo=tzfile('/usr/share/zoneinfo/Asia/Tokyo')),
  'production': {'biomass': None,
                 'coal': None,
                 'gas': None,
                 'geothermal': None,
                 'hydro': None,
                 'nuclear': None,
                 'oil': None,
                 'solar': 210.0,
                 'unknown': 42201.0,
                 'wind': None},
  'source': 'occtonet.or.jp, www.tepco.co.jp',
  'zoneKey': 'JP-TK'},
 {'capacity': {'wind': 440},
  'datetime': datetime.datetime(2024, 8, 2, 18, 25, tzinfo=tzfile('/usr/share/zoneinfo/Asia/Tokyo')),
  'production': {'biomass': None,
                 'coal': None,
                 'gas': None,
                 'geothermal': None,
                 'hydro': None,
                 'nuclear': None,
                 'oil': None,
                 'solar': 60.0,
                 'unknown': 42141.0,
                 'wind': None},
  'source': 'occtonet.or.jp, www.tepco.co.jp',
  'zoneKey': 'JP-TK'}]
---------------------
took 29.98s
min returned datetime: 2024-08-01 15:05:00+00:00 UTC
max returned datetime: 2024-08-02 09:25:00+00:00 UTC  -- OK, <2h from now :) (now=2024-08-02T09:32:56+00:00 UTC)
```

