### PR TITLE
chore: clean up unused prop in BarBreakdownChart

### DIFF
--- a/web/src/features/charts/bar-breakdown/BarBreakdownChart.tsx
+++ b/web/src/features/charts/bar-breakdown/BarBreakdownChart.tsx
@@ -10,7 +10,7 @@ import { useAtom, useAtomValue } from 'jotai';
 import { X } from 'lucide-react';
 import React, { useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { ElectricityModeType, ZoneDetail, ZoneKey } from 'types';
+import { ElectricityModeType, ZoneKey } from 'types';
 import useResizeObserver from 'use-resize-observer';
 import trackEvent from 'utils/analytics';
 import { TrackEvent } from 'utils/constants';
@@ -98,7 +98,6 @@ function BarBreakdownChart({
 
   const onMouseOver = (
     layerKey: ElectricityModeType | ZoneKey,
-    _: ZoneDetail,
     event: React.MouseEvent
   ) => {
     const { clientX, clientY } = event;
@@ -167,7 +166,6 @@ function BarBreakdownChart({
       )}
       {displayByEmissions ? (
         <BarBreakdownEmissionsChart
-          data={currentZoneDetail}
           productionData={productionData}
           exchangeData={exchangeData}
           onProductionRowMouseOver={onMouseOver}
@@ -181,7 +179,6 @@ function BarBreakdownChart({
       ) : (
         <BarElectricityBreakdownChart
           data={zoneDetails}
-          currentData={currentZoneDetail}
           productionData={productionData}
           exchangeData={exchangeData}
           onProductionRowMouseOver={onMouseOver}

--- a/web/src/features/charts/bar-breakdown/BarBreakdownEmissionsChart.stories.ts
+++ b/web/src/features/charts/bar-breakdown/BarBreakdownEmissionsChart.stories.ts
@@ -1,5 +1,4 @@
 import type { Meta, StoryObj } from '@storybook/react';
-import { zoneDetailMock } from 'stories/mockData';
 
 import BarBreakdownEmissionsChart from './BarBreakdownEmissionsChart';
 import type { ExchangeDataType, ProductionDataType } from './utils';
@@ -10,9 +9,6 @@ const meta: Meta<typeof BarBreakdownEmissionsChart> = {
 };
 
 type Story = StoryObj<typeof BarBreakdownEmissionsChart>;
-
-// Copying the mock data here to be able to make changes to it
-const zoneDetail = { ...zoneDetailMock };
 
 const productionData: ProductionDataType[] = [
   {
@@ -134,7 +130,6 @@ export const IncludesStorage: Story = {
   // More on args: https://storybook.js.org/docs/react/writing-stories/args
   args: {
     //testId: 'none',
-    data: zoneDetail,
     productionData: productionData,
     exchangeData: exchangeData,
     onExchangeRowMouseOut: () => {},

--- a/web/src/features/charts/bar-breakdown/BarBreakdownEmissionsChart.tsx
+++ b/web/src/features/charts/bar-breakdown/BarBreakdownEmissionsChart.tsx
@@ -1,7 +1,7 @@
 import { max as d3Max } from 'd3-array';
 import { scaleLinear } from 'd3-scale';
 import { useMemo } from 'react';
-import { ElectricityModeType, ZoneDetail, ZoneKey } from 'types';
+import { ElectricityModeType, ZoneKey } from 'types';
 import { formatCo2 } from 'utils/formatting';
 
 import BarEmissionExchangeChart from './BarEmissionExchangeChart';
@@ -12,26 +12,22 @@ import { ExchangeDataType, getDataBlockPositions, ProductionDataType } from './u
 interface BarBreakdownEmissionsChartProps {
   height: number;
   width: number;
-  data: ZoneDetail;
   exchangeData: ExchangeDataType[];
   productionData: ProductionDataType[];
   isMobile: boolean;
   onProductionRowMouseOver: (
     rowKey: ElectricityModeType,
-    data: ZoneDetail,
     event: React.MouseEvent<SVGPathElement, MouseEvent>
   ) => void;
   onProductionRowMouseOut: () => void;
   onExchangeRowMouseOver: (
     rowKey: ZoneKey,
-    data: ZoneDetail,
     event: React.MouseEvent<SVGPathElement, MouseEvent>
   ) => void;
   onExchangeRowMouseOut: () => void;
 }
 
 function BarBreakdownEmissionsChart({
-  data,
   exchangeData,
   height,
   isMobile,
@@ -78,7 +74,6 @@ function BarBreakdownEmissionsChart({
         co2Scale={co2Scale}
         productionY={productionY}
         productionData={productionData}
-        data={data}
         width={width}
         onProductionRowMouseOut={onProductionRowMouseOut}
         onProductionRowMouseOver={onProductionRowMouseOver}
@@ -89,7 +84,6 @@ function BarBreakdownEmissionsChart({
         onExchangeRowMouseOut={onExchangeRowMouseOut}
         onExchangeRowMouseOver={onExchangeRowMouseOver}
         exchangeData={exchangeData}
-        data={data}
         width={width}
         co2Scale={co2Scale}
         formatTick={formatTick}

--- a/web/src/features/charts/bar-breakdown/BarElectricityBreakdownChart.tsx
+++ b/web/src/features/charts/bar-breakdown/BarElectricityBreakdownChart.tsx
@@ -3,7 +3,7 @@ import { scaleLinear } from 'd3-scale';
 import { useCo2ColorScale } from 'hooks/theme';
 import { useAtomValue } from 'jotai';
 import { useMemo } from 'react';
-import { ElectricityModeType, ZoneDetail, ZoneDetails, ZoneKey } from 'types';
+import { ElectricityModeType, ZoneDetails, ZoneKey } from 'types';
 import { formatEnergy, formatPower } from 'utils/formatting';
 import { isHourlyAtom } from 'utils/state/atoms';
 
@@ -16,19 +16,16 @@ interface BarElectricityBreakdownChartProps {
   height: number;
   width: number;
   data: ZoneDetails;
-  currentData: ZoneDetail;
   exchangeData: ExchangeDataType[];
   productionData: ProductionDataType[];
   isMobile: boolean;
   onProductionRowMouseOver: (
     rowKey: ElectricityModeType,
-    data: ZoneDetail,
     event: React.MouseEvent<SVGPathElement, MouseEvent>
   ) => void;
   onProductionRowMouseOut: () => void;
   onExchangeRowMouseOver: (
     rowKey: ZoneKey,
-    data: ZoneDetail,
     event: React.MouseEvent<SVGPathElement, MouseEvent>
   ) => void;
   onExchangeRowMouseOut: () => void;
@@ -37,7 +34,6 @@ interface BarElectricityBreakdownChartProps {
 
 function BarElectricityBreakdownChart({
   data,
-  currentData,
   exchangeData,
   height,
   isMobile,
@@ -107,7 +103,6 @@ function BarElectricityBreakdownChart({
         formatTick={formatTick}
         productionY={productionY}
         productionData={productionData}
-        currentData={currentData}
         width={width}
         onProductionRowMouseOver={onProductionRowMouseOver}
         onProductionRowMouseOut={onProductionRowMouseOut}
@@ -118,7 +113,6 @@ function BarElectricityBreakdownChart({
         onExchangeRowMouseOut={onExchangeRowMouseOut}
         onExchangeRowMouseOver={onExchangeRowMouseOver}
         exchangeData={exchangeData}
-        data={currentData}
         width={width}
         powerScale={powerScale}
         formatTick={formatTick}

--- a/web/src/features/charts/bar-breakdown/BarElectricityExchangeChart.tsx
+++ b/web/src/features/charts/bar-breakdown/BarElectricityExchangeChart.tsx
@@ -2,7 +2,7 @@ import { CountryFlag } from 'components/Flag';
 import HorizontalColorbar from 'components/legend/ColorBar';
 import { ScaleLinear } from 'd3-scale';
 import { useTranslation } from 'react-i18next';
-import { ZoneDetail, ZoneKey } from 'types';
+import { ZoneKey } from 'types';
 import { CarbonUnits } from 'utils/units';
 
 import { EXCHANGE_PADDING } from './constants';
@@ -15,7 +15,6 @@ import { ExchangeDataType } from './utils';
 export default function BarElectricityExchangeChart({
   height,
   width,
-  data,
   exchangeData,
   powerScale,
   co2ColorScale,
@@ -26,7 +25,6 @@ export default function BarElectricityExchangeChart({
 }: {
   height: number;
   width: number;
-  data: ZoneDetail;
   exchangeData: ExchangeDataType[];
   powerScale: ScaleLinear<number, number, never>;
   co2ColorScale: ScaleLinear<string, string, string>;
@@ -35,7 +33,6 @@ export default function BarElectricityExchangeChart({
   onExchangeRowMouseOut: () => void;
   onExchangeRowMouseOver: (
     rowKey: ZoneKey,
-    data: ZoneDetail,
     event: React.MouseEvent<SVGPathElement, MouseEvent>
   ) => void;
 }) {
@@ -69,7 +66,7 @@ export default function BarElectricityExchangeChart({
               width={width}
               scale={powerScale}
               value={d.exchange}
-              onMouseOver={(event) => onExchangeRowMouseOver(d.zoneKey, data, event)}
+              onMouseOver={(event) => onExchangeRowMouseOver(d.zoneKey, event)}
               onMouseOut={onExchangeRowMouseOut}
               isMobile={false}
             >

--- a/web/src/features/charts/bar-breakdown/BarElectricityProductionChart.tsx
+++ b/web/src/features/charts/bar-breakdown/BarElectricityProductionChart.tsx
@@ -1,6 +1,6 @@
 import { ScaleLinear } from 'd3-scale';
 import { useTranslation } from 'react-i18next';
-import { ElectricityModeType, ZoneDetail } from 'types';
+import { ElectricityModeType } from 'types';
 import { modeColor } from 'utils/constants';
 
 import ProductionSourceLegend from '../ProductionSourceLegend';
@@ -16,7 +16,6 @@ export function BarElectricityProductionChart({
   formatTick,
   productionY,
   productionData,
-  currentData,
   width,
   onProductionRowMouseOver,
   onProductionRowMouseOut,
@@ -27,11 +26,9 @@ export function BarElectricityProductionChart({
   formatTick: (t: number) => string | number;
   productionY: number;
   productionData: ProductionDataType[];
-  currentData: ZoneDetail;
   width: number;
   onProductionRowMouseOver: (
     rowKey: ElectricityModeType,
-    data: ZoneDetail,
     event: React.MouseEvent<SVGPathElement, MouseEvent>
   ) => void;
   onProductionRowMouseOut: () => void;
@@ -58,7 +55,7 @@ export function BarElectricityProductionChart({
             width={width}
             scale={powerScale}
             value={getElectricityProductionValue(d)}
-            onMouseOver={(event) => onProductionRowMouseOver(d.mode, currentData, event)}
+            onMouseOver={(event) => onProductionRowMouseOver(d.mode, event)}
             onMouseOut={onProductionRowMouseOut}
             isMobile={isMobile}
           >

--- a/web/src/features/charts/bar-breakdown/BarEmissionExchangeChart.tsx
+++ b/web/src/features/charts/bar-breakdown/BarEmissionExchangeChart.tsx
@@ -1,7 +1,7 @@
 import { CountryFlag } from 'components/Flag';
 import { ScaleLinear } from 'd3-scale';
 import { useTranslation } from 'react-i18next';
-import { ZoneDetail, ZoneKey } from 'types';
+import { ZoneKey } from 'types';
 
 import { EXCHANGE_PADDING } from './constants';
 import Axis from './elements/Axis';
@@ -12,7 +12,6 @@ import { ExchangeDataType } from './utils';
 export default function BarEmissionExchangeChart({
   height,
   width,
-  data,
   exchangeData,
   co2Scale,
   formatTick,
@@ -21,14 +20,12 @@ export default function BarEmissionExchangeChart({
 }: {
   height: number;
   width: number;
-  data: ZoneDetail;
   exchangeData: ExchangeDataType[];
   co2Scale: ScaleLinear<number, number, never>;
   formatTick: (value: number) => string;
   onExchangeRowMouseOut: () => void;
   onExchangeRowMouseOver: (
     rowKey: ZoneKey,
-    data: ZoneDetail,
     event: React.MouseEvent<SVGPathElement, MouseEvent>
   ) => void;
 }) {
@@ -58,7 +55,7 @@ export default function BarEmissionExchangeChart({
               width={width}
               scale={co2Scale}
               value={d.exchange}
-              onMouseOver={(event) => onExchangeRowMouseOver(d.zoneKey, data, event)}
+              onMouseOver={(event) => onExchangeRowMouseOver(d.zoneKey, event)}
               onMouseOut={onExchangeRowMouseOut}
               isMobile={false}
             >

--- a/web/src/features/charts/bar-breakdown/BarEmissionProductionChart.tsx
+++ b/web/src/features/charts/bar-breakdown/BarEmissionProductionChart.tsx
@@ -1,6 +1,6 @@
 import { ScaleLinear } from 'd3-scale';
 import { useTranslation } from 'react-i18next';
-import { ElectricityModeType, ZoneDetail } from 'types';
+import { ElectricityModeType } from 'types';
 import { modeColor } from 'utils/constants';
 
 import ProductionSourceLegend from '../ProductionSourceLegend';
@@ -15,7 +15,6 @@ export function BarEmissionProductionChart({
   co2Scale,
   productionY,
   productionData,
-  data,
   width,
   onProductionRowMouseOut,
   onProductionRowMouseOver,
@@ -26,12 +25,10 @@ export function BarEmissionProductionChart({
   co2Scale: ScaleLinear<number, number, never>;
   productionY: number;
   productionData: ProductionDataType[];
-  data: ZoneDetail;
   width: number;
   onProductionRowMouseOut: () => void;
   onProductionRowMouseOver: (
     rowKey: ElectricityModeType,
-    data: ZoneDetail,
     event: React.MouseEvent<SVGPathElement, MouseEvent>
   ) => void;
   isMobile: boolean;
@@ -49,7 +46,7 @@ export function BarEmissionProductionChart({
             width={width}
             scale={co2Scale}
             value={Math.abs(d.gCo2eq)}
-            onMouseOver={(event) => onProductionRowMouseOver(d.mode, data, event)}
+            onMouseOver={(event) => onProductionRowMouseOver(d.mode, event)}
             onMouseOut={onProductionRowMouseOut}
             isMobile={isMobile}
           >


### PR DESCRIPTION
## Issue

While looking into AVO-361 I found a prop that was not used but still drilled through multiple components.

## Description
Removes said prop from these components.

### Double check

- [x] I have run `pnpx prettier@2 --write .` and `poetry run format` in the top level directory to format my changes.
