### PR TITLE
feat: Add button to our subreddit

### DIFF
--- a/web/src/components/buttons/RedditButton.stories.tsx
+++ b/web/src/components/buttons/RedditButton.stories.tsx
@@ -1,0 +1,15 @@
+import type { Meta, StoryObj } from '@storybook/react';
+
+import { RedditButton } from './RedditButton';
+
+const meta: Meta<typeof RedditButton> = {
+  title: 'Basics/Buttons/Reddit',
+  component: RedditButton,
+};
+
+export default meta;
+type Story = StoryObj<typeof RedditButton>;
+
+export const Primary: Story = {
+  name: 'Default Reddit Button',
+};

--- a/web/src/components/buttons/RedditButton.tsx
+++ b/web/src/components/buttons/RedditButton.tsx
@@ -1,0 +1,32 @@
+import { Button, ButtonProps } from 'components/Button';
+import { useTranslation } from 'react-i18next';
+import { FaReddit } from 'react-icons/fa6';
+import { DEFAULT_ICON_SIZE } from 'utils/constants';
+
+interface RedditButtonProps
+  extends Omit<
+    ButtonProps,
+    'icon' | 'children' | 'href' | 'onClick' | 'backgroundClasses' | 'foregroundClasses'
+  > {
+  iconSize?: number;
+  isIconOnly?: boolean;
+}
+
+export function RedditButton({
+  isIconOnly,
+  iconSize = DEFAULT_ICON_SIZE,
+  ...restProps
+}: RedditButtonProps) {
+  const { t } = useTranslation();
+  return (
+    <Button
+      backgroundClasses="bg-[#FF4500]"
+      foregroundClasses="text-white dark:text-white focus-visible:outline-[#0A66C2]"
+      href={'https://www.reddit.com/r/electricitymaps/'}
+      icon={<FaReddit size={iconSize} />}
+      {...restProps}
+    >
+      {isIconOnly ? undefined : t('button.reddit')}
+    </Button>
+  );
+}

--- a/web/src/features/panels/ranking-panel/RankingPanelAccordion.tsx
+++ b/web/src/features/panels/ranking-panel/RankingPanelAccordion.tsx
@@ -1,6 +1,7 @@
 import Accordion from 'components/Accordion';
 import { GithubButton } from 'components/buttons/GithubButton';
 import { LinkedinButton } from 'components/buttons/LinkedinButton';
+import { RedditButton } from 'components/buttons/RedditButton';
 import { SlackButton } from 'components/buttons/SlackButton';
 import InfoText from 'features/modals/InfoText';
 import { useTranslation } from 'react-i18next';
@@ -20,6 +21,7 @@ export default function RankingPanelAccordion() {
         <SlackButton size="sm" shouldShrink />
         <GithubButton size="sm" shouldShrink />
         <LinkedinButton size="sm" shouldShrink />
+        <RedditButton size="sm" shouldShrink />
       </div>
     </Accordion>
   );

--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -14,6 +14,7 @@
     "search": "Search areas"
   },
   "button": {
+    "reddit": "Join r/electricitymaps",
     "github": "Contribute on GitHub",
     "twitter": "Follow us on Twitter",
     "twitter-share": "Share on Twitter",

--- a/web/src/locales/sv.json
+++ b/web/src/locales/sv.json
@@ -7,6 +7,7 @@
     "feedback": "Ge återkoppling",
     "github": "Se vår GitHub",
     "twitter": "Dela på Twitter",
+    "reddit": "Gå med i r/electricitymaps",
     "slack": "Gå med i Slack-gemenskapen",
     "privacy-policy": "Integritetspolicy",
     "legal-notice": "Rättsligt meddelande"


### PR DESCRIPTION
## Description
Adds a button in the ranking panel accordion to our official subreddit at https://reddit.com/r/electricitymaps

### Preview

<img width="491" alt="image" src="https://github.com/user-attachments/assets/3da5bf04-03f3-41e1-af18-8025c6a34c46">


### Double check
- [x] I have run `pnpx prettier@2 --write .` and `poetry run format` in the top level directory to format my changes.
