### PR TITLE
switch back to useQuery instead of useSuspenseQuery

### DIFF
--- a/web/src/api/getZone.ts
+++ b/web/src/api/getZone.ts
@@ -1,5 +1,5 @@
-import type { UseSuspenseQueryResult } from '@tanstack/react-query';
-import { useSuspenseQuery } from '@tanstack/react-query';
+import type { UseQueryResult } from '@tanstack/react-query';
+import { useQuery } from '@tanstack/react-query';
 import { useAtom } from 'jotai';
 import invariant from 'tiny-invariant';
 import type { ZoneDetails } from 'types';
@@ -37,10 +37,10 @@ const getZone = async (
 
 // TODO: The frontend (graphs) expects that the datetimes in state are the same as in zone
 // should we add a check for this?
-const useGetZone = (): UseSuspenseQueryResult<ZoneDetails> => {
+const useGetZone = (): UseQueryResult<ZoneDetails> => {
   const zoneId = useGetZoneFromPath();
   const [timeAverage] = useAtom(timeAverageAtom);
-  return useSuspenseQuery<ZoneDetails>({
+  return useQuery<ZoneDetails>({
     queryKey: [QUERY_KEYS.ZONE, { zone: zoneId, aggregate: timeAverage }],
     queryFn: async () => getZone(timeAverage, zoneId),
   });

--- a/web/src/features/charts/hooks/useCarbonChartData.ts
+++ b/web/src/features/charts/hooks/useCarbonChartData.ts
@@ -11,7 +11,7 @@ export function useCarbonChartData() {
   const co2ColorScale = useCo2ColorScale();
   const [mixMode] = useAtom(productionConsumptionAtom);
 
-  if (isLoading || isError) {
+  if (isLoading || isError || !data) {
     return { isLoading, isError };
   }
 

--- a/web/src/features/charts/hooks/useEmissionChartData.ts
+++ b/web/src/features/charts/hooks/useEmissionChartData.ts
@@ -11,7 +11,7 @@ export function useEmissionChartData() {
   const { data, isLoading, isError } = useGetZone();
   const [mixMode] = useAtom(productionConsumptionAtom);
 
-  if (isLoading || isError) {
+  if (isLoading || isError || !data) {
     return { isLoading, isError };
   }
 

--- a/web/src/features/charts/hooks/useNetExchangeChartData.ts
+++ b/web/src/features/charts/hooks/useNetExchangeChartData.ts
@@ -34,7 +34,7 @@ export function useNetExchangeChartData() {
   const [displayByEmissions] = useAtom(displayByEmissionsAtom);
   const [timeAggregate] = useAtom(timeAverageAtom);
 
-  if (isLoading || isError) {
+  if (isLoading || isError || !zoneData) {
     return { isLoading, isError };
   }
 

--- a/web/src/features/charts/hooks/usePriceChartData.ts
+++ b/web/src/features/charts/hooks/usePriceChartData.ts
@@ -28,7 +28,7 @@ export function getFills(data: AreaGraphElement[]) {
 export function usePriceChartData() {
   const { data: zoneData, isLoading, isError } = useGetZone();
 
-  if (isLoading || isError) {
+  if (isLoading || isError || !zoneData) {
     return { isLoading, isError };
   }
 


### PR DESCRIPTION
## Issue
The switch from useQuery to useSuspenseQuery was intended to alleviate some CLS and allow components to load more gracefully. This had the unintended consequence of making the bottom sheet disappear when a zone is loading as it would suspend the whole component without a fallback.

## Description
Reverts that particular change to bring back the old behaviour.

### Double check

- [x] I have run `pnpx prettier@2 --write .` and `poetry run format` in the top level directory to format my changes.
