### PR TITLE
chore: fix button outlines

### DIFF
--- a/web/src/components/Button.tsx
+++ b/web/src/components/Button.tsx
@@ -96,12 +96,12 @@ function getBackground(type: string, disabled: boolean | undefined) {
   switch (type) {
     case 'primary': {
       if (disabled) {
-        return 'bg-zinc-50 dark:bg-gray-800 outline outline-neutral-200 dark:outline-gray-700';
+        return 'bg-zinc-50 dark:bg-gray-800 outline outline-1 outline-neutral-200 dark:outline-gray-700';
       }
       return 'bg-brand-green';
     }
     case 'secondary': {
-      return 'outline dark:outline-gray-700 outline-neutral-200 bg-white dark:bg-gray-900';
+      return 'outline outline-1 dark:outline-gray-700 outline-neutral-200 bg-white dark:bg-gray-900';
     }
     default: {
       return 'bg-inherit';


### PR DESCRIPTION
## Issue
A small change snuck into #7062 
## Description
This fixes the issue by setting the outline width to 1px to match the border width used before.

### Preview
On master:
<img width="427" alt="image" src="https://github.com/user-attachments/assets/b88fa323-72c4-4bc6-8504-c0d9f62b1f54">

In this branch:
<img width="427" alt="image" src="https://github.com/user-attachments/assets/447a73d5-d3c1-476c-a0dd-d8f491a04b5f">

### Double check

- [x] I have run `pnpx prettier@2 --write .` and `poetry run format` in the top level directory to format my changes.
