### PR TITLE
chore: use Lucide icons for ZoneHeaderTitle and simplify DOM

### DIFF
--- a/web/src/features/panels/zone/ZoneHeaderTitle.tsx
+++ b/web/src/features/panels/zone/ZoneHeaderTitle.tsx
@@ -3,7 +3,7 @@ import { TimeDisplay } from 'components/TimeDisplay';
 import TooltipWrapper from 'components/tooltips/TooltipWrapper';
 import { mapMovingAtom } from 'features/map/mapAtoms';
 import { useSetAtom } from 'jotai';
-import { HiArrowLeft } from 'react-icons/hi2';
+import { ArrowLeft, Info } from 'lucide-react';
 import { Link } from 'react-router-dom';
 import { getCountryName, getFullZoneName, getZoneName } from 'translation/translation';
 import { createToWithState } from 'utils/helpers';
@@ -31,49 +31,41 @@ export default function ZoneHeaderTitle({ zoneId }: ZoneHeaderTitleProps) {
   const onNavigateBack = () => setIsMapMoving(false);
 
   return (
-    <div className="flex w-full grow flex-row overflow-hidden py-2 pl-2">
+    <div className="flex w-full py-2 pl-2">
       <Link
         className="self-center py-4 pr-4 text-xl"
         to={returnToMapLink}
         data-test-id="left-panel-back-button"
         onClick={onNavigateBack}
       >
-        <HiArrowLeft />
+        <ArrowLeft />
       </Link>
 
       <div className="w-full overflow-hidden">
-        <div className="flex w-full  flex-row justify-between">
-          <div className="mb-0.5 flex  w-full  justify-between">
-            <div className="flex w-full flex-row items-center pr-4 sm:pr-0 ">
-              <CountryFlag
-                zoneId={zoneId}
-                size={18}
-                className="shadow-[0_0px_3px_rgba(0,0,0,0.2)]"
-              />
-              <TooltipWrapper
-                tooltipContent={showTooltip ? zoneNameFull : undefined}
-                side="bottom"
-              >
-                <div className="ml-2 flex w-full flex-row overflow-hidden">
-                  <h1 className="truncate font-medium" data-test-id="zone-name">
-                    {zoneName}
-                  </h1>
-                  {showCountryPill && (
-                    <div className="ml-2 flex w-auto items-center rounded-full bg-gray-200 px-2 py-0.5  text-sm dark:bg-gray-800/80">
-                      <p className="w-full truncate">{countryName ?? zoneId}</p>
-                    </div>
-                  )}
-                </div>
-              </TooltipWrapper>
-              {disclaimer && (
-                <TooltipWrapper side="bottom" tooltipContent={disclaimer}>
-                  <div className="ml-2 mr-4 h-6 w-6 shrink-0 select-none rounded-full bg-white text-center drop-shadow dark:border dark:border-gray-500 dark:bg-gray-900">
-                    <p>i</p>
-                  </div>
-                </TooltipWrapper>
-              )}
+        <div className="flex w-full items-center gap-2 pr-4 ">
+          <CountryFlag
+            zoneId={zoneId}
+            size={18}
+            className="shadow-[0_0px_3px_rgba(0,0,0,0.2)]"
+          />
+          <TooltipWrapper
+            tooltipContent={showTooltip ? zoneNameFull : undefined}
+            side="bottom"
+          >
+            <h1 className="grow truncate" data-test-id="zone-name">
+              {zoneName}
+            </h1>
+          </TooltipWrapper>
+          {showCountryPill && (
+            <div className="flex w-auto items-center rounded-full bg-gray-200 px-2 py-0.5 text-sm dark:bg-gray-800/80">
+              <p className="w-full truncate">{countryName ?? zoneId}</p>
             </div>
-          </div>
+          )}
+          {disclaimer && (
+            <TooltipWrapper side="bottom" tooltipContent={disclaimer}>
+              <Info className="shrink-0 text-gray-500" />
+            </TooltipWrapper>
+          )}
         </div>
         <TimeDisplay className="whitespace-nowrap text-sm" />
       </div>

--- a/web/src/features/panels/zone/ZoneHeaderTitle.tsx
+++ b/web/src/features/panels/zone/ZoneHeaderTitle.tsx
@@ -52,7 +52,7 @@ export default function ZoneHeaderTitle({ zoneId }: ZoneHeaderTitleProps) {
             tooltipContent={showTooltip ? zoneNameFull : undefined}
             side="bottom"
           >
-            <h1 className="grow truncate" data-test-id="zone-name">
+            <h1 className="truncate" data-test-id="zone-name">
               {zoneName}
             </h1>
           </TooltipWrapper>
@@ -63,7 +63,7 @@ export default function ZoneHeaderTitle({ zoneId }: ZoneHeaderTitleProps) {
           )}
           {disclaimer && (
             <TooltipWrapper side="bottom" tooltipContent={disclaimer}>
-              <Info className="shrink-0 text-gray-500" />
+              <Info className="ml-auto shrink-0 text-gray-500" />
             </TooltipWrapper>
           )}
         </div>


### PR DESCRIPTION
## Issue

We where not using Lucide icons and the DOM was bloated.

Part of: AVO-439

## Description

Switches to use Lucide icons and simplifies the the DOM structure to reduce the amount of rendered elements and size of the code.

This reduces the total app size from `4071.75 KiB` to `4070.90 KiB` spread across the index file, style.css and the ZoneDetails bundles.

### Preview

> [!NOTE]
> Previously the `i` was not an icon and therefore had some unexpected behaviour on hover.
> It however means we can't style it exactly the same way.


#### On master:
<img width="516" alt="image" src="https://github.com/user-attachments/assets/a5f7e2fe-05bd-486c-9ca3-cea082c4bac8">


#### On this branch:
<img width="516" alt="image" src="https://github.com/user-attachments/assets/a2f521b5-5a91-43f4-b2cf-8ea43f9fb21f">


### Double check

- [x] I have run `pnpx prettier@2 --write .` and `poetry run format` in the top level directory to format my changes.
