### PR TITLE
chore: use Lucide icons for MapControls and reuse logic

### DIFF
--- a/web/src/features/map-controls/LanguageSelector.tsx
+++ b/web/src/features/map-controls/LanguageSelector.tsx
@@ -1,7 +1,7 @@
 import { Button } from 'components/Button';
+import { Languages } from 'lucide-react';
 import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { HiLanguage } from 'react-icons/hi2';
 import { languageNames } from 'translation/locales';
 import trackEvent from 'utils/analytics';
 
@@ -30,14 +30,14 @@ export function LanguageSelector({ isMobile }: { isMobile?: boolean }) {
           <Button
             size="lg"
             type="secondary"
-            icon={<HiLanguage size={20} />}
+            icon={<Languages size={20} />}
             backgroundClasses="w-[330px] h-[45px]"
           >
             {t('tooltips.selectLanguage')}
           </Button>
         ) : (
           <MapButton
-            icon={<HiLanguage size={20} style={{ strokeWidth: '0.5' }} />}
+            icon={<Languages size={20} />}
             tooltipText={t('tooltips.selectLanguage')}
             ariaLabel={t('aria.label.selectLanguage')}
           />

--- a/web/src/features/map-controls/MapControls.tsx
+++ b/web/src/features/map-controls/MapControls.tsx
@@ -81,7 +81,10 @@ function WeatherButton({ type }: { type: 'wind' | 'solar' }) {
         isLoadingLayer ? (
           <MoonLoader size={14} color={spinnerColor} />
         ) : (
-          <Icon size={weatherButtonMap[type].iconSize} color={isEnabled ? '' : 'gray'} />
+          <Icon
+            size={weatherButtonMap[type].iconSize}
+            className={isEnabled ? '' : 'opacity-50'}
+          />
         )
       }
       tooltipText={tooltipTexts[type]}

--- a/web/src/features/map-controls/MapControls.tsx
+++ b/web/src/features/map-controls/MapControls.tsx
@@ -1,15 +1,13 @@
 import { useAtom, useAtomValue } from 'jotai';
+import { EyeOff, Sun, Wind } from 'lucide-react';
 import { useTransition } from 'react';
 import { useTranslation } from 'react-i18next';
-import { FiWind } from 'react-icons/fi';
-import { HiOutlineEyeOff, HiOutlineSun } from 'react-icons/hi';
 import { MoonLoader } from 'react-spinners';
 import trackEvent from 'utils/analytics';
 import { ThemeOptions, ToggleOptions } from 'utils/constants';
 import {
+  areWeatherLayersAllowedAtom,
   colorblindModeAtom,
-  isHourlyAtom,
-  selectedDatetimeIndexAtom,
   solarLayerAtom,
   solarLayerLoadingAtom,
   themeAtom,
@@ -35,14 +33,14 @@ function MobileMapControls() {
 
 export const weatherButtonMap = {
   wind: {
-    icon: FiWind,
-    iconSize: 18,
+    icon: Wind,
+    iconSize: 20,
     enabledAtom: windLayerAtom,
     loadingAtom: windLayerLoadingAtom,
   },
   solar: {
-    icon: HiOutlineSun,
-    iconSize: 21,
+    icon: Sun,
+    iconSize: 20,
     enabledAtom: solarLayerAtom,
     loadingAtom: solarLayerLoadingAtom,
   },
@@ -98,13 +96,9 @@ function WeatherButton({ type }: { type: 'wind' | 'solar' }) {
 
 function DesktopMapControls() {
   const { t } = useTranslation();
-  const isHourly = useAtomValue(isHourlyAtom);
-  const [selectedDatetime] = useAtom(selectedDatetimeIndexAtom);
+  const areWeatherLayersAllowed = useAtomValue(areWeatherLayersAllowedAtom);
   const [isColorblindModeEnabled, setIsColorblindModeEnabled] =
     useAtom(colorblindModeAtom);
-
-  // We are currently only supporting and fetching weather data for the latest hourly value
-  const areWeatherLayersAllowed = selectedDatetime.index === 24 && isHourly;
 
   const handleColorblindModeToggle = () => {
     setIsColorblindModeEnabled(!isColorblindModeEnabled);
@@ -121,7 +115,7 @@ function DesktopMapControls() {
         <LanguageSelector />
         <MapButton
           icon={
-            <HiOutlineEyeOff
+            <EyeOff
               size={20}
               className={`${isColorblindModeEnabled ? '' : 'opacity-50'}`}
             />

--- a/web/src/features/modals/SettingsModal.tsx
+++ b/web/src/features/modals/SettingsModal.tsx
@@ -6,15 +6,11 @@ import { weatherButtonMap } from 'features/map-controls/MapControls';
 import SpatialAggregatesToggle from 'features/map-controls/SpatialAggregatesToggle';
 import ThemeSelector from 'features/map-controls/ThemeSelector';
 import { useAtom, useAtomValue } from 'jotai';
+import { EyeOff } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
-import { HiOutlineEyeOff } from 'react-icons/hi';
 import { MoonLoader } from 'react-spinners';
 import { ToggleOptions } from 'utils/constants';
-import {
-  colorblindModeAtom,
-  isHourlyAtom,
-  selectedDatetimeIndexAtom,
-} from 'utils/state/atoms';
+import { areWeatherLayersAllowedAtom, colorblindModeAtom } from 'utils/state/atoms';
 
 import { isSettingsModalOpenAtom } from './modalAtoms';
 
@@ -68,13 +64,9 @@ function WeatherToggleButton({
 }
 
 export function SettingsModalContent() {
-  const isHourly = useAtomValue(isHourlyAtom);
-  const [selectedDatetime] = useAtom(selectedDatetimeIndexAtom);
+  const areWeatherLayersAllowed = useAtomValue(areWeatherLayersAllowedAtom);
   const [isColorblindModeEnabled, setIsColorblindModeEnabled] =
     useAtom(colorblindModeAtom);
-
-  // We are currently only supporting and fetching weather data for the latest hourly value
-  const areWeatherLayersAllowed = selectedDatetime.index === 24 && isHourly;
 
   const { t } = useTranslation();
   return (
@@ -93,7 +85,7 @@ export function SettingsModalContent() {
         type={isColorblindModeEnabled ? 'primary' : 'secondary'}
         backgroundClasses="w-[330px] h-[45px]"
         onClick={() => setIsColorblindModeEnabled(!isColorblindModeEnabled)}
-        icon={<HiOutlineEyeOff size={21} />}
+        icon={<EyeOff size={20} />}
       >
         {t('legends.colorblindmode')}
       </Button>

--- a/web/src/utils/state/atoms.ts
+++ b/web/src/utils/state/atoms.ts
@@ -19,7 +19,7 @@ export const isHourlyAtom = atom((get) => get(timeAverageAtom) === TimeAverages.
 // TODO: consider another initial value
 export const selectedDatetimeIndexAtom = atom({ datetime: new Date(), index: 0 });
 
-export const selectedDatetimeStringAtom = atom((get) => {
+export const selectedDatetimeStringAtom = atom<string>((get) => {
   const { datetime } = get(selectedDatetimeIndexAtom);
   return dateToDatetimeString(datetime);
 });
@@ -30,20 +30,18 @@ export const spatialAggregateAtom = atomWithStorage(
 );
 export const productionConsumptionAtom = atomWithStorage('mode', Mode.CONSUMPTION);
 
+export const areWeatherLayersAllowedAtom = atom<boolean>(
+  (get) => get(isHourlyAtom) && get(selectedDatetimeIndexAtom).index === 24
+);
+
 export const solarLayerAtom = atomWithStorage('solar', ToggleOptions.OFF);
-export const isSolarLayerEnabledAtom = atom(
-  (get) =>
-    get(isHourlyAtom) &&
-    get(solarLayerAtom) === ToggleOptions.ON &&
-    get(selectedDatetimeIndexAtom).index === 24
+export const isSolarLayerEnabledAtom = atom<boolean>(
+  (get) => get(solarLayerAtom) === ToggleOptions.ON && get(areWeatherLayersAllowedAtom)
 );
 
 export const windLayerAtom = atomWithStorage('wind', ToggleOptions.OFF);
-export const isWindLayerEnabledAtom = atom(
-  (get) =>
-    get(isHourlyAtom) &&
-    get(windLayerAtom) === ToggleOptions.ON &&
-    get(selectedDatetimeIndexAtom).index === 24
+export const isWindLayerEnabledAtom = atom<boolean>(
+  (get) => get(windLayerAtom) === ToggleOptions.ON && get(areWeatherLayersAllowedAtom)
 );
 
 export const solarLayerLoadingAtom = atom<boolean>(false);


### PR DESCRIPTION
## Issue

We still used old icons here, and we duplicated some logic.

Part of: AVO-439

## Description

Switches the icons to Lucide versions and refractors the atom logic a little so it can be reused in more places.

This reduces the bundle size from `4071.77 KiB` to `4070.87 KiB`.

### Double check

- [x] I have run `pnpx prettier@2 --write .` and `poetry run format` in the top level directory to format my changes.
