### PR TITLE
chore: use Lucide icons for Buttons and refractor code

### DIFF
--- a/web/src/components/buttons/CommercialApiButton.stories.tsx
+++ b/web/src/components/buttons/CommercialApiButton.stories.tsx
@@ -1,0 +1,22 @@
+import type { Meta, StoryObj } from '@storybook/react';
+
+import { CommercialApiButton } from './CommercialApiButton';
+
+const meta: Meta<typeof CommercialApiButton> = {
+  title: 'Basics/Buttons/Commercial API',
+  component: CommercialApiButton,
+};
+
+export default meta;
+type Story = StoryObj<typeof CommercialApiButton>;
+
+export const Primary: Story = {
+  name: 'Default Commercial API Button',
+};
+
+export const Link: Story = {
+  name: 'Link Commercial API Button',
+  args: {
+    type: 'link',
+  },
+};

--- a/web/src/components/buttons/CommercialApiButton.tsx
+++ b/web/src/components/buttons/CommercialApiButton.tsx
@@ -1,7 +1,6 @@
 import { Button, ButtonProps } from 'components/Button';
 import { CloudCog } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
-import { DEFAULT_ICON_SIZE } from 'utils/constants';
 
 interface CommercialApiButtonProps
   extends Omit<
@@ -13,7 +12,7 @@ interface CommercialApiButtonProps
 }
 
 export function CommercialApiButton({
-  iconSize = DEFAULT_ICON_SIZE,
+  iconSize = 20,
   type,
   ...restProps
 }: CommercialApiButtonProps) {

--- a/web/src/components/buttons/CommercialApiButton.tsx
+++ b/web/src/components/buttons/CommercialApiButton.tsx
@@ -1,0 +1,31 @@
+import { Button, ButtonProps } from 'components/Button';
+import { CloudCog } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
+import { DEFAULT_ICON_SIZE } from 'utils/constants';
+
+interface CommercialApiButtonProps
+  extends Omit<
+    ButtonProps,
+    'icon' | 'children' | 'href' | 'type' | 'onClick' | 'foregroundClasses'
+  > {
+  iconSize?: number;
+  type?: 'primary' | 'link';
+}
+
+export function CommercialApiButton({
+  iconSize = DEFAULT_ICON_SIZE,
+  type,
+  ...restProps
+}: CommercialApiButtonProps) {
+  const { t } = useTranslation();
+  return (
+    <Button
+      icon={<CloudCog size={iconSize} />}
+      type={type}
+      href="https://electricitymaps.com/?utm_source=app.electricitymaps.com&utm_medium=referral&utm_campaign=country_panel"
+      {...restProps}
+    >
+      {t('header.get-data')}
+    </Button>
+  );
+}

--- a/web/src/components/buttons/FAQButton.tsx
+++ b/web/src/components/buttons/FAQButton.tsx
@@ -1,8 +1,8 @@
 import { Button, ButtonProps } from 'components/Button';
 import { isFAQModalOpenAtom } from 'features/modals/modalAtoms';
 import { useSetAtom } from 'jotai';
+import { Info } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
-import { FaCircleInfo } from 'react-icons/fa6';
 import { DEFAULT_ICON_SIZE } from 'utils/constants';
 
 interface FAQButtonProps
@@ -30,7 +30,7 @@ export function FAQButton({
   return (
     <Button
       type="secondary"
-      icon={<FaCircleInfo size={iconSize} />}
+      icon={<Info size={iconSize} />}
       onClick={() => setIsFAQModalOpen(true)}
       {...restProps}
     >

--- a/web/src/components/buttons/FeedbackButton.tsx
+++ b/web/src/components/buttons/FeedbackButton.tsx
@@ -1,6 +1,6 @@
 import { Button, ButtonProps } from 'components/Button';
+import { MessageSquareText } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
-import { FaCommentDots } from 'react-icons/fa6';
 import { DEFAULT_ICON_SIZE } from 'utils/constants';
 
 interface FeedbackButtonProps
@@ -21,7 +21,7 @@ export function FeedbackButton({
   return (
     <Button
       href="https://forms.gle/VHaeHzXyGodFKZY18"
-      icon={<FaCommentDots size={iconSize} />}
+      icon={<MessageSquareText size={iconSize} />}
       {...restProps}
     >
       {isIconOnly ? undefined : t('button.feedback')}

--- a/web/src/features/panels/zone/ZoneDetails.tsx
+++ b/web/src/features/panels/zone/ZoneDetails.tsx
@@ -1,11 +1,9 @@
 import useGetZone from 'api/getZone';
-import { Button } from 'components/Button';
+import { CommercialApiButton } from 'components/buttons/CommercialApiButton';
 import LoadingSpinner from 'components/LoadingSpinner';
 import BarBreakdownChart from 'features/charts/bar-breakdown/BarBreakdownChart';
 import { useAtomValue, useSetAtom } from 'jotai';
 import { useEffect } from 'react';
-import { useTranslation } from 'react-i18next';
-import { MdOutlineCloudDownload } from 'react-icons/md';
 import { Navigate, useParams } from 'react-router-dom';
 import { ZoneMessage } from 'types';
 import { EstimationMethods, SpatialAggregate } from 'utils/constants';
@@ -35,7 +33,6 @@ export default function ZoneDetails(): JSX.Element {
   const setViewMode = useSetAtom(spatialAggregateAtom);
   const selectedDatetimeString = useAtomValue(selectedDatetimeStringAtom);
   const { data, isError, isLoading } = useGetZone();
-  const { t } = useTranslation();
   const isHourly = useAtomValue(isHourlyAtom);
   const isMobile = !useBreakpoint('sm');
 
@@ -101,15 +98,7 @@ export default function ZoneDetails(): JSX.Element {
           zoneDataStatus={zoneDataStatus}
         >
           <BarBreakdownChart hasEstimationPill={hasEstimationPill} />
-          <Button
-            backgroundClasses="mt-3 mb-1"
-            size="lg"
-            type="link"
-            icon={<MdOutlineCloudDownload size={20} />}
-            href="https://electricitymaps.com/?utm_source=app.electricitymaps.com&utm_medium=referral&utm_campaign=country_panel"
-          >
-            {t('left-panel.get-data')}
-          </Button>
+          <CommercialApiButton backgroundClasses="mt-3 mb-1" type="link" />
           {zoneDataStatus === ZoneDataStatus.AVAILABLE && (
             <AreaGraphContainer
               datetimes={datetimes}
@@ -120,13 +109,7 @@ export default function ZoneDetails(): JSX.Element {
           <MethodologyCard />
           <Attribution zoneId={zoneId} />
           {isMobile ? (
-            <Button
-              backgroundClasses="mt-3"
-              icon={<MdOutlineCloudDownload size={20} />}
-              href="https://electricitymaps.com/?utm_source=app.electricitymaps.com&utm_medium=referral&utm_campaign=country_panel"
-            >
-              {t('header.get-data')}
-            </Button>
+            <CommercialApiButton backgroundClasses="mt-3" />
           ) : (
             <div className="p-2" />
           )}


### PR DESCRIPTION
## Issue

We used old non Lucide icons here and had some duplicate code.

Part of: AVO-439

## Description

Switches to Lucide icons and deduplicates the Commercial API Button code into its own component + stories for it.

This reduces the total app size from `4071.77 KiB` to `4071.61 KiB`.

### Double check

- [x] I have run `pnpx prettier@2 --write .` and `poetry run format` in the top level directory to format my changes.
