### PR TITLE
chore: use Lucide icons for Onboarding and refractor code

### DIFF
--- a/web/src/components/Button.tsx
+++ b/web/src/components/Button.tsx
@@ -15,6 +15,7 @@ export interface ButtonProps {
   foregroundClasses?: string;
   asDiv?: boolean;
   onClick?: () => void;
+  dataTestId?: string;
 }
 
 export function Button({
@@ -29,6 +30,7 @@ export function Button({
   type = 'primary',
   asDiv, // If true, renders a div instead of a button to avoid nested buttons in components like ToastPrimitive.Action
   onClick,
+  dataTestId,
 }: ButtonProps) {
   const renderAsLink = Boolean(href);
   const As = getComponentType(renderAsLink, asDiv);
@@ -62,6 +64,7 @@ export function Button({
         target="_blank"
         // Used to prevent browser translation crashes on edge, see #6809
         translate="no"
+        data-test-id={dataTestId}
       >
         {icon}
         {children}

--- a/web/src/components/modals/OnboardingModal.tsx
+++ b/web/src/components/modals/OnboardingModal.tsx
@@ -1,5 +1,6 @@
 import { TFunction } from 'i18next';
 import { useAtom } from 'jotai';
+import { useCallback } from 'react';
 import { resolvePath, useSearchParams } from 'react-router-dom';
 import { hasOnboardingBeenSeenAtom } from 'utils/state/atoms';
 
@@ -11,15 +12,12 @@ interface ViewContentProps {
   isDangerouslySet?: boolean;
 }
 
-const HEADER_STYLE = 'mb-2 px-2 text-base font-semibold sm:text-lg sm:mb-4';
 const BODY_STYLE = 'text-sm px-4 sm:text-base pb-4';
 
 function ViewContent({ t, translationKey, isDangerouslySet = false }: ViewContentProps) {
   return (
     <>
-      <div>
-        <h2 className={HEADER_STYLE}>{t(`${translationKey}.header`)}</h2>
-      </div>
+      <h1>{t(`${translationKey}.header`)}</h1>
       {isDangerouslySet ? (
         <p
           dangerouslySetInnerHTML={{
@@ -80,9 +78,9 @@ export function OnboardingModal() {
   const [searchParameters] = useSearchParams();
   const skipOnboarding = searchParameters.get('skip-onboarding') === 'true';
   const visible = !hasOnboardingBeenSeen && !skipOnboarding;
-  const handleDismiss = () => {
+  const handleDismiss = useCallback(() => {
     setHasOnboardingBeenSeen(true);
-  };
+  }, [setHasOnboardingBeenSeen]);
   return (
     <Modal
       modalName="onboarding"

--- a/web/src/components/modals/OnboardingModal.tsx
+++ b/web/src/components/modals/OnboardingModal.tsx
@@ -17,7 +17,7 @@ const BODY_STYLE = 'text-sm px-4 sm:text-base pb-4';
 function ViewContent({ t, translationKey, isDangerouslySet = false }: ViewContentProps) {
   return (
     <>
-      <h1>{t(`${translationKey}.header`)}</h1>
+      <h1 className="mb-4">{t(`${translationKey}.header`)}</h1>
       {isDangerouslySet ? (
         <p
           dangerouslySetInnerHTML={{
@@ -26,7 +26,7 @@ function ViewContent({ t, translationKey, isDangerouslySet = false }: ViewConten
           className={BODY_STYLE}
         ></p>
       ) : (
-        <div className={BODY_STYLE}>{t(`${translationKey}.text`)}</div>
+        <p className={BODY_STYLE}>{t(`${translationKey}.text`)}</p>
       )}
     </>
   );

--- a/web/src/components/modals/OnboardingModalInner.tsx
+++ b/web/src/components/modals/OnboardingModalInner.tsx
@@ -1,14 +1,13 @@
+import { Button } from 'components/Button';
 import { TFunction } from 'i18next';
-import { X } from 'lucide-react';
-import { ReactElement, useState } from 'react';
+import { Check, ChevronLeft, ChevronRight, X } from 'lucide-react';
+import { ReactElement, useCallback, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { HiCheck, HiChevronLeft, HiChevronRight } from 'react-icons/hi2';
 
 export interface Page {
   headerImage: { pathname: string };
   isMainTitle?: boolean;
   renderContent: (translator: TFunction) => ReactElement;
-  title?: (translator: TFunction) => ReactElement;
   hasWebp?: boolean;
 }
 
@@ -25,19 +24,23 @@ function Modal({
 }) {
   const { t } = useTranslation();
   const [currentViewIndex, setCurrentViewIndex] = useState(0);
-  const isOnLastView = () => currentViewIndex === views.length - 1;
-  const isOnFirstView = () => currentViewIndex === 0;
+  const isOnLastView = useCallback(
+    () => currentViewIndex === views.length - 1,
+    [currentViewIndex, views.length]
+  );
+  const isOnFirstView = useCallback(() => currentViewIndex === 0, [currentViewIndex]);
 
-  const handleBack = () => {
+  const handleBack = useCallback(() => {
     if (!isOnFirstView()) {
       setCurrentViewIndex(currentViewIndex - 1);
     }
-  };
-  const handleForward = () => {
+  }, [currentViewIndex, isOnFirstView]);
+
+  const handleForward = useCallback(() => {
     if (!isOnLastView()) {
       setCurrentViewIndex(currentViewIndex + 1);
     }
-  };
+  }, [currentViewIndex, isOnLastView]);
 
   if (!visible) {
     return null;
@@ -45,55 +48,42 @@ function Modal({
   const currentView = views[currentViewIndex];
 
   const RightButton = isOnLastView() ? (
-    <button
-      className="flex h-10 w-10 items-center justify-center rounded-full bg-brand-green shadow"
-      data-test-id="close-modal"
-      onClick={onDismiss}
-    >
-      <HiCheck size="24" color="white" />
-    </button>
+    <Button icon={<Check />} onClick={onDismiss} dataTestId="close-modal" />
   ) : (
-    <button
-      className="flex h-10 w-10 items-center justify-center rounded-full bg-white pl-1 shadow dark:bg-gray-900"
-      onClick={handleForward}
-    >
-      <HiChevronRight size="24" />
-    </button>
+    <Button icon={<ChevronRight />} onClick={handleForward} type="secondary" />
   );
 
   return (
     <>
       <div
-        className="absolute inset-0 z-40  bg-gray-800   bg-opacity-20"
+        className="absolute inset-0 z-40 bg-gray-800/20"
         onClick={onDismiss}
         onKeyDown={onDismiss}
         role="presentation"
       />
       <div
-        className="px-auto pointer-events-none  absolute top-auto z-50 mx-auto flex w-full items-center justify-center
+        className="px-auto absolute top-auto z-50 mx-auto flex w-full items-center justify-center
        self-center sm:top-20 sm:min-w-[500px]"
         data-test-id={modalName}
       >
-        <div className="pointer-events-auto z-10 flex w-full max-w-[35px] shrink flex-col justify-around px-2 sm:max-w-[60px]">
+        <div className="z-10 flex w-full max-w-[35px] shrink flex-col justify-around px-2 sm:max-w-[60px]">
           {!isOnFirstView() && (
-            <button
-              className="flex h-10 w-10 items-center justify-center rounded-full bg-white pr-1 shadow dark:bg-gray-900"
+            <Button
+              icon={<ChevronLeft />}
               onClick={handleBack}
-            >
-              <HiChevronLeft size="24" />
-            </button>
+              type="secondary"
+              dataTestId="back-button"
+            />
           )}
         </div>
-        <div className="color-white pointer-events-auto relative flex h-[450px] w-auto max-w-[500px] flex-col rounded-3xl bg-gray-50 shadow-lg dark:bg-gray-700 sm:h-[500px]">
-          <div className="absolute self-end p-4 align-baseline">
-            <button
-              className="p-auto pointer-events-auto flex h-10 w-10 items-center justify-center rounded-full bg-white shadow dark:bg-gray-900"
-              onClick={onDismiss}
-              data-test-id="close-modal"
-            >
-              <X size="28" />
-            </button>
-          </div>
+        <div className="relative flex h-[450px] w-auto max-w-[500px] flex-col rounded-3xl bg-gray-50 shadow-lg dark:bg-gray-700 sm:h-[500px]">
+          <Button
+            icon={<X />}
+            backgroundClasses="absolute self-end m-4"
+            onClick={onDismiss}
+            type="secondary"
+            dataTestId="close-modal"
+          />
           <div
             className={`flex h-1/2 max-h-[264px] w-full grow self-center
               rounded-t-3xl bg-auto bg-center bg-no-repeat ${
@@ -122,13 +112,12 @@ function Modal({
                 />
               </picture>
             )}
-            <h1>{currentView.title?.(t)}</h1>
           </div>
           <div className="flex w-auto flex-col justify-center px-4 pt-6 text-center dark:bg-gray-700">
             {currentView.renderContent(t)}
           </div>
         </div>
-        <div className="pointer-events-auto absolute bottom-[-60px] left-auto  h-[40px] self-center">
+        <div className="absolute bottom-[-60px] left-auto  h-[40px] self-center">
           {views.map((view: Page, index: number) => (
             <button
               key={`modal-step-item-${index}`}
@@ -139,7 +128,7 @@ function Modal({
             />
           ))}
         </div>
-        <div className="pointer-events-auto z-10 flex w-full max-w-[35px] flex-col items-end px-2 sm:max-w-[60px]">
+        <div className="z-10 flex w-full max-w-[35px] flex-col items-end px-2 sm:max-w-[60px]">
           {RightButton}
         </div>
       </div>


### PR DESCRIPTION
## Issue

We don't use Lucide icons in the onboarding and the DOM is overly complex and duplicates code.

Part of: AVO-439

## Description

Uses Lucide icons, switches to use the `<Button />` component and cleans up the logic a bit.

### Double check

- [x] I have run `pnpx prettier@2 --write .` and `poetry run format` in the top level directory to format my changes.
