### PR TITLE
chore: use Lucide icons in Header and simplify DOM

### DIFF
--- a/web/src/features/header/Header.tsx
+++ b/web/src/features/header/Header.tsx
@@ -33,7 +33,7 @@ function MenuLink({
   return (
     <NavigationMenu.Item
       asChild
-      className="relative cursor-pointer rounded-md transition-colors hover:bg-zinc-100 dark:hover:bg-black/50"
+      className="relative my-3 cursor-pointer rounded-md transition-colors hover:bg-zinc-100 dark:hover:bg-black/50"
     >
       <NavigationMenu.Link
         onClick={handleClick}

--- a/web/src/features/header/Header.tsx
+++ b/web/src/features/header/Header.tsx
@@ -31,27 +31,25 @@ function MenuLink({
     onClick?.();
   };
   return (
-    <div className="relative my-3 flex">
-      <NavigationMenu.Item
-        asChild
-        className="cursor-pointer rounded-md transition-colors hover:bg-zinc-100 dark:hover:bg-black/50"
+    <NavigationMenu.Item
+      asChild
+      className="relative cursor-pointer rounded-md transition-colors hover:bg-zinc-100 dark:hover:bg-black/50"
+    >
+      <NavigationMenu.Link
+        onClick={handleClick}
+        href={href}
+        target={isExternal ? '_blank' : '_self'}
+        className="group px-1 py-2 text-sm lg:px-2 lg:text-base"
       >
-        <NavigationMenu.Link
-          onClick={handleClick}
-          href={href}
-          target={isExternal ? '_blank' : '_self'}
-          className="group px-1 py-2 text-sm lg:px-2 lg:text-base"
-        >
-          {children}
-          {isExternal && (
-            <ExternalLink
-              size={16}
-              className="absolute -right-2 -top-2 text-gray-500 opacity-0 transition-opacity group-hover:opacity-80"
-            />
-          )}
-        </NavigationMenu.Link>
-      </NavigationMenu.Item>
-    </div>
+        {children}
+        {isExternal && (
+          <ExternalLink
+            size={16}
+            className="absolute -right-2 -top-2 text-gray-500 opacity-0 transition-opacity group-hover:opacity-80"
+          />
+        )}
+      </NavigationMenu.Link>
+    </NavigationMenu.Item>
   );
 }
 

--- a/web/src/features/header/Header.tsx
+++ b/web/src/features/header/Header.tsx
@@ -4,8 +4,8 @@ import { Button } from 'components/Button';
 import { Link } from 'components/Link';
 import { isFAQModalOpenAtom } from 'features/modals/modalAtoms';
 import { useSetAtom } from 'jotai';
+import { ExternalLink } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
-import { HiOutlineExternalLink } from 'react-icons/hi';
 import { twMerge } from 'tailwind-merge';
 import trackEvent from 'utils/analytics';
 
@@ -31,7 +31,7 @@ function MenuLink({
     onClick?.();
   };
   return (
-    <div className="relative flex py-3">
+    <div className="relative my-3 flex">
       <NavigationMenu.Item
         asChild
         className="cursor-pointer rounded-md transition-colors hover:bg-zinc-100 dark:hover:bg-black/50"
@@ -40,13 +40,14 @@ function MenuLink({
           onClick={handleClick}
           href={href}
           target={isExternal ? '_blank' : '_self'}
-          className="group px-1 py-2 text-base lg:px-2 lg:text-[1rem]"
+          className="group px-1 py-2 text-sm lg:px-2 lg:text-base"
         >
           {children}
           {isExternal && (
-            <div className="absolute bottom-0 top-1 flex w-full justify-end text-gray-400 opacity-0 transition-opacity group-hover:opacity-80 dark:text-gray-600">
-              <HiOutlineExternalLink />
-            </div>
+            <ExternalLink
+              size={16}
+              className="absolute -right-2 -top-2 text-gray-500 opacity-0 transition-opacity group-hover:opacity-80"
+            />
           )}
         </NavigationMenu.Link>
       </NavigationMenu.Item>


### PR DESCRIPTION
## Issue

We were not using Lucide icons here and the DOM was bloated.

Part of: AVO-439

## Description

Switches to Lucide icons and simplifies the DOM, the colour used is the same colour that will be used in other places (such as info icons in some places).

### Preview
#### On master:
<img width="703" alt="image" src="https://github.com/user-attachments/assets/7739b750-0ee5-40a5-8f22-c57efb60f0b8">
<img width="703" alt="image" src="https://github.com/user-attachments/assets/e8b23865-04a0-4015-ba65-4e3097df9ed5">


#### On this branch:
<img width="703" alt="image" src="https://github.com/user-attachments/assets/3e19dd7a-a737-4b1a-955c-2509303c16fc">
<img width="703" alt="image" src="https://github.com/user-attachments/assets/bef0b4e8-d46c-41b7-871b-4aa23b965d11">


### Double check

- [x] I have run `pnpx prettier@2 --write .` and `poetry run format` in the top level directory to format my changes.
