### PR TITLE
fix(parser): use proxy for US-MIDA-PJM

### DIFF
--- a/parsers/US_PJM.py
+++ b/parsers/US_PJM.py
@@ -9,6 +9,7 @@ from zoneinfo import ZoneInfo
 
 import demjson3 as demjson
 import pandas as pd
+import requests
 from bs4 import BeautifulSoup
 from dateutil import parser
 from requests import Response, Session
@@ -17,9 +18,13 @@ from parsers.lib.config import refetch_frequency
 from parsers.lib.exceptions import ParserException
 
 TIMEZONE = ZoneInfo("America/New_York")
-
 # Used for consumption forecast data.
 API_ENDPOINT = "https://api.pjm.com/api/v1/"
+
+US_PROXY = "https://us-ca-proxy-jfnx5klx2a-uw.a.run.app"
+HOST_PARAM = "?host=https://api.pjm.com"
+DATA_PATH = "api/v1"
+
 # Used for both production and price data.
 url = "http://www.pjm.com/markets-and-operations.aspx"
 
@@ -77,15 +82,14 @@ def get_api_subscription_key(session: Session) -> str:
     )
 
 
-def fetch_api_data(kind: str, params: dict, session: Session) -> list:
+def fetch_api_data(kind: str, params: dict, session: Session) -> dict:
     headers = {
-        "Host": "api.pjm.com",
         "Ocp-Apim-Subscription-Key": get_api_subscription_key(session=session),
-        "Origin": "http://dataminer2.pjm.com",
-        "Referer": "http://dataminer2.pjm.com/",
+        "Accept-Encoding": "identity"
     }
-    url = API_ENDPOINT + kind
-    resp: Response = session.get(url=url, params=params, headers=headers)
+
+    url = f"{US_PROXY}/{DATA_PATH}/{kind}"
+    resp: Response = session.get(url=url, params={"host": "https://api.pjm.com", **params}, headers=headers)
     if resp.status_code == 200:
         data = resp.json()
         return data
@@ -94,42 +98,6 @@ def fetch_api_data(kind: str, params: dict, session: Session) -> list:
             parser="US_PJM.py",
             message=f"{kind} data is not available in the API",
         )
-
-
-def fetch_consumption_forecast_7_days(
-    zone_key: str = "US-PJM",
-    session: Session = Session(),
-    target_datetime: datetime | None = None,
-    logger: Logger = getLogger(__name__),
-) -> list:
-    """Gets consumption forecast for specified zone."""
-
-    if target_datetime:
-        raise NotImplementedError("This parser is not yet able to parse past dates")
-    if not session:
-        session = Session()
-
-    # startRow must be set if forecast_area is set.
-    # RTO_COMBINED is area for whole PJM zone.
-    params = {"download": True, "startRow": 1, "forecast_area": "RTO_COMBINED"}
-
-    # query API
-    data = fetch_api_data(kind="load_frcstd_7_day", params=params, session=session)
-
-    data_points = []
-    for elem in data:
-        utc_datetime = elem["forecast_datetime_beginning_utc"]
-        data_point = {
-            "zoneKey": zone_key,
-            "datetime": datetime.fromisoformat(utc_datetime).replace(
-                tzinfo=timezone.utc
-            ),
-            "value": elem["forecast_load_mw"],
-            "source": "pjm.com",
-        }
-        data_points.append(data_point)
-
-    return data_points
 
 
 @refetch_frequency(timedelta(days=1))
@@ -141,17 +109,16 @@ def fetch_production(
 ) -> list:
     """uses PJM API to get generation  by fuel. we assume that storage is battery storage (see https://learn.pjm.com/energy-innovations/energy-storage)"""
     if target_datetime is None:
-        target_datetime = datetime.now(timezone.utc)
+        target_datetime = datetime.now(timezone.utc).replace(hour=0, minute=0, second=0, microsecond=0)
 
     params = {
-        "download": True,
         "startRow": 1,
+        "rowCount": 500,
         "fields": "datetime_beginning_ept,fuel_type,mw",
         "datetime_beginning_ept": target_datetime.strftime("%Y-%m-%dT%H:00:00.0000000"),
     }
     resp_data = fetch_api_data(kind="gen_by_fuel", params=params, session=session)
-
-    data = pd.DataFrame(resp_data)
+    data = pd.DataFrame(resp_data.get("items", []))
     if not data.empty:
         data["datetime_beginning_ept"] = pd.to_datetime(data["datetime_beginning_ept"])
         data = data.set_index("datetime_beginning_ept")
@@ -384,8 +351,6 @@ def fetch_price(
 
 
 if __name__ == "__main__":
-    print("fetch_consumption_forecast_7_days() ->")
-    print(fetch_consumption_forecast_7_days())
     print("fetch_production() ->")
     print(fetch_production())
     print("fetch_exchange(US-NY, US-PJM) ->")

--- a/parsers/US_PJM.py
+++ b/parsers/US_PJM.py
@@ -9,7 +9,6 @@ from zoneinfo import ZoneInfo
 
 import demjson3 as demjson
 import pandas as pd
-import requests
 from bs4 import BeautifulSoup
 from dateutil import parser
 from requests import Response, Session
@@ -22,7 +21,6 @@ TIMEZONE = ZoneInfo("America/New_York")
 API_ENDPOINT = "https://api.pjm.com/api/v1/"
 
 US_PROXY = "https://us-ca-proxy-jfnx5klx2a-uw.a.run.app"
-HOST_PARAM = "?host=https://api.pjm.com"
 DATA_PATH = "api/v1"
 
 # Used for both production and price data.
@@ -85,11 +83,13 @@ def get_api_subscription_key(session: Session) -> str:
 def fetch_api_data(kind: str, params: dict, session: Session) -> dict:
     headers = {
         "Ocp-Apim-Subscription-Key": get_api_subscription_key(session=session),
-        "Accept-Encoding": "identity"
+        "Accept-Encoding": "identity",
     }
 
     url = f"{US_PROXY}/{DATA_PATH}/{kind}"
-    resp: Response = session.get(url=url, params={"host": "https://api.pjm.com", **params}, headers=headers)
+    resp: Response = session.get(
+        url=url, params={"host": "https://api.pjm.com", **params}, headers=headers
+    )
     if resp.status_code == 200:
         data = resp.json()
         return data
@@ -109,7 +109,9 @@ def fetch_production(
 ) -> list:
     """uses PJM API to get generation  by fuel. we assume that storage is battery storage (see https://learn.pjm.com/energy-innovations/energy-storage)"""
     if target_datetime is None:
-        target_datetime = datetime.now(timezone.utc).replace(hour=0, minute=0, second=0, microsecond=0)
+        target_datetime = datetime.now(timezone.utc).replace(
+            hour=0, minute=0, second=0, microsecond=0
+        )
 
     params = {
         "startRow": 1,


### PR DESCRIPTION
## Issue
fixes GMM-137

The parser was working locally but was broken in production. It seems like we have been blocked. This changes the parser to use the proxy. I needed to do a few more changes as it for some reason started returning the data in a slightly different format (and gzip'd).