### PR TITLE
fix(parsers):Change-some-interconnector-direction

### DIFF
--- a/parsers/ELEXON.py
+++ b/parsers/ELEXON.py
@@ -98,6 +98,17 @@ ZONEKEY_TO_INTERCONNECTOR = {
     "GB->NO-NO2": ["North Sea Link (INTNSL)"],
 }
 
+#Change direction of exchange for connectors where data is from Elexon and zonekey "GB->*". Due to Elexon showing wrt UK
+EXHANGE_KEY_IS_IMPORT = {
+    "BE->GB": False,
+    "DK-DK1->GB": False,
+    "FR->GB": False,
+    "GB->GB-NIR": False,
+    "GB->IE": True,
+    "GB->NL": True,
+    "GB->NO-NO2": False,
+}
+
 
 def query_elexon(url: str, session: Session, params: dict) -> list:
     r: Response = session.get(url, params=params)
@@ -329,6 +340,7 @@ def query_production_fuelhh(
     }
 
     fuelhh_data = query_elexon(ELEXON_URLS["production_fuelhh"], session, params)
+
     return fuelhh_data
 
 
@@ -362,6 +374,12 @@ def query_exchange(
         exchange_data = query_elexon(
             ELEXON_URLS["exchange"], session, exchange_params
         ).get("data")
+
+        if EXHANGE_KEY_IS_IMPORT.get(zone_key):
+            for event in exchange_data:
+                event['generation'] = -1 * event['generation']
+
+
 
         if not exchange_data:
             raise ParserException(
@@ -441,6 +459,7 @@ def fetch_production(
             logger,
             matching_timestamps_only=True,
         )
+
     return data.to_list()
 
 

--- a/parsers/ELEXON.py
+++ b/parsers/ELEXON.py
@@ -98,7 +98,7 @@ ZONEKEY_TO_INTERCONNECTOR = {
     "GB->NO-NO2": ["North Sea Link (INTNSL)"],
 }
 
-#Change direction of exchange for connectors where data is from Elexon and zonekey "GB->*". Due to Elexon showing wrt UK
+# Change direction of exchange for connectors where data is from Elexon and zonekey "GB->*". Due to Elexon showing wrt UK
 EXHANGE_KEY_IS_IMPORT = {
     "BE->GB": False,
     "DK-DK1->GB": False,
@@ -377,9 +377,7 @@ def query_exchange(
 
         if EXHANGE_KEY_IS_IMPORT.get(zone_key):
             for event in exchange_data:
-                event['generation'] = -1 * event['generation']
-
-
+                event["generation"] = -1 * event["generation"]
 
         if not exchange_data:
             raise ParserException(


### PR DESCRIPTION
## Issue
Interconnector wrong direction GB-IE and GB-NL
<!-- If you want to close an issue automatically when your PR is merged, write "Closes X" where X is the issue number. For example: Closes #000 -->

## Description
Change interconnector direction for GB-IE and GB-NL. Issue due to fetching data from Elexon which is given wrt GB, however due to alphabetical order we have the exchange as "GB->IE/NL", which is wrt IE/NL. 

<!-- Explains the goal of this PR -->

### Preview

<!-- Please add screenshots and/or gif that shows visual changes (if applicable) -->

### Double check

- [x] I have tested my parser changes locally with `poetry run test_parser "zone_key"`
- [x] I have run `pnpx prettier@2 --write .` and `poetry run format` in the top level directory to format my changes.
