### PR TITLE
feat(web): Deep linking prototype

### DIFF
--- a/web/src/api/getZone.ts
+++ b/web/src/api/getZone.ts
@@ -11,11 +11,20 @@ import { cacheBuster, getBasePath, getHeaders, QUERY_KEYS } from './helpers';
 
 const getZone = async (
   timeAverage: TimeAverages,
-  zoneId?: string
+  zoneId?: string,
+  startDate?: string,
+  endDate?: string
 ): Promise<ZoneDetails> => {
   invariant(zoneId, 'Zone ID is required');
   const path: URL = new URL(`v8/details/${timeAverage}/${zoneId}`, getBasePath());
   path.searchParams.append('cacheKey', cacheBuster());
+
+  if (startDate) {
+    path.searchParams.append('startDate', startDate);
+  }
+  if (endDate) {
+    path.searchParams.append('endDate', endDate);
+  }
 
   const requestOptions: RequestInit = {
     method: 'GET',
@@ -40,9 +49,18 @@ const getZone = async (
 const useGetZone = (): UseQueryResult<ZoneDetails> => {
   const zoneId = useGetZoneFromPath();
   const [timeAverage] = useAtom(timeAverageAtom);
+
+  // Get startDate and endDate from URL params
+  const urlParameters = new URLSearchParams(window.location.search);
+  const startDate = urlParameters.get('startDate') || undefined;
+  const endDate = urlParameters.get('endDate') || undefined;
+
   return useQuery<ZoneDetails>({
-    queryKey: [QUERY_KEYS.ZONE, { zone: zoneId, aggregate: timeAverage }],
-    queryFn: async () => getZone(timeAverage, zoneId),
+    queryKey: [
+      QUERY_KEYS.ZONE,
+      { zone: zoneId, aggregate: timeAverage, startDate, endDate },
+    ],
+    queryFn: async () => getZone(timeAverage, zoneId, startDate, endDate),
   });
 };
 


### PR DESCRIPTION
## Issue
We can't see historic hourly data in the app. I wanted to tweet hourly charts from a few days ago but this wasn't possible.

## Description
This draft PR allows the frontend to send state and zone requests with startDate and endDate query params from the url as follows:

`http://localhost:5173/zone/NZ?startDate=2024-08-07T10:00:00Z&endDate=2024-08-08T10:00:00Z`

This requires the backend PR to be running and will hopefully serve as some inspiration for us when we do more work to tackle deep linking in the future 🚀 