### PR TITLE
Add somme french translations

### DIFF
--- a/web/src/locales/fr.json
+++ b/web/src/locales/fr.json
@@ -1,13 +1,22 @@
 {
   "info": {
+    "title": "À propos de l'application",
     "text": "L'application Electricity Maps fournit des informations en temps réel sur le web et sur les mobiles pour les citoyens, les experts en énergie, les ONG et les décideurs politiques, favorisant ainsi une meilleure compréhension des défis de la transition énergétique.",
-    "open-source-text": "Cette application est <a href='{{link}}' target='_blank'>Open Source</a> et alimentée par la communauté."
+    "open-source-text": "Cette application est <a href='{{link}}' target='_blank'>Open Source</a> et alimentée par la communauté.",
+    "version": "Version de l'application: {{version}}"
   },
   "button": {
-    "feedback": "Partagez vos commentaires",
-    "github": "Visiter notre Github",
-    "twitter": "Partager sur Twitter",
+    "reddit": "Rejoignez r/electricitymaps",
+    "github": "Contribuez sur GitHub",
+    "twitter": "Suivez nous sur Twitter",
+    "twitter-share": "Partagez sur Twitter",
     "slack": "Rejoindre la communauté Slack",
+    "linkedin": "Suivez nous sur LinkedIn",
+    "linkedin-share": "Partagez sur LinkedIn",
+    "facebook": "Suivez nous sur Facebook",
+    "facebook-share": "Partagez sur Facebook",
+    "feedback": "Partagez vos commentaires",
+    "faq": "FAQ",
     "privacy-policy": "Politique de confidentialité",
     "legal-notice": "Informations légales"
   },


### PR DESCRIPTION
Add somme french translations for this part :

![FireShot Capture 127 - Electricity Maps - Émissions CO₂ de la consommation électrique en tem_ - app electricitymaps com](https://github.com/user-attachments/assets/7df764f0-1133-4f4a-bd1e-a66a6614bb31)

But : 

- found no translation key for "Share the app"
- for the "About the app" part, there is a translation in the info key object, but it seems it's not the used one.