### PR TITLE
fix(translation): Remove hardcoded string in favour of translation strings

### DIFF
--- a/web/src/features/panels/ranking-panel/SocialIcons.tsx
+++ b/web/src/features/panels/ranking-panel/SocialIcons.tsx
@@ -2,11 +2,13 @@ import { FacebookButton } from 'components/buttons/FacebookButton';
 import { FeedbackButton } from 'components/buttons/FeedbackButton';
 import { LinkedinButton } from 'components/buttons/LinkedinButton';
 import { TwitterButton } from 'components/buttons/TwitterButton';
+import { useTranslation } from 'react-i18next';
 
 export default function SocialIconRow() {
+  const { t } = useTranslation();
   return (
     <div className="flex w-full items-center gap-1">
-      <h3>Share the app:</h3>
+      <h3>{t('info.share-app')}</h3>
       <div className="mr-auto flex space-x-1">
         <FacebookButton isIconOnly size="sm" type="link" isShareLink />
         <LinkedinButton isIconOnly size="sm" type="link" isShareLink />

--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -3,7 +3,8 @@
     "title": "About the app",
     "text": "The Electricity Maps app provides real-time insights on web and mobile for citizens, energy experts, NGOs and policymakers promoting a deeper understanding of energy transition challenges.",
     "open-source-text": "This app is <a href='{{link}}' target='_blank'>Open Source</a> and powered by the community.",
-    "version": "App version: {{version}}"
+    "version": "App version: {{version}}",
+    "share-app": "Share the app:"
   },
   "settings-modal": {
     "title": "Settings"

--- a/web/src/locales/sv.json
+++ b/web/src/locales/sv.json
@@ -3,7 +3,8 @@
     "text": "Appen Electricity Maps ger insikter i realtid på webben och mobil för medborgare, energiexperter, icke-statliga organisationer och beslutsfattare och främjar en djupare förståelse för utmaningar i energiomställningen.",
     "open-source-text": "Den här appen har <a href='{{link}}' target='_blank'>Öppen Källkod</a> och drivs av en gemenskap.",
     "title": "Om appen",
-    "version": "App version: {{version}}"
+    "version": "App version: {{version}}",
+    "share-app": "Dela appen:"
   },
   "button": {
     "feedback": "Ge återkoppling",


### PR DESCRIPTION
## Issue

We had a hardcoded sting that could not be translated.

## Description

Fixes the above issue.

### Double check
- [x] I have run `pnpx prettier@2 --write .` and `poetry run format` in the top level directory to format my changes.
