### PR TITLE
chore: fix legend icons

### DIFF
--- a/web/src/features/charts/bar-breakdown/elements/BarBreakdownAxisLegend.tsx
+++ b/web/src/features/charts/bar-breakdown/elements/BarBreakdownAxisLegend.tsx
@@ -1,4 +1,4 @@
-import { FaArrowLeft, FaArrowRight } from 'react-icons/fa6';
+import { ArrowLeft, ArrowRight } from 'lucide-react';
 
 import { X_AXIS_HEIGHT } from '../constants';
 
@@ -9,6 +9,10 @@ export default function BarBreakdownAxisLegend({
   height: number;
   legendText: { left: string; right: string };
 }) {
+  const ARROW_OFFSET = 3;
+  const HALF_ARROW_OFFSET = ARROW_OFFSET / 2;
+  const ARROW_SIZE = X_AXIS_HEIGHT - ARROW_OFFSET;
+  const ARROW_Y_POSITION = height - X_AXIS_HEIGHT + HALF_ARROW_OFFSET;
   return (
     <>
       <line
@@ -19,29 +23,31 @@ export default function BarBreakdownAxisLegend({
         y2={height - X_AXIS_HEIGHT + 15}
       />
       <text
-        fill="rgba(115, 115, 115, 1)"
+        className="fill-neutral-500"
         fontSize={'0.7rem'}
         y={height - X_AXIS_HEIGHT + 12}
-        x={-18}
+        x={-18.5}
         textAnchor="end"
       >
         {legendText.left}
       </text>
-      <FaArrowLeft
-        className="text-neutral-300 dark:text-gray-700"
-        x={-15}
-        y={height - X_AXIS_HEIGHT + 3}
+      <ArrowLeft
+        className="text-neutral-500"
+        size={ARROW_SIZE}
+        x={-15 - HALF_ARROW_OFFSET}
+        y={ARROW_Y_POSITION}
       />
-      <FaArrowRight
-        className="text-neutral-300 dark:text-gray-700"
-        x={5}
-        y={height - X_AXIS_HEIGHT + 3}
+      <ArrowRight
+        className="text-neutral-500"
+        size={ARROW_SIZE}
+        x={2 + HALF_ARROW_OFFSET}
+        y={ARROW_Y_POSITION}
       />
       <text
-        fill="rgba(115, 115, 115, 1)"
+        className="fill-neutral-500"
         fontSize={'0.7rem'}
         y={height - X_AXIS_HEIGHT + 12}
-        x={18}
+        x={17.5}
         textAnchor="start"
       >
         {legendText.right}


### PR DESCRIPTION
## Issue

We are not using Lucid icons.

## Description

Removes the last bastion of non lucid icons we plan on keeping around.

### Preview
![image](https://github.com/user-attachments/assets/03076941-b085-4759-92e8-6ebc5edcfddf)


### Double check

- [x] I have run `pnpx prettier@2 --write .` and `poetry run format` in the top level directory to format my changes.
