### PR TITLE
chore(web):  Remove button xl from isIconOnly

### DIFF
--- a/web/src/components/Button.tsx
+++ b/web/src/components/Button.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { twMerge } from 'tailwind-merge';
 
-type SizeOptions = 'sm' | 'md' | 'lg' | 'xl';
+type SizeOptions = 'sm' | 'md' | 'lg';
 
 export interface ButtonProps {
   icon?: React.ReactNode;
@@ -137,9 +137,6 @@ function getSize(size: SizeOptions, type: string, isIconOnly: boolean) {
       }
       case 'lg': {
         return 'min-w-11 min-h-11';
-      }
-      case 'xl': {
-        return 'min-w-14 min-h-14';
       }
     }
   }


### PR DESCRIPTION
## Issue

[AVO-491](https://linear.app/electricitymaps/issue/AVO-491/remove-xl-from-isicononly-button)

## Description

Remove XL style from button component.

### Double check

- [ ] I have tested my parser changes locally with `poetry run test_parser "zone_key"`
- [x] I have run `pnpx prettier@2 --write .` and `poetry run format` in the top level directory to format my changes.
