### PR TITLE
Update solar capacity for Hungary

### DIFF
--- a/config/zones/HU.yaml
+++ b/config/zones/HU.yaml
@@ -44,7 +44,7 @@ capacity:
       value: 3300.0
     - datetime: '2024-01-01'
       source: entsoe.eu
-      value: 3688.0
+      value: 3888.0
   unknown:
     - datetime: '2023-01-01'
       source: entsoe.eu


### PR DESCRIPTION
Another month, another 5% increase in installed capacity.

Follow-up to https://github.com/electricitymaps/electricitymaps-contrib/pull/7102.

[[source](https://transparency.entsoe.eu/generation/r2/installedGenerationCapacityAggregation/show?name=&defaultValue=false&viewType=TABLE&areaType=BZN&atch=false&dateTime.dateTime=01.01.2024+00:00|UTC|YEAR&dateTime.endDateTime=01.01.2024+00:00|UTC|YEAR&area.values=CTY|10YHU-MAVIR----U!BZN|10YHU-MAVIR----U&productionType.values=B01&productionType.values=B25&productionType.values=B02&productionType.values=B03&productionType.values=B04&productionType.values=B05&productionType.values=B06&productionType.values=B07&productionType.values=B08&productionType.values=B09&productionType.values=B11&productionType.values=B12&productionType.values=B14&productionType.values=B20&productionType.values=B15&productionType.values=B16&productionType.values=B17&productionType.values=B19)]