### PR TITLE
fix: Fix unknown locale error

### DIFF
--- a/web/src/translation/i18n.test.ts
+++ b/web/src/translation/i18n.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest';
+
+import { sanitizeLocale } from './i18n';
+
+describe('sanitizeLocale', () => {
+  it.each([
+    ['en', 'en'],
+    ['en-US', 'en-US'],
+    ['fr', 'fr'],
+    ['fr-FR', 'fr-FR'],
+  ])('should return the locale if it is valid: %s', (input, expected) => {
+    expect(sanitizeLocale(input)).toBe(expected);
+  });
+
+  it.each([
+    ['de).', 'de'],
+    ['de-DE-1996', 'de-DE'],
+    ['de-DE-1996-1996', 'de-DE'],
+  ])('should sanitize partially valid locales: %s', (input, expected) => {
+    expect(sanitizeLocale(input)).toBe(expected);
+  });
+
+  it.each([
+    ['DE-de', 'de-DE'],
+    ['DE', 'de'],
+  ])('should return the canonical locale if it is valid: %s', (input, expected) => {
+    expect(sanitizeLocale(input)).toBe(expected);
+  });
+
+  it.each([
+    ['e'],
+    ['deAT'],
+    ['deNOX%20wird'],
+    ['itcarbon_intensity'],
+    ['carbon_intensity'],
+  ])('should return "en" if the locale is invalid', (input) => {
+    expect(sanitizeLocale(input)).toBe('en');
+  });
+});

--- a/web/src/translation/i18n.ts
+++ b/web/src/translation/i18n.ts
@@ -17,6 +17,14 @@ i18n
       order: ['querystring', 'localStorage', 'sessionStorage', 'navigator', 'htmlTag'],
       lookupQuerystring: 'lang',
       caches: ['localStorage'],
+      convertDetectedLanguage: (lng: string) => {
+        try {
+          return Intl.getCanonicalLocales(lng)[0];
+        } catch (error) {
+          console.warn('Error getting canonical locales, defaulting to English', error);
+          return 'en';
+        }
+      },
     },
     interpolation: {
       escapeValue: false, // Not needed for react as it escapes by default

--- a/web/src/translation/i18n.ts
+++ b/web/src/translation/i18n.ts
@@ -13,14 +13,12 @@ export const sanitizeLocale = (locale: string): string => {
   const validLocaleRegex = /^[A-Za-z]{2}(-[A-Za-z]{2})?$/;
 
   if (validLocaleRegex.test(locale)) {
-    try {
-      return Intl.getCanonicalLocales(locale)[0];
-    } catch (error) {
-      console.warn(`Error getting canonical locale: ${error}`);
-    }
+    return Intl.getCanonicalLocales(locale)[0];
   }
 
-  console.warn(`Invalid locale string: ${locale}, defaulting to 'en'`);
+  console.warn(
+    `Invalid locale string: ${locale}, could not sanitize, defaulting to 'en'`
+  );
   return 'en';
 };
 

--- a/web/src/translation/i18n.ts
+++ b/web/src/translation/i18n.ts
@@ -5,6 +5,25 @@ import resourcesToBackend from 'i18next-resources-to-backend';
 import { initReactI18next } from 'react-i18next';
 import { localeToFacebookLocale } from 'translation/locales';
 
+export const sanitizeLocale = (locale: string): string => {
+  // Get the first 5 characters and strip all non-alphabetic characters except hyphens from the locale string
+  locale = locale.slice(0, 5).replaceAll(/[^A-Za-z-]/g, '');
+
+  // Regular expression for valid language or locale strings
+  const validLocaleRegex = /^[A-Za-z]{2}(-[A-Za-z]{2})?$/;
+
+  if (validLocaleRegex.test(locale)) {
+    try {
+      return Intl.getCanonicalLocales(locale)[0];
+    } catch (error) {
+      console.warn(`Error getting canonical locale: ${error}`);
+    }
+  }
+
+  console.warn(`Invalid locale string: ${locale}, defaulting to 'en'`);
+  return 'en';
+};
+
 // Init localisation package and ensure it uses relevant plugins
 // eslint-disable-next-line import/no-named-as-default-member
 i18n
@@ -17,14 +36,7 @@ i18n
       order: ['querystring', 'localStorage', 'sessionStorage', 'navigator', 'htmlTag'],
       lookupQuerystring: 'lang',
       caches: ['localStorage'],
-      convertDetectedLanguage: (lng: string) => {
-        try {
-          return Intl.getCanonicalLocales(lng)[0];
-        } catch (error) {
-          console.warn('Error getting canonical locales, defaulting to English', error);
-          return 'en';
-        }
-      },
+      convertDetectedLanguage: sanitizeLocale,
     },
     interpolation: {
       escapeValue: false, // Not needed for react as it escapes by default


### PR DESCRIPTION
## Issue

It seems like the users locales are not sanetized properly so if they pass gibbrish to the lang query then the whole thing crashes at different points.

Resolves: [APP-WEB-3NP](https://electricitymaps.sentry.io/issues/5660167599/?project=4504366922989568&query=is:unresolved+issue.priority:%5Bhigh,+medium%5D+locale&statsPeriod=90d&stream_index=0)

## Description

This PR adds a check to ensure the locale is valid before setting it as the global and if it's not falls back to english and logs a warning.

### Double check

- [x] I have run `pnpx prettier@2 --write .` and `poetry run format` in the top level directory to format my changes.
