### PR TITLE
fix: make the ? smaller

### DIFF
--- a/web/src/features/charts/bar-breakdown/elements/Row.tsx
+++ b/web/src/features/charts/bar-breakdown/elements/Row.tsx
@@ -71,7 +71,7 @@ export default function Row({
       {!Number.isFinite(value) && (
         <text
           transform={`translate(3, ${TEXT_ADJUST_Y})`}
-          className="pointer-events-none"
+          className="pointer-events-none text-xs"
           fill="darkgray"
           x={LABEL_MAX_WIDTH + scale(0)}
         >


### PR DESCRIPTION
## Issue

The question mark is a tad to big.


## Description

Uses size-xs for the ? to match the other text in the graph.

### Preview

Before:

<img width="425" alt="image" src="https://github.com/user-attachments/assets/1516fee2-ca9b-48a6-b65a-b31c9ef69b01">


After:

<img width="425" alt="image" src="https://github.com/user-attachments/assets/57e36dc0-e577-4ba1-b4d7-62f619462f35">


### Double check

- [x] I have run `pnpx prettier@2 --write .` and `poetry run format` in the top level directory to format my changes.
