### PR TITLE
fix: fix TimeAverageToggle not visible on Firefox

### DIFF
--- a/web/src/components/TimeAverageToggle.tsx
+++ b/web/src/components/TimeAverageToggle.tsx
@@ -31,7 +31,7 @@ function TimeAverageToggle({ timeAverage, onToggleGroupClick }: TimeAverageToggl
   return (
     <ToggleGroupRoot
       className={
-        'mt-1 flex h-11 min-w-fit grow items-center justify-between gap-1 rounded-full bg-gray-300/50 p-1 backdrop-blur-sm dark:bg-gray-700/50'
+        'mt-1 flex h-11 min-w-fit grow items-center justify-between gap-1 rounded-full bg-gray-300/50 p-1 dark:bg-gray-700/50'
       }
       type="multiple"
       aria-label="Toggle between time averages"


### PR DESCRIPTION
## Issue

Fixes: #7194 

## Description

I don't know exactly why but apparently `backdrop-blur` breaks things when it's used here.
Let's just remove it for now since it don't affect the current styles and re-evaluate how this will be used in the future.

### Double check

- [x] I have run `pnpx prettier@2 --write .` and `poetry run format` in the top level directory to format my changes.
