### PR TITLE
Add french translations for tooltips

### DIFF
--- a/web/src/locales/fr.json
+++ b/web/src/locales/fr.json
@@ -290,7 +290,9 @@
   "tooltips": {
     "carbonintensity": "Intensité carbone",
     "zoneHeader": {
-      "lowcarbon": "Inclut les énergies renouvelables et le nucléaire"
+      "lowcarbon": "Inclut les énergies renouvelables et le nucléaire",
+      "renewable": "Inclut le solaire, l'éolien, l'hydroélectricité, la biomasse et la géothermie",
+      "carbonIntensity": "Grammes d'équivalent CO2 par kilowattheure (gCO2eq/kWh) mesurant les émissions de gaz à effet de serre issues de la production d'électricité"
     },
     "crossborderexport": "Export transfrontalier",
     "carbonintensityexport": "Intensité carbone de l’export",


### PR DESCRIPTION
Add french translations for the main indicators tooltips.

I followed the English wording, so "from generating electricity" gives "issues de la production d'électricité".

But it would be cool if this tooltip text was dynamic : the term "generating" should be "production" or "consumption" depending on the app current mode. 