### PR TITLE
chore(SEO): Use the correct link for get our data

### DIFF
--- a/web/src/components/buttons/CommercialApiButton.tsx
+++ b/web/src/components/buttons/CommercialApiButton.tsx
@@ -21,7 +21,7 @@ export function CommercialApiButton({
     <Button
       icon={<CloudCog size={iconSize} />}
       type={type}
-      href="https://electricitymaps.com/?utm_source=app.electricitymaps.com&utm_medium=referral&utm_campaign=country_panel"
+      href="https://electricitymaps.com/get-our-data?utm_source=app.electricitymaps.com&utm_medium=referral&utm_campaign=country_panel"
       {...restProps}
     >
       {t('header.get-data')}

--- a/web/src/locales/sv.json
+++ b/web/src/locales/sv.json
@@ -221,7 +221,7 @@
     }
   },
   "header": {
-    "get-data": "Hämta våra data",
+    "get-data": "Använd vår data",
     "blog": "Blogg",
     "open-source": "Öppen källkod",
     "hiring": "Vi anställer!",


### PR DESCRIPTION
## Issue

We are not actually linking to the get our data page. This can hurt the SEO for that page.

## Description

Updates the link to https://electricitymaps.com/get-our-data and adjusts the Swedish translation slightly.

### Double check

- [x] I have run `pnpx prettier@2 --write .` and `poetry run format` in the top level directory to format my changes.
