### PR TITLE
AVO-488: Add social media share Plausible tracking

### DIFF
--- a/web/src/components/buttons/FacebookButton.tsx
+++ b/web/src/components/buttons/FacebookButton.tsx
@@ -1,6 +1,7 @@
 import { Button, ButtonProps } from 'components/Button';
 import { useTranslation } from 'react-i18next';
 import { FaFacebook } from 'react-icons/fa6';
+import { SocialNetwork, trackShare } from 'utils/analytics';
 import { DEFAULT_ICON_SIZE } from 'utils/constants';
 
 interface FacebookButtonProps
@@ -13,6 +14,8 @@ interface FacebookButtonProps
   isShareLink?: boolean;
 }
 
+const trackFacebookShare = trackShare(SocialNetwork.FACEBOOK);
+
 export function FacebookButton({
   isIconOnly,
   iconSize = DEFAULT_ICON_SIZE,
@@ -20,6 +23,7 @@ export function FacebookButton({
   ...restProps
 }: FacebookButtonProps) {
   const { t } = useTranslation();
+
   return (
     <Button
       backgroundClasses="bg-[#1877F2]"
@@ -29,6 +33,7 @@ export function FacebookButton({
           ? 'https://facebook.com/sharer/sharer.php?u=https://app.electricitymaps.com/'
           : 'https://www.facebook.com/electricitymaps/'
       }
+      onClick={isShareLink ? trackFacebookShare : undefined}
       icon={<FaFacebook size={iconSize} />}
       {...restProps}
     >

--- a/web/src/components/buttons/FacebookButton.tsx
+++ b/web/src/components/buttons/FacebookButton.tsx
@@ -1,7 +1,7 @@
 import { Button, ButtonProps } from 'components/Button';
 import { useTranslation } from 'react-i18next';
 import { FaFacebook } from 'react-icons/fa6';
-import { SocialNetwork, trackShare } from 'utils/analytics';
+import { ShareType, trackShare } from 'utils/analytics';
 import { DEFAULT_ICON_SIZE } from 'utils/constants';
 
 interface FacebookButtonProps
@@ -14,7 +14,7 @@ interface FacebookButtonProps
   isShareLink?: boolean;
 }
 
-const trackFacebookShare = trackShare(SocialNetwork.FACEBOOK);
+const trackFacebookShare = trackShare(ShareType.FACEBOOK);
 
 export function FacebookButton({
   isIconOnly,

--- a/web/src/components/buttons/LinkedinButton.tsx
+++ b/web/src/components/buttons/LinkedinButton.tsx
@@ -1,6 +1,7 @@
 import { Button, ButtonProps } from 'components/Button';
 import { useTranslation } from 'react-i18next';
 import { FaLinkedin } from 'react-icons/fa6';
+import { SocialNetwork, trackShare } from 'utils/analytics';
 import { DEFAULT_ICON_SIZE } from 'utils/constants';
 
 interface LinkedinButtonProps
@@ -13,6 +14,8 @@ interface LinkedinButtonProps
   isShareLink?: boolean;
 }
 
+const trackLinkedinShare = trackShare(SocialNetwork.LINKEDIN);
+
 export function LinkedinButton({
   isIconOnly,
   iconSize = DEFAULT_ICON_SIZE,
@@ -20,6 +23,7 @@ export function LinkedinButton({
   ...restProps
 }: LinkedinButtonProps) {
   const { t } = useTranslation();
+
   return (
     <Button
       backgroundClasses="bg-[#0A66C2]"
@@ -29,6 +33,7 @@ export function LinkedinButton({
           ? 'https://www.linkedin.com/shareArticle?mini=true&url=https://app.electricitymaps.com'
           : 'https://www.linkedin.com/company/electricitymaps/'
       }
+      onClick={isShareLink ? trackLinkedinShare : undefined}
       icon={<FaLinkedin size={iconSize} />}
       {...restProps}
     >

--- a/web/src/components/buttons/LinkedinButton.tsx
+++ b/web/src/components/buttons/LinkedinButton.tsx
@@ -1,7 +1,7 @@
 import { Button, ButtonProps } from 'components/Button';
 import { useTranslation } from 'react-i18next';
 import { FaLinkedin } from 'react-icons/fa6';
-import { SocialNetwork, trackShare } from 'utils/analytics';
+import { ShareType, trackShare } from 'utils/analytics';
 import { DEFAULT_ICON_SIZE } from 'utils/constants';
 
 interface LinkedinButtonProps
@@ -14,7 +14,7 @@ interface LinkedinButtonProps
   isShareLink?: boolean;
 }
 
-const trackLinkedinShare = trackShare(SocialNetwork.LINKEDIN);
+const trackLinkedinShare = trackShare(ShareType.LINKEDIN);
 
 export function LinkedinButton({
   isIconOnly,

--- a/web/src/components/buttons/TwitterButton.tsx
+++ b/web/src/components/buttons/TwitterButton.tsx
@@ -1,6 +1,7 @@
 import { Button, ButtonProps } from 'components/Button';
 import { useTranslation } from 'react-i18next';
 import { FaXTwitter } from 'react-icons/fa6';
+import { SocialNetwork, trackShare } from 'utils/analytics';
 import { DEFAULT_ICON_SIZE } from 'utils/constants';
 
 interface TwitterButtonProps
@@ -12,6 +13,7 @@ interface TwitterButtonProps
   isIconOnly?: boolean;
   isShareLink?: boolean;
 }
+const trackTwitterShare = trackShare(SocialNetwork.TWITTER);
 
 export function TwitterButton({
   isIconOnly,
@@ -20,6 +22,7 @@ export function TwitterButton({
   ...restProps
 }: TwitterButtonProps) {
   const { t } = useTranslation();
+
   return (
     <Button
       backgroundClasses="bg-black"
@@ -29,6 +32,7 @@ export function TwitterButton({
           ? 'https://twitter.com/intent/tweet?url=https://app.electricitymaps.com'
           : undefined
       }
+      onClick={isShareLink ? trackTwitterShare : undefined}
       icon={<FaXTwitter size={iconSize} />}
       {...restProps}
     >

--- a/web/src/components/buttons/TwitterButton.tsx
+++ b/web/src/components/buttons/TwitterButton.tsx
@@ -1,7 +1,7 @@
 import { Button, ButtonProps } from 'components/Button';
 import { useTranslation } from 'react-i18next';
 import { FaXTwitter } from 'react-icons/fa6';
-import { SocialNetwork, trackShare } from 'utils/analytics';
+import { ShareType, trackShare } from 'utils/analytics';
 import { DEFAULT_ICON_SIZE } from 'utils/constants';
 
 interface TwitterButtonProps
@@ -13,7 +13,7 @@ interface TwitterButtonProps
   isIconOnly?: boolean;
   isShareLink?: boolean;
 }
-const trackTwitterShare = trackShare(SocialNetwork.TWITTER);
+const trackTwitterShare = trackShare(ShareType.TWITTER);
 
 export function TwitterButton({
   isIconOnly,

--- a/web/src/features/panels/ranking-panel/SocialIcons.tsx
+++ b/web/src/features/panels/ranking-panel/SocialIcons.tsx
@@ -6,6 +6,7 @@ import { useTranslation } from 'react-i18next';
 
 export default function SocialIconRow() {
   const { t } = useTranslation();
+
   return (
     <div className="flex w-full items-center justify-between gap-1">
       <section className="flex items-center gap-1">

--- a/web/src/utils/analytics.ts
+++ b/web/src/utils/analytics.ts
@@ -1,3 +1,5 @@
+import { TrackEvent } from 'utils/constants';
+
 type PlausibleEventProps = { readonly [propName: string]: string | number | boolean };
 type PlausibleArguments = [string, { props: PlausibleEventProps }];
 
@@ -12,6 +14,7 @@ declare global {
     plausible?: typeof plausible | undefined;
   }
 }
+
 export default function trackEvent(
   eventId: string,
   additionalProps: PlausibleEventProps = {}
@@ -22,3 +25,12 @@ export default function trackEvent(
   }
   window.plausible?.(eventId, { props: additionalProps });
 }
+
+export enum SocialNetwork {
+  FACEBOOK = 'facebook',
+  LINKEDIN = 'linkedin',
+  TWITTER = 'twitter',
+}
+
+export const trackShare = (social: SocialNetwork) => () =>
+  trackEvent(TrackEvent.SHARE_BUTTON_CLICKED, { social });

--- a/web/src/utils/analytics.ts
+++ b/web/src/utils/analytics.ts
@@ -26,11 +26,11 @@ export default function trackEvent(
   window.plausible?.(eventId, { props: additionalProps });
 }
 
-export enum SocialNetwork {
+export enum ShareType {
   FACEBOOK = 'facebook',
   LINKEDIN = 'linkedin',
   TWITTER = 'twitter',
 }
 
-export const trackShare = (social: SocialNetwork) => () =>
-  trackEvent(TrackEvent.SHARE_BUTTON_CLICKED, { social });
+export const trackShare = (shareType: ShareType) => () =>
+  trackEvent(TrackEvent.SHARE_BUTTON_CLICKED, { shareType });

--- a/web/src/utils/constants.ts
+++ b/web/src/utils/constants.ts
@@ -37,6 +37,7 @@ export enum LeftPanelToggleOptions {
 
 export enum TrackEvent {
   DATA_SOURCES_CLICKED = 'Data Sources Clicked',
+  SHARE_BUTTON_CLICKED = 'Share Button Clicked',
 }
 
 // color of different production modes are based on various industry standards


### PR DESCRIPTION
## Description

[AVO-488](https://linear.app/electricitymaps/issue/AVO-488/measure-use-of-new-some-buttons): Measure social media shares
- Adds 'Share Button Clicked' Plausible goal event
   - Sends custom `shareType` property: `facebook`, `linkedin`, or `twitter` (can be extended)
  
**Plausible**
[Goals:](https://plausible.io/app.electricitymaps.com/settings/goals)
<img width="820" alt="Screenshot 2024-09-17 at 09 04 13" src="https://github.com/user-attachments/assets/0e80eeac-3d78-4076-b643-f1c87ddad02a">
[Custom properties:](https://plausible.io/app.electricitymaps.com/settings/properties)
<img width="817" alt="Screenshot 2024-09-17 at 10 00 51" src="https://github.com/user-attachments/assets/a0698885-5298-481e-ba61-8eb7c2f16100">


### Double check

- [ ] I have tested my parser changes locally with `poetry run test_parser "zone_key"`
- [ ] I have run `pnpx prettier@2 --write .` and `poetry run format` in the top level directory to format my changes.
