### PR TITLE
fix: abbreviate month in hourly datetimes

### DIFF
--- a/web/src/utils/__snapshots__/formatting.test.ts.snap
+++ b/web/src/utils/__snapshots__/formatting.test.ts.snap
@@ -12,17 +12,17 @@ exports[`formatDate > handles daily data for it 1`] = `"1 gennaio 2021"`;
 
 exports[`formatDate > handles daily data for sv 1`] = `"1 januari 2021"`;
 
-exports[`formatDate > handles hourly data for de 1`] = `"1. Januar 2021 um 01:00 MEZ"`;
+exports[`formatDate > handles hourly data for de 1`] = `"1. Jan. 2021, 01:00 MEZ"`;
 
-exports[`formatDate > handles hourly data for en 1`] = `"January 1, 2021 at 1:00 AM GMT+1"`;
+exports[`formatDate > handles hourly data for en 1`] = `"Jan 1, 2021, 1:00 AM GMT+1"`;
 
-exports[`formatDate > handles hourly data for es 1`] = `"1 de enero de 2021, 1:00 CET"`;
+exports[`formatDate > handles hourly data for es 1`] = `"1 ene 2021, 1:00 CET"`;
 
-exports[`formatDate > handles hourly data for fr 1`] = `"1 janvier 2021 à 01:00 UTC+1"`;
+exports[`formatDate > handles hourly data for fr 1`] = `"1 janv. 2021, 01:00 UTC+1"`;
 
-exports[`formatDate > handles hourly data for it 1`] = `"1 gennaio 2021 alle ore 01:00 CET"`;
+exports[`formatDate > handles hourly data for it 1`] = `"1 gen 2021, 01:00 CET"`;
 
-exports[`formatDate > handles hourly data for sv 1`] = `"1 januari 2021 kl. 01:00 CET"`;
+exports[`formatDate > handles hourly data for sv 1`] = `"1 jan. 2021 01:00 CET"`;
 
 exports[`formatDate > handles monthly data for de 1`] = `"Januar 2021"`;
 

--- a/web/src/utils/formatting.test.ts
+++ b/web/src/utils/formatting.test.ts
@@ -359,7 +359,7 @@ describe('getDateTimeFormatOptions', () => {
     const actual = getDateTimeFormatOptions(TimeAverages.HOURLY);
     const expected = {
       year: 'numeric',
-      month: 'long',
+      month: 'short',
       day: 'numeric',
       hour: 'numeric',
       minute: 'numeric',

--- a/web/src/utils/formatting.ts
+++ b/web/src/utils/formatting.ts
@@ -144,7 +144,7 @@ export const getDateTimeFormatOptions = (
     case TimeAverages.HOURLY: {
       return {
         year: 'numeric',
-        month: 'long',
+        month: 'short',
         day: 'numeric',
         hour: 'numeric',
         minute: 'numeric',


### PR DESCRIPTION
## Issue

On very small screens the date can overflow now that we added the timezone which is causing some layout issues.

## Description
Abbreviate the months in hourly view and update the tests to match the new expected format.

### Preview

#### Master
<img width="377" alt="image" src="https://github.com/user-attachments/assets/2794bc50-63e2-457b-9082-eed4a6648807">


#### This branch
<img width="377" alt="image" src="https://github.com/user-attachments/assets/9d93b52a-c512-48fc-aaec-700559dad908">



### Double check

- [x] I have run `pnpx prettier@2 --write .` and `poetry run format` in the top level directory to format my changes.
