### PR TITLE
feat(SEO): Add dynamic meta titles

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -15,6 +15,7 @@ import { lazy, ReactElement, Suspense, useEffect, useLayoutEffect } from 'react'
 import { Helmet } from 'react-helmet-async';
 import { useTranslation } from 'react-i18next';
 import trackEvent from 'utils/analytics';
+import { metaTitleSuffix } from 'utils/constants';
 
 const MapWrapper = lazy(async () => import('features/map/MapWrapper'));
 const LeftPanel = lazy(async () => import('features/panels/LeftPanel'));
@@ -73,7 +74,7 @@ export default function App(): ReactElement {
         }}
         prioritizeSeoTags
       >
-        <title>{`Electricity Maps | ${t('misc.maintitle')}`}</title>
+        <title>{t('misc.maintitle') + metaTitleSuffix}</title>
         <meta property="og:locale" content={i18n.languages[0]} />
         <link rel="canonical" href={canonicalUrl} />
       </Helmet>

--- a/web/src/features/panels/ranking-panel/RankingPanel.tsx
+++ b/web/src/features/panels/ranking-panel/RankingPanel.tsx
@@ -6,7 +6,7 @@ import { useAtomValue } from 'jotai';
 import { ReactElement, useCallback, useState } from 'react';
 import { Helmet } from 'react-helmet-async';
 import { useTranslation } from 'react-i18next';
-import { Mode } from 'utils/constants';
+import { metaTitleSuffix, Mode } from 'utils/constants';
 import {
   productionConsumptionAtom,
   selectedDatetimeStringAtom,
@@ -57,6 +57,7 @@ export default function RankingPanel(): ReactElement {
   return (
     <div className="flex max-h-[calc(100vh-236px)] flex-col py-3 pl-4 pr-1 ">
       <Helmet prioritizeSeoTags>
+        <title>{t('misc.maintitle') + metaTitleSuffix}</title>
         <link rel="canonical" href={canonicalUrl} />
       </Helmet>
       <div className="pb-5">

--- a/web/src/features/panels/zone/ZoneHeaderTitle.tsx
+++ b/web/src/features/panels/zone/ZoneHeaderTitle.tsx
@@ -8,6 +8,7 @@ import { ArrowLeft, Info } from 'lucide-react';
 import { Helmet } from 'react-helmet-async';
 import { Link } from 'react-router-dom';
 import { getCountryName, getFullZoneName, getZoneName } from 'translation/translation';
+import { metaTitleSuffix } from 'utils/constants';
 import { createToWithState } from 'utils/helpers';
 
 import { getDisclaimer } from './util';
@@ -36,6 +37,7 @@ export default function ZoneHeaderTitle({ zoneId }: ZoneHeaderTitleProps) {
   return (
     <div className="flex w-full pl-2 pt-2">
       <Helmet prioritizeSeoTags>
+        <title>{zoneName + metaTitleSuffix}</title>
         <link rel="canonical" href={canonicalUrl} />
       </Helmet>
       <Link

--- a/web/src/utils/constants.ts
+++ b/web/src/utils/constants.ts
@@ -1,6 +1,7 @@
 import type { Duration } from 'date-fns';
 import { ElectricityModeType } from 'types';
 
+export const metaTitleSuffix = ' | App | Electricity Maps';
 export const baseUrl = 'https://app.electricitymaps.com';
 
 // The order here determines the order displayed


### PR DESCRIPTION
## Issue

We are using the same meta title for all our pages which could be hurting our SEO and goes against best practices.

Fixes: AVO-484

## Description
Updates the links to use a new suffix, `'title' | App | Electricity Maps` so we can match this with other parts of our websites and products. `'title' | Blog | Electricity Maps` or `'title' | Docs | Electricity Maps`, etc.

The title itself will be either the existing one on the `/map` view or the translated zone name on zone pages.


### Double check
- [x] I have run `pnpx prettier@2 --write .` and `poetry run format` in the top level directory to format my changes.
