### PR TITLE
French translation fix for new App banner

### DIFF
--- a/web/src/locales/fr.json
+++ b/web/src/locales/fr.json
@@ -30,8 +30,8 @@
     "about": "À propos"
   },
   "app-banner": {
-    "cta": "Télécharger l'app",
-    "description": "Données d'électricité en direct"
+    "cta": "Installer",
+    "description": "Données sur l'électricité en direct"
   },
   "onboarding-modal": {
     "view1": {


### PR DESCRIPTION
Address #7156

Change "Télécharger l'app" to "Installer", more close to what french see on mobile apps.

Change "Données d'électricité en direct" to "Données sur l'électricité en direct", more correct (and may be more UI friendly).