### PR TITLE
chore(SEO): Increase robustness of canonical links

### DIFF
--- a/web/src/features/panels/LeftPanel.tsx
+++ b/web/src/features/panels/LeftPanel.tsx
@@ -16,6 +16,7 @@ import {
 import { useIsMobile } from 'utils/styling';
 
 import { leftPanelOpenAtom } from './panelAtoms';
+import { zoneExists } from './zone/util';
 
 const RankingPanel = lazy(() => import('./ranking-panel/RankingPanel'));
 const ZoneDetails = lazy(() => import('./zone/ZoneDetails'));
@@ -48,16 +49,22 @@ function ValidZoneIdGuardWrapper({ children }: { children: JSX.Element }) {
   if (!zoneId) {
     return <Navigate to="/" replace />;
   }
+  const upperCaseZoneId = zoneId.toUpperCase();
+  if (zoneId !== upperCaseZoneId) {
+    return <Navigate to={`/zone/${upperCaseZoneId}?${searchParameters}`} replace />;
+  }
 
   // Handle legacy Australia zone names
-  if (zoneId.startsWith('AUS')) {
+  if (upperCaseZoneId.startsWith('AUS')) {
     return (
       <Navigate to={`/zone/${zoneId.replace('AUS', 'AU')}?${searchParameters}`} replace />
     );
   }
-  const upperCaseZoneId = zoneId.toUpperCase();
-  if (zoneId !== upperCaseZoneId) {
-    return <Navigate to={`/zone/${upperCaseZoneId}?${searchParameters}`} replace />;
+
+  // Only allow valid zone ids
+  // TODO: This should redirect to a 404 page specifically for zones
+  if (!zoneExists(upperCaseZoneId)) {
+    return <Navigate to="/" replace />;
   }
 
   return children;
@@ -120,6 +127,7 @@ export default function LeftPanel() {
     <OuterPanel>
       <Routes>
         <Route path="/" element={<HandleLegacyRoutes />} />
+        <Route path="/zone" element={<Navigate to="/" replace />} />
         <Route
           path="/zone/:zoneId"
           element={

--- a/web/src/features/panels/zone/util.ts
+++ b/web/src/features/panels/zone/util.ts
@@ -6,6 +6,8 @@ import { CombinedZonesConfig } from '../../../../geo/types';
 
 const { zones, contributors } = zonesConfigJSON as unknown as CombinedZonesConfig;
 
+export const zoneExists = (zoneId: string) => Boolean(zones[zoneId]);
+
 export const getHasSubZones = (zoneId?: string) => {
   if (!zoneId) {
     return null;

--- a/web/src/hooks/useGetCanonicalUrl.tsx
+++ b/web/src/hooks/useGetCanonicalUrl.tsx
@@ -1,5 +1,5 @@
 import { useTranslation } from 'react-i18next';
-import { useLocation } from 'react-router-dom';
+import { useMatch } from 'react-router-dom';
 import { baseUrl } from 'utils/constants';
 
 /**
@@ -7,9 +7,14 @@ import { baseUrl } from 'utils/constants';
  */
 export const useGetCanonicalUrl = () => {
   const { i18n } = useTranslation();
-  const { pathname } = useLocation();
+  // TODO: Replace with useMatches once we have migrated to react routers data routing
+  const mapMatch = useMatch('/map');
+  const zoneMatch = useMatch('/zone/:zoneId');
+
+  const pathname = mapMatch?.pathname ?? zoneMatch?.pathname;
+
   const currentLanguageKey = i18n.languages[0];
-  return `${baseUrl}${pathname}${
+  return `${baseUrl}${pathname ?? '/map'}${
     currentLanguageKey === 'en' ? '' : `?lang=${currentLanguageKey}`
   }`;
 };


### PR DESCRIPTION
## Issue

Closes: AVO-540

## Description

This PR does 3 small things to ensure our path logic is better validated.

- It checks that the zone that is requested is in our zone config so for example `/zone/xxx/` is no longer valid and will redirect to the map.
- It redirects `/zone` to the map as there is no content on that page otherwise and no way to navigate back from it using our own ui on mobile.
- It uses path matches to ensure that only valid paths ends up in the canonical URL. There has been malformed URLs such as `app.electricitymaps.com/ma`, and `app.electricitymaps.com/)?lang=fr` both which should not be considered canonical links. This PR fixes that.

### Double check
- [x] I have run `pnpx prettier@2 --write .` and `poetry run format` in the top level directory to format my changes.
