### PR TITLE
fix(parsers): Change behavior of continous mode in EIA parser

### DIFF
--- a/parsers/EIA.py
+++ b/parsers/EIA.py
@@ -681,9 +681,10 @@ def _fetch(
         end = target_datetime.astimezone(utc) + timedelta(hours=1)
         start = end - timedelta(days=1)
     else:
-        end = datetime.now(tz=tz.gettz("UTC")).replace(minute=0, second=0, microsecond=0) + timedelta(hours=1)
+        end = datetime.now(tz=tz.gettz("UTC")).replace(
+            minute=0, second=0, microsecond=0
+        ) + timedelta(hours=1)
         start = end - timedelta(hours=72)
-
 
     eia_ts_format = "%Y-%m-%dT%H"
     url = f"{url_prefix}&api_key={API_KEY}&start={start.strftime(eia_ts_format)}&end={end.strftime(eia_ts_format)}"

--- a/parsers/EIA.py
+++ b/parsers/EIA.py
@@ -669,6 +669,7 @@ def _fetch(
     # get EIA API key
     API_KEY = get_token("EIA_KEY")
 
+    start, end = None, None
     if target_datetime:
         try:
             target_datetime = arrow.get(target_datetime).datetime
@@ -677,12 +678,15 @@ def _fetch(
                 f"target_datetime must be a valid datetime - received {target_datetime}"
             ) from e
         utc = tz.gettz("UTC")
-        eia_ts_format = "%Y-%m-%dT%H"
         end = target_datetime.astimezone(utc) + timedelta(hours=1)
         start = end - timedelta(days=1)
-        url = f"{url_prefix}&api_key={API_KEY}&start={start.strftime(eia_ts_format)}&end={end.strftime(eia_ts_format)}"
     else:
-        url = f"{url_prefix}&api_key={API_KEY}&sort[0][column]=period&sort[0][direction]=desc&length=24"
+        end = datetime.now(tz=tz.gettz("UTC")).replace(minute=0, second=0, microsecond=0) + timedelta(hours=1)
+        start = end - timedelta(hours=72)
+
+
+    eia_ts_format = "%Y-%m-%dT%H"
+    url = f"{url_prefix}&api_key={API_KEY}&start={start.strftime(eia_ts_format)}&end={end.strftime(eia_ts_format)}"
 
     s = session or Session()
     req = s.get(url)


### PR DESCRIPTION
## Issue

The current EIA parser has a pretty severe bug. It turns out that it writes partially incomplete data. Here's the output of the following command:

```
> poetry run python test_parser.py US-NW-PSEI
[{'correctedModes': [],
  'datetime': datetime.datetime(2024, 9, 20, 7, 0, tzinfo=tzutc()),
  'production': {'coal': 0.0},
  'source': 'eia.gov',
  'sourceType': <EventSourceType.measured: 'measured'>,
  'storage': {},
  'zoneKey': 'US-NW-PSEI'},
 {'correctedModes': [],
  'datetime': datetime.datetime(2024, 9, 20, 8, 0, tzinfo=tzutc()),
  'production': {'coal': 0.0},
  'source': 'eia.gov',
  'sourceType': <EventSourceType.measured: 'measured'>,
  'storage': {},
  'zoneKey': 'US-NW-PSEI'},
 {'correctedModes': [],
  'datetime': datetime.datetime(2024, 9, 20, 9, 0, tzinfo=tzutc()),
  'production': {'coal': 0.0, 'oil': 0.0},
  'source': 'eia.gov',
  'sourceType': <EventSourceType.measured: 'measured'>,
  'storage': {},
  'zoneKey': 'US-NW-PSEI'},
 {'correctedModes': [],
  'datetime': datetime.datetime(2024, 9, 20, 10, 0, tzinfo=tzutc()),
  'production': {'coal': 0.0, 'oil': 0.0},
  'source': 'eia.gov',
  'sourceType': <EventSourceType.measured: 'measured'>,
  'storage': {},
  'zoneKey': 'US-NW-PSEI'},
 {'correctedModes': [],
  'datetime': datetime.datetime(2024, 9, 21, 7, 0, tzinfo=tzutc()),
  'production': {'coal': 0.0, 'oil': 0.0},
  'source': 'eia.gov',
  'sourceType': <EventSourceType.measured: 'measured'>,
  'storage': {},
  'zoneKey': 'US-NW-PSEI'},
 {'correctedModes': [],
  'datetime': datetime.datetime(2024, 9, 21, 8, 0, tzinfo=tzutc()),
  'production': {'coal': 0.0, 'oil': 0.0},
  'source': 'eia.gov',
  'sourceType': <EventSourceType.measured: 'measured'>,
  'storage': {},
  'zoneKey': 'US-NW-PSEI'},
 {'correctedModes': [],
  'datetime': datetime.datetime(2024, 9, 21, 9, 0, tzinfo=tzutc()),
  'production': {'coal': 0.0, 'oil': 0.0},
  'source': 'eia.gov',
  'sourceType': <EventSourceType.measured: 'measured'>,
  'storage': {},
  'zoneKey': 'US-NW-PSEI'},
 {'correctedModes': [],
  'datetime': datetime.datetime(2024, 9, 21, 10, 0, tzinfo=tzutc()),
  'production': {'coal': 0.0, 'oil': 0.0},
  'source': 'eia.gov',
  'sourceType': <EventSourceType.measured: 'measured'>,
  'storage': {},
  'zoneKey': 'US-NW-PSEI'},
 {'correctedModes': [],
  'datetime': datetime.datetime(2024, 9, 21, 11, 0, tzinfo=tzutc()),
  'production': {'coal': 0.0, 'oil': 0.0},
  'source': 'eia.gov',
  'sourceType': <EventSourceType.measured: 'measured'>,
  'storage': {},
  'zoneKey': 'US-NW-PSEI'},
 {'correctedModes': [],
  'datetime': datetime.datetime(2024, 9, 22, 7, 0, tzinfo=tzutc()),
  'production': {'coal': 0.0, 'oil': 0.0},
  'source': 'eia.gov',
  'sourceType': <EventSourceType.measured: 'measured'>,
  'storage': {},
  'zoneKey': 'US-NW-PSEI'},
 {'correctedModes': [],
  'datetime': datetime.datetime(2024, 9, 22, 8, 0, tzinfo=tzutc()),
  'production': {'coal': 0.0, 'oil': 0.0},
  'source': 'eia.gov',
  'sourceType': <EventSourceType.measured: 'measured'>,
  'storage': {},
  'zoneKey': 'US-NW-PSEI'},
 {'correctedModes': [],
  'datetime': datetime.datetime(2024, 9, 22, 9, 0, tzinfo=tzutc()),
  'production': {'coal': 0.0, 'oil': 0.0},
  'source': 'eia.gov',
  'sourceType': <EventSourceType.measured: 'measured'>,
  'storage': {},
  'zoneKey': 'US-NW-PSEI'},
 {'correctedModes': [],
  'datetime': datetime.datetime(2024, 9, 22, 10, 0, tzinfo=tzutc()),
  'production': {'coal': 0.0, 'oil': 0.0},
  'source': 'eia.gov',
  'sourceType': <EventSourceType.measured: 'measured'>,
  'storage': {},
  'zoneKey': 'US-NW-PSEI'},
 {'correctedModes': [],
  'datetime': datetime.datetime(2024, 9, 23, 7, 0, tzinfo=tzutc()),
  'production': {'coal': 0.0, 'oil': 0.0, 'solar': 0.0},
  'source': 'eia.gov',
  'sourceType': <EventSourceType.measured: 'measured'>,
  'storage': {},
  'zoneKey': 'US-NW-PSEI'},
 {'correctedModes': [],
  'datetime': datetime.datetime(2024, 9, 23, 8, 0, tzinfo=tzutc()),
  'production': {'coal': 0.0, 'oil': 0.0, 'solar': 0.0, 'unknown': 25.0},
  'source': 'eia.gov',
  'sourceType': <EventSourceType.measured: 'measured'>,
  'storage': {},
  'zoneKey': 'US-NW-PSEI'},
 {'correctedModes': [],
  'datetime': datetime.datetime(2024, 9, 23, 9, 0, tzinfo=tzutc()),
  'production': {'coal': 0.0, 'oil': 0.0, 'solar': 0.0, 'unknown': 25.0},
  'source': 'eia.gov',
  'sourceType': <EventSourceType.measured: 'measured'>,
  'storage': {},
  'zoneKey': 'US-NW-PSEI'},
 {'correctedModes': [],
  'datetime': datetime.datetime(2024, 9, 23, 10, 0, tzinfo=tzutc()),
  'production': {'coal': 0.0, 'oil': 0.0, 'solar': 0.0, 'unknown': 25.0},
  'source': 'eia.gov',
  'sourceType': <EventSourceType.measured: 'measured'>,
  'storage': {},
  'zoneKey': 'US-NW-PSEI'},
 {'correctedModes': [],
  'datetime': datetime.datetime(2024, 9, 23, 11, 0, tzinfo=tzutc()),
  'production': {'coal': 0.0, 'oil': 0.0, 'solar': 0.0, 'unknown': 24.0},
  'source': 'eia.gov',
  'sourceType': <EventSourceType.measured: 'measured'>,
  'storage': {},
  'zoneKey': 'US-NW-PSEI'},
 {'correctedModes': [],
  'datetime': datetime.datetime(2024, 9, 23, 12, 0, tzinfo=tzutc()),
  'production': {'coal': 0.0, 'gas': 364.0, 'hydro': 19.0, 'oil': 0.0, 'solar': 0.0, 'unknown': 27.0, 'wind': 277.0},
  'source': 'eia.gov',
  'sourceType': <EventSourceType.measured: 'measured'>,
  'storage': {},
  'zoneKey': 'US-NW-PSEI'},
 {'correctedModes': [],
  'datetime': datetime.datetime(2024, 9, 24, 7, 0, tzinfo=tzutc()),
  'production': {'coal': 0.0, 'gas': 407.0, 'hydro': 19.0, 'oil': 0.0, 'solar': 0.0, 'unknown': 26.0, 'wind': 83.0},
  'source': 'eia.gov',
  'sourceType': <EventSourceType.measured: 'measured'>,
  'storage': {},
  'zoneKey': 'US-NW-PSEI'},
 {'correctedModes': [],
  'datetime': datetime.datetime(2024, 9, 24, 8, 0, tzinfo=tzutc()),
  'production': {'coal': 0.0, 'gas': 346.0, 'hydro': 19.0, 'oil': 0.0, 'solar': 0.0, 'unknown': 25.0, 'wind': 313.0},
  'source': 'eia.gov',
  'sourceType': <EventSourceType.measured: 'measured'>,
  'storage': {},
  'zoneKey': 'US-NW-PSEI'},
 {'correctedModes': [],
  'datetime': datetime.datetime(2024, 9, 24, 9, 0, tzinfo=tzutc()),
  'production': {'coal': 0.0, 'gas': 345.0, 'hydro': 20.0, 'oil': 0.0, 'solar': 0.0, 'unknown': 25.0, 'wind': 293.0},
  'source': 'eia.gov',
  'sourceType': <EventSourceType.measured: 'measured'>,
  'storage': {},
  'zoneKey': 'US-NW-PSEI'},
 {'correctedModes': [],
  'datetime': datetime.datetime(2024, 9, 24, 10, 0, tzinfo=tzutc()),
  'production': {'coal': 0.0, 'gas': 347.0, 'hydro': 17.0, 'oil': 0.0, 'solar': 0.0, 'unknown': 25.0, 'wind': 293.0},
  'source': 'eia.gov',
  'sourceType': <EventSourceType.measured: 'measured'>,
  'storage': {},
  'zoneKey': 'US-NW-PSEI'},
 {'correctedModes': [],
  'datetime': datetime.datetime(2024, 9, 24, 11, 0, tzinfo=tzutc()),
  'production': {'coal': 0.0, 'gas': 350.0, 'hydro': 20.0, 'oil': 0.0, 'solar': 0.0, 'unknown': 24.0, 'wind': 297.0},
  'source': 'eia.gov',
  'sourceType': <EventSourceType.measured: 'measured'>,
  'storage': {},
  'zoneKey': 'US-NW-PSEI'}]
---------------------
took 8.24s
min returned datetime: 2024-09-20 07:00:00+00:00 UTC
max returned datetime: 2024-09-24 11:00:00+00:00 UTC  :( >2h from now !!! (now=2024-09-24T15:21:30+00:00 UTC)
```

As you can see, the first rows contain 0 rows. This problem doesn't seem to affect requests using the `start` and `end` parameter. (e.g. using `--target_datetime` the data looks fine)

This changes the parser to return the last 3 days by default instead of whatever the last 24 rows are as that seems to return wrongful data. It seems like this is a bug in the EIA API, so I don't see an easier fix.