### PR TITLE
chore(exchanges): Add missing US-NW-SCL exchanges

### DIFF
--- a/config/exchanges/US-NW-BPAT_US-NW-SCL.yaml
+++ b/config/exchanges/US-NW-BPAT_US-NW-SCL.yaml
@@ -1,0 +1,8 @@
+lonlat:
+  - -122.646129
+  - 47.587609
+
+rotation: 100
+
+parsers:
+  exchange: EIA.fetch_exchange

--- a/config/exchanges/US-NW-PSEI_US-NW-SCL.yaml
+++ b/config/exchanges/US-NW-PSEI_US-NW-SCL.yaml
@@ -1,0 +1,8 @@
+lonlat:
+  - -122.336493
+  - 47.647550
+
+rotation: 180
+
+parsers:
+  exchange: EIA.fetch_exchange


### PR DESCRIPTION
## Issue

They where missing...

## Description
Adds the exchange configs for the missing exchanges, I have verified both work with the EIA parser and is returning valid data. The rotations and locations are a bit of a guess but should work pretty good.


### Preview

#### `US-NW-BPAT->US-NW-SCL`
```
[{'datetime': datetime.datetime(2024, 9, 20, 23, 0, tzinfo=tzutc()),
  'netFlow': 797.0,
  'sortedZoneKeys': 'US-NW-BPAT->US-NW-SCL',
  'source': 'eia.gov',
  'sourceType': <EventSourceType.measured: 'measured'>},
 {'datetime': datetime.datetime(2024, 9, 21, 0, 0, tzinfo=tzutc()),
  'netFlow': 774.0,
  'sortedZoneKeys': 'US-NW-BPAT->US-NW-SCL',
  'source': 'eia.gov',
  'sourceType': <EventSourceType.measured: 'measured'>},
 {'datetime': datetime.datetime(2024, 9, 21, 1, 0, tzinfo=tzutc()),
  'netFlow': 756.0,
  'sortedZoneKeys': 'US-NW-BPAT->US-NW-SCL',
  'source': 'eia.gov',
  'sourceType': <EventSourceType.measured: 'measured'>},
 {'datetime': datetime.datetime(2024, 9, 21, 2, 0, tzinfo=tzutc()),
  'netFlow': 762.0,
  'sortedZoneKeys': 'US-NW-BPAT->US-NW-SCL',
  'source': 'eia.gov',
  'sourceType': <EventSourceType.measured: 'measured'>},
 {'datetime': datetime.datetime(2024, 9, 21, 3, 0, tzinfo=tzutc()),
  'netFlow': 754.0,
  'sortedZoneKeys': 'US-NW-BPAT->US-NW-SCL',
  'source': 'eia.gov',
  'sourceType': <EventSourceType.measured: 'measured'>},
 {'datetime': datetime.datetime(2024, 9, 21, 4, 0, tzinfo=tzutc()),
  'netFlow': 794.0,
  'sortedZoneKeys': 'US-NW-BPAT->US-NW-SCL',
  'source': 'eia.gov',
  'sourceType': <EventSourceType.measured: 'measured'>},
 {'datetime': datetime.datetime(2024, 9, 21, 5, 0, tzinfo=tzutc()),
  'netFlow': 768.0,
  'sortedZoneKeys': 'US-NW-BPAT->US-NW-SCL',
  'source': 'eia.gov',
  'sourceType': <EventSourceType.measured: 'measured'>},
 {'datetime': datetime.datetime(2024, 9, 21, 6, 0, tzinfo=tzutc()),
  'netFlow': 717.0,
  'sortedZoneKeys': 'US-NW-BPAT->US-NW-SCL',
  'source': 'eia.gov',
  'sourceType': <EventSourceType.measured: 'measured'>},
 {'datetime': datetime.datetime(2024, 9, 21, 7, 0, tzinfo=tzutc()),
  'netFlow': 610.0,
  'sortedZoneKeys': 'US-NW-BPAT->US-NW-SCL',
  'source': 'eia.gov',
  'sourceType': <EventSourceType.measured: 'measured'>},
 {'datetime': datetime.datetime(2024, 9, 21, 8, 0, tzinfo=tzutc()),
  'netFlow': 635.0,
  'sortedZoneKeys': 'US-NW-BPAT->US-NW-SCL',
  'source': 'eia.gov',
  'sourceType': <EventSourceType.measured: 'measured'>},
 {'datetime': datetime.datetime(2024, 9, 21, 9, 0, tzinfo=tzutc()),
  'netFlow': 614.0,
  'sortedZoneKeys': 'US-NW-BPAT->US-NW-SCL',
  'source': 'eia.gov',
  'sourceType': <EventSourceType.measured: 'measured'>},
 {'datetime': datetime.datetime(2024, 9, 21, 10, 0, tzinfo=tzutc()),
  'netFlow': 599.0,
  'sortedZoneKeys': 'US-NW-BPAT->US-NW-SCL',
  'source': 'eia.gov',
  'sourceType': <EventSourceType.measured: 'measured'>},
 {'datetime': datetime.datetime(2024, 9, 21, 11, 0, tzinfo=tzutc()),
  'netFlow': 604.0,
  'sortedZoneKeys': 'US-NW-BPAT->US-NW-SCL',
  'source': 'eia.gov',
  'sourceType': <EventSourceType.measured: 'measured'>},
 {'datetime': datetime.datetime(2024, 9, 21, 12, 0, tzinfo=tzutc()),
  'netFlow': 616.0,
  'sortedZoneKeys': 'US-NW-BPAT->US-NW-SCL',
  'source': 'eia.gov',
  'sourceType': <EventSourceType.measured: 'measured'>},
 {'datetime': datetime.datetime(2024, 9, 21, 13, 0, tzinfo=tzutc()),
  'netFlow': 560.0,
  'sortedZoneKeys': 'US-NW-BPAT->US-NW-SCL',
  'source': 'eia.gov',
  'sourceType': <EventSourceType.measured: 'measured'>},
 {'datetime': datetime.datetime(2024, 9, 21, 14, 0, tzinfo=tzutc()),
  'netFlow': 610.0,
  'sortedZoneKeys': 'US-NW-BPAT->US-NW-SCL',
  'source': 'eia.gov',
  'sourceType': <EventSourceType.measured: 'measured'>},
 {'datetime': datetime.datetime(2024, 9, 21, 15, 0, tzinfo=tzutc()),
  'netFlow': 691.0,
  'sortedZoneKeys': 'US-NW-BPAT->US-NW-SCL',
  'source': 'eia.gov',
  'sourceType': <EventSourceType.measured: 'measured'>},
 {'datetime': datetime.datetime(2024, 9, 21, 16, 0, tzinfo=tzutc()),
  'netFlow': 770.0,
  'sortedZoneKeys': 'US-NW-BPAT->US-NW-SCL',
  'source': 'eia.gov',
  'sourceType': <EventSourceType.measured: 'measured'>},
 {'datetime': datetime.datetime(2024, 9, 21, 17, 0, tzinfo=tzutc()),
  'netFlow': 781.0,
  'sortedZoneKeys': 'US-NW-BPAT->US-NW-SCL',
  'source': 'eia.gov',
  'sourceType': <EventSourceType.measured: 'measured'>},
 {'datetime': datetime.datetime(2024, 9, 21, 18, 0, tzinfo=tzutc()),
  'netFlow': 782.0,
  'sortedZoneKeys': 'US-NW-BPAT->US-NW-SCL',
  'source': 'eia.gov',
  'sourceType': <EventSourceType.measured: 'measured'>},
 {'datetime': datetime.datetime(2024, 9, 21, 19, 0, tzinfo=tzutc()),
  'netFlow': 779.0,
  'sortedZoneKeys': 'US-NW-BPAT->US-NW-SCL',
  'source': 'eia.gov',
  'sourceType': <EventSourceType.measured: 'measured'>},
 {'datetime': datetime.datetime(2024, 9, 21, 20, 0, tzinfo=tzutc()),
  'netFlow': 768.0,
  'sortedZoneKeys': 'US-NW-BPAT->US-NW-SCL',
  'source': 'eia.gov',
  'sourceType': <EventSourceType.measured: 'measured'>},
 {'datetime': datetime.datetime(2024, 9, 21, 21, 0, tzinfo=tzutc()),
  'netFlow': 737.0,
  'sortedZoneKeys': 'US-NW-BPAT->US-NW-SCL',
  'source': 'eia.gov',
  'sourceType': <EventSourceType.measured: 'measured'>},
 {'datetime': datetime.datetime(2024, 9, 21, 22, 0, tzinfo=tzutc()),
  'netFlow': 726.0,
  'sortedZoneKeys': 'US-NW-BPAT->US-NW-SCL',
  'source': 'eia.gov',
  'sourceType': <EventSourceType.measured: 'measured'>},
 {'datetime': datetime.datetime(2024, 9, 21, 23, 0, tzinfo=tzutc()),
  'netFlow': 677.0,
  'sortedZoneKeys': 'US-NW-BPAT->US-NW-SCL',
  'source': 'eia.gov',
  'sourceType': <EventSourceType.measured: 'measured'>},
 {'datetime': datetime.datetime(2024, 9, 22, 0, 0, tzinfo=tzutc()),
  'netFlow': 680.0,
  'sortedZoneKeys': 'US-NW-BPAT->US-NW-SCL',
  'source': 'eia.gov',
  'sourceType': <EventSourceType.measured: 'measured'>},
 {'datetime': datetime.datetime(2024, 9, 22, 1, 0, tzinfo=tzutc()),
  'netFlow': 687.0,
  'sortedZoneKeys': 'US-NW-BPAT->US-NW-SCL',
  'source': 'eia.gov',
  'sourceType': <EventSourceType.measured: 'measured'>},
 {'datetime': datetime.datetime(2024, 9, 22, 2, 0, tzinfo=tzutc()),
  'netFlow': 701.0,
  'sortedZoneKeys': 'US-NW-BPAT->US-NW-SCL',
  'source': 'eia.gov',
  'sourceType': <EventSourceType.measured: 'measured'>},
 {'datetime': datetime.datetime(2024, 9, 22, 3, 0, tzinfo=tzutc()),
  'netFlow': 690.0,
  'sortedZoneKeys': 'US-NW-BPAT->US-NW-SCL',
  'source': 'eia.gov',
  'sourceType': <EventSourceType.measured: 'measured'>},
 {'datetime': datetime.datetime(2024, 9, 22, 4, 0, tzinfo=tzutc()),
  'netFlow': 753.0,
  'sortedZoneKeys': 'US-NW-BPAT->US-NW-SCL',
  'source': 'eia.gov',
  'sourceType': <EventSourceType.measured: 'measured'>},
 {'datetime': datetime.datetime(2024, 9, 22, 5, 0, tzinfo=tzutc()),
  'netFlow': 736.0,
  'sortedZoneKeys': 'US-NW-BPAT->US-NW-SCL',
  'source': 'eia.gov',
  'sourceType': <EventSourceType.measured: 'measured'>},
 {'datetime': datetime.datetime(2024, 9, 22, 6, 0, tzinfo=tzutc()),
  'netFlow': 693.0,
  'sortedZoneKeys': 'US-NW-BPAT->US-NW-SCL',
  'source': 'eia.gov',
  'sourceType': <EventSourceType.measured: 'measured'>},
 {'datetime': datetime.datetime(2024, 9, 22, 7, 0, tzinfo=tzutc()),
  'netFlow': 580.0,
  'sortedZoneKeys': 'US-NW-BPAT->US-NW-SCL',
  'source': 'eia.gov',
  'sourceType': <EventSourceType.measured: 'measured'>},
 {'datetime': datetime.datetime(2024, 9, 22, 8, 0, tzinfo=tzutc()),
  'netFlow': 606.0,
  'sortedZoneKeys': 'US-NW-BPAT->US-NW-SCL',
  'source': 'eia.gov',
  'sourceType': <EventSourceType.measured: 'measured'>},
 {'datetime': datetime.datetime(2024, 9, 22, 9, 0, tzinfo=tzutc()),
  'netFlow': 587.0,
  'sortedZoneKeys': 'US-NW-BPAT->US-NW-SCL',
  'source': 'eia.gov',
  'sourceType': <EventSourceType.measured: 'measured'>},
 {'datetime': datetime.datetime(2024, 9, 22, 10, 0, tzinfo=tzutc()),
  'netFlow': 573.0,
  'sortedZoneKeys': 'US-NW-BPAT->US-NW-SCL',
  'source': 'eia.gov',
  'sourceType': <EventSourceType.measured: 'measured'>},
 {'datetime': datetime.datetime(2024, 9, 22, 11, 0, tzinfo=tzutc()),
  'netFlow': 577.0,
  'sortedZoneKeys': 'US-NW-BPAT->US-NW-SCL',
  'source': 'eia.gov',
  'sourceType': <EventSourceType.measured: 'measured'>},
 {'datetime': datetime.datetime(2024, 9, 22, 12, 0, tzinfo=tzutc()),
  'netFlow': 594.0,
  'sortedZoneKeys': 'US-NW-BPAT->US-NW-SCL',
  'source': 'eia.gov',
  'sourceType': <EventSourceType.measured: 'measured'>},
 {'datetime': datetime.datetime(2024, 9, 22, 13, 0, tzinfo=tzutc()),
  'netFlow': 621.0,
  'sortedZoneKeys': 'US-NW-BPAT->US-NW-SCL',
  'source': 'eia.gov',
  'sourceType': <EventSourceType.measured: 'measured'>},
 {'datetime': datetime.datetime(2024, 9, 22, 14, 0, tzinfo=tzutc()),
  'netFlow': 613.0,
  'sortedZoneKeys': 'US-NW-BPAT->US-NW-SCL',
  'source': 'eia.gov',
  'sourceType': <EventSourceType.measured: 'measured'>},
 {'datetime': datetime.datetime(2024, 9, 22, 15, 0, tzinfo=tzutc()),
  'netFlow': 672.0,
  'sortedZoneKeys': 'US-NW-BPAT->US-NW-SCL',
  'source': 'eia.gov',
  'sourceType': <EventSourceType.measured: 'measured'>},
 {'datetime': datetime.datetime(2024, 9, 22, 16, 0, tzinfo=tzutc()),
  'netFlow': 792.0,
  'sortedZoneKeys': 'US-NW-BPAT->US-NW-SCL',
  'source': 'eia.gov',
  'sourceType': <EventSourceType.measured: 'measured'>},
 {'datetime': datetime.datetime(2024, 9, 22, 17, 0, tzinfo=tzutc()),
  'netFlow': 827.0,
  'sortedZoneKeys': 'US-NW-BPAT->US-NW-SCL',
  'source': 'eia.gov',
  'sourceType': <EventSourceType.measured: 'measured'>},
 {'datetime': datetime.datetime(2024, 9, 22, 18, 0, tzinfo=tzutc()),
  'netFlow': 843.0,
  'sortedZoneKeys': 'US-NW-BPAT->US-NW-SCL',
  'source': 'eia.gov',
  'sourceType': <EventSourceType.measured: 'measured'>},
 {'datetime': datetime.datetime(2024, 9, 22, 19, 0, tzinfo=tzutc()),
  'netFlow': 821.0,
  'sortedZoneKeys': 'US-NW-BPAT->US-NW-SCL',
  'source': 'eia.gov',
  'sourceType': <EventSourceType.measured: 'measured'>},
 {'datetime': datetime.datetime(2024, 9, 22, 20, 0, tzinfo=tzutc()),
  'netFlow': 811.0,
  'sortedZoneKeys': 'US-NW-BPAT->US-NW-SCL',
  'source': 'eia.gov',
  'sourceType': <EventSourceType.measured: 'measured'>},
 {'datetime': datetime.datetime(2024, 9, 22, 21, 0, tzinfo=tzutc()),
  'netFlow': 805.0,
  'sortedZoneKeys': 'US-NW-BPAT->US-NW-SCL',
  'source': 'eia.gov',
  'sourceType': <EventSourceType.measured: 'measured'>},
 {'datetime': datetime.datetime(2024, 9, 22, 22, 0, tzinfo=tzutc()),
  'netFlow': 746.0,
  'sortedZoneKeys': 'US-NW-BPAT->US-NW-SCL',
  'source': 'eia.gov',
  'sourceType': <EventSourceType.measured: 'measured'>},
 {'datetime': datetime.datetime(2024, 9, 22, 23, 0, tzinfo=tzutc()),
  'netFlow': 749.0,
  'sortedZoneKeys': 'US-NW-BPAT->US-NW-SCL',
  'source': 'eia.gov',
  'sourceType': <EventSourceType.measured: 'measured'>},
 {'datetime': datetime.datetime(2024, 9, 23, 0, 0, tzinfo=tzutc()),
  'netFlow': 775.0,
  'sortedZoneKeys': 'US-NW-BPAT->US-NW-SCL',
  'source': 'eia.gov',
  'sourceType': <EventSourceType.measured: 'measured'>},
 {'datetime': datetime.datetime(2024, 9, 23, 1, 0, tzinfo=tzutc()),
  'netFlow': 791.0,
  'sortedZoneKeys': 'US-NW-BPAT->US-NW-SCL',
  'source': 'eia.gov',
  'sourceType': <EventSourceType.measured: 'measured'>},
 {'datetime': datetime.datetime(2024, 9, 23, 2, 0, tzinfo=tzutc()),
  'netFlow': 821.0,
  'sortedZoneKeys': 'US-NW-BPAT->US-NW-SCL',
  'source': 'eia.gov',
  'sourceType': <EventSourceType.measured: 'measured'>},
 {'datetime': datetime.datetime(2024, 9, 23, 3, 0, tzinfo=tzutc()),
  'netFlow': 799.0,
  'sortedZoneKeys': 'US-NW-BPAT->US-NW-SCL',
  'source': 'eia.gov',
  'sourceType': <EventSourceType.measured: 'measured'>},
 {'datetime': datetime.datetime(2024, 9, 23, 4, 0, tzinfo=tzutc()),
  'netFlow': 841.0,
  'sortedZoneKeys': 'US-NW-BPAT->US-NW-SCL',
  'source': 'eia.gov',
  'sourceType': <EventSourceType.measured: 'measured'>},
 {'datetime': datetime.datetime(2024, 9, 23, 5, 0, tzinfo=tzutc()),
  'netFlow': 786.0,
  'sortedZoneKeys': 'US-NW-BPAT->US-NW-SCL',
  'source': 'eia.gov',
  'sourceType': <EventSourceType.measured: 'measured'>},
 {'datetime': datetime.datetime(2024, 9, 23, 6, 0, tzinfo=tzutc()),
  'netFlow': 734.0,
  'sortedZoneKeys': 'US-NW-BPAT->US-NW-SCL',
  'source': 'eia.gov',
  'sourceType': <EventSourceType.measured: 'measured'>}]
  ```
  #### `US-NW-PSEI->US-NW-SCL`
  ```
  [{'datetime': datetime.datetime(2024, 9, 20, 23, 0, tzinfo=tzutc()),
  'netFlow': -4.0,
  'sortedZoneKeys': 'US-NW-PSEI->US-NW-SCL',
  'source': 'eia.gov',
  'sourceType': <EventSourceType.measured: 'measured'>},
 {'datetime': datetime.datetime(2024, 9, 21, 0, 0, tzinfo=tzutc()),
  'netFlow': 5.0,
  'sortedZoneKeys': 'US-NW-PSEI->US-NW-SCL',
  'source': 'eia.gov',
  'sourceType': <EventSourceType.measured: 'measured'>},
 {'datetime': datetime.datetime(2024, 9, 21, 1, 0, tzinfo=tzutc()),
  'netFlow': 1.0,
  'sortedZoneKeys': 'US-NW-PSEI->US-NW-SCL',
  'source': 'eia.gov',
  'sourceType': <EventSourceType.measured: 'measured'>},
 {'datetime': datetime.datetime(2024, 9, 21, 2, 0, tzinfo=tzutc()),
  'netFlow': -1.0,
  'sortedZoneKeys': 'US-NW-PSEI->US-NW-SCL',
  'source': 'eia.gov',
  'sourceType': <EventSourceType.measured: 'measured'>},
 {'datetime': datetime.datetime(2024, 9, 21, 3, 0, tzinfo=tzutc()),
  'netFlow': -10.0,
  'sortedZoneKeys': 'US-NW-PSEI->US-NW-SCL',
  'source': 'eia.gov',
  'sourceType': <EventSourceType.measured: 'measured'>},
 {'datetime': datetime.datetime(2024, 9, 21, 4, 0, tzinfo=tzutc()),
  'netFlow': 9.0,
  'sortedZoneKeys': 'US-NW-PSEI->US-NW-SCL',
  'source': 'eia.gov',
  'sourceType': <EventSourceType.measured: 'measured'>},
 {'datetime': datetime.datetime(2024, 9, 21, 5, 0, tzinfo=tzutc()),
  'netFlow': -12.0,
  'sortedZoneKeys': 'US-NW-PSEI->US-NW-SCL',
  'source': 'eia.gov',
  'sourceType': <EventSourceType.measured: 'measured'>},
 {'datetime': datetime.datetime(2024, 9, 21, 6, 0, tzinfo=tzutc()),
  'netFlow': -15.0,
  'sortedZoneKeys': 'US-NW-PSEI->US-NW-SCL',
  'source': 'eia.gov',
  'sourceType': <EventSourceType.measured: 'measured'>},
 {'datetime': datetime.datetime(2024, 9, 21, 7, 0, tzinfo=tzutc()),
  'netFlow': -25.0,
  'sortedZoneKeys': 'US-NW-PSEI->US-NW-SCL',
  'source': 'eia.gov',
  'sourceType': <EventSourceType.measured: 'measured'>},
 {'datetime': datetime.datetime(2024, 9, 21, 8, 0, tzinfo=tzutc()),
  'netFlow': -12.0,
  'sortedZoneKeys': 'US-NW-PSEI->US-NW-SCL',
  'source': 'eia.gov',
  'sourceType': <EventSourceType.measured: 'measured'>},
 {'datetime': datetime.datetime(2024, 9, 21, 9, 0, tzinfo=tzutc()),
  'netFlow': -12.0,
  'sortedZoneKeys': 'US-NW-PSEI->US-NW-SCL',
  'source': 'eia.gov',
  'sourceType': <EventSourceType.measured: 'measured'>},
 {'datetime': datetime.datetime(2024, 9, 21, 10, 0, tzinfo=tzutc()),
  'netFlow': -11.0,
  'sortedZoneKeys': 'US-NW-PSEI->US-NW-SCL',
  'source': 'eia.gov',
  'sourceType': <EventSourceType.measured: 'measured'>},
 {'datetime': datetime.datetime(2024, 9, 21, 11, 0, tzinfo=tzutc()),
  'netFlow': -11.0,
  'sortedZoneKeys': 'US-NW-PSEI->US-NW-SCL',
  'source': 'eia.gov',
  'sourceType': <EventSourceType.measured: 'measured'>},
 {'datetime': datetime.datetime(2024, 9, 21, 12, 0, tzinfo=tzutc()),
  'netFlow': -4.0,
  'sortedZoneKeys': 'US-NW-PSEI->US-NW-SCL',
  'source': 'eia.gov',
  'sourceType': <EventSourceType.measured: 'measured'>},
 {'datetime': datetime.datetime(2024, 9, 21, 13, 0, tzinfo=tzutc()),
  'netFlow': 16.0,
  'sortedZoneKeys': 'US-NW-PSEI->US-NW-SCL',
  'source': 'eia.gov',
  'sourceType': <EventSourceType.measured: 'measured'>},
 {'datetime': datetime.datetime(2024, 9, 21, 14, 0, tzinfo=tzutc()),
  'netFlow': 15.0,
  'sortedZoneKeys': 'US-NW-PSEI->US-NW-SCL',
  'source': 'eia.gov',
  'sourceType': <EventSourceType.measured: 'measured'>},
 {'datetime': datetime.datetime(2024, 9, 21, 15, 0, tzinfo=tzutc()),
  'netFlow': -9.0,
  'sortedZoneKeys': 'US-NW-PSEI->US-NW-SCL',
  'source': 'eia.gov',
  'sourceType': <EventSourceType.measured: 'measured'>},
 {'datetime': datetime.datetime(2024, 9, 21, 16, 0, tzinfo=tzutc()),
  'netFlow': -6.0,
  'sortedZoneKeys': 'US-NW-PSEI->US-NW-SCL',
  'source': 'eia.gov',
  'sourceType': <EventSourceType.measured: 'measured'>},
 {'datetime': datetime.datetime(2024, 9, 21, 17, 0, tzinfo=tzutc()),
  'netFlow': 2.0,
  'sortedZoneKeys': 'US-NW-PSEI->US-NW-SCL',
  'source': 'eia.gov',
  'sourceType': <EventSourceType.measured: 'measured'>},
 {'datetime': datetime.datetime(2024, 9, 21, 18, 0, tzinfo=tzutc()),
  'netFlow': 2.0,
  'sortedZoneKeys': 'US-NW-PSEI->US-NW-SCL',
  'source': 'eia.gov',
  'sourceType': <EventSourceType.measured: 'measured'>},
 {'datetime': datetime.datetime(2024, 9, 21, 19, 0, tzinfo=tzutc()),
  'netFlow': -1.0,
  'sortedZoneKeys': 'US-NW-PSEI->US-NW-SCL',
  'source': 'eia.gov',
  'sourceType': <EventSourceType.measured: 'measured'>},
 {'datetime': datetime.datetime(2024, 9, 21, 20, 0, tzinfo=tzutc()),
  'netFlow': 8.0,
  'sortedZoneKeys': 'US-NW-PSEI->US-NW-SCL',
  'source': 'eia.gov',
  'sourceType': <EventSourceType.measured: 'measured'>},
 {'datetime': datetime.datetime(2024, 9, 21, 21, 0, tzinfo=tzutc()),
  'netFlow': 3.0,
  'sortedZoneKeys': 'US-NW-PSEI->US-NW-SCL',
  'source': 'eia.gov',
  'sourceType': <EventSourceType.measured: 'measured'>},
 {'datetime': datetime.datetime(2024, 9, 21, 22, 0, tzinfo=tzutc()),
  'netFlow': 7.0,
  'sortedZoneKeys': 'US-NW-PSEI->US-NW-SCL',
  'source': 'eia.gov',
  'sourceType': <EventSourceType.measured: 'measured'>},
 {'datetime': datetime.datetime(2024, 9, 21, 23, 0, tzinfo=tzutc()),
  'netFlow': 12.0,
  'sortedZoneKeys': 'US-NW-PSEI->US-NW-SCL',
  'source': 'eia.gov',
  'sourceType': <EventSourceType.measured: 'measured'>},
 {'datetime': datetime.datetime(2024, 9, 22, 0, 0, tzinfo=tzutc()),
  'netFlow': 23.0,
  'sortedZoneKeys': 'US-NW-PSEI->US-NW-SCL',
  'source': 'eia.gov',
  'sourceType': <EventSourceType.measured: 'measured'>},
 {'datetime': datetime.datetime(2024, 9, 22, 1, 0, tzinfo=tzutc()),
  'netFlow': 23.0,
  'sortedZoneKeys': 'US-NW-PSEI->US-NW-SCL',
  'source': 'eia.gov',
  'sourceType': <EventSourceType.measured: 'measured'>},
 {'datetime': datetime.datetime(2024, 9, 22, 2, 0, tzinfo=tzutc()),
  'netFlow': 23.0,
  'sortedZoneKeys': 'US-NW-PSEI->US-NW-SCL',
  'source': 'eia.gov',
  'sourceType': <EventSourceType.measured: 'measured'>},
 {'datetime': datetime.datetime(2024, 9, 22, 3, 0, tzinfo=tzutc()),
  'netFlow': 22.0,
  'sortedZoneKeys': 'US-NW-PSEI->US-NW-SCL',
  'source': 'eia.gov',
  'sourceType': <EventSourceType.measured: 'measured'>},
 {'datetime': datetime.datetime(2024, 9, 22, 4, 0, tzinfo=tzutc()),
  'netFlow': 44.0,
  'sortedZoneKeys': 'US-NW-PSEI->US-NW-SCL',
  'source': 'eia.gov',
  'sourceType': <EventSourceType.measured: 'measured'>},
 {'datetime': datetime.datetime(2024, 9, 22, 5, 0, tzinfo=tzutc()),
  'netFlow': 19.0,
  'sortedZoneKeys': 'US-NW-PSEI->US-NW-SCL',
  'source': 'eia.gov',
  'sourceType': <EventSourceType.measured: 'measured'>},
 {'datetime': datetime.datetime(2024, 9, 22, 6, 0, tzinfo=tzutc()),
  'netFlow': 18.0,
  'sortedZoneKeys': 'US-NW-PSEI->US-NW-SCL',
  'source': 'eia.gov',
  'sourceType': <EventSourceType.measured: 'measured'>},
 {'datetime': datetime.datetime(2024, 9, 22, 7, 0, tzinfo=tzutc()),
  'netFlow': -10.0,
  'sortedZoneKeys': 'US-NW-PSEI->US-NW-SCL',
  'source': 'eia.gov',
  'sourceType': <EventSourceType.measured: 'measured'>},
 {'datetime': datetime.datetime(2024, 9, 22, 8, 0, tzinfo=tzutc()),
  'netFlow': 6.0,
  'sortedZoneKeys': 'US-NW-PSEI->US-NW-SCL',
  'source': 'eia.gov',
  'sourceType': <EventSourceType.measured: 'measured'>},
 {'datetime': datetime.datetime(2024, 9, 22, 9, 0, tzinfo=tzutc()),
  'netFlow': 4.0,
  'sortedZoneKeys': 'US-NW-PSEI->US-NW-SCL',
  'source': 'eia.gov',
  'sourceType': <EventSourceType.measured: 'measured'>},
 {'datetime': datetime.datetime(2024, 9, 22, 10, 0, tzinfo=tzutc()),
  'netFlow': 7.0,
  'sortedZoneKeys': 'US-NW-PSEI->US-NW-SCL',
  'source': 'eia.gov',
  'sourceType': <EventSourceType.measured: 'measured'>},
 {'datetime': datetime.datetime(2024, 9, 22, 11, 0, tzinfo=tzutc()),
  'netFlow': 6.0,
  'sortedZoneKeys': 'US-NW-PSEI->US-NW-SCL',
  'source': 'eia.gov',
  'sourceType': <EventSourceType.measured: 'measured'>},
 {'datetime': datetime.datetime(2024, 9, 22, 12, 0, tzinfo=tzutc()),
  'netFlow': 6.0,
  'sortedZoneKeys': 'US-NW-PSEI->US-NW-SCL',
  'source': 'eia.gov',
  'sourceType': <EventSourceType.measured: 'measured'>},
 {'datetime': datetime.datetime(2024, 9, 22, 13, 0, tzinfo=tzutc()),
  'netFlow': 4.0,
  'sortedZoneKeys': 'US-NW-PSEI->US-NW-SCL',
  'source': 'eia.gov',
  'sourceType': <EventSourceType.measured: 'measured'>},
 {'datetime': datetime.datetime(2024, 9, 22, 14, 0, tzinfo=tzutc()),
  'netFlow': -22.0,
  'sortedZoneKeys': 'US-NW-PSEI->US-NW-SCL',
  'source': 'eia.gov',
  'sourceType': <EventSourceType.measured: 'measured'>},
 {'datetime': datetime.datetime(2024, 9, 22, 15, 0, tzinfo=tzutc()),
  'netFlow': -18.0,
  'sortedZoneKeys': 'US-NW-PSEI->US-NW-SCL',
  'source': 'eia.gov',
  'sourceType': <EventSourceType.measured: 'measured'>},
 {'datetime': datetime.datetime(2024, 9, 22, 16, 0, tzinfo=tzutc()),
  'netFlow': -19.0,
  'sortedZoneKeys': 'US-NW-PSEI->US-NW-SCL',
  'source': 'eia.gov',
  'sourceType': <EventSourceType.measured: 'measured'>},
 {'datetime': datetime.datetime(2024, 9, 22, 17, 0, tzinfo=tzutc()),
  'netFlow': -21.0,
  'sortedZoneKeys': 'US-NW-PSEI->US-NW-SCL',
  'source': 'eia.gov',
  'sourceType': <EventSourceType.measured: 'measured'>},
 {'datetime': datetime.datetime(2024, 9, 22, 18, 0, tzinfo=tzutc()),
  'netFlow': -28.0,
  'sortedZoneKeys': 'US-NW-PSEI->US-NW-SCL',
  'source': 'eia.gov',
  'sourceType': <EventSourceType.measured: 'measured'>},
 {'datetime': datetime.datetime(2024, 9, 22, 19, 0, tzinfo=tzutc()),
  'netFlow': -34.0,
  'sortedZoneKeys': 'US-NW-PSEI->US-NW-SCL',
  'source': 'eia.gov',
  'sourceType': <EventSourceType.measured: 'measured'>},
 {'datetime': datetime.datetime(2024, 9, 22, 20, 0, tzinfo=tzutc()),
  'netFlow': -30.0,
  'sortedZoneKeys': 'US-NW-PSEI->US-NW-SCL',
  'source': 'eia.gov',
  'sourceType': <EventSourceType.measured: 'measured'>},
 {'datetime': datetime.datetime(2024, 9, 22, 21, 0, tzinfo=tzutc()),
  'netFlow': -22.0,
  'sortedZoneKeys': 'US-NW-PSEI->US-NW-SCL',
  'source': 'eia.gov',
  'sourceType': <EventSourceType.measured: 'measured'>},
 {'datetime': datetime.datetime(2024, 9, 22, 22, 0, tzinfo=tzutc()),
  'netFlow': -33.0,
  'sortedZoneKeys': 'US-NW-PSEI->US-NW-SCL',
  'source': 'eia.gov',
  'sourceType': <EventSourceType.measured: 'measured'>},
 {'datetime': datetime.datetime(2024, 9, 22, 23, 0, tzinfo=tzutc()),
  'netFlow': -23.0,
  'sortedZoneKeys': 'US-NW-PSEI->US-NW-SCL',
  'source': 'eia.gov',
  'sourceType': <EventSourceType.measured: 'measured'>},
 {'datetime': datetime.datetime(2024, 9, 23, 0, 0, tzinfo=tzutc()),
  'netFlow': -22.0,
  'sortedZoneKeys': 'US-NW-PSEI->US-NW-SCL',
  'source': 'eia.gov',
  'sourceType': <EventSourceType.measured: 'measured'>},
 {'datetime': datetime.datetime(2024, 9, 23, 1, 0, tzinfo=tzutc()),
  'netFlow': -19.0,
  'sortedZoneKeys': 'US-NW-PSEI->US-NW-SCL',
  'source': 'eia.gov',
  'sourceType': <EventSourceType.measured: 'measured'>},
 {'datetime': datetime.datetime(2024, 9, 23, 2, 0, tzinfo=tzutc()),
  'netFlow': -24.0,
  'sortedZoneKeys': 'US-NW-PSEI->US-NW-SCL',
  'source': 'eia.gov',
  'sourceType': <EventSourceType.measured: 'measured'>},
 {'datetime': datetime.datetime(2024, 9, 23, 3, 0, tzinfo=tzutc()),
  'netFlow': -23.0,
  'sortedZoneKeys': 'US-NW-PSEI->US-NW-SCL',
  'source': 'eia.gov',
  'sourceType': <EventSourceType.measured: 'measured'>},
 {'datetime': datetime.datetime(2024, 9, 23, 4, 0, tzinfo=tzutc()),
  'netFlow': -3.0,
  'sortedZoneKeys': 'US-NW-PSEI->US-NW-SCL',
  'source': 'eia.gov',
  'sourceType': <EventSourceType.measured: 'measured'>},
 {'datetime': datetime.datetime(2024, 9, 23, 5, 0, tzinfo=tzutc()),
  'netFlow': -12.0,
  'sortedZoneKeys': 'US-NW-PSEI->US-NW-SCL',
  'source': 'eia.gov',
  'sourceType': <EventSourceType.measured: 'measured'>},
 {'datetime': datetime.datetime(2024, 9, 23, 6, 0, tzinfo=tzutc()),
  'netFlow': -21.0,
  'sortedZoneKeys': 'US-NW-PSEI->US-NW-SCL',
  'source': 'eia.gov',
  'sourceType': <EventSourceType.measured: 'measured'>}]
  ```


### Double check

- [x] I have tested my parser changes locally with `poetry run test_parser "zone_key"`
- [x] I have run `pnpx prettier@2 --write .` and `poetry run format` in the top level directory to format my changes.
