### PR TITLE
feat(exchange): Add data for GB->IM

### DIFF
--- a/config/exchanges/GB_IM.yaml
+++ b/config/exchanges/GB_IM.yaml
@@ -5,3 +5,6 @@ lonlat:
   - -4
   - 53.8
 rotation: -40
+
+parsers:
+  exchange: ELEXON.fetch_exchange

--- a/config/zones/GB.yaml
+++ b/config/zones/GB.yaml
@@ -72,6 +72,8 @@ contributors:
   - AlexandreCouderc
   - gadakast
   - amv213
+  - VIKTORVAV99
+  - AJDelusion
 country: GB
 delays:
   production: 5

--- a/config/zones/IM.yaml
+++ b/config/zones/IM.yaml
@@ -1,3 +1,14 @@
 timezone: Europe/Isle_of_Man
 region: Europe
+contributors:
+  - VIKTORVAV99
+  - AJDelusion
 country: IM
+fallbackZoneMixes:
+  powerOriginRatios:
+    - _source: https://www.manxutilities.im/media/2830/mu_annual-report_r9.pdf
+      datetime: '2022-01-01'
+      value:
+        gas: 0.988
+        hydro: 0.007
+        oil: 0.005

--- a/parsers/ELEXON.py
+++ b/parsers/ELEXON.py
@@ -31,6 +31,7 @@ ELEXON_URLS = {
     "production": "/".join((ELEXON_API_ENDPOINT, "datasets/AGPT/stream")),
     "production_fuelhh": "/".join((ELEXON_API_ENDPOINT, "datasets/FUELHH/stream")),
     "exchange": "/".join((ELEXON_API_ENDPOINT, "generation/outturn/interconnectors")),
+    "balancing": "/".join((ELEXON_API_ENDPOINT, "balancing/physical")),
 }
 ELEXON_START_DATE = datetime(
     2019, 1, 1, tzinfo=timezone.utc
@@ -110,7 +111,7 @@ EXHANGE_KEY_IS_IMPORT = {
 }
 
 
-def query_elexon(url: str, session: Session, params: dict) -> list:
+def query_elexon(url: str, session: Session, params: dict) -> list | dict:
     r: Response = session.get(url, params=params)
     if not r.ok:
         raise ParserException(
@@ -146,9 +147,40 @@ def query_production(
     production_data = query_elexon(
         ELEXON_URLS["production"], session, production_params
     )
-
-    parsed_events = parse_production(production_data, logger, "B1620")
+    if isinstance(production_data, list):
+        parsed_events = parse_production(production_data, logger, "B1620")
     return parsed_events
+
+
+def query_IM_exchange(
+    session: Session, target_datetime: datetime, logger: Logger
+) -> ExchangeList:
+    """
+    Fetches balancing mechanism data from the ELEXON API.
+    This is used to get the imbalance quantity for the GB->IM interconnector.
+    """
+    bm_unit = "MANXENR-1"
+    balancing_params = {
+        "bmUnit": bm_unit,
+        "dataset": "PN",  # Physical data
+        "from": (target_datetime - timedelta(days=2)).strftime("%Y-%m-%d"),
+        "to": (target_datetime + timedelta(days=1)).strftime("%Y-%m-%d"),
+    }
+    balancing_data = query_elexon(ELEXON_URLS["balancing"], session, balancing_params)
+
+    exchange_list = ExchangeList(logger)
+    if isinstance(balancing_data, dict):
+        for event in balancing_data.get("data", []):
+            event_datetime = datetime.fromisoformat(
+                event["timeFrom"].replace("Z", "+00:00")
+            )
+            exchange_list.append(
+                zoneKey=ZoneKey("GB->IM"),
+                netFlow=event.get("levelFrom") * -1,
+                source=ELEXON_SOURCE,
+                datetime=event_datetime,
+            )
+    return exchange_list
 
 
 def get_event_value(event: dict[str, Any], key: str) -> float | None:
@@ -341,7 +373,7 @@ def query_production_fuelhh(
 
     fuelhh_data = query_elexon(ELEXON_URLS["production_fuelhh"], session, params)
 
-    return fuelhh_data
+    return fuelhh_data if isinstance(fuelhh_data, list) else []
 
 
 def query_and_merge_production_fuelhh_and_eso(
@@ -371,9 +403,8 @@ def query_exchange(
             "interconnectorName": interconnector,
             "format": "json",
         }
-        exchange_data = query_elexon(
-            ELEXON_URLS["exchange"], session, exchange_params
-        ).get("data")
+        data = query_elexon(ELEXON_URLS["exchange"], session, exchange_params)
+        exchange_data = data.get("data", []) if isinstance(data, dict) else []
 
         if EXHANGE_KEY_IS_IMPORT.get(zone_key):
             for event in exchange_data:
@@ -412,13 +443,20 @@ def fetch_exchange(
     if target_datetime is None:
         target_datetime = datetime.now(tz=timezone.utc)
 
+    if target_datetime.tzinfo is None:
+        target_datetime = target_datetime.replace(tzinfo=timezone.utc)
+
     exchangeKey = ZoneKey("->".join(sorted([zone_key1, zone_key2])))
     if target_datetime < ELEXON_START_DATE:
         raise ParserException(
             parser="ELEXON.py",
             message=f"Production data is not available before {ELEXON_START_DATE.date()}",
         )
-    exchange_data = query_exchange(exchangeKey, session, target_datetime, logger)
+    exchange_data = (
+        query_exchange(exchangeKey, session, target_datetime, logger)
+        if exchangeKey != "GB->IM"
+        else query_IM_exchange(session, target_datetime, logger)
+    )
 
     return exchange_data.to_list()
 


### PR DESCRIPTION
## Issue

Closes: #7123

## Description

Parses the exchange flow between GB and IM by using the balancing dataset as it's treated differently than the other exchanges.

>[!IMPORTANT]
>It seems like these flows are decided ahead of time, which is why the warnings occur but I've double checked it against the official website here: https://bmrs.elexon.co.uk/balancing-mechanism-bmu-view?bmuId=E_MANXENR-1&activeTab=Physical&startDate=2024-09-24T23:00:00.000Z&endDate=2024-09-25T15:00:00.000Z
I don't think there is anything we need to do about this though, just aware that the warnings are expected.

### Preview
```
[{'datetime': datetime.datetime(2024, 9, 24, 23, 30, tzinfo=datetime.timezone.utc),
  'netFlow': 14.0,
  'sortedZoneKeys': 'GB->IM',
  'source': 'elexon.co.uk',
  'sourceType': <EventSourceType.measured: 'measured'>},
 {'datetime': datetime.datetime(2024, 9, 25, 0, 0, tzinfo=datetime.timezone.utc),
  'netFlow': 12.0,
  'sortedZoneKeys': 'GB->IM',
  'source': 'elexon.co.uk',
  'sourceType': <EventSourceType.measured: 'measured'>},
 {'datetime': datetime.datetime(2024, 9, 25, 0, 30, tzinfo=datetime.timezone.utc),
  'netFlow': 12.0,
  'sortedZoneKeys': 'GB->IM',
  'source': 'elexon.co.uk',
  'sourceType': <EventSourceType.measured: 'measured'>},
 {'datetime': datetime.datetime(2024, 9, 25, 1, 0, tzinfo=datetime.timezone.utc),
  'netFlow': 9.0,
  'sortedZoneKeys': 'GB->IM',
  'source': 'elexon.co.uk',
  'sourceType': <EventSourceType.measured: 'measured'>},
 {'datetime': datetime.datetime(2024, 9, 25, 1, 30, tzinfo=datetime.timezone.utc),
  'netFlow': 9.0,
  'sortedZoneKeys': 'GB->IM',
  'source': 'elexon.co.uk',
  'sourceType': <EventSourceType.measured: 'measured'>},
 {'datetime': datetime.datetime(2024, 9, 25, 2, 0, tzinfo=datetime.timezone.utc),
  'netFlow': 9.0,
  'sortedZoneKeys': 'GB->IM',
  'source': 'elexon.co.uk',
  'sourceType': <EventSourceType.measured: 'measured'>},
 {'datetime': datetime.datetime(2024, 9, 25, 2, 30, tzinfo=datetime.timezone.utc),
  'netFlow': 9.0,
  'sortedZoneKeys': 'GB->IM',
  'source': 'elexon.co.uk',
  'sourceType': <EventSourceType.measured: 'measured'>},
 {'datetime': datetime.datetime(2024, 9, 25, 3, 0, tzinfo=datetime.timezone.utc),
  'netFlow': 9.0,
  'sortedZoneKeys': 'GB->IM',
  'source': 'elexon.co.uk',
  'sourceType': <EventSourceType.measured: 'measured'>},
 {'datetime': datetime.datetime(2024, 9, 25, 3, 30, tzinfo=datetime.timezone.utc),
  'netFlow': 9.0,
  'sortedZoneKeys': 'GB->IM',
  'source': 'elexon.co.uk',
  'sourceType': <EventSourceType.measured: 'measured'>},
 {'datetime': datetime.datetime(2024, 9, 25, 4, 0, tzinfo=datetime.timezone.utc),
  'netFlow': 9.0,
  'sortedZoneKeys': 'GB->IM',
  'source': 'elexon.co.uk',
  'sourceType': <EventSourceType.measured: 'measured'>},
 {'datetime': datetime.datetime(2024, 9, 25, 4, 30, tzinfo=datetime.timezone.utc),
  'netFlow': 9.0,
  'sortedZoneKeys': 'GB->IM',
  'source': 'elexon.co.uk',
  'sourceType': <EventSourceType.measured: 'measured'>},
 {'datetime': datetime.datetime(2024, 9, 25, 5, 0, tzinfo=datetime.timezone.utc),
  'netFlow': 9.0,
  'sortedZoneKeys': 'GB->IM',
  'source': 'elexon.co.uk',
  'sourceType': <EventSourceType.measured: 'measured'>},
 {'datetime': datetime.datetime(2024, 9, 25, 5, 30, tzinfo=datetime.timezone.utc),
  'netFlow': 9.0,
  'sortedZoneKeys': 'GB->IM',
  'source': 'elexon.co.uk',
  'sourceType': <EventSourceType.measured: 'measured'>},
 {'datetime': datetime.datetime(2024, 9, 25, 6, 0, tzinfo=datetime.timezone.utc),
  'netFlow': 13.0,
  'sortedZoneKeys': 'GB->IM',
  'source': 'elexon.co.uk',
  'sourceType': <EventSourceType.measured: 'measured'>},
 {'datetime': datetime.datetime(2024, 9, 25, 6, 30, tzinfo=datetime.timezone.utc),
  'netFlow': 15.0,
  'sortedZoneKeys': 'GB->IM',
  'source': 'elexon.co.uk',
  'sourceType': <EventSourceType.measured: 'measured'>},
 {'datetime': datetime.datetime(2024, 9, 25, 7, 0, tzinfo=datetime.timezone.utc),
  'netFlow': 18.0,
  'sortedZoneKeys': 'GB->IM',
  'source': 'elexon.co.uk',
  'sourceType': <EventSourceType.measured: 'measured'>},
 {'datetime': datetime.datetime(2024, 9, 25, 7, 30, tzinfo=datetime.timezone.utc),
  'netFlow': 21.0,
  'sortedZoneKeys': 'GB->IM',
  'source': 'elexon.co.uk',
  'sourceType': <EventSourceType.measured: 'measured'>},
 {'datetime': datetime.datetime(2024, 9, 25, 8, 0, tzinfo=datetime.timezone.utc),
  'netFlow': 24.0,
  'sortedZoneKeys': 'GB->IM',
  'source': 'elexon.co.uk',
  'sourceType': <EventSourceType.measured: 'measured'>},
 {'datetime': datetime.datetime(2024, 9, 25, 8, 30, tzinfo=datetime.timezone.utc),
  'netFlow': 26.0,
  'sortedZoneKeys': 'GB->IM',
  'source': 'elexon.co.uk',
  'sourceType': <EventSourceType.measured: 'measured'>},
 {'datetime': datetime.datetime(2024, 9, 25, 9, 0, tzinfo=datetime.timezone.utc),
  'netFlow': 28.0,
  'sortedZoneKeys': 'GB->IM',
  'source': 'elexon.co.uk',
  'sourceType': <EventSourceType.measured: 'measured'>},
 {'datetime': datetime.datetime(2024, 9, 25, 9, 30, tzinfo=datetime.timezone.utc),
  'netFlow': 28.0,
  'sortedZoneKeys': 'GB->IM',
  'source': 'elexon.co.uk',
  'sourceType': <EventSourceType.measured: 'measured'>},
 {'datetime': datetime.datetime(2024, 9, 25, 10, 0, tzinfo=datetime.timezone.utc),
  'netFlow': 29.0,
  'sortedZoneKeys': 'GB->IM',
  'source': 'elexon.co.uk',
  'sourceType': <EventSourceType.measured: 'measured'>},
 {'datetime': datetime.datetime(2024, 9, 25, 10, 30, tzinfo=datetime.timezone.utc),
  'netFlow': 29.0,
  'sortedZoneKeys': 'GB->IM',
  'source': 'elexon.co.uk',
  'sourceType': <EventSourceType.measured: 'measured'>},
 {'datetime': datetime.datetime(2024, 9, 25, 11, 0, tzinfo=datetime.timezone.utc),
  'netFlow': 30.0,
  'sortedZoneKeys': 'GB->IM',
  'source': 'elexon.co.uk',
  'sourceType': <EventSourceType.measured: 'measured'>},
 {'datetime': datetime.datetime(2024, 9, 25, 11, 30, tzinfo=datetime.timezone.utc),
  'netFlow': 29.0,
  'sortedZoneKeys': 'GB->IM',
  'source': 'elexon.co.uk',
  'sourceType': <EventSourceType.measured: 'measured'>},
 {'datetime': datetime.datetime(2024, 9, 25, 12, 0, tzinfo=datetime.timezone.utc),
  'netFlow': 29.0,
  'sortedZoneKeys': 'GB->IM',
  'source': 'elexon.co.uk',
  'sourceType': <EventSourceType.measured: 'measured'>},
 {'datetime': datetime.datetime(2024, 9, 25, 12, 30, tzinfo=datetime.timezone.utc),
  'netFlow': 29.0,
  'sortedZoneKeys': 'GB->IM',
  'source': 'elexon.co.uk',
  'sourceType': <EventSourceType.measured: 'measured'>},
 {'datetime': datetime.datetime(2024, 9, 25, 13, 0, tzinfo=datetime.timezone.utc),
  'netFlow': 29.0,
  'sortedZoneKeys': 'GB->IM',
  'source': 'elexon.co.uk',
  'sourceType': <EventSourceType.measured: 'measured'>},
 {'datetime': datetime.datetime(2024, 9, 25, 13, 30, tzinfo=datetime.timezone.utc),
  'netFlow': 30.0,
  'sortedZoneKeys': 'GB->IM',
  'source': 'elexon.co.uk',
  'sourceType': <EventSourceType.measured: 'measured'>},
 {'datetime': datetime.datetime(2024, 9, 25, 14, 0, tzinfo=datetime.timezone.utc),
  'netFlow': 30.0,
  'sortedZoneKeys': 'GB->IM',
  'source': 'elexon.co.uk',
  'sourceType': <EventSourceType.measured: 'measured'>},
 {'datetime': datetime.datetime(2024, 9, 25, 14, 30, tzinfo=datetime.timezone.utc),
  'netFlow': 30.0,
  'sortedZoneKeys': 'GB->IM',
  'source': 'elexon.co.uk',
  'sourceType': <EventSourceType.measured: 'measured'>},
 {'datetime': datetime.datetime(2024, 9, 25, 15, 0, tzinfo=datetime.timezone.utc),
  'netFlow': 31.0,
  'sortedZoneKeys': 'GB->IM',
  'source': 'elexon.co.uk',
  'sourceType': <EventSourceType.measured: 'measured'>},
 {'datetime': datetime.datetime(2024, 9, 25, 15, 30, tzinfo=datetime.timezone.utc),
  'netFlow': 33.0,
  'sortedZoneKeys': 'GB->IM',
  'source': 'elexon.co.uk',
  'sourceType': <EventSourceType.measured: 'measured'>},
 {'datetime': datetime.datetime(2024, 9, 25, 16, 0, tzinfo=datetime.timezone.utc),
  'netFlow': 35.0,
  'sortedZoneKeys': 'GB->IM',
  'source': 'elexon.co.uk',
  'sourceType': <EventSourceType.measured: 'measured'>},
 {'datetime': datetime.datetime(2024, 9, 25, 16, 30, tzinfo=datetime.timezone.utc),
  'netFlow': 36.0,
  'sortedZoneKeys': 'GB->IM',
  'source': 'elexon.co.uk',
  'sourceType': <EventSourceType.measured: 'measured'>},
 {'datetime': datetime.datetime(2024, 9, 25, 17, 0, tzinfo=datetime.timezone.utc),
  'netFlow': 36.0,
  'sortedZoneKeys': 'GB->IM',
  'source': 'elexon.co.uk',
  'sourceType': <EventSourceType.measured: 'measured'>},
 {'datetime': datetime.datetime(2024, 9, 25, 17, 30, tzinfo=datetime.timezone.utc),
  'netFlow': 35.0,
  'sortedZoneKeys': 'GB->IM',
  'source': 'elexon.co.uk',
  'sourceType': <EventSourceType.measured: 'measured'>},
 {'datetime': datetime.datetime(2024, 9, 25, 18, 0, tzinfo=datetime.timezone.utc),
  'netFlow': 36.0,
  'sortedZoneKeys': 'GB->IM',
  'source': 'elexon.co.uk',
  'sourceType': <EventSourceType.measured: 'measured'>},
 {'datetime': datetime.datetime(2024, 9, 25, 18, 30, tzinfo=datetime.timezone.utc),
  'netFlow': 36.0,
  'sortedZoneKeys': 'GB->IM',
  'source': 'elexon.co.uk',
  'sourceType': <EventSourceType.measured: 'measured'>},
 {'datetime': datetime.datetime(2024, 9, 25, 19, 0, tzinfo=datetime.timezone.utc),
  'netFlow': 35.0,
  'sortedZoneKeys': 'GB->IM',
  'source': 'elexon.co.uk',
  'sourceType': <EventSourceType.measured: 'measured'>},
 {'datetime': datetime.datetime(2024, 9, 25, 19, 30, tzinfo=datetime.timezone.utc),
  'netFlow': 33.0,
  'sortedZoneKeys': 'GB->IM',
  'source': 'elexon.co.uk',
  'sourceType': <EventSourceType.measured: 'measured'>},
 {'datetime': datetime.datetime(2024, 9, 25, 20, 0, tzinfo=datetime.timezone.utc),
  'netFlow': 31.0,
  'sortedZoneKeys': 'GB->IM',
  'source': 'elexon.co.uk',
  'sourceType': <EventSourceType.measured: 'measured'>},
 {'datetime': datetime.datetime(2024, 9, 25, 20, 30, tzinfo=datetime.timezone.utc),
  'netFlow': 28.0,
  'sortedZoneKeys': 'GB->IM',
  'source': 'elexon.co.uk',
  'sourceType': <EventSourceType.measured: 'measured'>},
 {'datetime': datetime.datetime(2024, 9, 25, 21, 0, tzinfo=datetime.timezone.utc),
  'netFlow': 24.0,
  'sortedZoneKeys': 'GB->IM',
  'source': 'elexon.co.uk',
  'sourceType': <EventSourceType.measured: 'measured'>},
 {'datetime': datetime.datetime(2024, 9, 25, 21, 30, tzinfo=datetime.timezone.utc),
  'netFlow': 20.0,
  'sortedZoneKeys': 'GB->IM',
  'source': 'elexon.co.uk',
  'sourceType': <EventSourceType.measured: 'measured'>},
 {'datetime': datetime.datetime(2024, 9, 25, 22, 0, tzinfo=datetime.timezone.utc),
  'netFlow': 17.0,
  'sortedZoneKeys': 'GB->IM',
  'source': 'elexon.co.uk',
  'sourceType': <EventSourceType.measured: 'measured'>},
 {'datetime': datetime.datetime(2024, 9, 25, 22, 30, tzinfo=datetime.timezone.utc),
  'netFlow': 13.0,
  'sortedZoneKeys': 'GB->IM',
  'source': 'elexon.co.uk',
  'sourceType': <EventSourceType.measured: 'measured'>},
 {'datetime': datetime.datetime(2024, 9, 25, 23, 0, tzinfo=datetime.timezone.utc),
  'netFlow': 15.0,
  'sortedZoneKeys': 'GB->IM',
  'source': 'elexon.co.uk',
  'sourceType': <EventSourceType.measured: 'measured'>},
 {'datetime': datetime.datetime(2024, 9, 25, 23, 30, tzinfo=datetime.timezone.utc),
  'netFlow': 14.0,
  'sortedZoneKeys': 'GB->IM',
  'source': 'elexon.co.uk',
  'sourceType': <EventSourceType.measured: 'measured'>},
 {'datetime': datetime.datetime(2024, 9, 26, 0, 0, tzinfo=datetime.timezone.utc),
  'netFlow': 12.0,
  'sortedZoneKeys': 'GB->IM',
  'source': 'elexon.co.uk',
  'sourceType': <EventSourceType.measured: 'measured'>},
 {'datetime': datetime.datetime(2024, 9, 26, 0, 30, tzinfo=datetime.timezone.utc),
  'netFlow': 12.0,
  'sortedZoneKeys': 'GB->IM',
  'source': 'elexon.co.uk',
  'sourceType': <EventSourceType.measured: 'measured'>},
 {'datetime': datetime.datetime(2024, 9, 26, 1, 0, tzinfo=datetime.timezone.utc),
  'netFlow': 9.0,
  'sortedZoneKeys': 'GB->IM',
  'source': 'elexon.co.uk',
  'sourceType': <EventSourceType.measured: 'measured'>},
 {'datetime': datetime.datetime(2024, 9, 26, 1, 30, tzinfo=datetime.timezone.utc),
  'netFlow': 9.0,
  'sortedZoneKeys': 'GB->IM',
  'source': 'elexon.co.uk',
  'sourceType': <EventSourceType.measured: 'measured'>},
 {'datetime': datetime.datetime(2024, 9, 26, 2, 0, tzinfo=datetime.timezone.utc),
  'netFlow': 9.0,
  'sortedZoneKeys': 'GB->IM',
  'source': 'elexon.co.uk',
  'sourceType': <EventSourceType.measured: 'measured'>},
 {'datetime': datetime.datetime(2024, 9, 26, 2, 30, tzinfo=datetime.timezone.utc),
  'netFlow': 9.0,
  'sortedZoneKeys': 'GB->IM',
  'source': 'elexon.co.uk',
  'sourceType': <EventSourceType.measured: 'measured'>},
 {'datetime': datetime.datetime(2024, 9, 26, 3, 0, tzinfo=datetime.timezone.utc),
  'netFlow': 9.0,
  'sortedZoneKeys': 'GB->IM',
  'source': 'elexon.co.uk',
  'sourceType': <EventSourceType.measured: 'measured'>},
 {'datetime': datetime.datetime(2024, 9, 26, 3, 30, tzinfo=datetime.timezone.utc),
  'netFlow': 9.0,
  'sortedZoneKeys': 'GB->IM',
  'source': 'elexon.co.uk',
  'sourceType': <EventSourceType.measured: 'measured'>},
 {'datetime': datetime.datetime(2024, 9, 26, 4, 0, tzinfo=datetime.timezone.utc),
  'netFlow': 9.0,
  'sortedZoneKeys': 'GB->IM',
  'source': 'elexon.co.uk',
  'sourceType': <EventSourceType.measured: 'measured'>},
 {'datetime': datetime.datetime(2024, 9, 26, 4, 30, tzinfo=datetime.timezone.utc),
  'netFlow': 9.0,
  'sortedZoneKeys': 'GB->IM',
  'source': 'elexon.co.uk',
  'sourceType': <EventSourceType.measured: 'measured'>},
 {'datetime': datetime.datetime(2024, 9, 26, 5, 0, tzinfo=datetime.timezone.utc),
  'netFlow': 9.0,
  'sortedZoneKeys': 'GB->IM',
  'source': 'elexon.co.uk',
  'sourceType': <EventSourceType.measured: 'measured'>},
 {'datetime': datetime.datetime(2024, 9, 26, 5, 30, tzinfo=datetime.timezone.utc),
  'netFlow': 9.0,
  'sortedZoneKeys': 'GB->IM',
  'source': 'elexon.co.uk',
  'sourceType': <EventSourceType.measured: 'measured'>},
 {'datetime': datetime.datetime(2024, 9, 26, 6, 0, tzinfo=datetime.timezone.utc),
  'netFlow': 13.0,
  'sortedZoneKeys': 'GB->IM',
  'source': 'elexon.co.uk',
  'sourceType': <EventSourceType.measured: 'measured'>},
 {'datetime': datetime.datetime(2024, 9, 26, 6, 30, tzinfo=datetime.timezone.utc),
  'netFlow': 15.0,
  'sortedZoneKeys': 'GB->IM',
  'source': 'elexon.co.uk',
  'sourceType': <EventSourceType.measured: 'measured'>},
 {'datetime': datetime.datetime(2024, 9, 26, 7, 0, tzinfo=datetime.timezone.utc),
  'netFlow': 18.0,
  'sortedZoneKeys': 'GB->IM',
  'source': 'elexon.co.uk',
  'sourceType': <EventSourceType.measured: 'measured'>},
 {'datetime': datetime.datetime(2024, 9, 26, 7, 30, tzinfo=datetime.timezone.utc),
  'netFlow': 21.0,
  'sortedZoneKeys': 'GB->IM',
  'source': 'elexon.co.uk',
  'sourceType': <EventSourceType.measured: 'measured'>},
 {'datetime': datetime.datetime(2024, 9, 26, 8, 0, tzinfo=datetime.timezone.utc),
  'netFlow': 24.0,
  'sortedZoneKeys': 'GB->IM',
  'source': 'elexon.co.uk',
  'sourceType': <EventSourceType.measured: 'measured'>},
 {'datetime': datetime.datetime(2024, 9, 26, 8, 30, tzinfo=datetime.timezone.utc),
  'netFlow': 26.0,
  'sortedZoneKeys': 'GB->IM',
  'source': 'elexon.co.uk',
  'sourceType': <EventSourceType.measured: 'measured'>},
 {'datetime': datetime.datetime(2024, 9, 26, 9, 0, tzinfo=datetime.timezone.utc),
  'netFlow': 28.0,
  'sortedZoneKeys': 'GB->IM',
  'source': 'elexon.co.uk',
  'sourceType': <EventSourceType.measured: 'measured'>},
 {'datetime': datetime.datetime(2024, 9, 26, 9, 30, tzinfo=datetime.timezone.utc),
  'netFlow': 28.0,
  'sortedZoneKeys': 'GB->IM',
  'source': 'elexon.co.uk',
  'sourceType': <EventSourceType.measured: 'measured'>},
 {'datetime': datetime.datetime(2024, 9, 26, 10, 0, tzinfo=datetime.timezone.utc),
  'netFlow': 29.0,
  'sortedZoneKeys': 'GB->IM',
  'source': 'elexon.co.uk',
  'sourceType': <EventSourceType.measured: 'measured'>},
 {'datetime': datetime.datetime(2024, 9, 26, 10, 30, tzinfo=datetime.timezone.utc),
  'netFlow': 29.0,
  'sortedZoneKeys': 'GB->IM',
  'source': 'elexon.co.uk',
  'sourceType': <EventSourceType.measured: 'measured'>},
 {'datetime': datetime.datetime(2024, 9, 26, 11, 0, tzinfo=datetime.timezone.utc),
  'netFlow': 30.0,
  'sortedZoneKeys': 'GB->IM',
  'source': 'elexon.co.uk',
  'sourceType': <EventSourceType.measured: 'measured'>},
 {'datetime': datetime.datetime(2024, 9, 26, 11, 30, tzinfo=datetime.timezone.utc),
  'netFlow': 29.0,
  'sortedZoneKeys': 'GB->IM',
  'source': 'elexon.co.uk',
  'sourceType': <EventSourceType.measured: 'measured'>},
 {'datetime': datetime.datetime(2024, 9, 26, 12, 0, tzinfo=datetime.timezone.utc),
  'netFlow': 29.0,
  'sortedZoneKeys': 'GB->IM',
  'source': 'elexon.co.uk',
  'sourceType': <EventSourceType.measured: 'measured'>},
 {'datetime': datetime.datetime(2024, 9, 26, 12, 30, tzinfo=datetime.timezone.utc),
  'netFlow': 29.0,
  'sortedZoneKeys': 'GB->IM',
  'source': 'elexon.co.uk',
  'sourceType': <EventSourceType.measured: 'measured'>},
 {'datetime': datetime.datetime(2024, 9, 26, 13, 0, tzinfo=datetime.timezone.utc),
  'netFlow': 29.0,
  'sortedZoneKeys': 'GB->IM',
  'source': 'elexon.co.uk',
  'sourceType': <EventSourceType.measured: 'measured'>},
 {'datetime': datetime.datetime(2024, 9, 26, 13, 30, tzinfo=datetime.timezone.utc),
  'netFlow': 30.0,
  'sortedZoneKeys': 'GB->IM',
  'source': 'elexon.co.uk',
  'sourceType': <EventSourceType.measured: 'measured'>},
 {'datetime': datetime.datetime(2024, 9, 26, 14, 0, tzinfo=datetime.timezone.utc),
  'netFlow': 30.0,
  'sortedZoneKeys': 'GB->IM',
  'source': 'elexon.co.uk',
  'sourceType': <EventSourceType.measured: 'measured'>},
 {'datetime': datetime.datetime(2024, 9, 26, 14, 30, tzinfo=datetime.timezone.utc),
  'netFlow': 30.0,
  'sortedZoneKeys': 'GB->IM',
  'source': 'elexon.co.uk',
  'sourceType': <EventSourceType.measured: 'measured'>},
 {'datetime': datetime.datetime(2024, 9, 26, 15, 0, tzinfo=datetime.timezone.utc),
  'netFlow': 31.0,
  'sortedZoneKeys': 'GB->IM',
  'source': 'elexon.co.uk',
  'sourceType': <EventSourceType.measured: 'measured'>},
 {'datetime': datetime.datetime(2024, 9, 26, 15, 30, tzinfo=datetime.timezone.utc),
  'netFlow': 33.0,
  'sortedZoneKeys': 'GB->IM',
  'source': 'elexon.co.uk',
  'sourceType': <EventSourceType.measured: 'measured'>},
 {'datetime': datetime.datetime(2024, 9, 26, 16, 0, tzinfo=datetime.timezone.utc),
  'netFlow': 35.0,
  'sortedZoneKeys': 'GB->IM',
  'source': 'elexon.co.uk',
  'sourceType': <EventSourceType.measured: 'measured'>},
 {'datetime': datetime.datetime(2024, 9, 26, 16, 30, tzinfo=datetime.timezone.utc),
  'netFlow': 36.0,
  'sortedZoneKeys': 'GB->IM',
  'source': 'elexon.co.uk',
  'sourceType': <EventSourceType.measured: 'measured'>},
 {'datetime': datetime.datetime(2024, 9, 26, 17, 0, tzinfo=datetime.timezone.utc),
  'netFlow': 36.0,
  'sortedZoneKeys': 'GB->IM',
  'source': 'elexon.co.uk',
  'sourceType': <EventSourceType.measured: 'measured'>},
 {'datetime': datetime.datetime(2024, 9, 26, 17, 30, tzinfo=datetime.timezone.utc),
  'netFlow': 35.0,
  'sortedZoneKeys': 'GB->IM',
  'source': 'elexon.co.uk',
  'sourceType': <EventSourceType.measured: 'measured'>},
 {'datetime': datetime.datetime(2024, 9, 26, 18, 0, tzinfo=datetime.timezone.utc),
  'netFlow': 36.0,
  'sortedZoneKeys': 'GB->IM',
  'source': 'elexon.co.uk',
  'sourceType': <EventSourceType.measured: 'measured'>}]
---------------------
took 0.37s
min returned datetime: 2024-09-24 23:30:00+00:00 UTC
max returned datetime: 2024-09-26 18:00:00+00:00 UTC 
WARNING:test_parser:Validation failed @ 2024-09-26 17:30:00+00:00: Data from GB->IM can't be in the future, data was 2024-09-26T17:30:00+00:00, now is 2024-09-26T17:28:23.052823+00:00
WARNING:test_parser:Validation failed @ 2024-09-26 18:00:00+00:00: Data from GB->IM can't be in the future, data was 2024-09-26T18:00:00+00:00, now is 2024-09-26T17:28:23.052899+00:00
```

### Double check

- [x] I have tested my parser changes locally with `poetry run test_parser "zone_key"`
- [x] I have run `pnpx prettier@2 --write .` and `poetry run format` in the top level directory to format my changes.
