### PR TITLE
fix: fix parsing 0 in elexon production

### DIFF
--- a/parsers/ELEXON.py
+++ b/parsers/ELEXON.py
@@ -237,7 +237,7 @@ def parse_production(
                 )
         else:
             production_value = get_event_value(event, quantity_key)
-            if production_value:
+            if production_value is not None:
                 production_mix.add_value(
                     production_mode, production_value, correct_negative_with_zero=True
                 )


### PR DESCRIPTION
## Issue

A too relaxed if check meant we where ignoring 0 values.

## Description

Fixes the issue by explicitly checking for None instead.


### Double check

- [x] I have tested my parser changes locally with `poetry run test_parser "zone_key"`
- [x] I have run `pnpx prettier@2 --write .` and `poetry run format` in the top level directory to format my changes.
