### PR TITLE
Avoid sending token

### DIFF
--- a/web/src/api/helpers.ts
+++ b/web/src/api/helpers.ts
@@ -51,7 +51,6 @@ export async function getHeaders(route: URL): Promise<Headers> {
   const signature = await sha256(`${token}${route.pathname}${timestamp}`);
 
   return new Headers({
-    'electricitymap-token': token,
     'x-request-timestamp': timestamp,
     'x-signature': signature,
     'Cache-Control': 'public,maxage=60',


### PR DESCRIPTION
## Issue
The electricity map secret token should never be sent in the header, but should only be used to sign the request.
I recommend rotating the secret.

Tested locally against our backend using the weather endpoint, bypassing cloudflare cache.