### PR TITLE
fix(web): add data source link for EU-ETS, ENTSO-E 2023

### DIFF
--- a/web/src/utils/constants.ts
+++ b/web/src/utils/constants.ts
@@ -135,6 +135,8 @@ export const timeAxisMapping: Record<TimeAverages, keyof Duration> = {
 export const sourceLinkMapping: { [key: string]: string } = {
   'EU-ETS, ENTSO-E 2022':
     'https://github.com/electricitymaps/electricitymaps-contrib/wiki/EU-emission-factors',
+  'EU-ETS, ENTSO-E 2023':
+    'https://github.com/electricitymaps/electricitymaps-contrib/wiki/EU-emission-factors',
   Climatescope: 'https://www.global-climatescope.org/',
   'ree.es': 'https://www.ree.es/en',
   'saskpower.com': 'https://www.saskpower.com/Our-Power-Future',


### PR DESCRIPTION
## Issue

<!-- If you want to close an issue automatically when your PR is merged, write "Closes X" where X is the issue number. For example: Closes #000 -->
[AVO-556](https://linear.app/electricitymaps/issue/AVO-556/data-sources-link-for-2023-emission-factor-data-is-missing)

## Description

<!-- Explains the goal of this PR -->
This PR adds a link from EU-ETS, ENTSO-E 2023 to our [wiki](https://github.com/electricitymaps/electricitymaps-contrib/wiki/EU-emission-factors).

### Preview

<!-- Please add screenshots and/or gif that shows visual changes (if applicable) -->

### Double check

- [ ] I have tested my parser changes locally with `poetry run test_parser "zone_key"`
- [x] I have run `pnpx prettier@2 --write .` and `poetry run format` in the top level directory to format my changes.
