### PR TITLE
feat(web): show breakdown chart in historical consumption views

### DIFF
--- a/web/src/features/charts/BreakdownChart.tsx
+++ b/web/src/features/charts/BreakdownChart.tsx
@@ -56,7 +56,7 @@ function BreakdownChart({
     return null;
   }
 
-  const isBreakdownGraphOverlayEnabled = isConsumption && !isHourly;
+  const isConsumptionAndAggregatedResolution = isConsumption && !isHourly;
 
   const { chartData, valueAxisLabel, layerFill, layerKeys } = data;
 
@@ -86,14 +86,10 @@ function BreakdownChart({
     <RoundedCard>
       <ChartTitle
         translationKey={`country-history.${titleDisplayMode}${titleMixMode}`}
-        badge={isBreakdownGraphOverlayEnabled ? undefined : badge}
+        badge={badge}
         unit={valueAxisLabel}
       />
       <div className="relative ">
-        {isBreakdownGraphOverlayEnabled && (
-          <DisabledMessage message={t(`country-panel.disabledBreakdownChartReason`)} />
-        )}
-
         <AreaGraph
           testId="history-mix-graph"
           data={chartData}
@@ -103,7 +99,6 @@ function BreakdownChart({
           markerHideHandler={noop}
           isMobile={false} // Todo: test on mobile https://linear.app/electricitymaps/issue/ELE-1498/test-and-improve-charts-on-mobile
           height="10em"
-          isDisabled={isBreakdownGraphOverlayEnabled}
           datetimes={datetimes}
           selectedTimeAggregate={timeAverage}
           tooltip={BreakdownChartTooltip}
@@ -111,48 +106,47 @@ function BreakdownChart({
           {...(displayByEmissions && { formatTick: formatAxisTick })}
         />
       </div>
-      {isBreakdownGraphOverlayEnabled && (
+      {isConsumptionAndAggregatedResolution && (
         <div
           className="prose my-1 rounded bg-gray-200 p-2 text-sm leading-snug dark:bg-gray-800 dark:text-white dark:prose-a:text-white"
           dangerouslySetInnerHTML={{ __html: t('country-panel.exchangesAreMissing') }}
         />
       )}
-      {!isBreakdownGraphOverlayEnabled && (
-        <>
-          <ProductionSourceLegendList
-            sources={getProductionSourcesInChart(chartData)}
-            className="py-1.5"
+
+      <>
+        <ProductionSourceLegendList
+          sources={getProductionSourcesInChart(chartData)}
+          className="py-1.5"
+        />
+        <HorizontalDivider />
+        <Accordion
+          onOpen={() => {
+            trackEvent(TrackEvent.DATA_SOURCES_CLICKED, {
+              chart: displayByEmissions
+                ? 'emission-origin-chart'
+                : 'electricity-origin-chart',
+            });
+          }}
+          title={t('data-sources.title')}
+          className="text-md"
+          isCollapsed={dataSourcesCollapsedBreakdown}
+          setState={setDataSourcesCollapsedBreakdown}
+        >
+          <DataSources
+            title={t('data-sources.power')}
+            icon={<Zap size={16} />}
+            sources={powerGenerationSources}
           />
-          <HorizontalDivider />
-          <Accordion
-            onOpen={() => {
-              trackEvent(TrackEvent.DATA_SOURCES_CLICKED, {
-                chart: displayByEmissions
-                  ? 'emission-origin-chart'
-                  : 'electricity-origin-chart',
-              });
-            }}
-            title={t('data-sources.title')}
-            className="text-md"
-            isCollapsed={dataSourcesCollapsedBreakdown}
-            setState={setDataSourcesCollapsedBreakdown}
-          >
-            <DataSources
-              title={t('data-sources.power')}
-              icon={<Zap size={16} />}
-              sources={powerGenerationSources}
-            />
-            <DataSources
-              title={t('data-sources.emission')}
-              icon={<Factory size={16} />}
-              sources={emissionFactorSources}
-              emissionFactorSourcesToProductionSources={
-                emissionFactorSourcesToProductionSources
-              }
-            />
-          </Accordion>
-        </>
-      )}
+          <DataSources
+            title={t('data-sources.emission')}
+            icon={<Factory size={16} />}
+            sources={emissionFactorSources}
+            emissionFactorSourcesToProductionSources={
+              emissionFactorSourcesToProductionSources
+            }
+          />
+        </Accordion>
+      </>
     </RoundedCard>
   );
 }

--- a/web/src/features/charts/BreakdownChart.tsx
+++ b/web/src/features/charts/BreakdownChart.tsx
@@ -17,7 +17,6 @@ import {
 
 import { ChartTitle } from './ChartTitle';
 import { DataSources } from './DataSources';
-import { DisabledMessage } from './DisabledMessage';
 import AreaGraph from './elements/AreaGraph';
 import { getBadgeTextAndIcon, getGenerationTypeKey, noop } from './graphUtils';
 import useBreakdownChartData from './hooks/useBreakdownChartData';

--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -100,7 +100,7 @@
     "estimated": "estimated",
     "aggregated": "aggregated",
     "dataIsEstimated": "Some of the data for this region is estimated. Read more about our estimation methodology <a href=\"https://github.com/electricityMaps/electricitymaps-contrib/wiki/Estimation-methods\" target=\"_blank\">here</a>.",
-    "exchangesAreMissing": "This chart does not include exchange data. Exchanges are visible in hourly views. Read more about our historical aggregations. <a href=\"https://github.com/electricityMaps/electricitymaps-contrib/wiki/Historical-aggregates\" target=\"_blank\">here</a>.",
+    "exchangesAreMissing": "This chart does not include exchange data. Exchanges are visible in hourly views. Read more about our historical aggregations <a href=\"https://github.com/electricityMaps/electricitymaps-contrib/wiki/Historical-aggregates\" target=\"_blank\">here</a>.",
     "estimatedTooltip": "The real-time data for this zone is estimated based on data from the source and the assumptions of the model.",
     "aggregatedTooltip": "The data for this zone is aggregated based on historical hourly values",
     "helpUs": "Help us identify the problem by taking a look at the <a href=\"{{link}}\" target=\"_blank\">runtime logs</a> or contact the data provider.",

--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -100,7 +100,7 @@
     "estimated": "estimated",
     "aggregated": "aggregated",
     "dataIsEstimated": "Some of the data for this region is estimated. Read more about our estimation methodology <a href=\"https://github.com/electricityMaps/electricitymaps-contrib/wiki/Estimation-methods\" target=\"_blank\">here</a>.",
-    "exchangesAreMissing": "Exchanges are accounted for in the calculations but not currently shown. Read more about our historical aggregations <a href=\"https://github.com/electricityMaps/electricitymaps-contrib/wiki/Historical-aggregates\" target=\"_blank\">here</a>.",
+    "exchangesAreMissing": "This chart does not include exchange data. Exchanges are visible in hourly views. Read more about our historical aggregations. <a href=\"https://github.com/electricityMaps/electricitymaps-contrib/wiki/Historical-aggregates\" target=\"_blank\">here</a>.",
     "estimatedTooltip": "The real-time data for this zone is estimated based on data from the source and the assumptions of the model.",
     "aggregatedTooltip": "The data for this zone is aggregated based on historical hourly values",
     "helpUs": "Help us identify the problem by taking a look at the <a href=\"{{link}}\" target=\"_blank\">runtime logs</a> or contact the data provider.",


### PR DESCRIPTION
## Issue
Breakdown chart isn't visible in historical consumption mode
AVO-578

## Description
This PR updates the breakdown chart to show in all views with a disclaimer of the data that is not included. 
