### PR TITLE
AVO-588: Match share/copy icon to functionality

### DIFF
--- a/web/src/features/panels/zone/ShareButton.cy.tsx
+++ b/web/src/features/panels/zone/ShareButton.cy.tsx
@@ -1,21 +1,20 @@
 import { Capacitor } from '@capacitor/core';
 import { ToastProvider } from '@radix-ui/react-toast';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { s } from 'vite/dist/node/types.d-aGj9QkWt';
 
 import { ShareButton } from './ShareButton';
 
 const queryClient = new QueryClient();
 
-describe.skip('Share Button', () => {
+describe('Share Button', () => {
   beforeEach(() => {
     cy.intercept('/feature-flags', {
       body: { 'share-button': true },
     });
-    cy.stub(Capacitor, 'isNativePlatform').returns(true);
   });
 
   it('should display copy button on desktop web', () => {
+    cy.stub(Capacitor, 'isNativePlatform').returns(false);
     cy.mount(
       <QueryClientProvider client={queryClient}>
         <ToastProvider>
@@ -29,10 +28,11 @@ describe.skip('Share Button', () => {
   });
 
   it('should display share icon for iOS native app', () => {
+    cy.stub(Capacitor, 'isNativePlatform').returns(true);
     cy.mount(
       <QueryClientProvider client={queryClient}>
         <ToastProvider>
-          <ShareButton showIosIcon={true} />
+          <ShareButton showIosIcon={true} hasMobileUserAgent={true} />
         </ToastProvider>
       </QueryClientProvider>
     );
@@ -42,10 +42,11 @@ describe.skip('Share Button', () => {
   });
 
   it('should display share icon for iOS mobile web', () => {
+    cy.stub(Capacitor, 'isNativePlatform').returns(false);
     cy.mount(
       <QueryClientProvider client={queryClient}>
         <ToastProvider>
-          <ShareButton showIosIcon={true} />
+          <ShareButton showIosIcon={true} hasMobileUserAgent={true} />
         </ToastProvider>
       </QueryClientProvider>
     );
@@ -55,10 +56,11 @@ describe.skip('Share Button', () => {
   });
 
   it('should display default share icon for non-iOS native app', () => {
+    cy.stub(Capacitor, 'isNativePlatform').returns(true);
     cy.mount(
       <QueryClientProvider client={queryClient}>
         <ToastProvider>
-          <ShareButton showIosIcon={false} />
+          <ShareButton showIosIcon={false} hasMobileUserAgent={true} />
         </ToastProvider>
       </QueryClientProvider>
     );
@@ -72,7 +74,7 @@ describe.skip('Share Button', () => {
     cy.mount(
       <QueryClientProvider client={queryClient}>
         <ToastProvider>
-          <ShareButton showIosIcon={false} />
+          <ShareButton showIosIcon={false} hasMobileUserAgent={true} />
         </ToastProvider>
       </QueryClientProvider>
     );
@@ -96,7 +98,6 @@ describe.skip('Share Button', () => {
   });
 
   it('should close toast on click', () => {
-    s;
     cy.mount(
       <QueryClientProvider client={queryClient}>
         <ToastProvider>

--- a/web/src/features/panels/zone/ShareButton.cy.tsx
+++ b/web/src/features/panels/zone/ShareButton.cy.tsx
@@ -1,18 +1,34 @@
+import { Capacitor } from '@capacitor/core';
 import { ToastProvider } from '@radix-ui/react-toast';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { s } from 'vite/dist/node/types.d-aGj9QkWt';
 
 import { ShareButton } from './ShareButton';
 
 const queryClient = new QueryClient();
 
-describe('Share Button', () => {
+describe.skip('Share Button', () => {
   beforeEach(() => {
     cy.intercept('/feature-flags', {
       body: { 'share-button': true },
     });
+    cy.stub(Capacitor, 'isNativePlatform').returns(true);
   });
 
-  it('should display share icon for iOS', () => {
+  it('should display copy button on desktop web', () => {
+    cy.mount(
+      <QueryClientProvider client={queryClient}>
+        <ToastProvider>
+          <ShareButton showIosIcon={true} />
+        </ToastProvider>
+      </QueryClientProvider>
+    );
+    cy.get('[data-test-id="linkIcon"]').should('be.visible');
+    cy.get('[data-test-id="iosShareIcon"]').should('not.exist');
+    cy.get('[data-test-id="defaultShareIcon"]').should('not.exist');
+  });
+
+  it('should display share icon for iOS native app', () => {
     cy.mount(
       <QueryClientProvider client={queryClient}>
         <ToastProvider>
@@ -22,9 +38,23 @@ describe('Share Button', () => {
     );
     cy.get('[data-test-id="iosShareIcon"]').should('be.visible');
     cy.get('[data-test-id="defaultShareIcon"]').should('not.exist');
+    cy.get('[data-test-id="linkIcon"]').should('not.exist');
   });
 
-  it('should display default share icon', () => {
+  it('should display share icon for iOS mobile web', () => {
+    cy.mount(
+      <QueryClientProvider client={queryClient}>
+        <ToastProvider>
+          <ShareButton showIosIcon={true} />
+        </ToastProvider>
+      </QueryClientProvider>
+    );
+    cy.get('[data-test-id="iosShareIcon"]').should('be.visible');
+    cy.get('[data-test-id="defaultShareIcon"]').should('not.exist');
+    cy.get('[data-test-id="linkIcon"]').should('not.exist');
+  });
+
+  it('should display default share icon for non-iOS native app', () => {
     cy.mount(
       <QueryClientProvider client={queryClient}>
         <ToastProvider>
@@ -34,6 +64,21 @@ describe('Share Button', () => {
     );
     cy.get('[data-test-id="defaultShareIcon"]').should('be.visible');
     cy.get('[data-test-id="iosShareIcon"]').should('not.exist');
+    cy.get('[data-test-id="linkIcon"]').should('not.exist');
+  });
+
+  it('should display default share icon for non-iOS mobile web', () => {
+    cy.stub(Capacitor, 'isNativePlatform').returns(false);
+    cy.mount(
+      <QueryClientProvider client={queryClient}>
+        <ToastProvider>
+          <ShareButton showIosIcon={false} />
+        </ToastProvider>
+      </QueryClientProvider>
+    );
+    cy.get('[data-test-id="defaultShareIcon"]').should('be.visible');
+    cy.get('[data-test-id="iosShareIcon"]').should('not.exist');
+    cy.get('[data-test-id="linkIcon"]').should('not.exist');
   });
 
   it('should trigger toast on click', () => {
@@ -51,6 +96,7 @@ describe('Share Button', () => {
   });
 
   it('should close toast on click', () => {
+    s;
     cy.mount(
       <QueryClientProvider client={queryClient}>
         <ToastProvider>

--- a/web/src/features/panels/zone/ShareButton.tsx
+++ b/web/src/features/panels/zone/ShareButton.tsx
@@ -18,6 +18,7 @@ interface ShareButtonProps
   iconSize?: number;
   shareUrl?: string;
   showIosIcon?: boolean;
+  hasMobileUserAgent?: boolean;
 }
 const trackShareClick = trackShare(ShareType.SHARE);
 const DURATION = 3 * 1000;
@@ -26,6 +27,7 @@ export function ShareButton({
   iconSize = DEFAULT_ICON_SIZE,
   shareUrl,
   showIosIcon = isIos(),
+  hasMobileUserAgent = isMobile(),
   ...restProps
 }: ShareButtonProps) {
   const { t } = useTranslation();
@@ -65,7 +67,7 @@ export function ShareButton({
   };
 
   const onClick = async () => {
-    if (isMobile() && (await CapShare.canShare())) {
+    if (hasMobileUserAgent && (await CapShare.canShare())) {
       share();
     } else {
       copyToClipboard();
@@ -74,7 +76,7 @@ export function ShareButton({
   };
 
   let shareIcon = <Link data-test-id="linkIcon" size={iconSize} />;
-  if (isMobile() || Capacitor.isNativePlatform()) {
+  if (hasMobileUserAgent || Capacitor.isNativePlatform()) {
     shareIcon = showIosIcon ? (
       <Share data-test-id="iosShareIcon" size={iconSize} />
     ) : (

--- a/web/src/features/panels/zone/ShareButton.tsx
+++ b/web/src/features/panels/zone/ShareButton.tsx
@@ -1,8 +1,9 @@
+import { Capacitor } from '@capacitor/core';
 import { Share as CapShare } from '@capacitor/share';
 import { Button, ButtonProps } from 'components/Button';
 import { Toast, useToastReference } from 'components/Toast';
 import { isIos, isMobile } from 'features/weather-layers/wind-layer/util';
-import { Share, Share2 } from 'lucide-react';
+import { Link, Share, Share2 } from 'lucide-react';
 import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { twMerge } from 'tailwind-merge';
@@ -72,6 +73,15 @@ export function ShareButton({
     trackShareClick();
   };
 
+  let shareIcon = <Link data-test-id="linkIcon" size={iconSize} />;
+  if (isMobile() || Capacitor.isNativePlatform()) {
+    shareIcon = showIosIcon ? (
+      <Share data-test-id="iosShareIcon" size={iconSize} />
+    ) : (
+      <Share2 data-test-id="defaultShareIcon" size={iconSize} />
+    );
+  }
+
   return (
     <>
       <Button
@@ -83,13 +93,7 @@ export function ShareButton({
           showIosIcon ? '' : '-translate-x-px'
         )}
         onClick={onClick}
-        icon={
-          showIosIcon ? (
-            <Share data-test-id="iosShareIcon" size={iconSize} />
-          ) : (
-            <Share2 data-test-id="defaultShareIcon" size={iconSize} />
-          )
-        }
+        icon={shareIcon}
         {...restProps}
       />
       <Toast


### PR DESCRIPTION
## Description
[AVO-588](https://linear.app/electricitymaps/issue/AVO-588/change-share-button-to-copy-button-when-on-desktop): Match share/copy icon to functionality

### Preview
Desktop:
<img width="561" alt="Screenshot 2024-10-14 at 13 11 54" src="https://github.com/user-attachments/assets/22f8078a-2d30-4d9a-b112-55f1d6a7512c">

Android:
<img width="424" alt="Screenshot 2024-10-14 at 13 12 23" src="https://github.com/user-attachments/assets/99103ed0-16f2-4f87-98c1-3d9aea26dd0b">

iPhone:
<img width="483" alt="Screenshot 2024-10-14 at 13 12 11" src="https://github.com/user-attachments/assets/c3dd1f3c-d2c3-4cda-bc37-ec4618fba2fd">

### Double check

- [ ] I have tested my parser changes locally with `poetry run test_parser "zone_key"`
- [ ] I have run `pnpx prettier@2 --write .` and `poetry run format` in the top level directory to format my changes.
