### PR TITLE
feat(web): zone specific datetimes

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -539,7 +539,6 @@ jobs:
           restore-keys: ${{ runner.os }}-venv-poetry_${{steps.get-poetry-version.outputs.poetry-version}}
       - name: Install libxml2-dev and tesseract-ocr
         run: |
-          poetry env use 3.10
           sudo apt-get update
           sudo apt-get install libxml2-dev tesseract-ocr tesseract-ocr-eng
       - name: Install Poetry dependencies

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -539,6 +539,7 @@ jobs:
           restore-keys: ${{ runner.os }}-venv-poetry_${{steps.get-poetry-version.outputs.poetry-version}}
       - name: Install libxml2-dev and tesseract-ocr
         run: |
+          poetry env use 3.10
           sudo apt-get update
           sudo apt-get install libxml2-dev tesseract-ocr tesseract-ocr-eng
       - name: Install Poetry dependencies

--- a/config/zones/BR-CS.yaml
+++ b/config/zones/BR-CS.yaml
@@ -274,4 +274,4 @@ parsers:
   production: ONS.fetch_production
   productionCapacity: ONS.fetch_production_capacity
 region: Americas
-timezone: null
+timezone: America/Sao_Paulo

--- a/config/zones/BR-N.yaml
+++ b/config/zones/BR-N.yaml
@@ -274,4 +274,4 @@ parsers:
   production: ONS.fetch_production
   productionCapacity: ONS.fetch_production_capacity
 region: Americas
-timezone: null
+timezone: America/Sao_Paulo

--- a/config/zones/BR-NE.yaml
+++ b/config/zones/BR-NE.yaml
@@ -274,4 +274,4 @@ parsers:
   production: ONS.fetch_production
   productionCapacity: ONS.fetch_production_capacity
 region: Americas
-timezone: null
+timezone: America/Sao_Paulo

--- a/config/zones/BR-S.yaml
+++ b/config/zones/BR-S.yaml
@@ -274,4 +274,4 @@ parsers:
   production: ONS.fetch_production
   productionCapacity: ONS.fetch_production_capacity
 region: Americas
-timezone: null
+timezone: America/Sao_Paulo

--- a/config/zones/BR.yaml
+++ b/config/zones/BR.yaml
@@ -176,3 +176,4 @@ subZoneNames:
   - BR-N
   - BR-NE
   - BR-S
+timezone: America/Sao_Paulo

--- a/config/zones/IQ-KUR.yaml
+++ b/config/zones/IQ-KUR.yaml
@@ -5,4 +5,4 @@ bounding_box:
     - 37.87549753800006
 country: IQ
 region: Asia
-timezone: null
+timezone: Asia/Baghdad

--- a/config/zones/NKR.yaml
+++ b/config/zones/NKR.yaml
@@ -12,4 +12,4 @@ fallbackZoneMixes:
     value:
       hydro: 1
 region: Asia
-timezone: null
+timezone: Asia/Baku

--- a/config/zones/RU-FE.yaml
+++ b/config/zones/RU-FE.yaml
@@ -5,4 +5,4 @@ bounding_box:
     - 71.6
 country: RU
 region: Europe
-timezone: null
+timezone: Asia/Kamchatka

--- a/web/geo/types.ts
+++ b/web/geo/types.ts
@@ -38,6 +38,7 @@ export interface OptimizedZoneConfig {
   subZoneNames?: string[];
   aggregates_displayed?: string[];
   generation_only?: boolean;
+  timezone?: string;
 }
 
 export interface ZonesConfig {

--- a/web/scripts/generateZonesConfig.ts
+++ b/web/scripts/generateZonesConfig.ts
@@ -38,6 +38,7 @@ const getConfig = (): CombinedZonesConfig => {
     'subZoneNames',
     'aggregates_displayed',
     'generation_only',
+    'timezone',
   ]);
 
   const contributors = new Set<string>();
@@ -65,7 +66,9 @@ const getConfig = (): CombinedZonesConfig => {
       const index = contributorArray.indexOf(contributor);
       zoneContributorsArray.push(index);
     }
-
+    if (!config.timezone) {
+      console.log('no timezone for', filepath);
+    }
     if (zoneContributorsArray && zoneContributorsArray.length > 0) {
       (config as unknown as OptimizedZoneConfig).contributors = zoneContributorsArray;
     }

--- a/web/src/components/Time.tsx
+++ b/web/src/components/Time.tsx
@@ -1,20 +1,23 @@
 import { TimeAverages } from 'utils/constants';
 import { formatDate } from 'utils/formatting';
-import { getZoneTimeZone, useGetZoneFromPath } from 'utils/helpers';
+import { getZoneTimezone, useGetZoneFromPath } from 'utils/helpers';
 
 export function FormattedTime({
   datetime,
   language,
   timeAverage,
   className,
+  zoneId,
 }: {
   datetime: Date;
   language: string;
   timeAverage: TimeAverages;
   className?: string;
+  zoneId?: string;
 }) {
-  const zoneId = useGetZoneFromPath();
-  const timezone = getZoneTimeZone(zoneId);
+  const pathZoneId = useGetZoneFromPath();
+  const timeZoneZoneId = zoneId || pathZoneId;
+  const timezone = getZoneTimezone(timeZoneZoneId);
   return (
     <time dateTime={datetime.toISOString()} className={className}>
       {formatDate(datetime, language, timeAverage, timezone)}

--- a/web/src/components/Time.tsx
+++ b/web/src/components/Time.tsx
@@ -1,5 +1,6 @@
 import { TimeAverages } from 'utils/constants';
 import { formatDate } from 'utils/formatting';
+import { getZoneTimeZone, useGetZoneFromPath } from 'utils/helpers';
 
 export function FormattedTime({
   datetime,
@@ -12,9 +13,11 @@ export function FormattedTime({
   timeAverage: TimeAverages;
   className?: string;
 }) {
+  const zoneId = useGetZoneFromPath();
+  const timezone = getZoneTimeZone(zoneId);
   return (
     <time dateTime={datetime.toISOString()} className={className}>
-      {formatDate(datetime, language, timeAverage)}
+      {formatDate(datetime, language, timeAverage, timezone)}
     </time>
   );
 }

--- a/web/src/components/TimeDisplay.tsx
+++ b/web/src/components/TimeDisplay.tsx
@@ -10,7 +10,7 @@ export function TimeDisplay({
   zoneId,
 }: {
   className?: string;
-  zoneId: ZoneKey;
+  zoneId?: ZoneKey;
 }) {
   const { i18n } = useTranslation();
   const timeAverage = useAtomValue(timeAverageAtom);

--- a/web/src/components/TimeDisplay.tsx
+++ b/web/src/components/TimeDisplay.tsx
@@ -1,10 +1,17 @@
 import { useAtomValue } from 'jotai';
 import { useTranslation } from 'react-i18next';
+import { ZoneKey } from 'types';
 import { selectedDatetimeIndexAtom, timeAverageAtom } from 'utils/state/atoms';
 
 import { FormattedTime } from './Time';
 
-export function TimeDisplay({ className }: { className?: string }) {
+export function TimeDisplay({
+  className,
+  zoneId,
+}: {
+  className?: string;
+  zoneId: ZoneKey;
+}) {
   const { i18n } = useTranslation();
   const timeAverage = useAtomValue(timeAverageAtom);
   const selectedDatetime = useAtomValue(selectedDatetimeIndexAtom);
@@ -15,6 +22,7 @@ export function TimeDisplay({ className }: { className?: string }) {
       language={i18n.languages[0]}
       timeAverage={timeAverage}
       className={className}
+      zoneId={zoneId}
     />
   );
 }

--- a/web/src/features/charts/elements/AreaGraph.tsx
+++ b/web/src/features/charts/elements/AreaGraph.tsx
@@ -8,6 +8,7 @@ import React, { useMemo, useRef, useState } from 'react';
 import { ZoneDetail } from 'types';
 import useResizeObserver from 'use-resize-observer';
 import { TimeAverages, timeAxisMapping } from 'utils/constants';
+import { getZoneTimezone, useGetZoneFromPath } from 'utils/helpers';
 import { selectedDatetimeIndexAtom } from 'utils/state/atoms';
 import { useBreakpoint } from 'utils/styling';
 
@@ -138,6 +139,8 @@ function AreaGraph({
   const [selectedDate] = useAtom(selectedDatetimeIndexAtom);
   const [tooltipData, setTooltipData] = useState<TooltipData | null>(null);
   const isBiggerThanMobile = useBreakpoint('sm');
+  const zoneId = useGetZoneFromPath();
+  const zoneTimezone = getZoneTimezone(zoneId);
 
   const containerWidth = Math.max(observerWidth - Y_AXIS_WIDTH, 0);
   const containerHeight = Math.max(observerHeight - X_AXIS_HEIGHT, 0);
@@ -277,6 +280,7 @@ function AreaGraph({
           scaleWidth={containerWidth}
           transform={`translate(5 ${containerHeight})`}
           className="h-[22px] w-full overflow-visible opacity-50"
+          timezone={zoneTimezone}
         />
         <ValueAxis scale={valueScale} width={containerWidth} formatTick={formatTick} />
         <GraphHoverLine

--- a/web/src/features/charts/tooltips/ChartTooltips.cy.tsx
+++ b/web/src/features/charts/tooltips/ChartTooltips.cy.tsx
@@ -1,3 +1,5 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { MemoryRouter } from 'react-router-dom';
 import { zoneDetailMock } from 'stories/mockData';
 import { CarbonUnits } from 'utils/units';
 
@@ -5,53 +7,91 @@ import BreakdownChartTooltip from './BreakdownChartTooltip';
 import CarbonChartTooltip from './CarbonChartTooltip';
 import EmissionChartTooltip from './EmissionChartTooltip';
 
-it('Carbon chart tooltip', () => {
-  cy.mount(
-    <CarbonChartTooltip zoneDetail={zoneDetailMock} selectedLayerKey="carbonIntensity" />
-  );
-  cy.contains('Carbon intensity');
-  cy.contains(`213 ${CarbonUnits.GRAMS_CO2EQ_PER_KILOWATT_HOUR}`);
-  cy.contains('2023');
-});
-it('Breakdown chart tooltip', () => {
-  cy.mount(
-    <BreakdownChartTooltip zoneDetail={zoneDetailMock} selectedLayerKey="hydro" />
-  );
-  cy.contains('Hydro');
-  cy.contains(`16.33 % of electricity available in`);
-  cy.contains(`representing 0.82 % of emissions`);
-  cy.contains('Sep');
-});
-it('Emmisions chart tooltip', () => {
-  cy.mount(<EmissionChartTooltip zoneDetail={zoneDetailMock} />);
-  cy.contains('Emissions');
-  cy.contains(`1.42 kt of CO₂eq`);
-  cy.contains('5');
-});
+describe('Chart Tooltips', () => {
+  const queryClient = new QueryClient();
 
-it('Carbon chart tooltip mobile', () => {
-  cy.viewport(500, 500);
-  cy.mount(
-    <CarbonChartTooltip zoneDetail={zoneDetailMock} selectedLayerKey="carbonIntensity" />
-  );
-  cy.contains('Carbon intensity');
-  cy.contains(`213 ${CarbonUnits.GRAMS_CO2EQ_PER_KILOWATT_HOUR}`);
-  cy.contains('2023');
-});
-it('Breakdown chart tooltip mobile', () => {
-  cy.viewport(500, 500);
-  cy.mount(
-    <BreakdownChartTooltip zoneDetail={zoneDetailMock} selectedLayerKey="hydro" />
-  );
-  cy.contains('Hydro');
-  cy.contains(`16.33 % of electricity available in`);
-  cy.contains(`representing 0.82 % of emissions`);
-  cy.contains('Sep');
-});
-it('Emmisions chart tooltip mobile', () => {
-  cy.viewport(500, 500);
-  cy.mount(<EmissionChartTooltip zoneDetail={zoneDetailMock} />);
-  cy.contains('Emissions');
-  cy.contains(`1.42 kt of CO₂eq`);
-  cy.contains('5');
+  function TestWrapper({ children }: any) {
+    return (
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>{children}</MemoryRouter>
+      </QueryClientProvider>
+    );
+  }
+
+  it('Carbon chart tooltip', () => {
+    cy.mount(
+      <TestWrapper>
+        <CarbonChartTooltip
+          zoneDetail={zoneDetailMock}
+          selectedLayerKey="carbonIntensity"
+        />
+      </TestWrapper>
+    );
+    cy.contains('Carbon intensity');
+    cy.contains(`213 ${CarbonUnits.GRAMS_CO2EQ_PER_KILOWATT_HOUR}`);
+    cy.contains('2023');
+  });
+
+  it('Breakdown chart tooltip', () => {
+    cy.mount(
+      <TestWrapper>
+        <BreakdownChartTooltip zoneDetail={zoneDetailMock} selectedLayerKey="hydro" />
+      </TestWrapper>
+    );
+    cy.contains('Hydro');
+    cy.contains(`16.33 % of electricity available in`);
+    cy.contains(`representing 0.82 % of emissions`);
+    cy.contains('Sep');
+  });
+
+  it('Emissions chart tooltip', () => {
+    cy.mount(
+      <TestWrapper>
+        <EmissionChartTooltip zoneDetail={zoneDetailMock} />
+      </TestWrapper>
+    );
+    cy.contains('Emissions');
+    cy.contains(`1.42 kt of CO₂eq`);
+    cy.contains('5');
+  });
+
+  it('Carbon chart tooltip mobile', () => {
+    cy.viewport(500, 500);
+    cy.mount(
+      <TestWrapper>
+        <CarbonChartTooltip
+          zoneDetail={zoneDetailMock}
+          selectedLayerKey="carbonIntensity"
+        />
+      </TestWrapper>
+    );
+    cy.contains('Carbon intensity');
+    cy.contains(`213 ${CarbonUnits.GRAMS_CO2EQ_PER_KILOWATT_HOUR}`);
+    cy.contains('2023');
+  });
+
+  it('Breakdown chart tooltip mobile', () => {
+    cy.viewport(500, 500);
+    cy.mount(
+      <TestWrapper>
+        <BreakdownChartTooltip zoneDetail={zoneDetailMock} selectedLayerKey="hydro" />
+      </TestWrapper>
+    );
+    cy.contains('Hydro');
+    cy.contains(`16.33 % of electricity available in`);
+    cy.contains(`representing 0.82 % of emissions`);
+    cy.contains('Sep');
+  });
+
+  it('Emissions chart tooltip mobile', () => {
+    cy.viewport(500, 500);
+    cy.mount(
+      <TestWrapper>
+        <EmissionChartTooltip zoneDetail={zoneDetailMock} />
+      </TestWrapper>
+    );
+    cy.contains('Emissions');
+    cy.contains(`1.42 kt of CO₂eq`);
+    cy.contains('5');
+  });
 });

--- a/web/src/features/map/MapTooltip.tsx
+++ b/web/src/features/map/MapTooltip.tsx
@@ -44,7 +44,10 @@ export function TooltipInner({
           <ZoneName zone={zoneId} textStyle="font-medium text-base font-poppins" />
           <DataValidityBadge hasOutage={o} estimated={e} hasZoneData={hasZoneData} />
         </div>
-        <TimeDisplay className="self-start text-neutral-600 dark:text-neutral-400" />
+        <TimeDisplay
+          zoneId={zoneId}
+          className="self-start text-neutral-600 dark:text-neutral-400"
+        />
       </div>
       <ZoneGaugesWithCO2Square zoneData={zoneData} />
     </div>

--- a/web/src/features/time/TimeAxis.tsx
+++ b/web/src/features/time/TimeAxis.tsx
@@ -21,7 +21,8 @@ const renderTick = (
   displayLive: boolean,
   lang: string,
   selectedTimeAggregate: TimeAverages,
-  isLoading: boolean
+  isLoading: boolean,
+  timezone?: string
 ) => {
   const shouldShowValue =
     index % TIME_TO_TICK_FREQUENCY[selectedTimeAggregate] === 0 && !isLoading;
@@ -34,7 +35,7 @@ const renderTick = (
     >
       <line stroke="currentColor" y2="6" opacity={shouldShowValue ? 0.5 : 0.2} />
       {shouldShowValue &&
-        renderTickValue(value, index, displayLive, lang, selectedTimeAggregate)}
+        renderTickValue(value, index, displayLive, lang, selectedTimeAggregate, timezone)}
     </g>
   );
 };
@@ -44,7 +45,8 @@ const renderTickValue = (
   index: number,
   displayLive: boolean,
   lang: string,
-  selectedTimeAggregate: TimeAverages
+  selectedTimeAggregate: TimeAverages,
+  timezone?: string
 ) => {
   const shouldDisplayLive = index === 24 && displayLive;
   const textOffset = selectedTimeAggregate === TimeAverages.HOURLY ? 5 : 0;
@@ -57,14 +59,13 @@ const renderTickValue = (
     </g>
   ) : (
     <text fill="currentColor" y="9" x={textOffset} dy="0.71em" fontSize={'0.65rem'}>
-      {formatDateTick(v, lang, selectedTimeAggregate)}
+      {formatDateTick(v, lang, selectedTimeAggregate, timezone)}
     </text>
   );
 };
 
 const getTimeScale = (rangeEnd: number, startDate: Date, endDate: Date) =>
   scaleTime().domain([startDate, endDate]).range([0, rangeEnd]);
-
 interface TimeAxisProps {
   selectedTimeAggregate: TimeAverages;
   datetimes: Date[] | undefined;
@@ -74,6 +75,7 @@ interface TimeAxisProps {
   transform?: string;
   scaleWidth?: number;
   className?: string;
+  timezone?: string;
 }
 
 function TimeAxis({
@@ -84,6 +86,7 @@ function TimeAxis({
   scaleWidth,
   isLiveDisplay,
   className,
+  timezone,
 }: TimeAxisProps) {
   const { i18n } = useTranslation();
   const { ref, width: observerWidth = 0 } = useResizeObserver<SVGSVGElement>();
@@ -118,7 +121,8 @@ function TimeAxis({
             isLiveDisplay ?? false,
             i18n.language,
             selectedTimeAggregate,
-            isLoading
+            isLoading,
+            timezone
           )
         )}
       </g>

--- a/web/src/features/time/TimeController.tsx
+++ b/web/src/features/time/TimeController.tsx
@@ -6,6 +6,7 @@ import { useCallback, useEffect, useMemo, useState } from 'react';
 import { twMerge } from 'tailwind-merge';
 import trackEvent from 'utils/analytics';
 import { TimeAverages, TrackEvent } from 'utils/constants';
+import { getZoneTimezone, useGetZoneFromPath } from 'utils/helpers';
 import {
   isHourlyAtom,
   selectedDatetimeIndexAtom,
@@ -23,6 +24,8 @@ export default function TimeController({ className }: { className?: string }) {
   const [numberOfEntries, setNumberOfEntries] = useState(0);
   const { data, isLoading: dataLoading } = useGetState();
   const isBiggerThanMobile = useIsBiggerThanMobile();
+  const zoneId = useGetZoneFromPath();
+  const zoneTimezone = getZoneTimezone(zoneId);
 
   // Show a loading state if isLoading is true or if there is only one datetime,
   // as this means we either have no data or only have latest hour loaded yet
@@ -97,6 +100,7 @@ export default function TimeController({ className }: { className?: string }) {
           className="h-[22px] w-full overflow-visible"
           transform={`translate(12, 0)`}
           isLiveDisplay={isHourly}
+          timezone={zoneTimezone}
         />
       </div>
     </div>

--- a/web/src/utils/formatting.test.ts
+++ b/web/src/utils/formatting.test.ts
@@ -356,6 +356,20 @@ describe('formatCo2', () => {
 
 describe('getDateTimeFormatOptions', () => {
   it('handles hourly data', () => {
+    const actual = getDateTimeFormatOptions(TimeAverages.HOURLY, 'UTC');
+    const expected = {
+      year: 'numeric',
+      month: 'short',
+      day: 'numeric',
+      hour: 'numeric',
+      minute: 'numeric',
+      timeZone: 'UTC',
+      timeZoneName: 'short',
+    };
+    expect(actual).to.deep.eq(expected);
+  });
+
+  it('handles hourly data without timezone', () => {
     const actual = getDateTimeFormatOptions(TimeAverages.HOURLY);
     const expected = {
       year: 'numeric',
@@ -363,10 +377,12 @@ describe('getDateTimeFormatOptions', () => {
       day: 'numeric',
       hour: 'numeric',
       minute: 'numeric',
+      timeZone: undefined,
       timeZoneName: 'short',
     };
     expect(actual).to.deep.eq(expected);
   });
+
   it('handles daily data', () => {
     const actual = getDateTimeFormatOptions(TimeAverages.DAILY);
     const expected = {

--- a/web/src/utils/formatting.ts
+++ b/web/src/utils/formatting.ts
@@ -138,7 +138,8 @@ const scalePower = (maxPower: number | undefined, isPower = false) => {
 };
 
 export const getDateTimeFormatOptions = (
-  timeAverage: TimeAverages
+  timeAverage: TimeAverages,
+  timezone?: string
 ): Intl.DateTimeFormatOptions => {
   switch (timeAverage) {
     case TimeAverages.HOURLY: {
@@ -149,6 +150,7 @@ export const getDateTimeFormatOptions = (
         hour: 'numeric',
         minute: 'numeric',
         timeZoneName: 'short',
+        timeZone: timezone,
       };
     }
     case TimeAverages.DAILY: {
@@ -177,13 +179,19 @@ export const getDateTimeFormatOptions = (
   }
 };
 
-const formatDate = (date: Date, lang: string, timeAverage: TimeAverages) => {
+const formatDate = (
+  date: Date,
+  lang: string,
+  timeAverage: TimeAverages,
+  timezone?: string
+) => {
   if (!isValidDate(date) || !timeAverage) {
     return '';
   }
-  return new Intl.DateTimeFormat(lang, getDateTimeFormatOptions(timeAverage)).format(
-    date
-  );
+  return new Intl.DateTimeFormat(
+    lang,
+    getDateTimeFormatOptions(timeAverage, timezone)
+  ).format(date);
 };
 
 const formatDateTick = (date: Date, lang: string, timeAggregate: TimeAverages) => {

--- a/web/src/utils/formatting.ts
+++ b/web/src/utils/formatting.ts
@@ -194,7 +194,12 @@ const formatDate = (
   ).format(date);
 };
 
-const formatDateTick = (date: Date, lang: string, timeAggregate: TimeAverages) => {
+const formatDateTick = (
+  date: Date,
+  lang: string,
+  timeAggregate: TimeAverages,
+  timezone?: string
+) => {
   if (!isValidDate(date) || !timeAggregate) {
     return '';
   }
@@ -203,6 +208,7 @@ const formatDateTick = (date: Date, lang: string, timeAggregate: TimeAverages) =
     case TimeAverages.HOURLY: {
       return new Intl.DateTimeFormat(lang, {
         timeStyle: 'short',
+        timeZone: timezone,
       }).format(date);
     }
     // Instantiate below DateTimeFormat objects using UTC to avoid displaying

--- a/web/src/utils/helpers.ts
+++ b/web/src/utils/helpers.ts
@@ -8,6 +8,9 @@ import {
   ZoneDetail,
 } from 'types';
 
+import zonesConfigJSON from '../../config/zones.json';
+import { CombinedZonesConfig } from '../../geo/types';
+
 export function useGetZoneFromPath() {
   const { zoneId } = useParams();
   const match = useMatch('/zone/:id');
@@ -158,3 +161,11 @@ export function getNetExchange(
 
   return netExchangeValue;
 }
+
+export const getZoneTimeZone = (zoneId?: string) => {
+  if (!zoneId) {
+    return undefined;
+  }
+  const { zones } = zonesConfigJSON as unknown as CombinedZonesConfig;
+  return zones[zoneId]?.timezone;
+};

--- a/web/src/utils/helpers.ts
+++ b/web/src/utils/helpers.ts
@@ -162,7 +162,7 @@ export function getNetExchange(
   return netExchangeValue;
 }
 
-export const getZoneTimeZone = (zoneId?: string) => {
+export const getZoneTimezone = (zoneId?: string) => {
   if (!zoneId) {
     return undefined;
   }


### PR DESCRIPTION
## Issue
AVO-586
It's not always valuable to have a zone date time formatted for a users location

## Description
This PR updates the date formatting to convert formatted dates to be zone specific, if no zone is selected it should revert to the users location. 

There were a few missing timezones in configs so I've also added those. 