### PR TITLE
bug(web): Japan/Tokyo invalid timezone

### DIFF
--- a/config/zones/JP.yaml
+++ b/config/zones/JP.yaml
@@ -189,4 +189,4 @@ subZoneNames:
   - JP-SK
   - JP-TH
   - JP-TK
-timezone: Japan/Tokyo
+timezone: Asia/Tokyo


### PR DESCRIPTION
## Issue
Invalid timezone for Japan combined

## Description
This PR updates the config for JP to have the correct timezone