### PR TITLE
translations(web): improve california display name to make it more readable

### DIFF
--- a/web/public/locales/en.json
+++ b/web/public/locales/en.json
@@ -1321,8 +1321,8 @@
     },
     "US-CAL-CISO": {
       "countryName": "USA",
-      "displayName": "CAISO",
-      "zoneName": "California ISO"
+      "displayName": "California ISO",
+      "zoneName": "CAISO"
     },
     "US-CAL-IID": {
       "countryName": "USA",

--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -1794,8 +1794,8 @@
     },
     "US-CAL-CISO": {
       "countryName": "USA",
-      "displayName": "CAISO",
-      "zoneName": "California ISO"
+      "displayName": "California ISO",
+      "zoneName": "CAISO"
     },
     "US-CAL-IID": {
       "countryName": "USA",

--- a/web/src/locales/nl.json
+++ b/web/src/locales/nl.json
@@ -540,8 +540,8 @@
     },
     "US-CAL-CISO": {
       "countryName": "VS",
-      "displayName": "CAISO",
-      "zoneName": "California ISO"
+      "displayName": "California ISO",
+      "zoneName": "CAISO"
     },
     "US-CENT-SWPP": {
       "countryName": "VS",

--- a/web/src/locales/pl.json
+++ b/web/src/locales/pl.json
@@ -1813,8 +1813,8 @@
     },
     "US-CAL-CISO": {
       "countryName": "USA",
-      "displayName": "CAISO",
-      "zoneName": "California ISO"
+      "displayName": "California ISO",
+      "zoneName": "CAISO"
     },
     "US-CAL-IID": {
       "countryName": "USA",

--- a/web/src/locales/pt-PT.json
+++ b/web/src/locales/pt-PT.json
@@ -1723,8 +1723,8 @@
     },
     "US-CAL-CISO": {
       "countryName": "Estados Unidos da América",
-      "displayName": "CAISO",
-      "zoneName": "Operador de sistema independente da Califórnia"
+      "displayName": "California ISO",
+      "zoneName": "CAISO"
     },
     "US-CAL-IID": {
       "countryName": "Estados Unidos da América",

--- a/web/src/locales/sv.json
+++ b/web/src/locales/sv.json
@@ -1763,8 +1763,8 @@
     },
     "US-CAL-CISO": {
       "countryName": "USA",
-      "displayName": "CAISO",
-      "zoneName": "California ISO"
+      "displayName": "California ISO",
+      "zoneName": "CAISO"
     },
     "US-CAL-IID": {
       "countryName": "USA",


### PR DESCRIPTION

## Issue
Before: <img width="284" alt="image" src="https://github.com/user-attachments/assets/c7454ac8-e124-4259-b240-1364a5668deb">

After:
<img width="461" alt="image" src="https://github.com/user-attachments/assets/f1a1a35d-afbb-47bf-9d36-5d90e91fb88e">


## Description
Update Caiso's display name to make it a bit more readable, CAISO still shows up on hover. 