### PR TITLE
AVO-592: Add Scroll-to functionality

### DIFF
--- a/web/cypress/e2e/countrypanel.spec.ts
+++ b/web/cypress/e2e/countrypanel.spec.ts
@@ -111,4 +111,35 @@ describe('Country Panel', () => {
     // eslint-disable-next-line cypress/require-data-selectors
     cy.get('#origin_chart').should('be.visible');
   });
+
+  it.only('scrolls to anchor element if provided a hash with caps in url', () => {
+    cy.interceptAPI('v8/details/hourly/DK-DK2');
+
+    cy.visit('/zone/DK-DK2?lang=en-GB#oRiGiN_ChArT', {
+      onBeforeLoad(win) {
+        delete win.navigator.__proto__.serviceWorker;
+      },
+    });
+    cy.get('[data-test-id=close-modal]').click();
+    cy.waitForAPISuccess('v8/state/hourly');
+    cy.waitForAPISuccess('v8/details/hourly/DK-DK2');
+    // eslint-disable-next-line cypress/require-data-selectors
+    cy.get('#origin_chart').should('be.visible');
+  });
+
+  it('does not scroll or error if provided a non-sensical hash in url', () => {
+    cy.interceptAPI('v8/details/hourly/DK-DK2');
+
+    cy.visit('/zone/DK-DK2?lang=en-GB##not-a-thing', {
+      onBeforeLoad(win) {
+        delete win.navigator.__proto__.serviceWorker;
+      },
+    });
+    cy.get('[data-test-id=close-modal]').click();
+    cy.waitForAPISuccess('v8/state/hourly');
+    cy.waitForAPISuccess('v8/details/hourly/DK-DK2');
+    cy.get('[data-test-id=left-panel] [data-test-id=co2-square-value]').should(
+      'be.visible'
+    );
+  });
 });

--- a/web/cypress/e2e/countrypanel.spec.ts
+++ b/web/cypress/e2e/countrypanel.spec.ts
@@ -96,4 +96,19 @@ describe('Country Panel', () => {
     cy.waitForAPISuccess('v8/details/hourly/CN');
     cy.get('[data-test-id=no-parser-message]').should('exist');
   });
+
+  it('scrolls to element if provided a hash', () => {
+    cy.interceptAPI('v8/details/hourly/DK-DK2');
+
+    cy.visit('/zone/DK-DK2?lang=en-GB#origin_chart', {
+      onBeforeLoad(win) {
+        delete win.navigator.__proto__.serviceWorker;
+      },
+    });
+    cy.get('[data-test-id=close-modal]').click();
+    cy.waitForAPISuccess('v8/state/hourly');
+    cy.waitForAPISuccess('v8/details/hourly/DK-DK2');
+    // eslint-disable-next-line cypress/require-data-selectors
+    cy.get('#origin_chart').should('be.visible');
+  });
 });

--- a/web/cypress/e2e/countrypanel.spec.ts
+++ b/web/cypress/e2e/countrypanel.spec.ts
@@ -97,7 +97,7 @@ describe('Country Panel', () => {
     cy.get('[data-test-id=no-parser-message]').should('exist');
   });
 
-  it('scrolls to element if provided a hash', () => {
+  it('scrolls to anchor element if provided a hash in url', () => {
     cy.interceptAPI('v8/details/hourly/DK-DK2');
 
     cy.visit('/zone/DK-DK2?lang=en-GB#origin_chart', {

--- a/web/src/features/charts/BreakdownChart.tsx
+++ b/web/src/features/charts/BreakdownChart.tsx
@@ -7,7 +7,7 @@ import { Factory, Zap } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import { ElectricityModeType } from 'types';
 import trackEvent from 'utils/analytics';
-import { TimeAverages, TrackEvent } from 'utils/constants';
+import { Charts, TimeAverages, TrackEvent } from 'utils/constants';
 import { formatCo2 } from 'utils/formatting';
 import {
   dataSourcesCollapsedBreakdownAtom,
@@ -76,6 +76,7 @@ function BreakdownChart({
   if (!hasEnoughDataToDisplay) {
     return (
       <NotEnoughDataMessage
+        id={Charts.ORIGIN_CHART}
         title={`country-history.${titleDisplayMode}${titleMixMode}`}
       />
     );
@@ -87,6 +88,7 @@ function BreakdownChart({
         translationKey={`country-history.${titleDisplayMode}${titleMixMode}`}
         badge={badge}
         unit={valueAxisLabel}
+        id={Charts.ORIGIN_CHART}
       />
       <div className="relative ">
         <AreaGraph

--- a/web/src/features/charts/CarbonChart.tsx
+++ b/web/src/features/charts/CarbonChart.tsx
@@ -7,7 +7,7 @@ import { useAtom } from 'jotai';
 import { Factory, Zap } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import trackEvent from 'utils/analytics';
-import { TimeAverages, TrackEvent } from 'utils/constants';
+import { Charts, TimeAverages, TrackEvent } from 'utils/constants';
 import { dataSourcesCollapsedEmissionAtom } from 'utils/state/atoms';
 
 import { ChartTitle } from './ChartTitle';
@@ -50,7 +50,12 @@ function CarbonChart({ datetimes, timeAverage }: CarbonChartProps) {
   const badge = <EstimationBadge text={text} Icon={icon} />;
 
   if (!hasEnoughDataToDisplay) {
-    return <NotEnoughDataMessage title="country-history.carbonintensity" />;
+    return (
+      <NotEnoughDataMessage
+        title="country-history.carbonintensity"
+        id={Charts.CARBON_CHART}
+      />
+    );
   }
   return (
     <RoundedCard className="pb-2">
@@ -58,6 +63,7 @@ function CarbonChart({ datetimes, timeAverage }: CarbonChartProps) {
         translationKey="country-history.carbonintensity"
         badge={badge}
         unit={'gCO₂eq / kWh'}
+        id={Charts.CARBON_CHART}
       />
       <AreaGraph
         testId="details-carbon-graph"

--- a/web/src/features/charts/ChartTitle.tsx
+++ b/web/src/features/charts/ChartTitle.tsx
@@ -1,13 +1,14 @@
 /* eslint-disable react/jsx-no-target-blank */
 import { useAtomValue } from 'jotai';
 import { useTranslation } from 'react-i18next';
+import { Charts } from 'utils/constants';
 import { timeAverageAtom } from 'utils/state/atoms';
 
 type Props = {
   translationKey: string;
   unit?: string;
   badge?: React.ReactElement;
-  id: string;
+  id?: Charts;
 };
 
 export function ChartTitle({ translationKey, unit, badge, id }: Props) {

--- a/web/src/features/charts/ChartTitle.tsx
+++ b/web/src/features/charts/ChartTitle.tsx
@@ -7,9 +7,10 @@ type Props = {
   translationKey: string;
   unit?: string;
   badge?: React.ReactElement;
+  id: string;
 };
 
-export function ChartTitle({ translationKey, unit, badge }: Props) {
+export function ChartTitle({ translationKey, unit, badge, id }: Props) {
   const { t } = useTranslation();
   const timeAverage = useAtomValue(timeAverageAtom);
   /*
@@ -18,7 +19,9 @@ export function ChartTitle({ translationKey, unit, badge }: Props) {
   return (
     <div className="flex flex-col pb-0.5">
       <div className="flex items-center gap-1.5 pt-4">
-        <h2 className="grow">{t(`${translationKey}.${timeAverage}`)}</h2>
+        <h2 id={id} className="grow">
+          {t(`${translationKey}.${timeAverage}`)}
+        </h2>
         {badge}
       </div>
       {unit && <div className="text-sm dark:text-gray-300">{unit}</div>}

--- a/web/src/features/charts/EmissionChart.tsx
+++ b/web/src/features/charts/EmissionChart.tsx
@@ -5,7 +5,7 @@ import { useAtom } from 'jotai';
 import { Factory, Zap } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import trackEvent from 'utils/analytics';
-import { TimeAverages, TrackEvent } from 'utils/constants';
+import { Charts, TimeAverages, TrackEvent } from 'utils/constants';
 import { formatCo2 } from 'utils/formatting';
 import { dataSourcesCollapsedEmissionAtom } from 'utils/state/atoms';
 
@@ -52,6 +52,7 @@ function EmissionChart({ timeAverage, datetimes }: EmissionChartProps) {
         translationKey="country-history.emissions"
         badge={badge}
         unit={'CO₂eq'}
+        id={Charts.EMISSION_CHART}
       />
       <AreaGraph
         testId="history-emissions-graph"

--- a/web/src/features/charts/NetExchangeChart.tsx
+++ b/web/src/features/charts/NetExchangeChart.tsx
@@ -1,5 +1,5 @@
 import { useAtom } from 'jotai';
-import { TimeAverages } from 'utils/constants';
+import { Charts, TimeAverages } from 'utils/constants';
 import { formatCo2 } from 'utils/formatting';
 import { displayByEmissionsAtom, productionConsumptionAtom } from 'utils/state/atoms';
 
@@ -42,7 +42,11 @@ function NetExchangeChart({ datetimes, timeAverage }: NetExchangeChartProps) {
 
   return (
     <RoundedCard className="pb-2">
-      <ChartTitle translationKey="country-history.netExchange" unit={valueAxisLabel} />
+      <ChartTitle
+        translationKey="country-history.netExchange"
+        unit={valueAxisLabel}
+        id={Charts.NET_EXCHANGE_CHART}
+      />
       <div className="relative">
         <AreaGraph
           testId="history-exchange-graph"

--- a/web/src/features/charts/NotEnoughDataMessage.tsx
+++ b/web/src/features/charts/NotEnoughDataMessage.tsx
@@ -2,11 +2,11 @@ import { useTranslation } from 'react-i18next';
 
 import { ChartTitle } from './ChartTitle';
 
-export function NotEnoughDataMessage({ title }: { title: string }) {
+export function NotEnoughDataMessage({ title, id }: { title: string; id: string }) {
   const { t } = useTranslation();
   return (
     <div className="w-full">
-      <ChartTitle translationKey={title} />
+      <ChartTitle translationKey={title} id={id} />
       <div className="my-2 rounded bg-gray-200 py-4 text-center text-sm dark:bg-gray-800">
         <p>{t('country-history.not-enough-data')}</p>
       </div>

--- a/web/src/features/charts/NotEnoughDataMessage.tsx
+++ b/web/src/features/charts/NotEnoughDataMessage.tsx
@@ -1,8 +1,9 @@
 import { useTranslation } from 'react-i18next';
+import { Charts } from 'utils/constants';
 
 import { ChartTitle } from './ChartTitle';
 
-export function NotEnoughDataMessage({ title, id }: { title: string; id: string }) {
+export function NotEnoughDataMessage({ title, id }: { title: string; id?: Charts }) {
   const { t } = useTranslation();
   return (
     <div className="w-full">

--- a/web/src/features/charts/PriceChart.tsx
+++ b/web/src/features/charts/PriceChart.tsx
@@ -53,7 +53,7 @@ function PriceChart({ datetimes, timeAverage }: PriceChartProps) {
   if (!hasEnoughDataToDisplay) {
     return (
       <NotEnoughDataMessage
-        id={Charts.ELECTRICITY_PRICES_CHART}
+        id={Charts.PRICE_CHART}
         title="country-history.electricityprices"
       />
     );
@@ -64,7 +64,7 @@ function PriceChart({ datetimes, timeAverage }: PriceChartProps) {
       <ChartTitle
         translationKey="country-history.electricityprices"
         unit={valueAxisLabel}
-        id={Charts.ELECTRICITY_PRICES_CHART}
+        id={Charts.PRICE_CHART}
       />
       <div className="relative">
         {isPriceDisabled && (

--- a/web/src/features/charts/PriceChart.tsx
+++ b/web/src/features/charts/PriceChart.tsx
@@ -1,5 +1,5 @@
 import { useTranslation } from 'react-i18next';
-import { TimeAverages } from 'utils/constants';
+import { Charts, TimeAverages } from 'utils/constants';
 
 import { ChartTitle } from './ChartTitle';
 import { DisabledMessage } from './DisabledMessage';
@@ -51,7 +51,12 @@ function PriceChart({ datetimes, timeAverage }: PriceChartProps) {
   const hasEnoughDataToDisplay = datetimes?.length > 2;
 
   if (!hasEnoughDataToDisplay) {
-    return <NotEnoughDataMessage title="country-history.electricityprices" />;
+    return (
+      <NotEnoughDataMessage
+        id={Charts.ELECTRICITY_PRICES_CHART}
+        title="country-history.electricityprices"
+      />
+    );
   }
 
   return (
@@ -59,6 +64,7 @@ function PriceChart({ datetimes, timeAverage }: PriceChartProps) {
       <ChartTitle
         translationKey="country-history.electricityprices"
         unit={valueAxisLabel}
+        id={Charts.ELECTRICITY_PRICES_CHART}
       />
       <div className="relative">
         {isPriceDisabled && (

--- a/web/src/features/charts/bar-breakdown/BarBreakdownChart.tsx
+++ b/web/src/features/charts/bar-breakdown/BarBreakdownChart.tsx
@@ -10,7 +10,7 @@ import { useTranslation } from 'react-i18next';
 import { ElectricityModeType, ZoneKey } from 'types';
 import useResizeObserver from 'use-resize-observer';
 import trackEvent from 'utils/analytics';
-import { TrackEvent } from 'utils/constants';
+import { Charts, TrackEvent } from 'utils/constants';
 import {
   dataSourcesCollapsedBarBreakdownAtom,
   displayByEmissionsAtom,
@@ -88,7 +88,7 @@ function BarBreakdownChart({
   if (!currentZoneDetail) {
     return (
       <div className="text-md relative w-full" ref={ref}>
-        <BySource className="opacity-40" />
+        <BySource className="opacity-40" id={Charts.BAR_BREAKDOWN_CHART} />
         <EmptyBarBreakdownChart
           height={height}
           width={width}
@@ -137,6 +137,7 @@ function BarBreakdownChart({
         estimatedPercentage={currentZoneDetail.estimatedPercentage}
         unit={graphUnit}
         estimationMethod={currentZoneDetail.estimationMethod}
+        id={Charts.BAR_BREAKDOWN_CHART}
       />
       {!displayByEmissions && (
         <CapacityLegend>

--- a/web/src/features/charts/bar-breakdown/elements/BySource.tsx
+++ b/web/src/features/charts/bar-breakdown/elements/BySource.tsx
@@ -38,12 +38,14 @@ export default function BySource({
   estimatedPercentage,
   unit,
   estimationMethod,
+  id,
 }: {
   className?: string;
   hasEstimationPill?: boolean;
   estimatedPercentage?: number;
   unit?: string | number;
   estimationMethod?: EstimationMethods;
+  id: string;
 }) {
   const { t } = useTranslation();
   const [timeAverage] = useAtom(timeAverageAtom);
@@ -64,7 +66,7 @@ export default function BySource({
         className={`text-md relative flex flex-row justify-between font-bold ${className}`}
       >
         <div className="flex gap-1">
-          <h2>{text}</h2>
+          <h2 id={id}>{text}</h2>
         </div>
         {hasEstimationPill && (
           <EstimationBadge

--- a/web/src/features/charts/bar-breakdown/elements/BySource.tsx
+++ b/web/src/features/charts/bar-breakdown/elements/BySource.tsx
@@ -4,7 +4,7 @@ import { TFunction } from 'i18next';
 import { useAtom } from 'jotai';
 import { CircleDashed, TrendingUpDown } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
-import { EstimationMethods, TimeAverages } from 'utils/constants';
+import { Charts, EstimationMethods, TimeAverages } from 'utils/constants';
 import {
   displayByEmissionsAtom,
   productionConsumptionAtom,
@@ -45,7 +45,7 @@ export default function BySource({
   estimatedPercentage?: number;
   unit?: string | number;
   estimationMethod?: EstimationMethods;
-  id: string;
+  id?: Charts;
 }) {
   const { t } = useTranslation();
   const [timeAverage] = useAtom(timeAverageAtom);

--- a/web/src/features/map/Map.tsx
+++ b/web/src/features/map/Map.tsx
@@ -253,6 +253,7 @@ export default function MapPage({ onMapLoad }: MapPageProps): ReactElement {
       setHoveredZone(null);
       if (feature?.properties) {
         const zoneId = feature.properties.zoneId;
+        // Do not keep hash on navigate so that users are not scrolled to id element in new view
         navigate(createToWithState(`/zone/${zoneId}`, false));
       } else {
         navigate(createToWithState('/map', false));

--- a/web/src/features/map/Map.tsx
+++ b/web/src/features/map/Map.tsx
@@ -253,9 +253,9 @@ export default function MapPage({ onMapLoad }: MapPageProps): ReactElement {
       setHoveredZone(null);
       if (feature?.properties) {
         const zoneId = feature.properties.zoneId;
-        navigate(createToWithState(`/zone/${zoneId}`));
+        navigate(createToWithState(`/zone/${zoneId}`, false));
       } else {
-        navigate(createToWithState('/map'));
+        navigate(createToWithState('/map', false));
       }
     },
     [map, selectedZoneId, hoveredZone, setHoveredZone, navigate]

--- a/web/src/features/panels/zone/ZoneDetails.tsx
+++ b/web/src/features/panels/zone/ZoneDetails.tsx
@@ -5,7 +5,7 @@ import LoadingSpinner from 'components/LoadingSpinner';
 import BarBreakdownChart from 'features/charts/bar-breakdown/BarBreakdownChart';
 import { useAtomValue, useSetAtom } from 'jotai';
 import { useEffect } from 'react';
-import { Navigate, useParams } from 'react-router-dom';
+import { Navigate, useLocation, useNavigate, useParams } from 'react-router-dom';
 import { twMerge } from 'tailwind-merge';
 import { ZoneMessage } from 'types';
 import { EstimationMethods, SpatialAggregate } from 'utils/constants';
@@ -53,6 +53,8 @@ export default function ZoneDetails(): JSX.Element {
       setViewMode(SpatialAggregate.ZONE);
     }
   }, [hasSubZones, isSubZone, setViewMode]);
+
+  useScrollHashIntoView(isLoading);
 
   if (!zoneId) {
     return <Navigate to="/" replace />;
@@ -190,3 +192,18 @@ function ZoneDetailsContent({
 
   return children as JSX.Element;
 }
+
+const useScrollHashIntoView = (isLoading: boolean) => {
+  const { hash, pathname, search } = useLocation();
+  const navigate = useNavigate();
+  useEffect(() => {
+    const hashElement = hash ? document.querySelector(hash) : null;
+    if (!isLoading && hashElement) {
+      hashElement.scrollIntoView({
+        behavior: 'smooth',
+        inline: 'nearest',
+      });
+    }
+    navigate(`${pathname}${search}`);
+  }, [hash, isLoading, navigate, pathname, search]);
+};

--- a/web/src/features/panels/zone/ZoneDetails.tsx
+++ b/web/src/features/panels/zone/ZoneDetails.tsx
@@ -202,7 +202,7 @@ const useScrollHashIntoView = (isLoading: boolean) => {
       return;
     }
     const chartIds = Object.values<string>(Charts);
-    const anchorId = anchor.slice(1); // remove leading #
+    const anchorId = anchor.slice(1).toLowerCase(); // remove leading #
     if (anchor && chartIds.includes(anchorId)) {
       const anchorElement = anchor ? document.querySelector(anchor) : null;
       if (anchorElement) {

--- a/web/src/features/panels/zone/ZoneDetails.tsx
+++ b/web/src/features/panels/zone/ZoneDetails.tsx
@@ -195,14 +195,18 @@ function ZoneDetailsContent({
 }
 
 const useScrollHashIntoView = (isLoading: boolean) => {
-  const { hash: anchor, pathname, search } = useLocation();
+  const { hash, pathname, search } = useLocation();
   const navigate = useNavigate();
+  const anchor = hash.toLowerCase();
+
   useEffect(() => {
     if (isLoading) {
       return;
     }
+
     const chartIds = Object.values<string>(Charts);
     const anchorId = anchor.slice(1).toLowerCase(); // remove leading #
+
     if (anchor && chartIds.includes(anchorId)) {
       const anchorElement = anchor ? document.querySelector(anchor) : null;
       if (anchorElement) {

--- a/web/src/features/panels/zone/ZoneDetails.tsx
+++ b/web/src/features/panels/zone/ZoneDetails.tsx
@@ -87,7 +87,6 @@ export default function ZoneDetails(): JSX.Element {
           isIosCapacitor ? 'pb-72' : 'pb-48'
         )}
       >
-        {/* move up zone details content? */}
         {cardType != 'none' &&
           zoneDataStatus !== ZoneDataStatus.NO_INFORMATION &&
           zoneDataStatus !== ZoneDataStatus.AGGREGATE_DISABLED && (

--- a/web/src/features/panels/zone/ZoneDetails.tsx
+++ b/web/src/features/panels/zone/ZoneDetails.tsx
@@ -8,7 +8,7 @@ import { useEffect } from 'react';
 import { Navigate, useLocation, useNavigate, useParams } from 'react-router-dom';
 import { twMerge } from 'tailwind-merge';
 import { ZoneMessage } from 'types';
-import { EstimationMethods, SpatialAggregate } from 'utils/constants';
+import { Charts, EstimationMethods, SpatialAggregate } from 'utils/constants';
 import {
   displayByEmissionsAtom,
   isHourlyAtom,
@@ -83,7 +83,7 @@ export default function ZoneDetails(): JSX.Element {
       <div
         id="panel-scroller"
         className={twMerge(
-          'mb-3 h-full overflow-y-scroll px-3  pt-2 sm:h-full sm:pb-60',
+          'mb-3 h-full scroll-pt-5 overflow-y-scroll px-3 pt-2.5 sm:h-full sm:pb-60',
           isIosCapacitor ? 'pb-72' : 'pb-48'
         )}
       >
@@ -195,17 +195,18 @@ function ZoneDetailsContent({
 }
 
 const useScrollHashIntoView = (isLoading: boolean) => {
-  const { hash, pathname, search } = useLocation();
+  const { hash: anchor, pathname, search } = useLocation();
   const navigate = useNavigate();
   useEffect(() => {
     if (isLoading) {
       return;
     }
-
-    if (hash) {
-      const hashElement = hash ? document.querySelector(hash) : null;
-      if (hashElement) {
-        hashElement.scrollIntoView({
+    const chartIds = Object.values<string>(Charts);
+    const anchorId = anchor.slice(1); // remove leading #
+    if (anchor && chartIds.includes(anchorId)) {
+      const anchorElement = anchor ? document.querySelector(anchor) : null;
+      if (anchorElement) {
+        anchorElement.scrollIntoView({
           behavior: 'smooth',
           inline: 'nearest',
         });
@@ -217,5 +218,5 @@ const useScrollHashIntoView = (isLoading: boolean) => {
         element.scrollTop = 0;
       }
     }
-  }, [hash, isLoading, navigate, pathname, search]);
+  }, [anchor, isLoading, navigate, pathname, search]);
 };

--- a/web/src/features/panels/zone/ZoneDetails.tsx
+++ b/web/src/features/panels/zone/ZoneDetails.tsx
@@ -81,11 +81,13 @@ export default function ZoneDetails(): JSX.Element {
     <>
       <ZoneHeaderTitle zoneId={zoneId} />
       <div
+        id="panel-scroller"
         className={twMerge(
           'mb-3 h-full overflow-y-scroll px-3  pt-2 sm:h-full sm:pb-60',
           isIosCapacitor ? 'pb-72' : 'pb-48'
         )}
       >
+        {/* move up zone details content? */}
         {cardType != 'none' &&
           zoneDataStatus !== ZoneDataStatus.NO_INFORMATION &&
           zoneDataStatus !== ZoneDataStatus.AGGREGATE_DISABLED && (
@@ -197,13 +199,23 @@ const useScrollHashIntoView = (isLoading: boolean) => {
   const { hash, pathname, search } = useLocation();
   const navigate = useNavigate();
   useEffect(() => {
-    const hashElement = hash ? document.querySelector(hash) : null;
-    if (!isLoading && hashElement) {
-      hashElement.scrollIntoView({
-        behavior: 'smooth',
-        inline: 'nearest',
-      });
+    if (isLoading) {
+      return;
     }
-    navigate(`${pathname}${search}`);
+
+    if (hash) {
+      const hashElement = hash ? document.querySelector(hash) : null;
+      if (hashElement) {
+        hashElement.scrollIntoView({
+          behavior: 'smooth',
+          inline: 'nearest',
+        });
+      }
+    } else {
+      const element = document.querySelector('#panel-scroller');
+      if (element) {
+        element.scrollTop = 0;
+      }
+    }
   }, [hash, isLoading, navigate, pathname, search]);
 };

--- a/web/src/features/panels/zone/ZoneDetails.tsx
+++ b/web/src/features/panels/zone/ZoneDetails.tsx
@@ -211,6 +211,7 @@ const useScrollHashIntoView = (isLoading: boolean) => {
         });
       }
     } else {
+      // If already scrolled to element, then reset scroll on re-navigation (i.e. clicking on new zone on map)
       const element = document.querySelector('#panel-scroller');
       if (element) {
         element.scrollTop = 0;

--- a/web/src/features/panels/zone/ZoneHeaderTitle.tsx
+++ b/web/src/features/panels/zone/ZoneHeaderTitle.tsx
@@ -33,7 +33,7 @@ export default function ZoneHeaderTitle({ zoneId }: ZoneHeaderTitleProps) {
   const zoneName = getZoneName(zoneId);
   const zoneNameFull = getFullZoneName(zoneId);
   const showTooltip = zoneName !== zoneNameFull || zoneName.length >= MAX_TITLE_LENGTH;
-  const returnToMapLink = createToWithState('/map');
+  const returnToMapLink = createToWithState('/map', true);
   const countryName = getCountryName(zoneId);
   const disclaimer = getDisclaimer(zoneId);
   const showCountryPill =

--- a/web/src/utils/constants.ts
+++ b/web/src/utils/constants.ts
@@ -39,7 +39,7 @@ export enum LeftPanelToggleOptions {
 }
 
 export enum Charts {
-  ELECTRICITY_PRICES_CHART = 'electricity_prices_chart',
+  PRICE_CHART = 'price_chart',
   ORIGIN_CHART = 'origin_chart',
   BAR_BREAKDOWN_CHART = 'bar_breakdown_chart',
   CARBON_CHART = 'carbon_chart',

--- a/web/src/utils/constants.ts
+++ b/web/src/utils/constants.ts
@@ -38,6 +38,15 @@ export enum LeftPanelToggleOptions {
   EMISSIONS = 'emissions',
 }
 
+export enum Charts {
+  ELECTRICITY_PRICES_CHART = 'electricity_prices_chart',
+  ORIGIN_CHART = 'origin_chart',
+  BAR_BREAKDOWN_CHART = 'bar_breakdown_chart',
+  CARBON_CHART = 'carbon_chart',
+  EMISSION_CHART = 'emission_chart',
+  NET_EXCHANGE_CHART = 'net_exchange_chart',
+}
+
 export enum TrackEvent {
   DATA_SOURCES_CLICKED = 'Data Sources Clicked',
   APP_BANNER_CTA_CLICKED = 'App Banner CTA Clicked',

--- a/web/src/utils/helpers.test.ts
+++ b/web/src/utils/helpers.test.ts
@@ -171,7 +171,7 @@ describe('createToWithState', () => {
     global.location = { ...global.location, search: '', hash: '' } as Location;
 
     const to = '/path';
-    const result = createToWithState(to);
+    const result = createToWithState(to, true);
     expect(result).toBe('/path');
 
     global.location = originalLocation; // Restore original location
@@ -186,7 +186,7 @@ describe('createToWithState', () => {
     } as Location;
 
     const to = '/path';
-    const result = createToWithState(to);
+    const result = createToWithState(to, true);
     expect(result).toBe('/path?query=1#section');
 
     global.location = originalLocation; // Restore original location

--- a/web/src/utils/helpers.ts
+++ b/web/src/utils/helpers.ts
@@ -65,7 +65,7 @@ export function getProductionCo2Intensity(
  * @param to
  */
 
-export function createToWithState(to: string, includeHash: boolean = true) {
+export function createToWithState(to: string, includeHash: boolean = false) {
   return `${to}${location.search}${includeHash ? location.hash : ''}`;
 }
 

--- a/web/src/utils/helpers.ts
+++ b/web/src/utils/helpers.ts
@@ -64,8 +64,9 @@ export function getProductionCo2Intensity(
  * Returns a link which maintains search and hash parameters
  * @param to
  */
-export function createToWithState(to: string) {
-  return `${to}${location.search}${location.hash}`;
+
+export function createToWithState(to: string, includeHash: boolean = true) {
+  return `${to}${location.search}${includeHash ? location.hash : ''}`;
 }
 
 /**


### PR DESCRIPTION
## Description
[AVO-592](https://linear.app/electricitymaps/issue/AVO-592/scroll-to-chart-functionality): This PR isolates the scroll-to-chart functionality. Please feel free to suggest better [chart ids](https://github.com/electricitymaps/electricitymaps-contrib/pull/7333/files#diff-1ac6db0f44da47b2b62b6104bfa25eedda711fc08240a6424473ec8ccc351174R41).

### Preview
<!-- Please add screenshots and/or gif that shows visual changes (if applicable) -->
Examples links:
- `/zone/DK-DK2?remote=true#carbon_chart`
- `/zone/DK-DK2?remote=true#origin_chart`


### Double check

- [ ] I have tested my parser changes locally with `poetry run test_parser "zone_key"`
- [ ] I have run `pnpx prettier@2 --write .` and `poetry run format` in the top level directory to format my changes.
