### PR TITLE
Fix code scanning alert no. 989: Disallow unused variables

### DIFF
--- a/web/src/features/charts/bar-breakdown/utils.ts
+++ b/web/src/features/charts/bar-breakdown/utils.ts
@@ -8,7 +8,7 @@ import {
   ZoneKey,
 } from 'types';
 import { modeOrderBarBreakdown } from 'utils/constants';
-import { getProductionCo2Intensity, round } from 'utils/helpers';
+import { getProductionCo2Intensity } from 'utils/helpers';
 import { EnergyUnits } from 'utils/units';
 
 import exchangesToExclude from '../../../../config/excluded_aggregated_exchanges.json';


### PR DESCRIPTION
Fixes [https://github.com/electricitymaps/electricitymaps-contrib/security/code-scanning/989](https://github.com/electricitymaps/electricitymaps-contrib/security/code-scanning/989)

To fix the problem, we need to remove the unused import `round` from the file. This will resolve the ESLint error and clean up the code by removing unnecessary imports.

- **General Fix:** Remove the unused variable or import.
- **Detailed Fix:** Specifically, remove the `round` import from the import statement on line 11 in the file `web/src/features/charts/bar-breakdown/utils.ts`.
- **Files/Regions/Lines to Change:** Edit the import statement on line 11.
- **Needed:** No additional methods, imports, or definitions are required to implement this change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
