### PR TITLE
chore(capacities): Update EIA capacities for 2024-07-01

### DIFF
--- a/config/zones/US-CAL-CISO.yaml
+++ b/config/zones/US-CAL-CISO.yaml
@@ -26,6 +26,9 @@ capacity:
     - datetime: '2024-06-01'
       source: EIA.gov
       value: 9428.4
+    - datetime: '2024-07-01'
+      source: EIA.gov
+      value: 9821.4
   biomass:
     - datetime: '2023-10-01'
       source: EIA.gov
@@ -39,6 +42,9 @@ capacity:
     - datetime: '2024-06-01'
       source: EIA.gov
       value: 934.9
+    - datetime: '2024-07-01'
+      source: EIA.gov
+      value: 936.7
   coal:
     - datetime: '2023-10-01'
       source: EIA.gov
@@ -62,6 +68,9 @@ capacity:
     - datetime: '2024-04-01'
       source: EIA.gov
       value: 31888.5
+    - datetime: '2024-07-01'
+      source: EIA.gov
+      value: 31886.7
   geothermal:
     - datetime: '2023-10-01'
       source: EIA.gov
@@ -76,6 +85,9 @@ capacity:
     - datetime: '2024-01-01'
       source: EIA.gov
       value: 6149.4
+    - datetime: '2024-07-01'
+      source: EIA.gov
+      value: 6052.1
   hydro storage:
     - datetime: '2023-10-01'
       source: EIA.gov
@@ -119,6 +131,9 @@ capacity:
     - datetime: '2024-06-01'
       source: EIA.gov
       value: 21522.2
+    - datetime: '2024-07-01'
+      source: EIA.gov
+      value: 21498.2
   unknown:
     - datetime: '2023-10-01'
       source: EIA.gov

--- a/config/zones/US-CAL-LDWP.yaml
+++ b/config/zones/US-CAL-LDWP.yaml
@@ -26,6 +26,9 @@ capacity:
     - datetime: '2024-02-01'
       source: EIA.gov
       value: 4631.7
+    - datetime: '2024-07-01'
+      source: EIA.gov
+      value: 4597.2
   geothermal:
     - datetime: '2023-10-01'
       source: EIA.gov

--- a/config/zones/US-CAR-DUK.yaml
+++ b/config/zones/US-CAR-DUK.yaml
@@ -65,6 +65,9 @@ capacity:
     - datetime: '2024-04-01'
       source: EIA.gov
       value: 2138.0
+    - datetime: '2024-07-01'
+      source: EIA.gov
+      value: 2143.0
   unknown:
     - datetime: '2023-10-01'
       source: EIA.gov

--- a/config/zones/US-CENT-SWPP.yaml
+++ b/config/zones/US-CENT-SWPP.yaml
@@ -88,6 +88,9 @@ capacity:
     - datetime: '2024-06-01'
       source: EIA.gov
       value: 2236.3
+    - datetime: '2024-07-01'
+      source: EIA.gov
+      value: 2238.7
   solar:
     - datetime: '2023-10-01'
       source: EIA.gov

--- a/config/zones/US-MIDA-PJM.yaml
+++ b/config/zones/US-MIDA-PJM.yaml
@@ -17,6 +17,9 @@ capacity:
     - datetime: '2024-02-01'
       source: EIA.gov
       value: 362.1
+    - datetime: '2024-07-01'
+      source: EIA.gov
+      value: 402.1
   biomass:
     - datetime: '2023-10-01'
       source: EIA.gov
@@ -33,6 +36,9 @@ capacity:
     - datetime: '2024-06-01'
       source: EIA.gov
       value: 2085.3
+    - datetime: '2024-07-01'
+      source: EIA.gov
+      value: 2025.3
   coal:
     - datetime: '2023-10-01'
       source: EIA.gov
@@ -71,6 +77,9 @@ capacity:
     - datetime: '2024-06-01'
       source: EIA.gov
       value: 104186.2
+    - datetime: '2024-07-01'
+      source: EIA.gov
+      value: 104180.7
   geothermal:
     - datetime: '2023-10-01'
       source: EIA.gov
@@ -134,6 +143,9 @@ capacity:
     - datetime: '2024-06-01'
       source: EIA.gov
       value: 12414.2
+    - datetime: '2024-07-01'
+      source: EIA.gov
+      value: 12437.1
   unknown:
     - datetime: '2023-10-01'
       source: EIA.gov

--- a/config/zones/US-MIDW-MISO.yaml
+++ b/config/zones/US-MIDW-MISO.yaml
@@ -74,6 +74,9 @@ capacity:
     - datetime: '2024-06-01'
       source: EIA.gov
       value: 81889.2
+    - datetime: '2024-07-01'
+      source: EIA.gov
+      value: 81978.8
   geothermal:
     - datetime: '2023-10-01'
       source: EIA.gov
@@ -124,6 +127,9 @@ capacity:
     - datetime: '2024-05-01'
       source: EIA.gov
       value: 3940.6
+    - datetime: '2024-07-01'
+      source: EIA.gov
+      value: 3939.4
   solar:
     - datetime: '2023-10-01'
       source: EIA.gov
@@ -149,6 +155,9 @@ capacity:
     - datetime: '2024-06-01'
       source: EIA.gov
       value: 8168.7
+    - datetime: '2024-07-01'
+      source: EIA.gov
+      value: 8478.0
   unknown:
     - datetime: '2023-10-01'
       source: EIA.gov

--- a/config/zones/US-NE-ISNE.yaml
+++ b/config/zones/US-NE-ISNE.yaml
@@ -53,6 +53,9 @@ capacity:
     - datetime: '2024-06-01'
       source: EIA.gov
       value: 16288.3
+    - datetime: '2024-07-01'
+      source: EIA.gov
+      value: 16353.3
   geothermal:
     - datetime: '2023-10-01'
       source: EIA.gov
@@ -125,6 +128,9 @@ capacity:
     - datetime: '2024-06-01'
       source: EIA.gov
       value: 2823.0
+    - datetime: '2024-07-01'
+      source: EIA.gov
+      value: 2943.5
   unknown:
     - datetime: '2023-10-01'
       source: EIA.gov

--- a/config/zones/US-NW-BPAT.yaml
+++ b/config/zones/US-NW-BPAT.yaml
@@ -43,6 +43,9 @@ capacity:
     - datetime: '2024-06-01'
       source: EIA.gov
       value: 19732.0
+    - datetime: '2024-07-01'
+      source: EIA.gov
+      value: 19732.4
   hydro storage:
     - datetime: '2023-10-01'
       source: EIA.gov
@@ -59,6 +62,9 @@ capacity:
     - datetime: '2023-10-01'
       source: EIA.gov
       value: 137.9
+    - datetime: '2024-07-01'
+      source: EIA.gov
+      value: 140.8
   unknown:
     - datetime: '2023-10-01'
       source: EIA.gov

--- a/config/zones/US-NW-NEVP.yaml
+++ b/config/zones/US-NW-NEVP.yaml
@@ -29,6 +29,9 @@ capacity:
     - datetime: '2023-10-01'
       source: EIA.gov
       value: 7606.2
+    - datetime: '2024-07-01'
+      source: EIA.gov
+      value: 8061.8
   geothermal:
     - datetime: '2023-10-01'
       source: EIA.gov
@@ -80,6 +83,9 @@ capacity:
     - datetime: '2024-06-01'
       source: EIA.gov
       value: 4015.9
+    - datetime: '2024-07-01'
+      source: EIA.gov
+      value: 4080.9
   unknown:
     - datetime: '2023-10-01'
       source: EIA.gov

--- a/config/zones/US-NW-NWMT.yaml
+++ b/config/zones/US-NW-NWMT.yaml
@@ -23,6 +23,9 @@ capacity:
     - datetime: '2023-10-01'
       source: EIA.gov
       value: 258.0
+    - datetime: '2024-07-01'
+      source: EIA.gov
+      value: 465.0
   geothermal:
     - datetime: '2023-10-01'
       source: EIA.gov

--- a/config/zones/US-NW-PACE.yaml
+++ b/config/zones/US-NW-PACE.yaml
@@ -41,6 +41,9 @@ capacity:
     - datetime: '2024-03-01'
       source: EIA.gov
       value: 3439.4
+    - datetime: '2024-07-01'
+      source: EIA.gov
+      value: 3446.9
   geothermal:
     - datetime: '2023-10-01'
       source: EIA.gov

--- a/config/zones/US-NW-PSCO.yaml
+++ b/config/zones/US-NW-PSCO.yaml
@@ -14,10 +14,16 @@ capacity:
     - datetime: '2024-06-01'
       source: EIA.gov
       value: 240.6
+    - datetime: '2024-07-01'
+      source: EIA.gov
+      value: 248.4
   biomass:
     - datetime: '2023-10-01'
       source: EIA.gov
       value: 22.8
+    - datetime: '2024-07-01'
+      source: EIA.gov
+      value: 10.2
   coal:
     - datetime: '2023-10-01'
       source: EIA.gov
@@ -29,6 +35,9 @@ capacity:
     - datetime: '2024-01-01'
       source: EIA.gov
       value: 6870.0
+    - datetime: '2024-07-01'
+      source: EIA.gov
+      value: 6816.8
   geothermal:
     - datetime: '2023-10-01'
       source: EIA.gov
@@ -52,6 +61,9 @@ capacity:
     - datetime: '2023-10-01'
       source: EIA.gov
       value: 28.0
+    - datetime: '2024-07-01'
+      source: EIA.gov
+      value: 81.2
   solar:
     - datetime: '2023-10-01'
       source: EIA.gov

--- a/config/zones/US-NY-NYIS.yaml
+++ b/config/zones/US-NY-NYIS.yaml
@@ -17,6 +17,9 @@ capacity:
     - datetime: '2024-06-01'
       source: EIA.gov
       value: 236.5
+    - datetime: '2024-07-01'
+      source: EIA.gov
+      value: 239.5
   biomass:
     - datetime: '2023-10-01'
       source: EIA.gov
@@ -98,6 +101,9 @@ capacity:
     - datetime: '2024-06-01'
       source: EIA.gov
       value: 1804.0
+    - datetime: '2024-07-01'
+      source: EIA.gov
+      value: 1817.8
   unknown:
     - datetime: '2023-10-01'
       source: EIA.gov
@@ -109,6 +115,9 @@ capacity:
     - datetime: '2023-12-01'
       source: EIA.gov
       value: 2745.6
+    - datetime: '2024-07-01'
+      source: EIA.gov
+      value: 2875.6
 comment: New York Independent System Operator
 contributors:
   - systemcatch

--- a/config/zones/US-SW-SRP.yaml
+++ b/config/zones/US-SW-SRP.yaml
@@ -14,6 +14,9 @@ capacity:
     - datetime: '2024-06-01'
       source: EIA.gov
       value: 1033.0
+    - datetime: '2024-07-01'
+      source: EIA.gov
+      value: 1123.0
   biomass:
     - datetime: '2023-10-01'
       source: EIA.gov
@@ -26,6 +29,9 @@ capacity:
     - datetime: '2023-10-01'
       source: EIA.gov
       value: 7672.8
+    - datetime: '2024-07-01'
+      source: EIA.gov
+      value: 7772.6
   geothermal:
     - datetime: '2023-10-01'
       source: EIA.gov
@@ -70,6 +76,9 @@ capacity:
     - datetime: '2023-10-01'
       source: EIA.gov
       value: 63.0
+    - datetime: '2024-07-01'
+      source: EIA.gov
+      value: 226.0
 comment: Salt River Project
 contributors:
   - systemcatch

--- a/config/zones/US-TEN-TVA.yaml
+++ b/config/zones/US-TEN-TVA.yaml
@@ -65,6 +65,9 @@ capacity:
     - datetime: '2024-05-01'
       source: EIA.gov
       value: 1085.7
+    - datetime: '2024-07-01'
+      source: EIA.gov
+      value: 1118.1
   unknown:
     - datetime: '2023-10-01'
       source: EIA.gov

--- a/config/zones/US-TEX-ERCO.yaml
+++ b/config/zones/US-TEX-ERCO.yaml
@@ -29,6 +29,9 @@ capacity:
     - datetime: '2024-06-01'
       source: EIA.gov
       value: 4562.6
+    - datetime: '2024-07-01'
+      source: EIA.gov
+      value: 4825.1
   biomass:
     - datetime: '2023-10-01'
       source: EIA.gov
@@ -65,6 +68,9 @@ capacity:
     - datetime: '2024-06-01'
       source: EIA.gov
       value: 66106.4
+    - datetime: '2024-07-01'
+      source: EIA.gov
+      value: 66635.4
   geothermal:
     - datetime: '2023-10-01'
       source: EIA.gov
@@ -116,6 +122,9 @@ capacity:
     - datetime: '2024-06-01'
       source: EIA.gov
       value: 17493.8
+    - datetime: '2024-07-01'
+      source: EIA.gov
+      value: 17696.6
   unknown:
     - datetime: '2023-10-01'
       source: EIA.gov
@@ -139,6 +148,9 @@ capacity:
     - datetime: '2024-06-01'
       source: EIA.gov
       value: 38011.9
+    - datetime: '2024-07-01'
+      source: EIA.gov
+      value: 38235.6
 comment: Electric Reliability Council Of Texas, Inc.
 contributors:
   - systemcatch


### PR DESCRIPTION
## Description

Pulls the latest capacity figures from EIA. This mostly include modest increases to battery, solar and wind.

### Double check

- [x] I have run `pnpx prettier@2 --write .` and `poetry run format` in the top level directory to format my changes.
