### PR TITLE
fix(parsers):Add new gas plant to PA parser

### DIFF
--- a/parsers/PA.py
+++ b/parsers/PA.py
@@ -41,6 +41,7 @@ PRODUCTION_SOURCE = "sitr.cnd.com.pa"
 # 8. https://www.asep.gob.pa/wp-content/uploads/electricidad/resoluciones/anno_12528_elec.pdf
 # 9. https://www.irena.org/-/media/Files/IRENA/Agency/Publication/2018/May/IRENA_RRA_Panama_2018_En.pdf
 # 10. https://www.asep.gob.pa/wp-content/uploads/electricidad/concesiones_licencias/concesiones_licencias/2021/listado_licencias_abr27.pdf
+# 11. https://generadoragatun.com/
 MAP_THERMAL_GENERATION_UNIT_NAME_TO_FUEL_TYPE = {
     "ACP Miraflores 2": "oil",  # [7] Sheet "C-GE-1A-1 CapInstXEmp"
     "ACP Miraflores 5": "oil",  # [7] Sheet "C-GE-1A-1 CapInstXEmp"
@@ -94,6 +95,9 @@ MAP_THERMAL_GENERATION_UNIT_NAME_TO_FUEL_TYPE = {
     "PanAm 7": "oil",  # [6][7]
     "PanAm 8": "oil",  # [6][7]
     "PanAm 9": "oil",  # [6][7]
+    "Proyecto Gatún 1": "gas",  # [11]
+    "Proyecto Gatún 2": "gas",  # [11]
+    "Proyecto Gatún 3": "gas",  # [11]
     "Sparkle Power 1": "oil",  # [10]
     "Sparkle Power 2": "oil",  # [10]
     "Sparkle Power 3": "oil",  # [10]


### PR DESCRIPTION
## Issue
Capacity outliers detected on a regular basis for unknown mode. 

<!-- If you want to close an issue automatically when your PR is merged, write "Closes X" where X is the issue number. For example: Closes #000 -->


## Description
Gas power plants, Proyecto Gatún 1-3, are added to the MAP_THERMAL_GENERATION_UNIT_NAME_TO_FUEL_TYPE mapper, that maps unknown production to a specific mode. By specifying these plants as gas, their production will not be categorised as unknown. 

Not completely sure the unknown outliers were only due to these specific plants missing in the mapper as the parser does not support historic data.

https://sitr.cnd.com.pa/m/pub/gen.html
https://generadoragatun.com/ 

<!-- Explains the goal of this PR -->

### Preview
<img width="841" alt="Screenshot 2024-10-22 at 10 47 27" src="https://github.com/user-attachments/assets/61e321a2-96d2-4c1b-bee8-6e0fddbaeef8">

<!-- Please add screenshots and/or gif that shows visual changes (if applicable) -->

### Double check

- [ ] I have tested my parser changes locally with `poetry run test_parser "zone_key"`
- [ ] I have run `pnpx prettier@2 --write .` and `poetry run format` in the top level directory to format my changes.
