### PR TITLE
Reverse chart layer opacity on hover

### DIFF
--- a/web/src/features/charts/BreakdownChart.tsx
+++ b/web/src/features/charts/BreakdownChart.tsx
@@ -94,6 +94,7 @@ function BreakdownChart({
       <div className="relative ">
         <AreaGraph
           testId="history-mix-graph"
+          showHoverHighlight={true}
           data={chartData}
           layerKeys={layerKeys}
           layerFill={layerFill}

--- a/web/src/features/charts/elements/AreaGraph.tsx
+++ b/web/src/features/charts/elements/AreaGraph.tsx
@@ -109,6 +109,7 @@ interface AreagraphProps {
   tooltip: (props: InnerAreaGraphTooltipProps) => JSX.Element | null;
   tooltipSize?: 'small' | 'large';
   formatTick?: (t: number) => string | number;
+  showHoverHighlight?: boolean;
 }
 
 interface TooltipData {
@@ -133,6 +134,7 @@ function AreaGraph({
   tooltip,
   tooltipSize,
   formatTick = String,
+  showHoverHighlight,
 }: AreagraphProps) {
   const reference = useRef(null);
   const { width: observerWidth = 0, height: observerHeight = 0 } =
@@ -266,6 +268,7 @@ function AreaGraph({
           />
         )}
         <AreaGraphLayers
+          showHoverHighlight={showHoverHighlight}
           layers={layers}
           datetimes={datetimesWithNext}
           timeScale={timeScale}

--- a/web/src/features/charts/elements/AreaGraph.tsx
+++ b/web/src/features/charts/elements/AreaGraph.tsx
@@ -274,6 +274,7 @@ function AreaGraph({
           mouseOutHandler={mouseOutHandler}
           isMobile={isMobile}
           svgNode={reference.current}
+          selectedLayerIndex={selectedLayerIndex}
         />
         <TimeAxis
           isLoading={false}

--- a/web/src/features/charts/elements/AreaGraphLayers.tsx
+++ b/web/src/features/charts/elements/AreaGraphLayers.tsx
@@ -103,7 +103,8 @@ function AreaGraphLayers({
         );
 
         const isLayerSelected = selectedLayerIndex && selectedLayerIndex === ind;
-        const shouldLayerBeSaturated = isLayerSelected === null || isLayerSelected;
+        const shouldLayerBeSaturated =
+          isLayerSelected === null || layers.length === 1 || isLayerSelected;
 
         return (
           <React.Fragment key={layer.key}>

--- a/web/src/features/charts/elements/AreaGraphLayers.tsx
+++ b/web/src/features/charts/elements/AreaGraphLayers.tsx
@@ -17,6 +17,7 @@ interface AreaGraphLayersProps {
   mouseOutHandler: any;
   isMobile: boolean;
   svgNode: any;
+  selectedLayerIndex?: number | null;
 }
 
 function AreaGraphLayers({
@@ -28,6 +29,7 @@ function AreaGraphLayers({
   mouseOutHandler,
   isMobile,
   svgNode,
+  selectedLayerIndex,
 }: AreaGraphLayersProps) {
   const [x1, x2] = timeScale.range();
   const [y2, y1] = valueScale.range();
@@ -100,10 +102,13 @@ function AreaGraphLayers({
           ]
         );
 
+        const isLayerSelected = selectedLayerIndex && selectedLayerIndex === ind;
+        const shouldLayerBeSaturated = isLayerSelected === null || isLayerSelected;
+
         return (
           <React.Fragment key={layer.key}>
             <path
-              className={layers.length > 1 ? 'sm:hover:opacity-75' : ''}
+              className={shouldLayerBeSaturated ? 'sm:hover:opacity-100' : 'opacity-30'}
               style={{ cursor: 'pointer' }}
               stroke={layer.stroke}
               fill={isGradient ? `url(#${gradientId})` : layer.fill(layer.key)}


### PR DESCRIPTION
## Description
<!-- Explains the goal of this PR -->
Previously, the hourly electricity origin chart reduced the opacity of the highlighted data series, making it challenging for a user to visually isolate the relevant data. This PR reverses the that behavior.

### Preview

<!-- Please add screenshots and/or gif that shows visual changes (if applicable) -->
|Before|After|
|---|---|
|<img width="449" alt="Screenshot 2024-10-25 at 16 14 52" src="https://github.com/user-attachments/assets/183a63b7-743c-4e5c-8e6d-2078c30e965b">|<img width="445" alt="Screenshot 2024-10-28 at 15 44 24" src="https://github.com/user-attachments/assets/dbd8b883-e2c5-4a1a-8d6f-47385cb2f5b2">|
| <img width="458" alt="Screenshot 2024-10-25 at 16 15 00" src="https://github.com/user-attachments/assets/bbebd795-1f30-47db-9c00-ad0bfe97c1c4">|<img width="448" alt="Screenshot 2024-10-28 at 15 44 30" src="https://github.com/user-attachments/assets/834247f4-74f9-4057-a7aa-e4c9fa5df2b0">|

Dark Mode:
<img width="362" alt="Screenshot 2024-10-28 at 15 44 07" src="https://github.com/user-attachments/assets/41fc772d-71f6-41a6-8edd-be8f771a0470">

Handling 0s in origin data series:
<img width="332" alt="Screenshot 2024-10-28 at 19 30 53" src="https://github.com/user-attachments/assets/c1922889-a1f2-4653-bb2d-f2fc2dd29e9e">

### Double check

- [ ] I have tested my parser changes locally with `poetry run test_parser "zone_key"`
- [ ] I have run `pnpx prettier@2 --write .` and `poetry run format` in the top level directory to format my changes.
