### PR TITLE
Feat: Create shareUrl and hook up More Options dropdown UI to scroll to chart

### DIFF
--- a/web/src/components/MoreOptionsDropdown.cy.tsx
+++ b/web/src/components/MoreOptionsDropdown.cy.tsx
@@ -4,6 +4,7 @@ import { Ellipsis } from 'lucide-react';
 import { I18nextProvider } from 'react-i18next';
 import { BrowserRouter } from 'react-router-dom';
 import i18n from 'translation/i18n';
+import { Charts } from 'utils/constants';
 
 import { MoreOptionsDropdown } from './MoreOptionsDropdown';
 
@@ -37,6 +38,7 @@ describe('MoreOptionsDropdown', () => {
           hasMobileUserAgent={true}
           shareUrl="hello"
           isEstimated={false}
+          id={Charts.ORIGIN_CHART}
         >
           <Ellipsis />
         </MoreOptionsDropdown>
@@ -55,6 +57,7 @@ describe('MoreOptionsDropdown', () => {
           hasMobileUserAgent={true}
           shareUrl="hello"
           isEstimated={false}
+          id={Charts.ORIGIN_CHART}
         >
           <Ellipsis />
         </MoreOptionsDropdown>
@@ -73,6 +76,7 @@ describe('MoreOptionsDropdown', () => {
           hasMobileUserAgent={true}
           shareUrl="hello"
           isEstimated={false}
+          id={Charts.ORIGIN_CHART}
         >
           <Ellipsis />
         </MoreOptionsDropdown>
@@ -92,6 +96,7 @@ describe('MoreOptionsDropdown', () => {
           hasMobileUserAgent={false}
           shareUrl="hello"
           isEstimated={false}
+          id={Charts.ORIGIN_CHART}
         >
           <Ellipsis />
         </MoreOptionsDropdown>
@@ -135,6 +140,7 @@ describe('MoreOptionsDropdown', () => {
           hasMobileUserAgent={false}
           shareUrl="hello"
           isEstimated={true}
+          id={Charts.ORIGIN_CHART}
         >
           <Ellipsis />
         </MoreOptionsDropdown>
@@ -151,6 +157,7 @@ describe('MoreOptionsDropdown', () => {
           hasMobileUserAgent={false}
           shareUrl="hello"
           isEstimated={true}
+          id={Charts.ORIGIN_CHART}
         >
           <Ellipsis />
         </MoreOptionsDropdown>
@@ -170,6 +177,7 @@ describe('MoreOptionsDropdown', () => {
           hasMobileUserAgent={false}
           shareUrl="hello"
           isEstimated={true}
+          id={Charts.ORIGIN_CHART}
         >
           <Ellipsis />
         </MoreOptionsDropdown>

--- a/web/src/components/MoreOptionsDropdown.tsx
+++ b/web/src/components/MoreOptionsDropdown.tsx
@@ -7,8 +7,13 @@ import { useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { FaFacebook, FaLinkedin, FaReddit, FaSquareXTwitter } from 'react-icons/fa6';
 import { twMerge } from 'tailwind-merge';
-import { ShareType, trackShareChart } from 'utils/analytics';
-import { baseUrl, DEFAULT_ICON_SIZE, DEFAULT_TOAST_DURATION } from 'utils/constants';
+import { getTrackChartShares, ShareType } from 'utils/analytics';
+import {
+  baseUrl,
+  Charts,
+  DEFAULT_ICON_SIZE,
+  DEFAULT_TOAST_DURATION,
+} from 'utils/constants';
 import { hasMobileUserAgent as hasMobileUA } from 'utils/helpers';
 import { displayByEmissionsAtom, isHourlyAtom } from 'utils/state/atoms';
 
@@ -17,18 +22,12 @@ import { MemoizedShareIcon } from './ShareIcon';
 import { TimeDisplay } from './TimeDisplay';
 import { Toast, useToastReference } from './Toast';
 
-// TODO: add chartId to tracking
-const onTrackShareChartReddit = trackShareChart(ShareType.REDDIT);
-const onTrackShareChartTwitter = trackShareChart(ShareType.TWITTER);
-const onTrackShareChartLinkedin = trackShareChart(ShareType.LINKEDIN);
-const onTrackShareChartFacebook = trackShareChart(ShareType.FACEBOOK);
-const onTrackShareChart = trackShareChart(ShareType.SHARE);
-
 export interface MoreOptionsDropdownProps {
   children: React.ReactElement;
   shareUrl?: string;
   hasMobileUserAgent?: boolean;
   isEstimated?: boolean;
+  id: Charts;
 }
 
 const dropdownItemStyle = 'flex items-center gap-2 py-2';
@@ -39,6 +38,7 @@ export function MoreOptionsDropdown({
   shareUrl = baseUrl,
   hasMobileUserAgent = hasMobileUA(),
   isEstimated = false,
+  id,
 }: MoreOptionsDropdownProps) {
   const { t } = useTranslation();
   const [toastMessage, setToastMessage] = useState('');
@@ -47,6 +47,8 @@ export function MoreOptionsDropdown({
   const { copyToClipboard, share } = useShare();
 
   const summary = `${t('more-options-dropdown.summary')} ${baseUrl}`;
+
+  const handleTrackShares = getTrackChartShares(id);
 
   const { onShare, copyShareUrl } = useMemo(() => {
     const toastMessageCallback = (message: string) => {
@@ -57,7 +59,7 @@ export function MoreOptionsDropdown({
     return {
       copyShareUrl: () => {
         copyToClipboard(shareUrl, toastMessageCallback);
-        trackShareChart(ShareType.COPY);
+        handleTrackShares[ShareType.COPY]();
       },
       onShare: () => {
         share(
@@ -68,10 +70,10 @@ export function MoreOptionsDropdown({
           },
           toastMessageCallback
         );
-        onTrackShareChart();
+        handleTrackShares[ShareType.SHARE]();
       },
     };
-  }, [reference, shareUrl, summary, share, copyToClipboard]);
+  }, [reference, shareUrl, summary, share, copyToClipboard, handleTrackShares]);
 
   return (
     <>
@@ -118,7 +120,7 @@ export function MoreOptionsDropdown({
                     data-test-id="twitter-chart-share"
                     target="_blank"
                     rel="noopener"
-                    onClick={onTrackShareChartTwitter}
+                    onClick={handleTrackShares[ShareType.TWITTER]}
                     href={`https://twitter.com/intent/tweet?&url=${shareUrl}&text=${encodeURI(
                       summary
                     )}&hashtags=electricitymaps`}
@@ -132,7 +134,7 @@ export function MoreOptionsDropdown({
                     data-test-id="facebook-chart-share"
                     target="_blank"
                     rel="noopener"
-                    onClick={onTrackShareChartFacebook}
+                    onClick={handleTrackShares[ShareType.FACEBOOK]}
                     href={`https://facebook.com/sharer/sharer.php?u=${shareUrl}&quote=${encodeURI(
                       summary
                     )}`}
@@ -147,7 +149,7 @@ export function MoreOptionsDropdown({
                     href={`https://www.linkedin.com/shareArticle?mini=true&url=${shareUrl}`}
                     target="_blank"
                     rel="noopener"
-                    onClick={onTrackShareChartLinkedin}
+                    onClick={handleTrackShares[ShareType.LINKEDIN]}
                   >
                     <DropdownMenu.Item className={dropdownItemStyle}>
                       <FaLinkedin size={DEFAULT_ICON_SIZE} />
@@ -159,7 +161,7 @@ export function MoreOptionsDropdown({
                     href={`https://www.reddit.com/web/submit?url=${shareUrl}`}
                     target="_blank"
                     rel="noopener"
-                    onClick={onTrackShareChartReddit}
+                    onClick={handleTrackShares[ShareType.REDDIT]}
                   >
                     <DropdownMenu.Item className={dropdownItemStyle}>
                       <FaReddit size={DEFAULT_ICON_SIZE} />

--- a/web/src/features/charts/ChartTitle.tsx
+++ b/web/src/features/charts/ChartTitle.tsx
@@ -1,6 +1,7 @@
 import { MoreOptionsDropdown, useShowMoreOptions } from 'components/MoreOptionsDropdown';
 import { Ellipsis } from 'lucide-react';
-import { Charts } from 'utils/constants';
+import { baseUrl, Charts } from 'utils/constants';
+import { useGetZoneFromPath } from 'utils/helpers';
 
 type Props = {
   titleText?: string;
@@ -8,7 +9,7 @@ type Props = {
   badge?: React.ReactElement;
   className?: string;
   isEstimated?: boolean;
-  id?: Charts;
+  id: Charts;
 };
 
 export function ChartTitle({
@@ -20,6 +21,10 @@ export function ChartTitle({
   id,
 }: Props) {
   const showMoreOptions = useShowMoreOptions();
+  const zoneId = useGetZoneFromPath();
+  const url = `${baseUrl}/zone/${zoneId}`;
+  const shareUrl = id ? `${url}#${id}` : url;
+
   return (
     <div className="flex flex-col pb-0.5">
       <div className={`flex items-center gap-1.5 pt-4 ${className}`}>
@@ -28,7 +33,7 @@ export function ChartTitle({
         </h2>
         {badge}
         {showMoreOptions && (
-          <MoreOptionsDropdown isEstimated={isEstimated}>
+          <MoreOptionsDropdown isEstimated={isEstimated} id={id} shareUrl={shareUrl}>
             <Ellipsis />
           </MoreOptionsDropdown>
         )}

--- a/web/src/features/charts/NotEnoughDataMessage.tsx
+++ b/web/src/features/charts/NotEnoughDataMessage.tsx
@@ -3,7 +3,7 @@ import { Charts } from 'utils/constants';
 
 import { ChartTitle } from './ChartTitle';
 
-export function NotEnoughDataMessage({ title, id }: { title: string; id?: Charts }) {
+export function NotEnoughDataMessage({ title, id }: { title: string; id: Charts }) {
   const { t } = useTranslation();
   return (
     <div className="w-full">

--- a/web/src/utils/analytics.ts
+++ b/web/src/utils/analytics.ts
@@ -50,21 +50,16 @@ interface TrackChartSharesByShareType {
   };
 }
 
-const makeTrackChartShareFunctions = () => {
-  const trackChartShareByType: TrackChartSharesByShareType = {};
-
-  for (const chartId of Object.values(Charts)) {
-    for (const shareType of Object.values(ShareType)) {
-      if (!(chartId in trackChartShareByType)) {
-        trackChartShareByType[chartId] = {};
-      }
-      trackChartShareByType[chartId][shareType] = trackShareChart(shareType, chartId);
-    }
-  }
-
-  return trackChartShareByType;
-};
-
-const trackChartShareByType: TrackChartSharesByShareType = makeTrackChartShareFunctions();
+const trackChartShareByType: TrackChartSharesByShareType = Object.fromEntries(
+  Object.values(Charts).map((chartId) => [
+    chartId,
+    Object.fromEntries(
+      Object.values(ShareType).map((shareType) => [
+        shareType,
+        trackShareChart(shareType, chartId),
+      ])
+    ),
+  ])
+);
 
 export const getTrackChartShares = (chartId: Charts) => trackChartShareByType[chartId];


### PR DESCRIPTION
## Description
Per comment https://github.com/electricitymaps/electricitymaps-contrib/pull/7346#discussion_r1814778666: Creates the shareUrl and hooks up the More Options dropdown UI to the scroll to chart functionality. 

Related PRs:
https://github.com/electricitymaps/electricitymaps-contrib/pull/7346
https://github.com/electricitymaps/electricitymaps-contrib/pull/7333

### Preview

<!-- Please add screenshots and/or gif that shows visual changes (if applicable) -->

### Double check

- [ ] I have tested my parser changes locally with `poetry run test_parser "zone_key"`
- [ ] I have run `pnpx prettier@2 --write .` and `poetry run format` in the top level directory to format my changes.
