### PR TITLE
Clean up ChartTitle props

### DIFF
--- a/web/src/features/charts/BreakdownChart.tsx
+++ b/web/src/features/charts/BreakdownChart.tsx
@@ -70,6 +70,7 @@ function BreakdownChart({
   const hasEnoughDataToDisplay = datetimes?.length > 2;
 
   const { text, icon } = getBadgeTextAndIcon(chartData, t);
+  const hasEstimation = text && icon;
 
   if (!hasEnoughDataToDisplay) {
     return (
@@ -84,7 +85,9 @@ function BreakdownChart({
     <RoundedCard>
       <ChartTitle
         titleText={t(`country-history.${titleDisplayMode}${titleMixMode}.${timeAverage}`)}
-        estimationBadge={<EstimationBadge text={text} Icon={icon} />}
+        estimationBadge={
+          hasEstimation ? <EstimationBadge text={text} Icon={icon} /> : null
+        }
         unit={valueAxisLabel}
         id={Charts.ORIGIN_CHART}
       />

--- a/web/src/features/charts/BreakdownChart.tsx
+++ b/web/src/features/charts/BreakdownChart.tsx
@@ -71,8 +71,6 @@ function BreakdownChart({
 
   const { text, icon } = getBadgeTextAndIcon(chartData, t);
 
-  const badge = <EstimationBadge text={text} Icon={icon} />;
-
   if (!hasEnoughDataToDisplay) {
     return (
       <NotEnoughDataMessage
@@ -86,8 +84,7 @@ function BreakdownChart({
     <RoundedCard>
       <ChartTitle
         titleText={t(`country-history.${titleDisplayMode}${titleMixMode}.${timeAverage}`)}
-        badge={badge}
-        isEstimated={Boolean(text)}
+        estimationBadge={<EstimationBadge text={text} Icon={icon} />}
         unit={valueAxisLabel}
         id={Charts.ORIGIN_CHART}
       />

--- a/web/src/features/charts/CarbonChart.tsx
+++ b/web/src/features/charts/CarbonChart.tsx
@@ -47,7 +47,6 @@ function CarbonChart({ datetimes, timeAverage }: CarbonChartProps) {
   const hasEnoughDataToDisplay = datetimes?.length > 2;
 
   const { text, icon } = getBadgeTextAndIcon(chartData, t);
-  const badge = <EstimationBadge text={text} Icon={icon} />;
 
   if (!hasEnoughDataToDisplay) {
     return (
@@ -61,9 +60,8 @@ function CarbonChart({ datetimes, timeAverage }: CarbonChartProps) {
     <RoundedCard className="pb-2">
       <ChartTitle
         titleText={t(`country-history.carbonintensity.${timeAverage}`)}
-        badge={badge}
+        estimationBadge={<EstimationBadge text={text} Icon={icon} />}
         unit={'gCO₂eq / kWh'}
-        isEstimated={Boolean(text)}
         id={Charts.CARBON_CHART}
       />
       <AreaGraph

--- a/web/src/features/charts/CarbonChart.tsx
+++ b/web/src/features/charts/CarbonChart.tsx
@@ -47,6 +47,7 @@ function CarbonChart({ datetimes, timeAverage }: CarbonChartProps) {
   const hasEnoughDataToDisplay = datetimes?.length > 2;
 
   const { text, icon } = getBadgeTextAndIcon(chartData, t);
+  const hasEstimation = text && icon;
 
   if (!hasEnoughDataToDisplay) {
     return (
@@ -60,7 +61,9 @@ function CarbonChart({ datetimes, timeAverage }: CarbonChartProps) {
     <RoundedCard className="pb-2">
       <ChartTitle
         titleText={t(`country-history.carbonintensity.${timeAverage}`)}
-        estimationBadge={<EstimationBadge text={text} Icon={icon} />}
+        estimationBadge={
+          hasEstimation ? <EstimationBadge text={text} Icon={icon} /> : null
+        }
         unit={'gCO₂eq / kWh'}
         id={Charts.CARBON_CHART}
       />

--- a/web/src/features/charts/ChartTitle.tsx
+++ b/web/src/features/charts/ChartTitle.tsx
@@ -6,7 +6,7 @@ import { useGetZoneFromPath } from 'utils/helpers';
 type Props = {
   titleText?: string;
   unit?: string;
-  estimationBadge?: React.ReactElement;
+  estimationBadge?: React.ReactElement | null;
   className?: string;
   id: Charts;
 };

--- a/web/src/features/charts/ChartTitle.tsx
+++ b/web/src/features/charts/ChartTitle.tsx
@@ -5,20 +5,12 @@ import { Charts } from 'utils/constants';
 type Props = {
   titleText?: string;
   unit?: string;
-  badge?: React.ReactElement;
+  estimationBadge?: React.ReactElement;
   className?: string;
-  isEstimated?: boolean;
   id?: Charts;
 };
 
-export function ChartTitle({
-  titleText,
-  unit,
-  badge,
-  className,
-  isEstimated,
-  id,
-}: Props) {
+export function ChartTitle({ titleText, unit, estimationBadge, className, id }: Props) {
   const showMoreOptions = useShowMoreOptions();
   return (
     <div className="flex flex-col pb-0.5">
@@ -26,9 +18,9 @@ export function ChartTitle({
         <h2 id={id} className="grow">
           {titleText}
         </h2>
-        {badge}
+        {estimationBadge}
         {showMoreOptions && (
-          <MoreOptionsDropdown isEstimated={isEstimated}>
+          <MoreOptionsDropdown isEstimated={Boolean(estimationBadge)}>
             <Ellipsis />
           </MoreOptionsDropdown>
         )}

--- a/web/src/features/charts/EmissionChart.tsx
+++ b/web/src/features/charts/EmissionChart.tsx
@@ -44,12 +44,15 @@ function EmissionChart({ timeAverage, datetimes }: EmissionChartProps) {
   const formatAxisTick = (t: number) => formatCo2({ value: t, total: maxEmissions });
 
   const { text, icon } = getBadgeTextAndIcon(chartData, t);
+  const hasEstimation = text && icon;
 
   return (
     <RoundedCard className="pb-2">
       <ChartTitle
         titleText={t(`country-history.emissions.${timeAverage}`)}
-        estimationBadge={<EstimationBadge text={text} Icon={icon} />}
+        estimationBadge={
+          hasEstimation ? <EstimationBadge text={text} Icon={icon} /> : null
+        }
         unit={'CO₂eq'}
         id={Charts.EMISSION_CHART}
       />

--- a/web/src/features/charts/EmissionChart.tsx
+++ b/web/src/features/charts/EmissionChart.tsx
@@ -44,13 +44,12 @@ function EmissionChart({ timeAverage, datetimes }: EmissionChartProps) {
   const formatAxisTick = (t: number) => formatCo2({ value: t, total: maxEmissions });
 
   const { text, icon } = getBadgeTextAndIcon(chartData, t);
-  const badge = <EstimationBadge text={text} Icon={icon} />;
 
   return (
     <RoundedCard className="pb-2">
       <ChartTitle
         titleText={t(`country-history.emissions.${timeAverage}`)}
-        badge={badge}
+        estimationBadge={<EstimationBadge text={text} Icon={icon} />}
         unit={'CO₂eq'}
         id={Charts.EMISSION_CHART}
       />

--- a/web/src/features/charts/bar-breakdown/BarBreakdownChart.tsx
+++ b/web/src/features/charts/bar-breakdown/BarBreakdownChart.tsx
@@ -148,7 +148,7 @@ function BarBreakdownChart({
       <ChartTitle
         titleText={titleText}
         unit={graphUnit}
-        badge={
+        estimationBadge={
           hasEstimationPill ? (
             <EstimationBadge
               text={pillText}


### PR DESCRIPTION
## Description

Use presence of badge as source of truth for estimation in ChartTitle component.

### Preview

<!-- Please add screenshots and/or gif that shows visual changes (if applicable) -->

### Double check

- [ ] I have tested my parser changes locally with `poetry run test_parser "zone_key"`
- [ ] I have run `pnpx prettier@2 --write .` and `poetry run format` in the top level directory to format my changes.
