### PR TITLE
AVO-619: Remove partially estimated tag from charts

### DIFF
--- a/web/src/features/charts/CarbonChart.tsx
+++ b/web/src/features/charts/CarbonChart.tsx
@@ -1,4 +1,3 @@
-import EstimationBadge from 'components/EstimationBadge';
 import HorizontalColorbar from 'components/legend/ColorBar';
 import { useCo2ColorScale } from 'hooks/theme';
 import { useTranslation } from 'react-i18next';
@@ -6,7 +5,7 @@ import { Charts, TimeAverages } from 'utils/constants';
 
 import { ChartTitle } from './ChartTitle';
 import AreaGraph from './elements/AreaGraph';
-import { getBadgeTextAndIcon, noop } from './graphUtils';
+import { analyzeChartData, noop } from './graphUtils';
 import { useCarbonChartData } from './hooks/useCarbonChartData';
 import { NotEnoughDataMessage } from './NotEnoughDataMessage';
 import { RoundedCard } from './RoundedCard';
@@ -30,8 +29,7 @@ function CarbonChart({ datetimes, timeAverage }: CarbonChartProps) {
 
   const hasEnoughDataToDisplay = datetimes?.length > 2;
 
-  const { text, icon } = getBadgeTextAndIcon(chartData, t);
-  const badge = <EstimationBadge text={text} Icon={icon} />;
+  const { hasEstimation } = analyzeChartData(chartData);
 
   if (!hasEnoughDataToDisplay) {
     return (
@@ -45,9 +43,8 @@ function CarbonChart({ datetimes, timeAverage }: CarbonChartProps) {
     <RoundedCard className="pb-2">
       <ChartTitle
         titleText={t(`country-history.carbonintensity.${timeAverage}`)}
-        badge={badge}
         unit={'gCO₂eq / kWh'}
-        isEstimated={Boolean(text)}
+        isEstimated={hasEstimation}
         id={Charts.CARBON_CHART}
       />
       <AreaGraph

--- a/web/src/features/charts/ChartTitle.tsx
+++ b/web/src/features/charts/ChartTitle.tsx
@@ -6,12 +6,20 @@ import { useGetZoneFromPath } from 'utils/helpers';
 type Props = {
   titleText?: string;
   unit?: string;
+  badge?: React.ReactElement;
   className?: string;
   isEstimated?: boolean;
   id: Charts;
 };
 
-export function ChartTitle({ titleText, unit, className, isEstimated, id }: Props) {
+export function ChartTitle({
+  titleText,
+  unit,
+  className,
+  isEstimated,
+  id,
+  badge,
+}: Props) {
   const showMoreOptions = useShowMoreOptions();
   const zoneId = useGetZoneFromPath();
   const url = `${baseUrl}/zone/${zoneId}`;
@@ -23,8 +31,13 @@ export function ChartTitle({ titleText, unit, className, isEstimated, id }: Prop
         <h2 id={id} className="grow">
           {titleText}
         </h2>
+        {badge}
         {showMoreOptions && (
-          <MoreOptionsDropdown isEstimated={isEstimated} id={id} shareUrl={shareUrl}>
+          <MoreOptionsDropdown
+            isEstimated={isEstimated || Boolean(badge)}
+            id={id}
+            shareUrl={shareUrl}
+          >
             <Ellipsis />
           </MoreOptionsDropdown>
         )}

--- a/web/src/features/charts/ChartTitle.tsx
+++ b/web/src/features/charts/ChartTitle.tsx
@@ -6,20 +6,12 @@ import { useGetZoneFromPath } from 'utils/helpers';
 type Props = {
   titleText?: string;
   unit?: string;
-  badge?: React.ReactElement;
   className?: string;
   isEstimated?: boolean;
   id: Charts;
 };
 
-export function ChartTitle({
-  titleText,
-  unit,
-  badge,
-  className,
-  isEstimated,
-  id,
-}: Props) {
+export function ChartTitle({ titleText, unit, className, isEstimated, id }: Props) {
   const showMoreOptions = useShowMoreOptions();
   const zoneId = useGetZoneFromPath();
   const url = `${baseUrl}/zone/${zoneId}`;
@@ -31,7 +23,6 @@ export function ChartTitle({
         <h2 id={id} className="grow">
           {titleText}
         </h2>
-        {badge}
         {showMoreOptions && (
           <MoreOptionsDropdown isEstimated={isEstimated} id={id} shareUrl={shareUrl}>
             <Ellipsis />

--- a/web/src/features/charts/EmissionChart.tsx
+++ b/web/src/features/charts/EmissionChart.tsx
@@ -1,11 +1,10 @@
-import EstimationBadge from 'components/EstimationBadge';
 import { useTranslation } from 'react-i18next';
 import { Charts, TimeAverages } from 'utils/constants';
 import { formatCo2 } from 'utils/formatting';
 
 import { ChartTitle } from './ChartTitle';
 import AreaGraph from './elements/AreaGraph';
-import { getBadgeTextAndIcon, noop } from './graphUtils';
+import { analyzeChartData, noop } from './graphUtils';
 import { useEmissionChartData } from './hooks/useEmissionChartData';
 import { RoundedCard } from './RoundedCard';
 import EmissionChartTooltip from './tooltips/EmissionChartTooltip';
@@ -28,14 +27,13 @@ function EmissionChart({ timeAverage, datetimes }: EmissionChartProps) {
   const maxEmissions = Math.max(...chartData.map((o) => o.layerData.emissions));
   const formatAxisTick = (t: number) => formatCo2({ value: t, total: maxEmissions });
 
-  const { text, icon } = getBadgeTextAndIcon(chartData, t);
-  const badge = <EstimationBadge text={text} Icon={icon} />;
+  const { hasEstimation } = analyzeChartData(chartData);
 
   return (
     <RoundedCard className="pb-2">
       <ChartTitle
         titleText={t(`country-history.emissions.${timeAverage}`)}
-        badge={badge}
+        isEstimated={hasEstimation}
         unit={'CO₂eq'}
         id={Charts.EMISSION_CHART}
       />

--- a/web/src/features/charts/OriginChart.tsx
+++ b/web/src/features/charts/OriginChart.tsx
@@ -1,4 +1,3 @@
-import EstimationBadge from 'components/EstimationBadge';
 import { max, sum } from 'd3-array';
 import { useAtomValue } from 'jotai';
 import { useTranslation } from 'react-i18next';
@@ -9,7 +8,7 @@ import { isConsumptionAtom, isHourlyAtom } from 'utils/state/atoms';
 
 import { ChartTitle } from './ChartTitle';
 import AreaGraph from './elements/AreaGraph';
-import { getBadgeTextAndIcon, getGenerationTypeKey, noop } from './graphUtils';
+import { analyzeChartData, getGenerationTypeKey, noop } from './graphUtils';
 import useOriginChartData from './hooks/useOriginChartData';
 import { NotEnoughDataMessage } from './NotEnoughDataMessage';
 import ProductionSourceLegendList from './ProductionSourceLegendList';
@@ -47,9 +46,7 @@ function OriginChart({ displayByEmissions, datetimes, timeAverage }: OriginChart
 
   const hasEnoughDataToDisplay = datetimes?.length > 2;
 
-  const { text, icon } = getBadgeTextAndIcon(chartData, t);
-
-  const badge = <EstimationBadge text={text} Icon={icon} />;
+  const { hasEstimation } = analyzeChartData(chartData);
 
   if (!hasEnoughDataToDisplay) {
     return (
@@ -64,8 +61,7 @@ function OriginChart({ displayByEmissions, datetimes, timeAverage }: OriginChart
     <RoundedCard>
       <ChartTitle
         titleText={t(`country-history.${titleDisplayMode}${titleMixMode}.${timeAverage}`)}
-        badge={badge}
-        isEstimated={Boolean(text)}
+        isEstimated={hasEstimation}
         unit={valueAxisLabel}
         id={Charts.ORIGIN_CHART}
       />

--- a/web/src/features/charts/bar-breakdown/BarBreakdownChart.tsx
+++ b/web/src/features/charts/bar-breakdown/BarBreakdownChart.tsx
@@ -1,14 +1,16 @@
 import * as Portal from '@radix-ui/react-portal';
+import EstimationBadge from 'components/EstimationBadge';
 import { getOffsetTooltipPosition } from 'components/tooltips/utilities';
+import { useGetEstimationTranslation } from 'hooks/getEstimationTranslation';
 import { useHeaderHeight } from 'hooks/headerHeight';
 import { TFunction } from 'i18next';
 import { useAtom, useAtomValue } from 'jotai';
-import { X } from 'lucide-react';
+import { CircleDashed, TrendingUpDown, X } from 'lucide-react';
 import React, { useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { ElectricityModeType, ZoneKey } from 'types';
 import useResizeObserver from 'use-resize-observer';
-import { Charts, TimeAverages } from 'utils/constants';
+import { Charts, EstimationMethods, TimeAverages } from 'utils/constants';
 import {
   displayByEmissionsAtom,
   isConsumptionAtom,
@@ -68,6 +70,12 @@ function BarBreakdownChart({
   const headerHeight = useHeaderHeight();
 
   const titleText = useBarBreakdownChartTitle();
+  const estimationMethod = currentZoneDetail?.estimationMethod;
+  const pillText = useGetEstimationTranslation(
+    'pill',
+    estimationMethod,
+    currentZoneDetail?.estimatedPercentage
+  );
 
   if (isLoading) {
     return null;
@@ -115,7 +123,16 @@ function BarBreakdownChart({
       <ChartTitle
         titleText={titleText}
         unit={graphUnit}
-        isEstimated={hasEstimationPill}
+        badge={
+          hasEstimationPill ? (
+            <EstimationBadge
+              text={pillText}
+              Icon={
+                estimationMethod === EstimationMethods.TSA ? CircleDashed : TrendingUpDown
+              }
+            />
+          ) : undefined
+        }
         id={Charts.BAR_BREAKDOWN_CHART}
       />
       {!displayByEmissions && (

--- a/web/src/features/charts/bar-breakdown/BarBreakdownChart.tsx
+++ b/web/src/features/charts/bar-breakdown/BarBreakdownChart.tsx
@@ -118,6 +118,10 @@ function BarBreakdownChart({
     setTooltipData(null);
   };
 
+  const hasEstimation =
+    estimationMethod === EstimationMethods.TSA ||
+    estimationMethod === EstimationMethods.FORECASTS_HIERARCHY;
+
   return (
     <RoundedCard ref={ref}>
       <ChartTitle
@@ -127,9 +131,7 @@ function BarBreakdownChart({
           hasEstimationPill ? (
             <EstimationBadge
               text={pillText}
-              Icon={
-                estimationMethod === EstimationMethods.TSA ? CircleDashed : TrendingUpDown
-              }
+              Icon={hasEstimation ? CircleDashed : TrendingUpDown}
             />
           ) : undefined
         }

--- a/web/src/features/charts/bar-breakdown/BarBreakdownChart.tsx
+++ b/web/src/features/charts/bar-breakdown/BarBreakdownChart.tsx
@@ -1,16 +1,14 @@
 import * as Portal from '@radix-ui/react-portal';
-import EstimationBadge from 'components/EstimationBadge';
 import { getOffsetTooltipPosition } from 'components/tooltips/utilities';
-import { useGetEstimationTranslation } from 'hooks/getEstimationTranslation';
 import { useHeaderHeight } from 'hooks/headerHeight';
 import { TFunction } from 'i18next';
 import { useAtom, useAtomValue } from 'jotai';
-import { CircleDashed, TrendingUpDown, X } from 'lucide-react';
+import { X } from 'lucide-react';
 import React, { useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { ElectricityModeType, ZoneKey } from 'types';
 import useResizeObserver from 'use-resize-observer';
-import { Charts, EstimationMethods, TimeAverages } from 'utils/constants';
+import { Charts, TimeAverages } from 'utils/constants';
 import {
   displayByEmissionsAtom,
   isConsumptionAtom,
@@ -70,12 +68,6 @@ function BarBreakdownChart({
   const headerHeight = useHeaderHeight();
 
   const titleText = useBarBreakdownChartTitle();
-  const estimationMethod = currentZoneDetail?.estimationMethod;
-  const pillText = useGetEstimationTranslation(
-    'pill',
-    estimationMethod,
-    currentZoneDetail?.estimatedPercentage
-  );
 
   if (isLoading) {
     return null;
@@ -123,16 +115,7 @@ function BarBreakdownChart({
       <ChartTitle
         titleText={titleText}
         unit={graphUnit}
-        badge={
-          hasEstimationPill ? (
-            <EstimationBadge
-              text={pillText}
-              Icon={
-                estimationMethod === EstimationMethods.TSA ? CircleDashed : TrendingUpDown
-              }
-            />
-          ) : undefined
-        }
+        isEstimated={hasEstimationPill}
         id={Charts.BAR_BREAKDOWN_CHART}
       />
       {!displayByEmissions && (

--- a/web/src/features/charts/graphUtils.ts
+++ b/web/src/features/charts/graphUtils.ts
@@ -211,7 +211,7 @@ export function getElectricityProductionValue({
   return generationTypeStorage === 0 ? 0 : -generationTypeStorage;
 }
 
-function analyzeChartData(chartData: AreaGraphElement[]) {
+export function analyzeChartData(chartData: AreaGraphElement[]) {
   let estimatedCount = 0;
   let tsaCount = 0;
   for (const chartElement of chartData) {

--- a/web/src/features/charts/tooltips/AreaGraphTooltipHeader.tsx
+++ b/web/src/features/charts/tooltips/AreaGraphTooltipHeader.tsx
@@ -35,6 +35,11 @@ export default function AreaGraphToolTipHeader({
     estimationMethod,
     estimatedPercentage
   );
+
+  const hasEstimation =
+    estimationMethod === EstimationMethods.TSA ||
+    estimationMethod === EstimationMethods.FORECASTS_HIERARCHY;
+
   return (
     <>
       <div className="flex items-center gap-1 font-bold">
@@ -50,9 +55,7 @@ export default function AreaGraphToolTipHeader({
         {hasEstimationPill && (
           <EstimationBadge
             text={pillText}
-            Icon={
-              estimationMethod === EstimationMethods.TSA ? CircleDashed : TrendingUpDown
-            }
+            Icon={hasEstimation ? CircleDashed : TrendingUpDown}
           />
         )}
       </div>


### PR DESCRIPTION
## Description
[AVO-619](https://linear.app/electricitymaps/issue/AVO-619/remove-partially-estimated-tag-from-charts-and-show-it-only-for): Remove partially estimated tag from charts
- Removes `preliminary` and `estimated` badges from charts except for bar breakdown
- Keeps zone disclaimer and tooltip badges

TODO: Discuss internally - does this conflict with our stance on scientific integrity?

### Preview
Hourly:
<img width="368" alt="Screenshot 2024-10-31 at 12 28 53" src="https://github.com/user-attachments/assets/c58f32e9-ff0b-4edd-bd79-fa7603e033fd">
<img width="635" alt="Screenshot 2024-10-31 at 12 28 38" src="https://github.com/user-attachments/assets/597f152b-3022-4cda-9596-18e40fe0d462">
<img width="355" alt="Screenshot 2024-10-31 at 12 29 15" src="https://github.com/user-attachments/assets/a6e51a80-6a15-4c6e-bde5-1f76f0ee4510">

Aggregation:
<img width="367" alt="Screenshot 2024-10-31 at 12 43 08" src="https://github.com/user-attachments/assets/9525309f-c96b-491d-802b-1735a9882f59">
<img width="636" alt="Screenshot 2024-10-31 at 12 42 51" src="https://github.com/user-attachments/assets/4edd168b-75af-4e5f-9c57-f63c9896a9af">

### Double check

- [ ] I have tested my parser changes locally with `poetry run test_parser "zone_key"`
- [ ] I have run `pnpx prettier@2 --write .` and `poetry run format` in the top level directory to format my changes.
