### PR TITLE
Rename BreakdownChart to OriginChart

### DIFF
--- a/web/src/features/charts/OriginChart.stories.ts
+++ b/web/src/features/charts/OriginChart.stories.ts
@@ -6,10 +6,10 @@ import { colors } from '../../hooks/colors';
 import { getCo2ColorScale } from '../../hooks/theme';
 import { TimeAverages } from '../../utils/constants';
 import AreaGraph from './elements/AreaGraph';
-import { getLayerFill } from './hooks/useBreakdownChartData';
+import { getLayerFill } from './hooks/useOriginChartData';
 
 const meta: Meta<typeof AreaGraph> = {
-  title: 'charts/BreakdownChart',
+  title: 'charts/OriginChart',
   component: AreaGraph,
 };
 

--- a/web/src/features/charts/OriginChart.tsx
+++ b/web/src/features/charts/OriginChart.tsx
@@ -10,25 +10,21 @@ import { isConsumptionAtom, isHourlyAtom } from 'utils/state/atoms';
 import { ChartTitle } from './ChartTitle';
 import AreaGraph from './elements/AreaGraph';
 import { getBadgeTextAndIcon, getGenerationTypeKey, noop } from './graphUtils';
-import useBreakdownChartData from './hooks/useBreakdownChartData';
+import useOriginChartData from './hooks/useOriginChartData';
 import { NotEnoughDataMessage } from './NotEnoughDataMessage';
 import ProductionSourceLegendList from './ProductionSourceLegendList';
 import { RoundedCard } from './RoundedCard';
 import BreakdownChartTooltip from './tooltips/BreakdownChartTooltip';
 import { AreaGraphElement } from './types';
 
-interface BreakdownChartProps {
+interface OriginChartProps {
   displayByEmissions: boolean;
   datetimes: Date[];
   timeAverage: TimeAverages;
 }
 
-function BreakdownChart({
-  displayByEmissions,
-  datetimes,
-  timeAverage,
-}: BreakdownChartProps) {
-  const { data } = useBreakdownChartData();
+function OriginChart({ displayByEmissions, datetimes, timeAverage }: OriginChartProps) {
+  const { data } = useOriginChartData();
   const isConsumption = useAtomValue(isConsumptionAtom);
   const { t } = useTranslation();
   const isHourly = useAtomValue(isHourlyAtom);
@@ -105,7 +101,7 @@ function BreakdownChart({
   );
 }
 
-export default BreakdownChart;
+export default OriginChart;
 
 function getProductionSourcesInChart(chartData: AreaGraphElement[]) {
   const productionSources = new Set<ElectricityModeType>();

--- a/web/src/features/charts/hooks/useOriginChartData.ts
+++ b/web/src/features/charts/hooks/useOriginChartData.ts
@@ -38,7 +38,7 @@ export const getLayerFill =
       co2ColorScale(d.data.meta.exchangeCo2Intensities?.[key]);
   };
 
-export default function useBreakdownChartData() {
+export default function useOriginChartData() {
   const { data: zoneData, isLoading, isError } = useGetZone();
   const co2ColorScale = useCo2ColorScale();
   const { zoneId } = useParams();

--- a/web/src/features/panels/zone/AreaGraphContainer.tsx
+++ b/web/src/features/panels/zone/AreaGraphContainer.tsx
@@ -1,8 +1,8 @@
 import { HorizontalDivider } from 'components/Divider';
-import BreakdownChart from 'features/charts/BreakdownChart';
 import CarbonChart from 'features/charts/CarbonChart';
 import EmissionChart from 'features/charts/EmissionChart';
 import NetExchangeChart from 'features/charts/NetExchangeChart';
+import OriginChart from 'features/charts/OriginChart';
 import PriceChart from 'features/charts/PriceChart';
 import { TimeAverages } from 'utils/constants';
 
@@ -22,7 +22,7 @@ export default function AreaGraphContainer({
       ) : (
         <CarbonChart datetimes={datetimes} timeAverage={timeAverage} />
       )}
-      <BreakdownChart
+      <OriginChart
         displayByEmissions={displayByEmissions}
         datetimes={datetimes}
         timeAverage={timeAverage}


### PR DESCRIPTION
## Description
Rename BreakdownChart to OriginChart.
BarBreakdownChart and BreakdownChart are very similarly named and the naming convention can cause confusion.

### Preview

<!-- Please add screenshots and/or gif that shows visual changes (if applicable) -->

### Double check

- [ ] I have tested my parser changes locally with `poetry run test_parser "zone_key"`
- [ ] I have run `pnpx prettier@2 --write .` and `poetry run format` in the top level directory to format my changes.
