### PR TITLE
Consolidate data sources and methodologies

### DIFF
--- a/web/src/features/charts/BreakdownChart.tsx
+++ b/web/src/features/charts/BreakdownChart.tsx
@@ -1,26 +1,16 @@
-import Accordion from 'components/Accordion';
-import { HorizontalDivider } from 'components/Divider';
 import EstimationBadge from 'components/EstimationBadge';
 import { max, sum } from 'd3-array';
-import { useAtom, useAtomValue } from 'jotai';
-import { Factory, Zap } from 'lucide-react';
+import { useAtomValue } from 'jotai';
 import { useTranslation } from 'react-i18next';
 import { ElectricityModeType } from 'types';
-import trackEvent from 'utils/analytics';
-import { Charts, TimeAverages, TrackEvent } from 'utils/constants';
+import { Charts, TimeAverages } from 'utils/constants';
 import { formatCo2 } from 'utils/formatting';
-import {
-  dataSourcesCollapsedBreakdownAtom,
-  isConsumptionAtom,
-  isHourlyAtom,
-} from 'utils/state/atoms';
+import { isConsumptionAtom, isHourlyAtom } from 'utils/state/atoms';
 
 import { ChartTitle } from './ChartTitle';
-import { DataSources } from './DataSources';
 import AreaGraph from './elements/AreaGraph';
 import { getBadgeTextAndIcon, getGenerationTypeKey, noop } from './graphUtils';
 import useBreakdownChartData from './hooks/useBreakdownChartData';
-import useZoneDataSources from './hooks/useZoneDataSources';
 import { NotEnoughDataMessage } from './NotEnoughDataMessage';
 import ProductionSourceLegendList from './ProductionSourceLegendList';
 import { RoundedCard } from './RoundedCard';
@@ -40,14 +30,6 @@ function BreakdownChart({
 }: BreakdownChartProps) {
   const { data } = useBreakdownChartData();
   const isConsumption = useAtomValue(isConsumptionAtom);
-  const [dataSourcesCollapsedBreakdown, setDataSourcesCollapsedBreakdown] = useAtom(
-    dataSourcesCollapsedBreakdownAtom
-  );
-  const {
-    emissionFactorSources,
-    powerGenerationSources,
-    emissionFactorSourcesToProductionSources,
-  } = useZoneDataSources();
   const { t } = useTranslation();
   const isHourly = useAtomValue(isHourlyAtom);
 
@@ -115,41 +97,10 @@ function BreakdownChart({
           dangerouslySetInnerHTML={{ __html: t('country-panel.exchangesAreMissing') }}
         />
       )}
-
-      <>
-        <ProductionSourceLegendList
-          sources={getProductionSourcesInChart(chartData)}
-          className="py-1.5"
-        />
-        <HorizontalDivider />
-        <Accordion
-          onOpen={() => {
-            trackEvent(TrackEvent.DATA_SOURCES_CLICKED, {
-              chart: displayByEmissions
-                ? 'emission-origin-chart'
-                : 'electricity-origin-chart',
-            });
-          }}
-          title={t('data-sources.title')}
-          className="text-md"
-          isCollapsed={dataSourcesCollapsedBreakdown}
-          setState={setDataSourcesCollapsedBreakdown}
-        >
-          <DataSources
-            title={t('data-sources.power')}
-            icon={<Zap size={16} />}
-            sources={powerGenerationSources}
-          />
-          <DataSources
-            title={t('data-sources.emission')}
-            icon={<Factory size={16} />}
-            sources={emissionFactorSources}
-            emissionFactorSourcesToProductionSources={
-              emissionFactorSourcesToProductionSources
-            }
-          />
-        </Accordion>
-      </>
+      <ProductionSourceLegendList
+        sources={getProductionSourcesInChart(chartData)}
+        className="py-1.5"
+      />
     </RoundedCard>
   );
 }

--- a/web/src/features/charts/CarbonChart.tsx
+++ b/web/src/features/charts/CarbonChart.tsx
@@ -1,21 +1,13 @@
-import Accordion from 'components/Accordion';
-import { HorizontalDivider } from 'components/Divider';
 import EstimationBadge from 'components/EstimationBadge';
 import HorizontalColorbar from 'components/legend/ColorBar';
 import { useCo2ColorScale } from 'hooks/theme';
-import { useAtom } from 'jotai';
-import { Factory, Zap } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
-import trackEvent from 'utils/analytics';
-import { Charts, TimeAverages, TrackEvent } from 'utils/constants';
-import { dataSourcesCollapsedEmissionAtom } from 'utils/state/atoms';
+import { Charts, TimeAverages } from 'utils/constants';
 
 import { ChartTitle } from './ChartTitle';
-import { DataSources } from './DataSources';
 import AreaGraph from './elements/AreaGraph';
 import { getBadgeTextAndIcon, noop } from './graphUtils';
 import { useCarbonChartData } from './hooks/useCarbonChartData';
-import useZoneDataSources from './hooks/useZoneDataSources';
 import { NotEnoughDataMessage } from './NotEnoughDataMessage';
 import { RoundedCard } from './RoundedCard';
 import CarbonChartTooltip from './tooltips/CarbonChartTooltip';
@@ -27,14 +19,6 @@ interface CarbonChartProps {
 
 function CarbonChart({ datetimes, timeAverage }: CarbonChartProps) {
   const { data, isLoading, isError } = useCarbonChartData();
-  const [dataSourcesCollapsedEmission, setDataSourcesCollapsedEmission] = useAtom(
-    dataSourcesCollapsedEmissionAtom
-  );
-  const {
-    emissionFactorSources,
-    powerGenerationSources,
-    emissionFactorSourcesToProductionSources,
-  } = useZoneDataSources();
   const { t } = useTranslation();
   const co2ColorScale = useCo2ColorScale();
 
@@ -82,29 +66,6 @@ function CarbonChart({ datetimes, timeAverage }: CarbonChartProps) {
       <div className="pb-1 pt-2">
         <HorizontalColorbar colorScale={co2ColorScale} ticksCount={6} id={'co2'} />
       </div>
-      <HorizontalDivider />
-      <Accordion
-        onOpen={() => {
-          trackEvent(TrackEvent.DATA_SOURCES_CLICKED, { chart: 'carbon-chart' });
-        }}
-        title={t('data-sources.title')}
-        isCollapsed={dataSourcesCollapsedEmission}
-        setState={setDataSourcesCollapsedEmission}
-      >
-        <DataSources
-          title={t('data-sources.power')}
-          icon={<Zap size={16} />}
-          sources={powerGenerationSources}
-        />
-        <DataSources
-          title={t('data-sources.emission')}
-          icon={<Factory size={16} />}
-          sources={emissionFactorSources}
-          emissionFactorSourcesToProductionSources={
-            emissionFactorSourcesToProductionSources
-          }
-        />
-      </Accordion>
     </RoundedCard>
   );
 }

--- a/web/src/features/charts/DataSources.tsx
+++ b/web/src/features/charts/DataSources.tsx
@@ -26,7 +26,8 @@ export function DataSources({
   const { t } = useTranslation();
   const isMobile = !useBreakpoint('md');
   const showDataSources = Boolean(
-    sources?.length > 0 || emissionFactorSourcesToProductionSources
+    sources?.length > 0 ||
+      Object.keys(emissionFactorSourcesToProductionSources || {}).length > 0
   );
 
   if (showDataSources == false) {

--- a/web/src/features/charts/EmissionChart.tsx
+++ b/web/src/features/charts/EmissionChart.tsx
@@ -1,20 +1,12 @@
-import Accordion from 'components/Accordion';
-import { HorizontalDivider } from 'components/Divider';
 import EstimationBadge from 'components/EstimationBadge';
-import { useAtom } from 'jotai';
-import { Factory, Zap } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
-import trackEvent from 'utils/analytics';
-import { Charts, TimeAverages, TrackEvent } from 'utils/constants';
+import { Charts, TimeAverages } from 'utils/constants';
 import { formatCo2 } from 'utils/formatting';
-import { dataSourcesCollapsedEmissionAtom } from 'utils/state/atoms';
 
 import { ChartTitle } from './ChartTitle';
-import { DataSources } from './DataSources';
 import AreaGraph from './elements/AreaGraph';
 import { getBadgeTextAndIcon, noop } from './graphUtils';
 import { useEmissionChartData } from './hooks/useEmissionChartData';
-import useZoneDataSources from './hooks/useZoneDataSources';
 import { RoundedCard } from './RoundedCard';
 import EmissionChartTooltip from './tooltips/EmissionChartTooltip';
 
@@ -25,14 +17,7 @@ interface EmissionChartProps {
 
 function EmissionChart({ timeAverage, datetimes }: EmissionChartProps) {
   const { data, isLoading, isError } = useEmissionChartData();
-  const [dataSourcesCollapsedEmission, setDataSourcesCollapsedEmission] = useAtom(
-    dataSourcesCollapsedEmissionAtom
-  );
-  const {
-    emissionFactorSources,
-    powerGenerationSources,
-    emissionFactorSourcesToProductionSources,
-  } = useZoneDataSources();
+
   const { t } = useTranslation();
   if (isLoading || isError || !data) {
     return null;
@@ -68,30 +53,6 @@ function EmissionChart({ timeAverage, datetimes }: EmissionChartProps) {
         tooltip={EmissionChartTooltip}
         formatTick={formatAxisTick}
       />
-      <HorizontalDivider />
-      <Accordion
-        onOpen={() => {
-          trackEvent(TrackEvent.DATA_SOURCES_CLICKED, { chart: 'emission-chart' });
-        }}
-        title={t('data-sources.title')}
-        className="text-md"
-        isCollapsed={dataSourcesCollapsedEmission}
-        setState={setDataSourcesCollapsedEmission}
-      >
-        <DataSources
-          title={t('data-sources.power')}
-          icon={<Zap size={16} />}
-          sources={powerGenerationSources}
-        />
-        <DataSources
-          title={t('data-sources.emission')}
-          icon={<Factory size={16} />}
-          sources={emissionFactorSources}
-          emissionFactorSourcesToProductionSources={
-            emissionFactorSourcesToProductionSources
-          }
-        />
-      </Accordion>
     </RoundedCard>
   );
 }

--- a/web/src/features/charts/bar-breakdown/BarBreakdownChart.tsx
+++ b/web/src/features/charts/bar-breakdown/BarBreakdownChart.tsx
@@ -1,21 +1,17 @@
 import * as Portal from '@radix-ui/react-portal';
-import Accordion from 'components/Accordion';
-import { HorizontalDivider } from 'components/Divider';
 import EstimationBadge from 'components/EstimationBadge';
 import { getOffsetTooltipPosition } from 'components/tooltips/utilities';
 import { useGetEstimationTranslation } from 'hooks/getEstimationTranslation';
 import { useHeaderHeight } from 'hooks/headerHeight';
 import { TFunction } from 'i18next';
 import { useAtom, useAtomValue } from 'jotai';
-import { CircleDashed, Factory, TrendingUpDown, UtilityPole, X, Zap } from 'lucide-react';
+import { CircleDashed, TrendingUpDown, X } from 'lucide-react';
 import React, { useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { ElectricityModeType, ZoneKey } from 'types';
 import useResizeObserver from 'use-resize-observer';
-import trackEvent from 'utils/analytics';
-import { Charts, EstimationMethods, TimeAverages, TrackEvent } from 'utils/constants';
+import { Charts, EstimationMethods, TimeAverages } from 'utils/constants';
 import {
-  dataSourcesCollapsedBarBreakdownAtom,
   displayByEmissionsAtom,
   isConsumptionAtom,
   isHourlyAtom,
@@ -25,10 +21,8 @@ import {
 import { useBreakpoint } from 'utils/styling';
 
 import { ChartTitle } from '../ChartTitle';
-import { DataSources } from '../DataSources';
 import { determineUnit } from '../graphUtils';
 import useBarBreakdownChartData from '../hooks/useBarElectricityBreakdownChartData';
-import useZoneDataSources from '../hooks/useZoneDataSources';
 import { RoundedCard } from '../RoundedCard';
 import BreakdownChartTooltip from '../tooltips/BreakdownChartTooltip';
 import BarBreakdownEmissionsChart from './BarBreakdownEmissionsChart';
@@ -52,13 +46,6 @@ function BarBreakdownChart({
     height,
   } = useBarBreakdownChartData();
 
-  const {
-    capacitySources,
-    powerGenerationSources,
-    emissionFactorSources,
-    emissionFactorSourcesToProductionSources,
-  } = useZoneDataSources();
-
   const [displayByEmissions] = useAtom(displayByEmissionsAtom);
   const { ref, width: observerWidth = 0 } = useResizeObserver<HTMLDivElement>();
   const { t } = useTranslation();
@@ -79,10 +66,6 @@ function BarBreakdownChart({
     x: number;
     y: number;
   } | null>(null);
-
-  const [dataSourcesCollapsedBarBreakdown, setDataSourcesCollapsedBarBreakdown] = useAtom(
-    dataSourcesCollapsedBarBreakdownAtom
-  );
 
   const headerHeight = useHeaderHeight();
 
@@ -134,14 +117,6 @@ function BarBreakdownChart({
   const onMouseOut = () => {
     setTooltipData(null);
   };
-
-  const showPowerSources = Boolean(powerGenerationSources?.length > 0);
-  const showEmissionSources = Boolean(emissionFactorSources?.length > 0);
-  const showCapacitySources = Boolean(capacitySources?.length > 0);
-
-  const showDataSourceAccordion = Boolean(
-    showCapacitySources || showPowerSources || showEmissionSources
-  );
 
   return (
     <RoundedCard ref={ref}>
@@ -211,41 +186,6 @@ function BarBreakdownChart({
           isMobile={false}
           graphUnit={graphUnit}
         />
-      )}
-      {showDataSourceAccordion && (
-        <>
-          <HorizontalDivider />
-          <Accordion
-            onOpen={() => {
-              trackEvent(TrackEvent.DATA_SOURCES_CLICKED, {
-                chart: 'bar-breakdown-chart',
-              });
-            }}
-            title={t('data-sources.title')}
-            className="text-md"
-            isCollapsed={dataSourcesCollapsedBarBreakdown}
-            setState={setDataSourcesCollapsedBarBreakdown}
-          >
-            <DataSources
-              title={t('data-sources.capacity')}
-              icon={<UtilityPole size={16} />}
-              sources={capacitySources}
-            />
-            <DataSources
-              title={t('data-sources.power')}
-              icon={<Zap size={16} />}
-              sources={powerGenerationSources}
-            />
-            <DataSources
-              title={t('data-sources.emission')}
-              icon={<Factory size={16} />}
-              sources={emissionFactorSources}
-              emissionFactorSourcesToProductionSources={
-                emissionFactorSourcesToProductionSources
-              }
-            />
-          </Accordion>
-        </>
       )}
     </RoundedCard>
   );

--- a/web/src/features/panels/zone/MethodologyCard.tsx
+++ b/web/src/features/panels/zone/MethodologyCard.tsx
@@ -1,34 +1,71 @@
 import Accordion from 'components/Accordion';
 import { Link } from 'components/Link';
+import { DataSources } from 'features/charts/DataSources';
+import useZoneDataSources from 'features/charts/hooks/useZoneDataSources';
 import { RoundedCard } from 'features/charts/RoundedCard';
 import { t } from 'i18next';
 import { EmapsIcon } from 'icons/emapsIcon';
+import { Factory, UtilityPole, Zap } from 'lucide-react';
 import { useState } from 'react';
 import trackEvent from 'utils/analytics';
 import { TrackEvent } from 'utils/constants';
 
 export default function MethodologyCard() {
   const [isCollapsed, setIsCollapsed] = useState(true);
+  const {
+    capacitySources,
+    emissionFactorSources,
+    powerGenerationSources,
+    emissionFactorSourcesToProductionSources,
+  } = useZoneDataSources();
+
   return (
     <RoundedCard>
       <Accordion
-        icon={<EmapsIcon styling="dark:text-white" />}
-        title={t('left-panel.applied-methodologies.title')}
+        title={t('left-panel.methodologies-and-data-sources.title')}
         className="text-md pt-2"
-        onOpen={() => trackEvent(TrackEvent.APPLIED_METHODOLOGIES_EXPANDED)}
+        onOpen={() => trackEvent(TrackEvent.METHODOLOGIES_AND_DATA_SOURCES_EXPANDED)}
         isCollapsed={isCollapsed}
         setState={setIsCollapsed}
       >
         <div className="flex flex-col gap-2 py-1">
-          <Link href="https://www.electricitymaps.com/methodology#missing-data">
-            {t('left-panel.applied-methodologies.estimations')}
-          </Link>
-          <Link href="https://www.electricitymaps.com/methodology#data-collection-and-processing">
-            {t('left-panel.applied-methodologies.flowtracing')}
-          </Link>
-          <Link href="https://www.electricitymaps.com/methodology#carbon-intensity-and-emission-factors">
-            {t('left-panel.applied-methodologies.carbonintensity')}
-          </Link>
+          <div className="flex items-center gap-1 py-2">
+            <EmapsIcon styling="dark:text-white" />
+            <p className="font-semibold">{t('left-panel.applied-methodologies.title')}</p>
+          </div>
+          <div className="flex flex-col gap-2 pl-5">
+            <Link href="https://www.electricitymaps.com/methodology#missing-data">
+              {t('left-panel.applied-methodologies.estimations')}
+            </Link>
+            <Link href="https://www.electricitymaps.com/methodology#data-collection-and-processing">
+              {t('left-panel.applied-methodologies.flowtracing')}
+            </Link>
+            <Link href="https://www.electricitymaps.com/methodology#carbon-intensity-and-emission-factors">
+              {t('left-panel.applied-methodologies.carbonintensity')}
+            </Link>
+            <Link href="https://github.com/electricityMaps/electricitymaps-contrib/wiki/Historical-aggregates">
+              {t('left-panel.applied-methodologies.historicalAggregations')}
+            </Link>
+          </div>
+
+          <DataSources
+            title={t('data-sources.capacity')}
+            icon={<UtilityPole size={16} />}
+            sources={capacitySources}
+          />
+          <DataSources
+            title={t('data-sources.power')}
+            icon={<Zap size={16} />}
+            sources={powerGenerationSources}
+          />
+          <DataSources
+            title={t('data-sources.emission')}
+            icon={<Factory size={16} />}
+            sources={emissionFactorSources}
+            emissionFactorSourcesToProductionSources={
+              emissionFactorSourcesToProductionSources
+            }
+          />
         </div>
       </Accordion>
     </RoundedCard>

--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -244,7 +244,11 @@
       "title": "Applied methodologies",
       "estimations": "Electricity Maps - Estimations",
       "flowtracing": "Electricity Maps - Flow-tracing",
-      "carbonintensity": "Electricity Maps - Carbon intensity"
+      "carbonintensity": "Electricity Maps - Carbon intensity",
+      "historicalAggregations": "Electricity Maps - Historical aggregations"
+    },
+    "methodologies-and-data-sources": {
+      "title": "Methodologies and data sources"
     }
   },
   "header": {

--- a/web/src/utils/constants.ts
+++ b/web/src/utils/constants.ts
@@ -48,7 +48,6 @@ export enum Charts {
 }
 
 export enum TrackEvent {
-  DATA_SOURCES_CLICKED = 'Data Sources Clicked',
   APP_BANNER_CTA_CLICKED = 'App Banner CTA Clicked',
   APP_BANNER_DISMISSED = 'App Banner Dismissed',
   SHARE_BUTTON_CLICKED = 'Share Button Clicked',
@@ -67,7 +66,7 @@ export enum TrackEvent {
   PANEL_PRODUCTION_BUTTON_CLICKED = 'PanelProductionButton Clicked',
   PANEL_EMISSION_BUTTON_CLICKED = 'PanelEmissionButton Clicked',
   ESTIMATION_CARD_METHODOLOGY_LINK_CLICKED = 'EstimationCard Methodology Link Clicked',
-  APPLIED_METHODOLOGIES_EXPANDED = 'AppliedMethodologies Expanded',
+  METHODOLOGIES_AND_DATA_SOURCES_EXPANDED = 'Methodologies and Data Sources Expanded',
   TIME_AGGREGATE_BUTTON_CLICKED = 'Time Aggregate Button Clicked',
   SOLAR_ENABLED = 'Solar Enabled',
   SOLAR_DISABLED = 'Solar Disabled',


### PR DESCRIPTION
## Description
[AVO-621](https://linear.app/electricitymaps/issue/AVO-621/move-data-sources-to-a-unified-methodology-and-data-sources): Consolidate data sources and methodologies.
Hopefully this change will allow users to capture more than one chart in a screenshot.

Notes:
- I didn't see any sources in the code re:exchange data (per [designs](https://www.figma.com/design/O1DtS6UyZHSH4IymG8Ufsw/%F0%9F%8E%B9-Design-Hack?node-id=5808-14093&node-type=frame&t=mBzICACphNUG5VxQ-0))
- Do we want to use the wind turbine fa-icon for power generation, also per designs?

### Preview
|Accordian|Charts|
|---|---|
|<img width="369" alt="Screenshot 2024-11-05 at 13 03 25" src="https://github.com/user-attachments/assets/a129d5d3-dc93-4fd4-9b8e-76056807e9df">|<img width="368" alt="Screenshot 2024-11-05 at 13 03 55" src="https://github.com/user-attachments/assets/4e983998-3592-466f-9a40-d3e11e06f71a">|

Dark Mode:
<img width="265" alt="Screenshot 2024-11-05 at 13 21 03" src="https://github.com/user-attachments/assets/a0a1f12a-ace5-4fec-8b2f-c64e10db8bde">

### Double check

- [ ] I have tested my parser changes locally with `poetry run test_parser "zone_key"`
- [ ] I have run `pnpx prettier@2 --write .` and `poetry run format` in the top level directory to format my changes.
