### PR TITLE
feat(web): handle historcal linking with basic navigation

### DIFF
--- a/web/cypress/e2e/countrypanel.spec.ts
+++ b/web/cypress/e2e/countrypanel.spec.ts
@@ -3,7 +3,6 @@
 describe('Country Panel', () => {
   beforeEach(() => {
     cy.interceptAPI('v8/state/hourly');
-    cy.interceptAPI('v8/state/last_hour');
     cy.interceptAPI('v8/meta');
   });
 
@@ -86,7 +85,6 @@ describe('Country Panel', () => {
 
   it('asserts countryPanel contains no parser message when zone has no data', () => {
     // Add all required API intercepts
-    cy.interceptAPI('v8/state/last_hour');
     cy.interceptAPI('v8/state/hourly');
     cy.interceptAPI('v8/details/hourly/CN');
     cy.interceptAPI('v8/meta'); // Add this if needed
@@ -97,7 +95,6 @@ describe('Country Panel', () => {
       },
     });
 
-    cy.waitForAPISuccess('v8/state/last_hour');
     cy.waitForAPISuccess('v8/state/hourly');
     cy.waitForAPISuccess('v8/details/hourly/CN');
 

--- a/web/cypress/e2e/countrypanel.spec.ts
+++ b/web/cypress/e2e/countrypanel.spec.ts
@@ -85,15 +85,22 @@ describe('Country Panel', () => {
   });
 
   it('asserts countryPanel contains no parser message when zone has no data', () => {
+    // Add all required API intercepts
+    cy.interceptAPI('v8/state/last_hour');
+    cy.interceptAPI('v8/state/hourly');
     cy.interceptAPI('v8/details/hourly/CN');
-    cy.visit('/zone/CN?lang=en-GB', {
+    cy.interceptAPI('v8/meta'); // Add this if needed
+
+    cy.visit('/zone/CN/24h?lang=en-GB', {
       onBeforeLoad(win) {
         delete win.navigator.__proto__.serviceWorker;
       },
     });
+
     cy.waitForAPISuccess('v8/state/last_hour');
     cy.waitForAPISuccess('v8/state/hourly');
     cy.waitForAPISuccess('v8/details/hourly/CN');
+
     cy.get('[data-test-id=no-parser-message]').should('exist');
   });
 

--- a/web/cypress/e2e/ranking.spec.ts
+++ b/web/cypress/e2e/ranking.spec.ts
@@ -2,13 +2,11 @@
 describe('Ranking Panel', () => {
   it('interacts with details', () => {
     cy.interceptAPI('v8/meta');
-    cy.interceptAPI('v8/state/last_hour');
     cy.interceptAPI('v8/state/hourly');
     cy.interceptAPI('v8/details/hourly/DK-DK2');
     cy.visit('/?lang=en-GB');
     cy.get('[data-test-id=close-modal]').click();
     cy.waitForAPISuccess(`v8/meta`);
-    cy.waitForAPISuccess(`v8/state/last_hour`);
     cy.waitForAPISuccess(`v8/state/hourly`);
     cy.get('[data-test-id=loading-overlay]').should('not.exist');
 

--- a/web/src/api/getState.ts
+++ b/web/src/api/getState.ts
@@ -8,7 +8,7 @@ import { URL_TO_TIME_AVERAGE } from 'utils/state/atoms';
 import { cacheBuster, getBasePath, isValidDate, QUERY_KEYS } from './helpers';
 
 const getState = async (
-  timeAverage: TimeAverages | 'last_hour',
+  timeAverage: TimeAverages,
   targetDatetime?: string
 ): Promise<GridState> => {
   const shouldQueryHistorical =

--- a/web/src/api/getState.ts
+++ b/web/src/api/getState.ts
@@ -37,11 +37,15 @@ const useGetState = (): UseQueryResult<GridState> => {
     urlTimeAverage: UrlTimeAverages;
     urlDatetime?: string;
   }>();
-  const isHourly = urlTimeAverage === UrlTimeAverages['24h'];
+  const isHourly = urlTimeAverage
+    ? URL_TO_TIME_AVERAGE[urlTimeAverage] === TimeAverages.HOURLY
+    : false;
+
   const shouldUseLastHour = isHourly && !urlDatetime;
   const timeAverage = urlTimeAverage
     ? URL_TO_TIME_AVERAGE[urlTimeAverage]
     : TimeAverages.HOURLY;
+  console.log('shouldUseLastHour', shouldUseLastHour, isHourly, urlTimeAverage);
   const lastHourQuery = useQuery<GridState>({
     queryKey: [QUERY_KEYS.STATE, { aggregate: 'last_hour' }],
     queryFn: () => getState('last_hour'),

--- a/web/src/api/getState.ts
+++ b/web/src/api/getState.ts
@@ -1,17 +1,28 @@
 import type { UseQueryResult } from '@tanstack/react-query';
-import { useQuery } from '@tanstack/react-query';
-import { useAtom, useAtomValue } from 'jotai';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
+import { useEffect } from 'react';
+import { useParams } from 'react-router-dom';
 import type { GridState } from 'types';
-import { isHourlyAtom, timeAverageAtom } from 'utils/state/atoms';
+import { TimeAverages, UrlTimeAverages } from 'utils/constants';
+import { URL_TO_TIME_AVERAGE } from 'utils/state/atoms';
 
-import { cacheBuster, getBasePath, QUERY_KEYS } from './helpers';
+import { cacheBuster, getBasePath, isValidDate, QUERY_KEYS } from './helpers';
 
-const getState = async (timeAverage: string): Promise<GridState> => {
-  const path: URL = new URL(`v8/state/${timeAverage}`, getBasePath());
-  path.searchParams.append('cacheKey', cacheBuster());
+const getState = async (
+  timeAverage: TimeAverages | 'last_hour',
+  targetDatetime?: string
+): Promise<GridState> => {
+  const shouldQueryHistorical =
+    targetDatetime && isValidDate(targetDatetime) && timeAverage === TimeAverages.HOURLY;
+  const path: URL = new URL(
+    `v8/state/${timeAverage}${
+      shouldQueryHistorical ? `?targetDate=${targetDatetime}` : ''
+    }`,
+    getBasePath()
+  );
 
+  !targetDatetime && path.searchParams.append('cacheKey', cacheBuster());
   const response = await fetch(path);
-
   if (response.ok) {
     const result = (await response.json()) as GridState;
     return result;
@@ -21,30 +32,52 @@ const getState = async (timeAverage: string): Promise<GridState> => {
 };
 
 const useGetState = (): UseQueryResult<GridState> => {
-  const [timeAverage] = useAtom(timeAverageAtom);
-  const isHourly = useAtomValue(isHourlyAtom);
-
-  // First fetch last hour only
-  const last_hour = useQuery<GridState>({
+  const queryClient = useQueryClient();
+  const { urlTimeAverage, urlDatetime } = useParams<{
+    urlTimeAverage: UrlTimeAverages;
+    urlDatetime?: string;
+  }>();
+  console.log('urlDatetime', urlDatetime);
+  const isHourly = urlTimeAverage === UrlTimeAverages['24h'];
+  const shouldUseLastHour = isHourly && !urlDatetime;
+  const timeAverage = urlTimeAverage
+    ? URL_TO_TIME_AVERAGE[urlTimeAverage]
+    : TimeAverages.HOURLY;
+  const lastHourQuery = useQuery<GridState>({
     queryKey: [QUERY_KEYS.STATE, { aggregate: 'last_hour' }],
-    queryFn: async () => getState('last_hour'),
-    enabled: isHourly,
+    queryFn: () => getState('last_hour'),
+    enabled: shouldUseLastHour,
   });
 
-  const hourZeroWasSuccessful = Boolean(last_hour.isLoading === false && last_hour.data);
-
-  const shouldFetchFullState =
-    !isHourly || hourZeroWasSuccessful || last_hour.isError === true;
-
-  // Then fetch the rest of the data
-  const all_data = useQuery<GridState>({
-    queryKey: [QUERY_KEYS.STATE, { aggregate: timeAverage }],
-    queryFn: async () => getState(timeAverage),
-
-    // The query should not execute until the last_hour query is done
-    enabled: shouldFetchFullState,
+  const fullDataQuery = useQuery<GridState>({
+    queryKey: [
+      QUERY_KEYS.STATE,
+      {
+        aggregate: timeAverage,
+        targetDatetime: urlDatetime,
+      },
+    ],
+    queryFn: () => getState(timeAverage, urlDatetime),
+    enabled: !shouldUseLastHour || (shouldUseLastHour && lastHourQuery.isSuccess),
   });
-  return (all_data.data || !isHourly ? all_data : last_hour) ?? {};
+
+  useEffect(() => {
+    if (shouldUseLastHour && fullDataQuery.data) {
+      queryClient.setQueryData(
+        [QUERY_KEYS.STATE, { aggregate: 'last_hour' }],
+        fullDataQuery.data
+      );
+    }
+  }, [shouldUseLastHour, fullDataQuery.data, queryClient]);
+
+  if (shouldUseLastHour) {
+    if (!fullDataQuery.data && lastHourQuery.data) {
+      return lastHourQuery;
+    }
+    return fullDataQuery;
+  }
+
+  return fullDataQuery;
 };
 
 export default useGetState;

--- a/web/src/api/getState.ts
+++ b/web/src/api/getState.ts
@@ -37,7 +37,6 @@ const useGetState = (): UseQueryResult<GridState> => {
     urlTimeAverage: UrlTimeAverages;
     urlDatetime?: string;
   }>();
-  console.log('urlDatetime', urlDatetime);
   const isHourly = urlTimeAverage === UrlTimeAverages['24h'];
   const shouldUseLastHour = isHourly && !urlDatetime;
   const timeAverage = urlTimeAverage

--- a/web/src/api/getZone.ts
+++ b/web/src/api/getZone.ts
@@ -25,8 +25,9 @@ const getZone = async (
     }`,
     getBasePath()
   );
-  !targetDatetime && path.searchParams.append('cacheKey', cacheBuster());
-
+  if (!targetDatetime) {
+    path.searchParams.append('cacheKey', cacheBuster());
+  }
   const requestOptions: RequestInit = {
     method: 'GET',
     headers: await getHeaders(path),

--- a/web/src/api/getZone.ts
+++ b/web/src/api/getZone.ts
@@ -1,22 +1,31 @@
 import type { UseQueryResult } from '@tanstack/react-query';
 import { useQuery } from '@tanstack/react-query';
-import { useAtomValue } from 'jotai';
 import { useParams } from 'react-router-dom';
 import invariant from 'tiny-invariant';
 import type { ZoneDetails } from 'types';
 import { RouteParameters } from 'types';
 import { TimeAverages } from 'utils/constants';
-import { timeAverageAtom } from 'utils/state/atoms';
+import { URL_TO_TIME_AVERAGE } from 'utils/state/atoms';
 
-import { cacheBuster, getBasePath, getHeaders, QUERY_KEYS } from './helpers';
+import { cacheBuster, getBasePath, getHeaders, isValidDate, QUERY_KEYS } from './helpers';
 
 const getZone = async (
   timeAverage: TimeAverages,
-  zoneId?: string
+  zoneId: string,
+  targetDatetime?: string
 ): Promise<ZoneDetails> => {
   invariant(zoneId, 'Zone ID is required');
-  const path: URL = new URL(`v8/details/${timeAverage}/${zoneId}`, getBasePath());
-  path.searchParams.append('cacheKey', cacheBuster());
+
+  const shouldQueryHistorical =
+    targetDatetime && isValidDate(targetDatetime) && timeAverage === TimeAverages.HOURLY;
+
+  const path: URL = new URL(
+    `v8/details/${timeAverage}/${zoneId}${
+      shouldQueryHistorical ? `?targetDate=${targetDatetime}` : ''
+    }`,
+    getBasePath()
+  );
+  !targetDatetime && path.searchParams.append('cacheKey', cacheBuster());
 
   const requestOptions: RequestInit = {
     method: 'GET',
@@ -36,14 +45,26 @@ const getZone = async (
   throw new Error(await response.text());
 };
 
-// TODO: The frontend (graphs) expects that the datetimes in state are the same as in zone
-// should we add a check for this?
 const useGetZone = (): UseQueryResult<ZoneDetails> => {
-  const { zoneId } = useParams<RouteParameters>();
-  const timeAverage = useAtomValue(timeAverageAtom);
+  const { zoneId, urlTimeAverage, urlDatetime } = useParams<RouteParameters>();
+  const timeAverage = urlTimeAverage
+    ? URL_TO_TIME_AVERAGE[urlTimeAverage]
+    : TimeAverages.HOURLY;
   return useQuery<ZoneDetails>({
-    queryKey: [QUERY_KEYS.ZONE, { zone: zoneId, aggregate: timeAverage }],
-    queryFn: async () => getZone(timeAverage, zoneId),
+    queryKey: [
+      QUERY_KEYS.ZONE,
+      {
+        zone: zoneId,
+        aggregate: urlTimeAverage,
+        targetDatetime: urlDatetime,
+      },
+    ],
+    queryFn: async () => {
+      if (!zoneId) {
+        throw new Error('Zone ID is required');
+      }
+      return getZone(timeAverage, zoneId, urlDatetime);
+    },
   });
 };
 

--- a/web/src/api/helpers.ts
+++ b/web/src/api/helpers.ts
@@ -84,8 +84,7 @@ export const QUERY_KEYS = {
 };
 export function isValidDate(dateString: string) {
   if (Number.isNaN(Date.parse(dateString))) {
-    console.error('Invalid date string', dateString);
-    return false;
+    throw new TypeError('Invalid date string: ' + dateString);
   }
   const oldestDatetimeToSupport = new Date('2017-01-01T00:00:00Z');
   const parsedDate = new Date(dateString);

--- a/web/src/api/helpers.ts
+++ b/web/src/api/helpers.ts
@@ -82,3 +82,15 @@ export const QUERY_KEYS = {
   ZONE: 'zone',
   META: 'meta',
 };
+export function isValidDate(dateString: string) {
+  if (Number.isNaN(Date.parse(dateString))) {
+    console.error('Invalid date string', dateString);
+    return false;
+  }
+  const oldestDatetimeToSupport = new Date('2017-01-01T00:00:00Z');
+  const parsedDate = new Date(dateString);
+  if (parsedDate > oldestDatetimeToSupport) {
+    return true;
+  }
+  return false;
+}

--- a/web/src/components/Button.tsx
+++ b/web/src/components/Button.tsx
@@ -38,7 +38,6 @@ export function Button({
   const As = getComponentType(renderAsLink, asDiv);
   const componentType = renderAsLink ? undefined : 'button';
   const isIconOnly = !children && Boolean(icon);
-
   return (
     <div
       className={twMerge(
@@ -49,7 +48,7 @@ export function Button({
     >
       <As
         className={twMerge(
-          `flex h-full w-full flex-row items-center justify-center rounded-full text-sm font-semibold
+          `flex h-full w-full select-none flex-row items-center justify-center rounded-full text-sm font-semibold
         focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-brand-green disabled:text-neutral-400
         disabled:hover:bg-inherit disabled:dark:text-gray-500 ${getSize(
           size,

--- a/web/src/components/Time.tsx
+++ b/web/src/components/Time.tsx
@@ -1,7 +1,7 @@
 import { useParams } from 'react-router-dom';
 import { RouteParameters } from 'types';
 import { TimeAverages } from 'utils/constants';
-import { formatDate } from 'utils/formatting';
+import { formatDate, formatDateRange } from 'utils/formatting';
 import { getZoneTimezone } from 'utils/helpers';
 
 export function FormattedTime({
@@ -10,19 +10,28 @@ export function FormattedTime({
   timeAverage,
   className,
   zoneId,
+  endDatetime,
 }: {
   datetime: Date;
   language: string;
-  timeAverage: TimeAverages;
+  timeAverage?: TimeAverages;
   className?: string;
   zoneId?: string;
+  endDatetime?: Date;
 }) {
   const { zoneId: pathZoneId } = useParams<RouteParameters>();
   const timeZoneZoneId = zoneId || pathZoneId;
   const timezone = getZoneTimezone(timeZoneZoneId);
+  if (timeAverage) {
+    return (
+      <time dateTime={datetime.toISOString()} className={className}>
+        {formatDate(datetime, language, timeAverage, timezone)}
+      </time>
+    );
+  }
   return (
     <time dateTime={datetime.toISOString()} className={className}>
-      {formatDate(datetime, language, timeAverage, timezone)}
+      {endDatetime && formatDateRange(datetime, endDatetime, language, timezone)}
     </time>
   );
 }

--- a/web/src/features/time/HistoricalTimeHeader.tsx
+++ b/web/src/features/time/HistoricalTimeHeader.tsx
@@ -22,27 +22,29 @@ export default function HistoricalTimeHeader() {
   const { urlDatetime } = useParams<RouteParameters>();
   const navigate = useNavigateWithParameters();
 
-  const handleTimeNavigation = (direction: 'left' | 'right') => {
-    if (!endDatetime || (!urlDatetime && direction === 'right')) {
+  function handleRightClick() {
+    if (!endDatetime || !urlDatetime) {
       return;
     }
+    const currentEndDatetime = new Date(endDatetime);
+    const newDate = new Date(currentEndDatetime.getTime() + TWENTY_FOUR_HOURS);
 
-    const currentDate = urlDatetime ? new Date(urlDatetime) : new Date(endDatetime);
-    const newDate = new Date(
-      currentDate.getTime() +
-        (direction === 'left' ? -TWENTY_FOUR_HOURS : TWENTY_FOUR_HOURS)
-    );
-
-    if (direction === 'right') {
-      const twentyFourHoursAgo = new Date(Date.now() - TWENTY_FOUR_HOURS);
-      if (newDate >= twentyFourHoursAgo) {
-        navigate({ datetime: '' });
-        return;
-      }
+    const twentyFourHoursAgo = new Date(Date.now() - TWENTY_FOUR_HOURS);
+    if (newDate >= twentyFourHoursAgo) {
+      navigate({ datetime: '' });
+      return;
     }
-
     navigate({ datetime: newDate.toISOString() });
-  };
+  }
+
+  function handleLeftClick() {
+    if (!endDatetime) {
+      return;
+    }
+    const currentEndDatetime = new Date(endDatetime);
+    const newDate = new Date(currentEndDatetime.getTime() - TWENTY_FOUR_HOURS);
+    navigate({ datetime: newDate.toISOString() });
+  }
 
   return (
     <div className="flex min-h-6 flex-row items-center justify-between">
@@ -61,7 +63,7 @@ export default function HistoricalTimeHeader() {
       <div className="flex flex-row items-center gap-2">
         <Button
           backgroundClasses="bg-transparent"
-          onClick={() => handleTimeNavigation('left')}
+          onClick={handleLeftClick}
           size="sm"
           type="tertiary"
           isDisabled={!isHourly}
@@ -74,7 +76,7 @@ export default function HistoricalTimeHeader() {
         <Button
           backgroundClasses="bg-transparent"
           size="sm"
-          onClick={() => handleTimeNavigation('right')}
+          onClick={handleRightClick}
           type="tertiary"
           isDisabled={!isHourly || !urlDatetime}
           icon={

--- a/web/src/features/time/HistoricalTimeHeader.tsx
+++ b/web/src/features/time/HistoricalTimeHeader.tsx
@@ -101,7 +101,6 @@ export default function HistoricalTimeHeader() {
           isDisabled={!isHourly || !urlDatetime}
           icon={
             <ChevronRight
-              onClick={handleRightClick}
               className={twMerge(
                 'text-brand-green',
                 (!urlDatetime || !isHourly) && 'opacity-50'

--- a/web/src/features/time/HistoricalTimeHeader.tsx
+++ b/web/src/features/time/HistoricalTimeHeader.tsx
@@ -9,7 +9,7 @@ import { useParams } from 'react-router-dom';
 import { twMerge } from 'tailwind-merge';
 import { RouteParameters } from 'types';
 import { useNavigateWithParameters } from 'utils/helpers';
-import { endDatetimeAtom, startDatetimeAtom } from 'utils/state/atoms';
+import { endDatetimeAtom, isHourlyAtom, startDatetimeAtom } from 'utils/state/atoms';
 
 function setToMidnightUTC(date: Date): Date {
   const newDate = new Date(date);
@@ -27,6 +27,7 @@ export default function HistoricalTimeHeader() {
   const { isLoading } = useGetState();
   const { urlDatetime } = useParams<RouteParameters>();
   const navigate = useNavigateWithParameters();
+  const isHourly = useAtomValue(isHourlyAtom);
   function handleLeftClick() {
     if (!urlDatetime && !endDatetime) {
       return;
@@ -58,7 +59,6 @@ export default function HistoricalTimeHeader() {
     const now = new Date();
     const twentyFourHoursAgo = setToMidnightUTC(now);
     twentyFourHoursAgo.setUTCDate(twentyFourHoursAgo.getUTCDate() - 1);
-
     if (newDate >= twentyFourHoursAgo) {
       navigate({ datetime: '' });
       return;
@@ -81,11 +81,34 @@ export default function HistoricalTimeHeader() {
         />
       )}
       <div className="flex flex-row items-center gap-2">
-        <ChevronLeft onClick={handleLeftClick} className="text-brand-green" />
-        <ChevronRight
-          onClick={handleRightClick}
-          className={twMerge('text-brand-green', !urlDatetime && 'opacity-50')}
+        <Button
+          backgroundClasses="bg-transparent"
+          onClick={handleLeftClick}
+          size="sm"
+          type="tertiary"
+          isDisabled={!isHourly}
+          icon={
+            <ChevronLeft
+              className={twMerge('text-brand-green', !isHourly && 'opacity-50')}
+            />
+          }
         />
+        <Button
+          backgroundClasses="bg-transparent"
+          size="sm"
+          onClick={handleRightClick}
+          type="tertiary"
+          isDisabled={!isHourly || !urlDatetime}
+          icon={
+            <ChevronRight
+              onClick={handleRightClick}
+              className={twMerge(
+                'text-brand-green',
+                (!urlDatetime || !isHourly) && 'opacity-50'
+              )}
+            />
+          }
+        ></Button>
         <Button
           size="sm"
           type="secondary"

--- a/web/src/features/time/HistoricalTimeHeader.tsx
+++ b/web/src/features/time/HistoricalTimeHeader.tsx
@@ -1,0 +1,102 @@
+import useGetState from 'api/getState';
+import Badge from 'components/Badge';
+import { Button } from 'components/Button';
+import { FormattedTime } from 'components/Time';
+import { useAtomValue } from 'jotai';
+import { ChevronLeft, ChevronRight } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
+import { useParams } from 'react-router-dom';
+import { twMerge } from 'tailwind-merge';
+import { RouteParameters } from 'types';
+import { useNavigateWithParameters } from 'utils/helpers';
+import { endDatetimeAtom, startDatetimeAtom } from 'utils/state/atoms';
+
+function setToMidnightUTC(date: Date): Date {
+  const newDate = new Date(date);
+  newDate.setUTCHours(0, 0, 0, 0);
+  return newDate;
+}
+function formatDateToISO(date: Date): string {
+  return date.toISOString().slice(0, -5) + 'Z';
+}
+
+export default function HistoricalTimeHeader() {
+  const { i18n } = useTranslation();
+  const startDatetime = useAtomValue(startDatetimeAtom);
+  const endDatetime = useAtomValue(endDatetimeAtom);
+  const { isLoading } = useGetState();
+  const { urlDatetime } = useParams<RouteParameters>();
+  const navigate = useNavigateWithParameters();
+  function handleLeftClick() {
+    if (!urlDatetime && !endDatetime) {
+      return;
+    }
+
+    const targetDate = urlDatetime ? new Date(urlDatetime) : endDatetime;
+    if (!targetDate) {
+      return;
+    }
+
+    const midnightDate = setToMidnightUTC(targetDate);
+    const newDate = new Date(midnightDate);
+    urlDatetime
+      ? newDate.setUTCDate(midnightDate.getUTCDate() - 1)
+      : newDate.setUTCDate(midnightDate.getUTCDate());
+
+    navigate({ datetime: formatDateToISO(newDate) });
+  }
+
+  function handleRightClick() {
+    if (!endDatetime) {
+      return;
+    }
+
+    const midnightDate = setToMidnightUTC(new Date(endDatetime));
+    const newDate = new Date(midnightDate);
+    newDate.setUTCDate(midnightDate.getUTCDate() + 1);
+
+    const now = new Date();
+    const twentyFourHoursAgo = setToMidnightUTC(now);
+    twentyFourHoursAgo.setUTCDate(twentyFourHoursAgo.getUTCDate() - 1);
+
+    if (newDate >= twentyFourHoursAgo) {
+      navigate({ datetime: '' });
+      return;
+    }
+
+    navigate({ datetime: formatDateToISO(newDate) });
+  }
+  return (
+    <div className="flex min-h-6 flex-row items-center justify-between">
+      {!isLoading && startDatetime && endDatetime && (
+        <Badge
+          pillText={
+            <FormattedTime
+              datetime={startDatetime}
+              language={i18n.languages[0]}
+              endDatetime={endDatetime}
+            />
+          }
+          type="success"
+        />
+      )}
+      <div className="flex flex-row items-center gap-2">
+        <ChevronLeft onClick={handleLeftClick} className="text-brand-green" />
+        <ChevronRight
+          onClick={handleRightClick}
+          className={twMerge('text-brand-green', !urlDatetime && 'opacity-50')}
+        />
+        <Button
+          size="sm"
+          type="secondary"
+          onClick={() => {
+            navigate({ datetime: '' });
+          }}
+          isDisabled={!urlDatetime}
+        >
+          Latest
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/web/src/features/time/TimeController.tsx
+++ b/web/src/features/time/TimeController.tsx
@@ -1,7 +1,8 @@
 import useGetState from 'api/getState';
 import TimeAverageToggle from 'components/TimeAverageToggle';
 import TimeSlider from 'components/TimeSlider';
-import { useAtom, useAtomValue } from 'jotai';
+import { useFeatureFlag } from 'features/feature-flags/api';
+import { useAtom, useAtomValue, useSetAtom } from 'jotai';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useParams } from 'react-router-dom';
 import { twMerge } from 'tailwind-merge';
@@ -10,12 +11,15 @@ import trackEvent from 'utils/analytics';
 import { TimeAverages, TrackEvent } from 'utils/constants';
 import { getZoneTimezone } from 'utils/helpers';
 import {
+  endDatetimeAtom,
   isHourlyAtom,
   selectedDatetimeIndexAtom,
+  startDatetimeAtom,
   useTimeAverageSync,
 } from 'utils/state/atoms';
 import { useIsBiggerThanMobile } from 'utils/styling';
 
+import HistoricalTimeHeader from './HistoricalTimeHeader';
 import TimeAxis from './TimeAxis';
 import TimeHeader from './TimeHeader';
 
@@ -27,9 +31,11 @@ export default function TimeController({ className }: { className?: string }) {
   const isBiggerThanMobile = useIsBiggerThanMobile();
   const { zoneId } = useParams<RouteParameters>();
   const [selectedTimeAverage, setTimeAverage] = useTimeAverageSync();
-
+  const setEndDatetime = useSetAtom(endDatetimeAtom);
+  const setStartDatetime = useSetAtom(startDatetimeAtom);
+  const { urlDatetime } = useParams();
+  const historicalLinkingEnabled = useFeatureFlag('historical-linking');
   const zoneTimezone = getZoneTimezone(zoneId);
-
   // Show a loading state if isLoading is true or if there is only one datetime,
   // as this means we either have no data or only have latest hour loaded yet
   const isLoading = dataLoading || Object.keys(data?.data?.datetimes ?? {}).length === 1;
@@ -52,8 +58,10 @@ export default function TimeController({ className }: { className?: string }) {
         datetime: datetimes.at(-1) as Date,
         index: datetimes.length - 1,
       });
+      setEndDatetime(datetimes.at(-1));
+      setStartDatetime(datetimes.at(0));
     }
-  }, [data, datetimes, setSelectedDatetime]);
+  }, [data, datetimes, setEndDatetime, setSelectedDatetime, setStartDatetime]);
 
   const onTimeSliderChange = useCallback(
     (index: number) => {
@@ -81,14 +89,17 @@ export default function TimeController({ className }: { className?: string }) {
     },
     [setSelectedDatetime, selectedDatetime.datetime, numberOfEntries, setTimeAverage]
   );
-
   return (
     <div className={twMerge(className, 'flex flex-col gap-3')}>
-      {isBiggerThanMobile && <TimeHeader />}
-      <TimeAverageToggle
-        timeAverage={selectedTimeAverage || TimeAverages.HOURLY}
-        onToggleGroupClick={onToggleGroupClick}
-      />
+      {isBiggerThanMobile && !historicalLinkingEnabled && <TimeHeader />}
+      {isBiggerThanMobile && historicalLinkingEnabled && <HistoricalTimeHeader />}
+      <div className="flex items-center gap-2">
+        <TimeAverageToggle
+          timeAverage={selectedTimeAverage || TimeAverages.HOURLY}
+          onToggleGroupClick={onToggleGroupClick}
+        />
+      </div>
+
       <div>
         {/* The above div is needed to treat the TimeSlider and TimeAxis as one DOM element */}
         <TimeSlider
@@ -102,7 +113,7 @@ export default function TimeController({ className }: { className?: string }) {
           isLoading={isLoading}
           className="h-[22px] w-full overflow-visible"
           transform={`translate(12, 0)`}
-          isLiveDisplay={isHourly}
+          isLiveDisplay={isHourly && !urlDatetime}
           timezone={zoneTimezone}
         />
       </div>

--- a/web/src/utils/formatting.ts
+++ b/web/src/utils/formatting.ts
@@ -247,6 +247,33 @@ const formatDateTick = (
   }
 };
 
+export function formatDateRange(
+  startDate: Date,
+  endDate: Date,
+  locale = 'en-US',
+  timeZone?: string
+) {
+  const formatter = new Intl.DateTimeFormat(locale, {
+    month: 'short',
+    day: 'numeric',
+    year: 'numeric',
+    timeZone,
+  });
+
+  // If dates are in the same month and year
+  if (
+    startDate.getMonth() === endDate.getMonth() &&
+    startDate.getFullYear() === endDate.getFullYear()
+  ) {
+    return `${new Intl.DateTimeFormat(locale, { month: 'short' }).format(
+      startDate
+    )} ${startDate.getDate()} - ${endDate.getDate()}, ${startDate.getFullYear()}`;
+  }
+
+  // If dates are in different months or years
+  return `${formatter.format(startDate)} - ${formatter.format(endDate)}`;
+}
+
 function isValidDate(date: Date) {
   if (!date || !(date instanceof Date)) {
     return false;

--- a/web/src/utils/formatting.ts
+++ b/web/src/utils/formatting.ts
@@ -260,18 +260,7 @@ export function formatDateRange(
     timeZone,
   });
 
-  // If dates are in the same month and year
-  if (
-    startDate.getMonth() === endDate.getMonth() &&
-    startDate.getFullYear() === endDate.getFullYear()
-  ) {
-    return `${new Intl.DateTimeFormat(locale, { month: 'short' }).format(
-      startDate
-    )} ${startDate.getDate()} - ${endDate.getDate()}, ${startDate.getFullYear()}`;
-  }
-
-  // If dates are in different months or years
-  return `${formatter.format(startDate)} - ${formatter.format(endDate)}`;
+  return formatter.formatRange(startDate, endDate);
 }
 
 function isValidDate(date: Date) {

--- a/web/src/utils/state/atoms.ts
+++ b/web/src/utils/state/atoms.ts
@@ -18,7 +18,7 @@ import {
 
 export const timeAverageAtom = atom<TimeAverages>(TimeAverages.HOURLY);
 
-const URL_TO_TIME_AVERAGE: Record<string, TimeAverages> = {
+export const URL_TO_TIME_AVERAGE: Record<string, TimeAverages> = {
   '24h': TimeAverages.HOURLY,
   '30d': TimeAverages.DAILY,
   '12mo': TimeAverages.MONTHLY,
@@ -54,7 +54,8 @@ export const isHourlyAtom = atom((get) => get(timeAverageAtom) === TimeAverages.
 
 // TODO: consider another initial value
 export const selectedDatetimeIndexAtom = atom({ datetime: new Date(), index: 0 });
-
+export const endDatetimeAtom = atom<Date | undefined>(undefined);
+export const startDatetimeAtom = atom<Date | undefined>(undefined);
 export const selectedDatetimeStringAtom = atom<string>((get) => {
   const { datetime } = get(selectedDatetimeIndexAtom);
   return dateToDatetimeString(datetime);


### PR DESCRIPTION
## Issue
View historical data with hourly granularity

## Description
Currently behind the feature flag `historical-linking`

This PR updates the state and zone requests to be able to query historical data at at hourly granularity and some basic navigation between time windows.

The navigation currently going back to the more recent utc 00:00 hour for the first click and subtracts 24 hours from there. 

In the spirit of deploying early and often I'd like to release this behind the feature flag and get it in the hands of our test users asap for feedback. 