### PR TITLE
bug(web): multiple api calls when not hourly

### DIFF
--- a/web/src/api/getState.ts
+++ b/web/src/api/getState.ts
@@ -23,13 +23,11 @@ const getState = async (timeAverage: string): Promise<GridState> => {
 };
 
 const useGetState = (): UseQueryResult<GridState> => {
-  const [timeAverage] = useAtom(timeAverageAtom);
   const { urlTimeAverage } = useParams<RouteParameters>();
-  const isHourly = urlTimeAverage
-    ? URL_TO_TIME_AVERAGE[urlTimeAverage] === TimeAverages.HOURLY
-    : false;
-
-  console.log('isHourly', isHourly, urlTimeAverage);
+  const timeAverage = urlTimeAverage
+    ? URL_TO_TIME_AVERAGE[urlTimeAverage]
+    : TimeAverages.HOURLY;
+  const isHourly = urlTimeAverage ? timeAverage === TimeAverages.HOURLY : false;
 
   // First fetch last hour only
   const last_hour = useQuery<GridState>({
@@ -41,10 +39,7 @@ const useGetState = (): UseQueryResult<GridState> => {
   const hourZeroWasSuccessful = Boolean(last_hour.isLoading === false && last_hour.data);
 
   const shouldFetchFullState =
-    isHourly ||
-    hourZeroWasSuccessful ||
-    last_hour.isError === true ||
-    timeAverage !== 'hourly';
+    !isHourly || hourZeroWasSuccessful || last_hour.isError === true;
 
   // Then fetch the rest of the data
   const all_data = useQuery<GridState>({

--- a/web/src/api/getState.ts
+++ b/web/src/api/getState.ts
@@ -32,7 +32,7 @@ const useGetState = (): UseQueryResult<GridState> => {
   const last_hour = useQuery<GridState>({
     queryKey: [QUERY_KEYS.STATE, { aggregate: 'last_hour' }],
     queryFn: async () => getState('last_hour'),
-    enabled: isHourly && timeAverage === 'hourly',
+    enabled: isHourly,
   });
 
   const hourZeroWasSuccessful = Boolean(last_hour.isLoading === false && last_hour.data);

--- a/web/src/api/getState.ts
+++ b/web/src/api/getState.ts
@@ -1,10 +1,9 @@
 import type { UseQueryResult } from '@tanstack/react-query';
 import { useQuery } from '@tanstack/react-query';
-import { useAtom } from 'jotai';
 import { useParams } from 'react-router-dom';
 import type { GridState, RouteParameters } from 'types';
 import { TimeAverages } from 'utils/constants';
-import { timeAverageAtom, URL_TO_TIME_AVERAGE } from 'utils/state/atoms';
+import { URL_TO_TIME_AVERAGE } from 'utils/state/atoms';
 
 import { cacheBuster, getBasePath, QUERY_KEYS } from './helpers';
 

--- a/web/src/api/getZone.ts
+++ b/web/src/api/getZone.ts
@@ -1,12 +1,11 @@
 import type { UseQueryResult } from '@tanstack/react-query';
 import { useQuery } from '@tanstack/react-query';
-import { useAtomValue } from 'jotai';
 import { useParams } from 'react-router-dom';
 import invariant from 'tiny-invariant';
 import type { ZoneDetails } from 'types';
 import { RouteParameters } from 'types';
 import { TimeAverages } from 'utils/constants';
-import { timeAverageAtom } from 'utils/state/atoms';
+import { URL_TO_TIME_AVERAGE } from 'utils/state/atoms';
 
 import { cacheBuster, getBasePath, getHeaders, QUERY_KEYS } from './helpers';
 
@@ -40,7 +39,10 @@ const getZone = async (
 // should we add a check for this?
 const useGetZone = (): UseQueryResult<ZoneDetails> => {
   const { zoneId } = useParams<RouteParameters>();
-  const timeAverage = useAtomValue(timeAverageAtom);
+  const { urlTimeAverage } = useParams<RouteParameters>();
+  const timeAverage = urlTimeAverage
+    ? URL_TO_TIME_AVERAGE[urlTimeAverage]
+    : TimeAverages.HOURLY;
   return useQuery<ZoneDetails>({
     queryKey: [QUERY_KEYS.ZONE, { zone: zoneId, aggregate: timeAverage }],
     queryFn: async () => getZone(timeAverage, zoneId),

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -23,6 +23,7 @@ import {
 } from 'react-router-dom';
 import i18n from 'translation/i18n';
 import { RouteParameters } from 'types';
+import { UrlTimeAverages } from 'utils/constants';
 import { createConsoleGreeting } from 'utils/createConsoleGreeting';
 import enableErrorsInOverlay from 'utils/errorOverlay';
 import { getSentryUuid } from 'utils/getSentryUuid';
@@ -79,24 +80,35 @@ function TimeAverageGuardWrapper({ children }: { children: JSX.Element }) {
   const [searchParameters] = useSearchParams();
   const { urlTimeAverage } = useParams<RouteParameters>();
   const location = useLocation();
+
   if (!urlTimeAverage) {
     return (
       <Navigate
         to={`${location.pathname}/24h?${searchParameters}${location.hash}`}
         replace
-        state={{ preserveSearch: true, preserveHash: true }}
       />
     );
   }
 
   const lowerCaseTimeAverage = urlTimeAverage.toLowerCase();
-  if (urlTimeAverage !== lowerCaseTimeAverage) {
-    const newPath = location.pathname.replace(urlTimeAverage, lowerCaseTimeAverage);
+
+  if (!(lowerCaseTimeAverage in UrlTimeAverages)) {
     return (
       <Navigate
-        to={`${newPath}?${searchParameters}${location.hash}`}
+        to={`${location.pathname}/24h?${searchParameters}${location.hash}`}
         replace
-        state={{ preserveSearch: true, preserveHash: true }}
+      />
+    );
+  }
+
+  if (urlTimeAverage !== lowerCaseTimeAverage) {
+    return (
+      <Navigate
+        to={`${location.pathname.replace(
+          urlTimeAverage,
+          lowerCaseTimeAverage
+        )}?${searchParameters}${location.hash}`}
+        replace
       />
     );
   }
@@ -108,7 +120,7 @@ export function ValidZoneIdGuardWrapper({ children }: { children: JSX.Element })
   const [searchParameters] = useSearchParams();
   const { zoneId, urlTimeAverage } = useParams<RouteParameters>();
   if (!zoneId) {
-    return <Navigate to="/map/24h" replace />;
+    return <Navigate to={`/map/24h?${searchParameters}`} replace />;
   }
 
   const upperCaseZoneId = zoneId.toUpperCase();
@@ -134,7 +146,7 @@ export function ValidZoneIdGuardWrapper({ children }: { children: JSX.Element })
   // Only allow valid zone ids
   // TODO: This should redirect to a 404 page specifically for zones
   if (!zoneExists(upperCaseZoneId)) {
-    return <Navigate to="/map/24h" replace />;
+    return <Navigate to={`/map/24h?${searchParameters}`} replace />;
   }
 
   return children;
@@ -171,23 +183,11 @@ const router = createBrowserRouter([
       },
       {
         path: '/map',
-        element: (
-          <Navigate
-            to="/map/24h"
-            replace
-            state={{ preserveSearch: true, preserveHash: true }}
-          />
-        ),
+        element: <Navigate to="/map/24h" replace />,
       },
       {
         path: '/zone',
-        element: (
-          <Navigate
-            to="/map/24h"
-            replace
-            state={{ preserveSearch: true, preserveHash: true }}
-          />
-        ),
+        element: <Navigate to="/map/24h" replace />,
       },
       {
         path: '/map/:urlTimeAverage?/:urlDatetime?',

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -17,6 +17,7 @@ import {
   createBrowserRouter,
   Navigate,
   RouterProvider,
+  useLocation,
   useParams,
   useSearchParams,
 } from 'react-router-dom';
@@ -77,9 +78,20 @@ refetchDataOnHourChange(queryClient);
 export function ValidZoneIdGuardWrapper({ children }: { children: JSX.Element }) {
   const [searchParameters] = useSearchParams();
   const { zoneId, urlTimeAverage } = useParams<RouteParameters>();
+  const location = useLocation();
   if (!zoneId) {
     return <Navigate to="/map/24h" replace />;
   }
+  if (!urlTimeAverage) {
+    return (
+      <Navigate
+        to={`/zone/${zoneId}/24h?${searchParameters}${location.hash}`}
+        replace
+        state={{ preserveSearch: true, preserveHash: true }}
+      />
+    );
+  }
+
   const upperCaseZoneId = zoneId.toUpperCase();
   if (zoneId !== upperCaseZoneId) {
     return (

--- a/web/src/utils/state/atoms.ts
+++ b/web/src/utils/state/atoms.ts
@@ -18,7 +18,7 @@ import {
 
 export const timeAverageAtom = atom<TimeAverages>(TimeAverages.HOURLY);
 
-const URL_TO_TIME_AVERAGE: Record<string, TimeAverages> = {
+export const URL_TO_TIME_AVERAGE: Record<string, TimeAverages> = {
   '24h': TimeAverages.HOURLY,
   '30d': TimeAverages.DAILY,
   '12mo': TimeAverages.MONTHLY,


### PR DESCRIPTION
## Issue
When not in the hourly view we are fetching data twice as the atoms initialize.

## Description
This PR updates our fetching to treat the url as the source of truth.


The bug is present on staging so it would be good to get this fix out before releasing contrib. 