### PR TITLE
chore(sitemap): Add url time averages to sitemap links

### DIFF
--- a/web/scripts/generateSitemap.js
+++ b/web/scripts/generateSitemap.js
@@ -2,8 +2,13 @@
 
 import fs from 'node:fs';
 import path from 'node:path';
+
 import { fileURLToPath } from 'url';
+
 import zonesConfig from '../config/zones.json' assert { type: 'json' };
+
+// Import this from the constant file when this script is in typescript
+const UrlTimeAverages = ['24h', '30d', '12mo', 'all'];
 
 // Fix the paths for Windows/Linux consistency
 let dirname = path.dirname(fileURLToPath(import.meta.url));
@@ -25,7 +30,12 @@ function generateSitemap() {
   }
 
   const zoneUrls = Object.keys(zonesConfig.zones)
-    .map((zone) => `<url><loc>https://app.electricitymaps.com/zone/${zone}</loc></url>`)
+    .flatMap((zone) =>
+      UrlTimeAverages.map(
+        (timeAverage) =>
+          `<url><loc>https://app.electricitymaps.com/zone/${zone}/${timeAverage}</loc></url>`
+      )
+    )
     .join('');
 
   const sitemap = `<?xml version="1.0" encoding="UTF-8"?>


### PR DESCRIPTION
## Issue

We are not including the new links with the urlTimeAverages in the sitemap.

## Description

Adds this to the sitemap to ensure it's properly picked up by Google and other search engines.

### Double check

- [x] I have run `pnpx prettier@2 --write .` and `poetry run format` in the top level directory to format my changes.
