### PR TITLE
fix(parsers): Make negative wind values zero GB-NIR

### DIFF
--- a/parsers/SMARTGRIDDASHBOARD.py
+++ b/parsers/SMARTGRIDDASHBOARD.py
@@ -156,7 +156,7 @@ def fetch_production(
 
         productionMix = ProductionMix()
         if all([item["Value"], wind_prod]):
-            productionMix.add_value("wind", wind_prod)
+            productionMix.add_value("wind", wind_prod, correct_negative_with_zero=True)
             productionMix.add_value("unknown", float(item["Value"]) - wind_prod)
 
         production.append(


### PR DESCRIPTION
## Issue
Repeated ExpectedMode outliers detected for GB-NIR due to missing wind values
<!-- If you want to close an issue automatically when your PR is merged, write "Closes X" where X is the issue number. For example: Closes #000 -->

## Description
Sometimes EirGrid reports negative wind generation values (around -1 to -3 MW) these values are currently set to None in our parser which results in a lot of outliers being detected. It does not seem to be outliers but rather some consumption when the turbines stand still as it fits with EirGrids own low forecasted wind values. This PR makes the negative values zero instead of None. 

The issue is appearing repeatedly. 

<!-- Explains the goal of this PR -->

### Preview
![Screenshot 2024-11-13 at 13 06 44](https://github.com/user-attachments/assets/99c18189-30ee-4b80-99a5-8ca6b5993c60)

Below EirGrids forecast and actual value for wind generation is seen, the negative values seem to be due to turbine consumption. 
![Screenshot 2024-11-13 at 13 10 14](https://github.com/user-attachments/assets/ae0bb201-42b1-4fe6-abef-c3c2f6092327)

<!-- Please add screenshots and/or gif that shows visual changes (if applicable) -->

### Double check

- [x] I have tested my parser changes locally with `poetry run test_parser "zone_key"`
- [x] I have run `pnpx prettier@2 --write .` and `poetry run format` in the top level directory to format my changes.
