### PR TITLE
fix(parsers): GB-NIR update to not add negative wind to unknown

### DIFF
--- a/parsers/SMARTGRIDDASHBOARD.py
+++ b/parsers/SMARTGRIDDASHBOARD.py
@@ -157,7 +157,9 @@ def fetch_production(
         productionMix = ProductionMix()
         if all([item["Value"], wind_prod]):
             productionMix.add_value("wind", wind_prod, correct_negative_with_zero=True)
-            productionMix.add_value("unknown", float(item["Value"]) - wind_prod)
+            productionMix.add_value(
+                "unknown", float(item["Value"]) - productionMix.wind
+            )
 
         production.append(
             zoneKey=zone_key,


### PR DESCRIPTION
## Issue
When receiving negative wind values they are effectively added to the unknown. Now we subtract the productionMix.wind which is zero for negative wind_prod values due to the "correct_negative_with_zero = True"

## Description

<!-- Explains the goal of this PR -->

### Preview

<!-- Please add screenshots and/or gif that shows visual changes (if applicable) -->

### Double check

- [x] I have tested my parser changes locally with `poetry run test_parser "zone_key"`
- [x] I have run `pnpx prettier@2 --write .` and `poetry run format` in the top level directory to format my changes.
