### PR TITLE
chore(SEO): Sanitze zone names in URL

### DIFF
--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -123,21 +123,23 @@ export function ValidZoneIdGuardWrapper({ children }: { children: JSX.Element })
     return <Navigate to={`/map/24h?${searchParameters}`} replace />;
   }
 
-  const upperCaseZoneId = zoneId.toUpperCase();
-  if (zoneId !== upperCaseZoneId) {
-    return (
-      <Navigate
-        to={`/zone/${upperCaseZoneId}/${urlTimeAverage}?${searchParameters}`}
-        replace
-      />
-    );
+  // Sanitize the zone ID by removing any special characters except for hyphens and making it uppercase
+  let sanitizedZoneId = zoneId.replaceAll(/[^\dA-Za-z-]/g, '').toUpperCase();
+
+  // Remove trailing hyphens
+  if (sanitizedZoneId.endsWith('-')) {
+    sanitizedZoneId = sanitizedZoneId.slice(0, -1);
   }
 
-  // Handle legacy Australia zone names
-  if (upperCaseZoneId.startsWith('AUS')) {
+  // Handle legacy Australian zone IDs
+  if (sanitizedZoneId.startsWith('AUS')) {
+    sanitizedZoneId = sanitizedZoneId.replace('AUS', 'AU');
+  }
+
+  if (zoneId !== sanitizedZoneId) {
     return (
       <Navigate
-        to={`/zone/${zoneId.replace('AUS', 'AU')}/${urlTimeAverage}?${searchParameters}`}
+        to={`/zone/${sanitizedZoneId}/${urlTimeAverage}?${searchParameters}`}
         replace
       />
     );
@@ -145,7 +147,7 @@ export function ValidZoneIdGuardWrapper({ children }: { children: JSX.Element })
 
   // Only allow valid zone ids
   // TODO: This should redirect to a 404 page specifically for zones
-  if (!zoneExists(upperCaseZoneId)) {
+  if (!zoneExists(sanitizedZoneId)) {
     return <Navigate to={`/map/24h?${searchParameters}`} replace />;
   }
 


### PR DESCRIPTION
## Issue

In some online platforms when you write a link like this https://app.electricitymaps.com/DK-DK1: Denmark, the colon is included which breaks the links. Similar problems can occur with (https://app.electricitymaps.com/DK-DK2) causing the trailing parentheses to be included in the link.

## Description

In order to avoid this I added a regex that only allows the zoneID to contain, letters, numbers and `-` which we use as a subzone delimiter. This should resolve the issue quite nicely.

I also took to opportunity to clean up the code a bit so it handles more things internally and not potentially causing multiple navigations requests. So instead of going `aus -> AUS -> AU` it simply goes `aus -> AU`.

### Double check

- [x] I have run `pnpx prettier@2 --write .` and `poetry run format` in the top level directory to format my changes.
