### PR TITLE
fruit(web): update US translations with SEO friendly zone names

### DIFF
--- a/web/public/locales/en.json
+++ b/web/public/locales/en.json
@@ -1424,7 +1424,7 @@
     },
     "US-NE-ISNE": {
       "countryName": "USA",
-      "zoneName": "New England ISO"
+      "zoneName": "ISO New England"
     },
     "US-NW-AVA": {
       "countryName": "USA",

--- a/web/src/features/panels/zone/ZoneHeaderTitle.tsx
+++ b/web/src/features/panels/zone/ZoneHeaderTitle.tsx
@@ -7,7 +7,12 @@ import { useGetCanonicalUrl } from 'hooks/useGetCanonicalUrl';
 import { useSetAtom } from 'jotai';
 import { ArrowLeft, Info } from 'lucide-react';
 import { Helmet } from 'react-helmet-async';
-import { getCountryName, getFullZoneName, getZoneName } from 'translation/translation';
+import {
+  getCountryName,
+  getFullZoneName,
+  getSEOZoneName,
+  getZoneName,
+} from 'translation/translation';
 import { ZoneKey } from 'types';
 import { baseUrl, metaTitleSuffix } from 'utils/constants';
 import { useNavigateWithParameters } from 'utils/helpers';
@@ -30,6 +35,7 @@ function getCurrentUrl({ zoneId }: { zoneId: ZoneKey }) {
 
 export default function ZoneHeaderTitle({ zoneId }: ZoneHeaderTitleProps) {
   const zoneName = getZoneName(zoneId);
+  const seoZoneName = getSEOZoneName(zoneId);
   const zoneNameFull = getFullZoneName(zoneId);
   const showTooltip = zoneName !== zoneNameFull || zoneName.length >= MAX_TITLE_LENGTH;
   const navigate = useNavigateWithParameters();
@@ -53,7 +59,7 @@ export default function ZoneHeaderTitle({ zoneId }: ZoneHeaderTitleProps) {
   return (
     <div className="flex w-full items-center pl-2 pr-3 pt-2">
       <Helmet prioritizeSeoTags>
-        <title>{zoneName + metaTitleSuffix}</title>
+        <title>{seoZoneName + metaTitleSuffix}</title>
         <link rel="canonical" href={canonicalUrl} />
       </Helmet>
       <div

--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -1756,7 +1756,8 @@
       "zoneName": "United States Minor Outlying Islands"
     },
     "US": {
-      "zoneName": "Contiguous United States"
+      "zoneName": "Contiguous United States",
+      "seoZoneName": "United States of America - USA"
     },
     "US-AK": {
       "countryName": "USA",

--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -1757,7 +1757,7 @@
     },
     "US": {
       "zoneName": "Contiguous United States",
-      "seoZoneName": "United States of America - USA"
+      "seoZoneName": "United States of America - U.S."
     },
     "US-AK": {
       "countryName": "USA",

--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -1920,7 +1920,8 @@
     },
     "US-NE-ISNE": {
       "countryName": "USA",
-      "zoneName": "New England ISO"
+      "zoneName": "ISO New England",
+      "seoZoneName": "ISO New England - ISO-NE"
     },
     "US-NW-AVA": {
       "countryName": "USA",

--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -1802,7 +1802,7 @@
       "countryName": "USA",
       "displayName": "BANC",
       "zoneName": "Balancing Authority of Northern California",
-      "seoZoneName": "Balancing Authority of Northern California (BANC)"
+      "seoZoneName": "Balancing Authority of Northern California - BANC"
     },
     "US-CAL-CISO": {
       "countryName": "USA",

--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -1801,16 +1801,19 @@
     "US-CAL-BANC": {
       "countryName": "USA",
       "displayName": "BANC",
-      "zoneName": "Balancing Authority of Northern California"
+      "zoneName": "Balancing Authority of Northern California",
+      "seoZoneName": "Balancing Authority of Northern California (BANC)"
     },
     "US-CAL-CISO": {
       "countryName": "USA",
       "displayName": "California ISO",
-      "zoneName": "CAISO"
+      "zoneName": "CAISO",
+      "seoZoneName": "California ISO - CAISO "
     },
     "US-CAL-IID": {
       "countryName": "USA",
-      "zoneName": "Imperial Irrigation District"
+      "zoneName": "Imperial Irrigation District",
+      "seoZoneName": "Imperial Irrigation District - California"
     },
     "US-CAL-LDWP": {
       "countryName": "USA",
@@ -1822,15 +1825,18 @@
     },
     "US-CAR-CPLE": {
       "countryName": "USA",
-      "zoneName": "Duke Energy Progress East"
+      "zoneName": "Duke Energy Progress East",
+      "seoZoneName": "Duke Energy Progress East - North Carolina"
     },
     "US-CAR-CPLW": {
       "countryName": "USA",
-      "zoneName": "Duke Energy Progress West"
+      "zoneName": "Duke Energy Progress West",
+      "seoZoneName": "Duke Energy Progress West - North Carolina"
     },
     "US-CAR-DUK": {
       "countryName": "USA",
-      "zoneName": "Duke Energy Carolinas"
+      "zoneName": "Duke Energy Carolinas",
+      "seoZoneName": "Duke Energy Carolinas - North and South Carolina"
     },
     "US-CAR-SC": {
       "countryName": "USA",
@@ -1852,7 +1858,8 @@
     "US-CENT-SWPP": {
       "countryName": "USA",
       "displayName": "SPP",
-      "zoneName": "Southwest Power Pool"
+      "zoneName": "Southwest Power Pool",
+      "seoZoneName": "Southwest Power Pool - SPP"
     },
     "US-FLA-FMPP": {
       "countryName": "USA",
@@ -1893,7 +1900,8 @@
     "US-MIDA-PJM": {
       "countryName": "USA",
       "displayName": "PJM",
-      "zoneName": "PJM Interconnection"
+      "zoneName": "PJM Interconnection",
+      "seoZoneName": "PJM Interconnection - Mid-Atlantic US"
     },
     "US-MIDW-AECI": {
       "countryName": "USA",
@@ -1907,7 +1915,8 @@
     "US-MIDW-MISO": {
       "countryName": "USA",
       "displayName": "MISO",
-      "zoneName": "Midcontinent ISO"
+      "zoneName": "Midcontinent ISO",
+      "seoZoneName": "Midcontinent ISO - MISO"
     },
     "US-NE-ISNE": {
       "countryName": "USA",
@@ -1968,7 +1977,8 @@
     "US-NW-PSCO": {
       "countryName": "USA",
       "displayName": "PSCo",
-      "zoneName": "Public Service Company of Colorado"
+      "zoneName": "Public Service Company of Colorado",
+      "seoZoneName": "Public Service Company of Colorado - PSCo"
     },
     "US-NW-PSEI": {
       "countryName": "USA",
@@ -1998,7 +2008,8 @@
     },
     "US-NY-NYIS": {
       "countryName": "USA",
-      "zoneName": "New York ISO"
+      "zoneName": "New York ISO",
+      "seoZoneName": "New York ISO - NYISO"
     },
     "US-SE-SEPA": {
       "countryName": "USA",
@@ -2040,12 +2051,14 @@
     "US-TEN-TVA": {
       "countryName": "USA",
       "displayName": "TVA",
-      "zoneName": "Tennessee Valley Authority"
+      "zoneName": "Tennessee Valley Authority",
+      "seoZoneName": "Tennessee Valley Authority - TVA"
     },
     "US-TEX-ERCO": {
       "countryName": "USA",
       "displayName": "ERCOT",
-      "zoneName": "Electric Reliability Council of Texas"
+      "zoneName": "Electric Reliability Council of Texas",
+      "seoZoneName": "Electric Reliability Council of Texas - ERCOT"
     },
     "UY": {
       "zoneName": "Uruguay"

--- a/web/src/translation/translation.ts
+++ b/web/src/translation/translation.ts
@@ -15,6 +15,14 @@ export const getZoneName = (zoneCode: string) => {
   return fullName;
 };
 
+export const getSEOZoneName = (zoneCode: string) => {
+  const seoZoneName = translateIfExists(`zoneShortName.${zoneCode}.seoZoneName`);
+  if (seoZoneName) {
+    return seoZoneName;
+  }
+  return getZoneName(zoneCode);
+};
+
 export const getCountryName = (zoneCode: string) =>
   translateIfExists(`zoneShortName.${zoneCode}.countryName`);
 

--- a/web/src/utils/constants.ts
+++ b/web/src/utils/constants.ts
@@ -1,7 +1,7 @@
 import type { Duration } from 'date-fns';
 import { ElectricityModeType } from 'types';
 
-export const metaTitleSuffix = ' | App | Electricity Maps';
+export const metaTitleSuffix = ' | Electricity Emissions | Electricity Maps';
 export const baseUrl = 'https://app.electricitymaps.com';
 
 // The order here determines the order displayed

--- a/web/src/utils/constants.ts
+++ b/web/src/utils/constants.ts
@@ -1,7 +1,7 @@
 import type { Duration } from 'date-fns';
 import { ElectricityModeType } from 'types';
 
-export const metaTitleSuffix = ' | Electricity Emissions | Electricity Maps';
+export const metaTitleSuffix = ' | App | Electricity Maps';
 export const baseUrl = 'https://app.electricitymaps.com';
 
 // The order here determines the order displayed


### PR DESCRIPTION
## Issue
It's not always clear what zone is what in search results

## Description
This PR updates some US zone page meta titles to include full SEO zone names. 