### PR TITLE
fix(SEO): Generate time average urls for /map in sitemap

### DIFF
--- a/web/scripts/generateSitemap.js
+++ b/web/scripts/generateSitemap.js
@@ -29,21 +29,22 @@ function generateSitemap() {
     }
   }
 
-  const zoneUrls = Object.keys(zonesConfig.zones)
-    .flatMap((zone) =>
-      UrlTimeAverages.map(
-        (timeAverage) =>
-          `<url><loc>https://app.electricitymaps.com/zone/${zone}/${timeAverage}</loc></url>`
-      )
+  const mapUrls = UrlTimeAverages.map(
+    (timeAverage) =>
+      `<url><loc>https://app.electricitymaps.com/map/${timeAverage}</loc></url>`
+  );
+
+  const zoneUrls = Object.keys(zonesConfig.zones).flatMap((zone) =>
+    UrlTimeAverages.map(
+      (timeAverage) =>
+        `<url><loc>https://app.electricitymaps.com/zone/${zone}/${timeAverage}</loc></url>`
     )
-    .join('');
+  );
 
   const sitemap = `<?xml version="1.0" encoding="UTF-8"?>
   <urlset xmlns="https://www.sitemaps.org/schemas/sitemap/0.9">
-  <url><loc>https://app.electricitymaps.com/</loc></url>
-  <url><loc>https://app.electricitymaps.com/map/</loc></url>
-  ${zoneUrls}
-</urlset>`.replaceAll(/\n\s*/g, '');
+    ${[...mapUrls, ...zoneUrls].join('')}
+  </urlset>`.replaceAll(/\n\s*/g, '');
 
   fs.writeFileSync(SITEMAP_PATH, sitemap);
 }


### PR DESCRIPTION
## Issue

In my previous PR I forgot to generate the links for `/map`.

## Description

Adds a generator function for `/map` and includes the output in the final sitemap.

### Preview
```xml
<?xml version="1.0" encoding="UTF-8"?><urlset xmlns="https://www.sitemaps.org/schemas/sitemap/0.9"><url><loc>https://app.electricitymaps.com/map/24h</loc></url><url><loc>https://app.electricitymaps.com/map/30d</loc></url><url><loc>https://app.electricitymaps.com/map/12mo</loc></url><url><loc>https://app.electricitymaps.com/map/all</loc></url><url><loc>https://app.electricitymaps.com/zone/AD/24h</loc></url><url><loc>https://app.electricitymaps.com/zone/AD/30d</loc></url><url><loc>https://app.electricitymaps.com/zone/AD/12mo</loc></url><url><loc>https://app.electricitymaps.com/zone/AD/all</loc></url><url>
```

### Double check

- [x] I have run `pnpx prettier@2 --write .` and `poetry run format` in the top level directory to format my changes.
