### PR TITLE
bug(web): deselect zone on navigate back

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -67,7 +67,7 @@ export default function App(): ReactElement {
   useEffect(() => {
     if (Capacitor.isNativePlatform() && Capacitor.getPlatform() === 'android') {
       Cap.addListener('backButton', () => {
-        if (window.location.pathname === '/map') {
+        if (window.location.pathname === '/map/24h') {
           Cap.exitApp();
         } else {
           window.history.back();

--- a/web/src/features/map/Map.tsx
+++ b/web/src/features/map/Map.tsx
@@ -198,7 +198,7 @@ export default function MapPage({ onMapLoad }: MapPageProps): ReactElement {
   useEffect(() => {
     // Run when the selected zone changes
     // deselect and dehover zone when navigating to /map (e.g. using back button on mobile panel)
-    if (map && location.pathname === '/map' && selectedZoneId) {
+    if (map && location.pathname.startsWith('/map') && selectedZoneId) {
       map.setFeatureState(
         { source: ZONE_SOURCE, id: selectedZoneId },
         { selected: false, hover: false }


### PR DESCRIPTION
## Issue
On navigating back the current selected zone remains highlighted on the map

## Description
This PR updates the map logic to deselect the current selected zone with the url matches `/map` and aligns the native back button to exit the app from the root path.