### PR TITLE
Origin Chart Legend tweaks

### DIFF
--- a/web/src/features/charts/ProductionSourceLegendList.tsx
+++ b/web/src/features/charts/ProductionSourceLegendList.tsx
@@ -1,4 +1,5 @@
 import { Button } from 'components/Button';
+import { useTranslation } from 'react-i18next';
 import { twMerge } from 'tailwind-merge';
 import { ElectricityModeType } from 'types';
 
@@ -16,12 +17,16 @@ export default function ProductionSourceLegendList({
   selectedData?: SelectedData;
   isDataInteractive?: boolean;
 }) {
+  const { t } = useTranslation();
   // TODO(cady): memoize
   return (
     <div className={twMerge('flex w-fit flex-row flex-wrap gap-1 py-1', className)}>
       {sources.map((source, index) => {
         const onClick = () => selectedData?.toggle(source);
-        const capitalizedLabel = `${source.charAt(0).toUpperCase()}${source.slice(1)}`;
+        const translatedSource = t(source.toLowerCase());
+        const capitalizedLabel = `${translatedSource
+          .charAt(0)
+          .toUpperCase()}${translatedSource.slice(1)}`;
         const isSourceSelected = selectedData?.isSelected(source);
 
         return (
@@ -30,12 +35,14 @@ export default function ProductionSourceLegendList({
             key={index}
             type="tertiary"
             size="sm"
-            foregroundClasses={'text-xs font-normal text-neutral-600 dark:text-gray-300'}
-            backgroundClasses={
-              isSourceSelected
-                ? 'outline outline-1 outline-neutral-200 bg-neutral-400/10 dark:bg-gray-600/80 dark:outline-gray-400/80'
-                : ''
-            }
+            foregroundClasses={twMerge(
+              'text-xs font-normal text-neutral-600 dark:text-gray-300',
+              isSourceSelected && 'text-neutral-800 dark:text-white'
+            )}
+            backgroundClasses={twMerge(
+              isSourceSelected &&
+                'outline outline-1 outline-neutral-200 bg-neutral-400/10 dark:bg-gray-600/80 dark:outline-gray-400/50'
+            )}
             onClick={onClick}
             icon={<ProductionSourceLegend key={index} electricityType={source} />}
           >


### PR DESCRIPTION
## Issue
<!-- If you want to close an issue automatically when your PR is merged, write "Closes X" where X is the issue number. For example: Closes #000 -->

Closes #7417

## Description
Tweaks to origin chart legend
- Fixes button contrast
- Adds translations

### Preview
<img width="355" alt="Screenshot 2024-11-15 at 11 03 57" src="https://github.com/user-attachments/assets/b9003c75-1846-4f3e-a8f3-3245f765a745">
<img width="349" alt="Screenshot 2024-11-15 at 11 04 13" src="https://github.com/user-attachments/assets/5e0c3cfa-e97e-4668-bdc5-c7e81455d122">


### Double check

- [ ] I have tested my parser changes locally with `poetry run test_parser "zone_key"`
- [ ] I have run `pnpx prettier@2 --write .` and `poetry run format` in the top level directory to format my changes.
