### PR TITLE
add Greenlink to GB->IE interconnector

### DIFF
--- a/parsers/ELEXON.py
+++ b/parsers/ELEXON.py
@@ -94,7 +94,7 @@ ZONEKEY_TO_INTERCONNECTOR = {
     "DK-DK1->GB": ["Denmark (Viking link)"],
     "FR->GB": ["Eleclink (INTELEC)", "France(IFA)", "IFA2 (INTIFA2)"],
     "GB->GB-NIR": ["Northern Ireland(Moyle)"],
-    "GB->IE": ["Ireland(East-West)"],
+    "GB->IE": ["Ireland(East-West)", "Ireland (Greenlink)"],
     "GB->NL": ["Netherlands(BritNed)"],
     "GB->NO-NO2": ["North Sea Link (INTNSL)"],
 }


### PR DESCRIPTION
## Issue

 Greenlink Interconnector active #7235 

Closes #7235 

## Description

Add the Greenlink interconnector between GB and IE. This was partially done already in PR fix: fix elexon parser #7340, which added Greenlink to FUEL_INST_MAPPING. This PR adds Greenlink to ZONEKEY_TO_INTERCONNECTOR for GB->IE.

This is my first PR for this project, so I'm still learning how everything fits together. Thank you for letting me contribute. :)

### Double check

- [ x] I have tested my parser changes locally with `poetry run test_parser "zone_key"`
- [ x] I have run `pnpx prettier@2 --write .` and `poetry run format` in the top level directory to format my changes.
