### PR TITLE
fix(events): downgrade negative production values from warning to debug

### DIFF
--- a/electricitymap/contrib/lib/models/events.py
+++ b/electricitymap/contrib/lib/models/events.py
@@ -600,7 +600,7 @@ class ProductionBreakdown(AggregatableEvent):
         try:
             # Log warning if production has been corrected.
             if production is not None and production.has_corrected_negative_values:
-                logger.warning(
+                logger.debug(
                     f"Negative production values were detected: {production._corrected_negative_values}.\
                     They have been set to None."
                 )

--- a/electricitymap/contrib/lib/tests/test_event_lists.py
+++ b/electricitymap/contrib/lib/tests/test_event_lists.py
@@ -285,14 +285,14 @@ class TestProductionBreakdownList(unittest.TestCase):
                 source="trust.me",
             )
             mock_error.assert_called_once()
-        with patch.object(production_list.logger, "warning") as mock_warning:
+        with patch.object(production_list.logger, "debug") as mock_logger:
             production_list.append(
                 zoneKey=ZoneKey("AT"),
                 datetime=datetime(2023, 1, 1, tzinfo=timezone.utc),
                 production=ProductionMix(wind=-10),
                 source="trust.me",
             )
-            mock_warning.assert_called_once()
+            mock_logger.assert_called_once()
 
     def test_merge_production_list_production_mix_only(self):
         production_list_1 = ProductionBreakdownList(logging.Logger("test"))

--- a/electricitymap/contrib/lib/tests/test_events.py
+++ b/electricitymap/contrib/lib/tests/test_events.py
@@ -377,7 +377,7 @@ class TestProductionBreakdown(unittest.TestCase):
             hydro=-20,
         )
         logger = logging.Logger("test")
-        with patch.object(logger, "warning") as mock_warning:
+        with patch.object(logger, "debug") as mock_logger:
             breakdown = ProductionBreakdown.create(
                 logger=logger,
                 zoneKey=ZoneKey("DE"),
@@ -385,7 +385,7 @@ class TestProductionBreakdown(unittest.TestCase):
                 production=mix,
                 source="trust.me",
             )
-            mock_warning.assert_called_once()
+            mock_logger.assert_called_once()
             assert breakdown is not None
             assert breakdown.production is not None
             assert breakdown.production.hydro is None
@@ -402,7 +402,7 @@ class TestProductionBreakdown(unittest.TestCase):
         # This one has been set through the attributes and should be reported as None.
         mix.biomass = -10
         logger = logging.Logger("test")
-        with patch.object(logger, "warning") as mock_warning:
+        with patch.object(logger, "debug") as mock_logger:
             breakdown = ProductionBreakdown.create(
                 logger=logger,
                 zoneKey=ZoneKey("DE"),
@@ -410,7 +410,7 @@ class TestProductionBreakdown(unittest.TestCase):
                 production=mix,
                 source="trust.me",
             )
-            mock_warning.assert_called_once()
+            mock_logger.assert_called_once()
             assert breakdown is not None
             assert breakdown.production is not None
             assert breakdown.production.wind == 0

--- a/test_parser.py
+++ b/test_parser.py
@@ -66,9 +66,7 @@ def test_parser(zone: ZoneKey, data_type: str, target_datetime: str | None):
 
     logger = getLogger(__name__)
     logger.setLevel(DEBUG)
-    res = parser(
-        *args, target_datetime=parsed_target_datetime, logger=logger
-    )
+    res = parser(*args, target_datetime=parsed_target_datetime, logger=logger)
 
     if not res:
         raise ValueError(f"Error: parser returned nothing ({res})")

--- a/test_parser.py
+++ b/test_parser.py
@@ -63,8 +63,11 @@ def test_parser(zone: ZoneKey, data_type: str, target_datetime: str | None):
     ][zone]
 
     args = zone.split("->") if data_type in ["exchange", "exchangeForecast"] else [zone]
+
+    logger = getLogger(__name__)
+    logger.setLevel(DEBUG)
     res = parser(
-        *args, target_datetime=parsed_target_datetime, logger=getLogger(__name__)
+        *args, target_datetime=parsed_target_datetime, logger=logger
     )
 
     if not res:


### PR DESCRIPTION
The warning log is expected for many parsers and we are therefore polluting our log files with millions of these logs. I have therefore downgraded it to debug so that it only shows up when we use `test_parser.py` and stop storing it in google cloud logs.
