### PR TITLE
Fix: Allow Origin Chart source selection on mobile

### DIFF
--- a/web/src/features/charts/elements/AreaGraphLayers.tsx
+++ b/web/src/features/charts/elements/AreaGraphLayers.tsx
@@ -117,7 +117,7 @@ function AreaGraphLayers({
           hoveredIndex: hoverLayerIndex,
           index: ind,
           layerKey: layer.key,
-          selectedData: selectedData,
+          selectedData,
         });
 
         const isInteracted =
@@ -134,9 +134,7 @@ function AreaGraphLayers({
         return (
           <React.Fragment key={layer.key}>
             <path
-              className={
-                shouldLayerBeSaturated ? 'sm:hover:opacity-100' : 'sm:opacity-30'
-              }
+              className={shouldLayerBeSaturated ? 'opacity-100' : 'opacity-30'}
               style={{ cursor: 'pointer' }}
               stroke={stroke}
               strokeWidth={0.5}


### PR DESCRIPTION
## Description
Currently the Origin Chart source selection doesn't work on mobile (to test, toggle device in devtools). This PR fixes that by removing the 'sm' prefix from graph layer styling.

### Preview
**Before & After:**
<img width="314" alt="Screenshot 2024-11-18 at 11 31 49" src="https://github.com/user-attachments/assets/8ba91249-1153-4420-816f-a8152ebf2e84"><img width="314" alt="Screenshot 2024-11-18 at 11 31 31" src="https://github.com/user-attachments/assets/c76ab3b9-b836-4d8c-9e15-de6487530208">


### Double check

- [ ] I have tested my parser changes locally with `poetry run test_parser "zone_key"`
- [ ] I have run `pnpx prettier@2 --write .` and `poetry run format` in the top level directory to format my changes.
