### PR TITLE
fix(parsers): add hydro to bypassed modes for US-SE-SOCO

### DIFF
--- a/parsers/EIA.py
+++ b/parsers/EIA.py
@@ -382,7 +382,7 @@ FILTER_INCOMPLETE_DATA_BYPASSED_MODES = {
     "US-NW-PACE": ["biomass", "geothermal", "oil"],
     "US-MIDW-MISO": ["biomass", "geothermal", "oil"],
     "US-TEN-TVA": ["biomass", "geothermal", "oil"],
-    "US-SE-SOCO": ["biomass", "geothermal", "oil"],
+    "US-SE-SOCO": ["biomass", "geothermal", "oil", "hydro"],
     "US-FLA-FPL": ["biomass", "geothermal", "oil"],
 }
 
@@ -507,7 +507,6 @@ def fetch_production_mix(
             for datapoint in production_values
             if datapoint["value"] is not None
         ]
-
         # EIA does not currently split production from the Virgil Summer C
         # plant across the two owning/ utilizing BAs:
         # US-CAR-SCEG and US-CAR-SC,


### PR DESCRIPTION
## Issue
Data currently removed for US-SE-SOCO due to missing hydro values. Hydro is added to bypassed modes, so we can start getting data for this zone again.

### Double check

- [ ] I have tested my parser changes locally with `poetry run test_parser "zone_key"`
- [ ] I have run `pnpx prettier@2 --write .` and `poetry run format` in the top level directory to format my changes.
