### PR TITLE
Mobile app release 1.188.0

### DIFF
--- a/mobileapp/android/app/build.gradle
+++ b/mobileapp/android/app/build.gradle
@@ -13,8 +13,8 @@ android {
         applicationId "com.tmrow.electricitymap"
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
-        versionCode 1018402
-        versionName "1.184.2"
+        versionCode 1018800
+        versionName "1.188.0"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         aaptOptions {
             // Files and dirs to omit from the packaged assets dir, modified to accommodate modern web apps.

--- a/mobileapp/ios/App/App.xcodeproj/project.pbxproj
+++ b/mobileapp/ios/App/App.xcodeproj/project.pbxproj
@@ -351,7 +351,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 1.184.2;
+				CURRENT_PROJECT_VERSION = 1.188.0;
 				DEVELOPMENT_TEAM = MP3LBAUPG8;
 				INFOPLIST_FILE = App/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = "Electricity Maps";
@@ -361,7 +361,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.184.2;
+				MARKETING_VERSION = 1.188.0;
 				OTHER_SWIFT_FLAGS = "$(inherited) \"-D\" \"COCOAPODS\" \"-DDEBUG\"";
 				PRODUCT_BUNDLE_IDENTIFIER = com.tmrow.electricitymap;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -380,7 +380,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 1.184.2;
+				CURRENT_PROJECT_VERSION = 1.188.0;
 				DEVELOPMENT_TEAM = MP3LBAUPG8;
 				INFOPLIST_FILE = App/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = "Electricity Maps";
@@ -390,7 +390,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.184.2;
+				MARKETING_VERSION = 1.188.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.tmrow.electricitymap;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";

--- a/mobileapp/package.json
+++ b/mobileapp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "electricitymaps-mobile",
-  "version": "1.184.2",
+  "version": "1.188.0",
   "description": "A real-time visualisation of the CO2 emissions of electricity consumption",
   "license": "AGPL-3.0-or-later",
   "main": "index.js",


### PR DESCRIPTION
## Description
Mobile app release 1.188.0! 🎉 

Changes include:
- Allow origin chart to allow source selection
- Origin chart label translations
- Capture successful SoMe shares
- Sanitized URL zone names
- Bugfixes:
   - Deselect zone on back nav
   - iPad layout

### Double check

- [ ] I have tested my parser changes locally with `poetry run test_parser "zone_key"`
- [ ] I have run `pnpx prettier@2 --write .` and `poetry run format` in the top level directory to format my changes.
