### PR TITLE
use with instead of assert

### DIFF
--- a/web/scripts/generateSitemap.js
+++ b/web/scripts/generateSitemap.js
@@ -5,7 +5,7 @@ import path from 'node:path';
 
 import { fileURLToPath } from 'url';
 
-import zonesConfig from '../config/zones.json' assert { type: 'json' };
+import zonesConfig from '../config/zones.json' with { type: 'json' };
 
 // Import this from the constant file when this script is in typescript
 const UrlTimeAverages = ['24h', '30d', '12mo', 'all'];


### PR DESCRIPTION
## Description

`assert` is deprecated and in fact doesn't work in new versions of node
`with` is basically the same thing and has been supported since node 18
this pr changes `assert` to `with`

## Double check

- [ ] I have tested my parser changes locally with `poetry run test_parser "zone_key"`
- [ ] I have run `pnpx prettier@2 --write .` and `poetry run format` in the top level directory to format my changes.
