### PR TITLE
Installed capacity

### DIFF
--- a/web/src/features/charts/bar-breakdown/BarBreakdownChart.tsx
+++ b/web/src/features/charts/bar-breakdown/BarBreakdownChart.tsx
@@ -135,7 +135,7 @@ function BarBreakdownChart({
         }
         id={Charts.BAR_BREAKDOWN_CHART}
       />
-      {!displayByEmissions && (
+      {!displayByEmissions && isHourly && (
         <CapacityLegend>
           {t('country-panel.graph-legends.installed-capacity')} ({graphUnit})
         </CapacityLegend>


### PR DESCRIPTION
I see the issue was assigned but hadn't been worked on in the 2 weeks since assignment, so went ahead since it looked like a simple fix. Please feel free to reject if that isn't protocol :)

## Issue

Closes #7320. 

## Description

"Installed capacity" label should not be shown for aggregated data. This fix makes the label appear only when "isHourly" is true, since all other data periods (daily, monthly, yearly) are considered aggregates.

### Preview
![image](https://github.com/user-attachments/assets/a4effda1-ca9b-4263-a062-ea2426449afc)

![image](https://github.com/user-attachments/assets/d0d1dd3d-d157-44a7-835a-c41c277cac94)


### Double check

- [x] I have tested my parser changes locally with `poetry run test_parser "zone_key"` (N/A)
- [x] I have run `pnpx prettier@2 --write .` and `poetry run format` in the top level directory to format my changes.
