### PR TITLE
Fix Mongolia parser, add thermal + battery support [Mostly complete, needs some work so if someone else wants to complete this please do]

### DIFF
--- a/config/zones/MN.yaml
+++ b/config/zones/MN.yaml
@@ -32,6 +32,9 @@ emissionFactors:
         datetime: '2020-01-01'
         source: IEA 2020; assumes 92.85% coal, 5.78%% oil, 1.37% hydro in unknown
         value: 729.1
+      - datetime: '2024-11-25'
+        source: IEA 2020; assumes 94.14% coal, 5.86% oil in unknown
+        value: 739
   lifecycle:
     battery discharge:
       - datetime: '2023-01-01'
@@ -46,6 +49,9 @@ emissionFactors:
         datetime: '2020-01-01'
         source: IEA 2020; assumes 92.85% coal, 5.78%% oil, 1.37% hydro in unknown
         value: 799.2
+      - datetime: '2024-11-25'
+        source: IEA 2020; assumes 94.14% coal, 5.86% oil in unknown
+        value: 810
 fallbackZoneMixes:
   powerOriginRatios:
     - _source: Electricity Maps, 2023 average
@@ -68,11 +74,15 @@ isLowCarbon:
     - _url: https://www.iea.org/fuels-and-technologies/electricity
       datetime: '2020-01-01'
       value: 0.0137
+    - datetime: '2024-11-25'
+      value: 0
 isRenewable:
   unknown:
     - _url: https://www.iea.org/fuels-and-technologies/electricity
       datetime: '2020-01-01'
       value: 0.0137
+    - datetime: '2024-11-25'
+      value: 0
 parsers:
   consumption: MN.fetch_consumption
   production: MN.fetch_production


### PR DESCRIPTION
## Issue

See #5906

## Description

Fixes the Mongolia parser by correcting a renamed field in the API, determining that 'Songino' stands for battery (https://github.com/electricitymaps/electricitymaps-contrib/issues/5906#issuecomment-2495091821). It also maps `tpp` to thermal.

# Still to be done:
- [ ] From now on, I'm assuming that tpp = thermal and any remaining production = hydro, so 'unknown' needs to have an override for [oil + coal](https://www.iea.org/countries/mongolia/electricity) instead of oil + coal + hydro. Keep the old override for the old data though, that's not based on `tpp` production but on total unaccounted for production and therefore should include hydro).
- [ ] Test if it works
- [ ] Formatting

_(I wrote this in the GitHub web editor hoping to give someone else a starting point for fixing this, if someone else can do the last steps that would be appreciated. May even be tagged 'help wanted'.)_

### Double check

- [ ] I have tested my parser changes locally with `poetry run test_parser "zone_key"`
- [ ] I have run `pnpx prettier@2 --write .` and `poetry run format` in the top level directory to format my changes.
