### PR TITLE
chore(deps): Add tzdata to dependabot allow list

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -82,13 +82,14 @@ updates:
         patterns:
           - '@visx/*'
 
-  # Ensure ruff is updated.
+  # Ensure ruff and tzdata is updated.
   - package-ecosystem: 'pip'
     directory: '/'
     schedule:
       interval: 'monthly'
     allow:
       - dependency-name: 'ruff'
+      - dependency-name: 'tzdata'
     reviewers:
       - 'VIKTORVAV99'
 


### PR DESCRIPTION
## Issue
To ensure the TZ data package don't drift we should have it automatically create PRs for new versions.
