### PR TITLE
Fix: Hide share options for production mode

### DIFF
--- a/web/src/components/MoreOptionsDropdown.tsx
+++ b/web/src/components/MoreOptionsDropdown.tsx
@@ -15,7 +15,7 @@ import {
   DEFAULT_TOAST_DURATION,
 } from 'utils/constants';
 import { hasMobileUserAgent as hasMobileUA } from 'utils/helpers';
-import { displayByEmissionsAtom, isHourlyAtom } from 'utils/state/atoms';
+import { displayByEmissionsAtom, isConsumptionAtom } from 'utils/state/atoms';
 
 import { DefaultCloseButton } from './DefaultCloseButton';
 import { MemoizedShareIcon } from './ShareIcon';
@@ -207,7 +207,7 @@ const useDropdownCtl = () => {
 export function useShowMoreOptions() {
   const isMoreOptionsEnabled = useFeatureFlag('more-options-dropdown');
   const displayByEmissions = useAtomValue(displayByEmissionsAtom);
-  const showMoreOptions = isMoreOptionsEnabled && !displayByEmissions;
+  const isConsumption = useAtomValue(isConsumptionAtom);
 
-  return showMoreOptions;
+  return isMoreOptionsEnabled && !displayByEmissions && isConsumption;
 }

--- a/web/src/features/panels/zone/ZoneHeaderTitle.tsx
+++ b/web/src/features/panels/zone/ZoneHeaderTitle.tsx
@@ -6,7 +6,7 @@ import { useFeatureFlag } from 'features/feature-flags/api';
 import { mapMovingAtom } from 'features/map/mapAtoms';
 import { useGetCanonicalUrl } from 'hooks/useGetCanonicalUrl';
 import { useGetCurrentUrl } from 'hooks/useGetCurrentUrl';
-import { useSetAtom } from 'jotai';
+import { useAtomValue, useSetAtom } from 'jotai';
 import { ArrowLeft, Ellipsis, Info } from 'lucide-react';
 import { Helmet } from 'react-helmet-async';
 import { useTranslation } from 'react-i18next';
@@ -18,6 +18,7 @@ import {
 } from 'translation/translation';
 import { metaTitleSuffix } from 'utils/constants';
 import { useNavigateWithParameters } from 'utils/helpers';
+import { isConsumptionAtom } from 'utils/state/atoms';
 
 import { ShareButton } from './ShareButton';
 import { getDisclaimer } from './util';
@@ -44,6 +45,7 @@ export default function ZoneHeaderTitle({ zoneId, isEstimated }: ZoneHeaderTitle
   const setIsMapMoving = useSetAtom(mapMovingAtom);
   const canonicalUrl = useGetCanonicalUrl();
   const isShareButtonEnabled = useFeatureFlag('share-button');
+  const isConsumption = useAtomValue(isConsumptionAtom);
 
   const onNavigateBack = () => {
     setIsMapMoving(false);
@@ -105,6 +107,7 @@ export default function ZoneHeaderTitle({ zoneId, isEstimated }: ZoneHeaderTitle
         <TimeDisplay className="whitespace-nowrap text-sm" />
       </div>
       {isShareButtonEnabled &&
+        isConsumption &&
         (showMoreOptions ? (
           <MoreOptionsDropdown
             id="zone"


### PR DESCRIPTION
## Description
Fix: Hide share options for production mode
Relates to [AVO-589](https://linear.app/electricitymaps/issue/AVO-589/add-copyable-permalinks-to-each-of-the-charts).
Hides share options because we do not currently encode production/consumption in share urls.

### Preview

<!-- Please add screenshots and/or gif that shows visual changes (if applicable) -->

### Double check

- [ ] I have tested my parser changes locally with `poetry run test_parser "zone_key"`
- [ ] I have run `pnpx prettier@2 --write .` and `poetry run format` in the top level directory to format my changes.
