### PR TITLE
fix(timezone): Fix the timezone for Guadeloupe (GP)

### DIFF
--- a/config/zones/GP.yaml
+++ b/config/zones/GP.yaml
@@ -172,4 +172,4 @@ parsers:
   price: FR_O.fetch_price
   production: FR_O.fetch_production
 region: Americas
-timezone: Europe/Paris
+timezone: America/Puerto_Rico


### PR DESCRIPTION
## Issue

The timezone is currently set to paris even though it should be AST / Puerto Rico.

## Description

Changes the timezone to the correct one.

### Double check

- [x] I have run `pnpx prettier@2 --write .` and `poetry run format` in the top level directory to format my changes.
