### PR TITLE
feat(web): add trackevents for historical time interactions

### DIFF
--- a/web/src/features/time/HistoricalTimeHeader.tsx
+++ b/web/src/features/time/HistoricalTimeHeader.tsx
@@ -8,7 +8,8 @@ import { useTranslation } from 'react-i18next';
 import { useParams } from 'react-router-dom';
 import { twMerge } from 'tailwind-merge';
 import { RouteParameters } from 'types';
-import { MAX_HISTORICAL_LOOKBACK_DAYS } from 'utils/constants';
+import trackEvent from 'utils/analytics';
+import { MAX_HISTORICAL_LOOKBACK_DAYS, TrackEvent } from 'utils/constants';
 import { useNavigateWithParameters } from 'utils/helpers';
 import { endDatetimeAtom, isHourlyAtom, startDatetimeAtom } from 'utils/state/atoms';
 
@@ -41,6 +42,7 @@ export default function HistoricalTimeHeader() {
     if (!endDatetime || !urlDatetime) {
       return;
     }
+    trackEvent(TrackEvent.HISTORICAL_TIME_RIGHT_CLICKED);
     const currentEndDatetime = new Date(endDatetime);
     const newDate = new Date(currentEndDatetime.getTime() + TWENTY_FOUR_HOURS);
 
@@ -56,6 +58,7 @@ export default function HistoricalTimeHeader() {
     if (!endDatetime || !isWithinHistoricalLimit) {
       return;
     }
+    trackEvent(TrackEvent.HISTORICAL_TIME_LEFT_CLICKED);
     const currentEndDatetime = new Date(endDatetime);
     const newDate = new Date(currentEndDatetime.getTime() - TWENTY_FOUR_HOURS);
     navigate({ datetime: newDate.toISOString() });
@@ -109,7 +112,10 @@ export default function HistoricalTimeHeader() {
           <Button
             size="sm"
             type="tertiary"
-            onClick={() => navigate({ datetime: '' })}
+            onClick={() => {
+              trackEvent(TrackEvent.HISTORICAL_TIME_LATEST_CLICKED);
+              navigate({ datetime: '' });
+            }}
             isDisabled={!urlDatetime}
             icon={
               <ArrowRightToLine

--- a/web/src/utils/constants.ts
+++ b/web/src/utils/constants.ts
@@ -81,6 +81,9 @@ export enum TrackEvent {
   SOLAR_DISABLED = 'Solar Disabled',
   WIND_ENABLED = 'Wind Enabled',
   WIND_DISABLED = 'Wind Disabled',
+  HISTORICAL_TIME_LEFT_CLICKED = 'Historical Time Left Clicked',
+  HISTORICAL_TIME_RIGHT_CLICKED = 'Historical Time Right Clicked',
+  HISTORICAL_TIME_LATEST_CLICKED = 'Historical Time Latest Clicked',
 }
 
 // color of different production modes are based on various industry standards


### PR DESCRIPTION
## Issue

<!-- If you want to close an issue automatically when your PR is merged, write "Closes X" where X is the issue number. For example: Closes #000 -->
[AVO-657](https://linear.app/electricitymaps/issue/AVO-657/add-tracking-for-historical-story-telling)

## Description

<!-- Explains the goal of this PR -->
This PR adds trackevents for the 3 buttons for historical time; Left button, Right button and Latest button.

### Double check

- [x] I have run `pnpx prettier@2 --write .` and `poetry run format` in the top level directory to format my changes.
