### PR TITLE
fix(web): change chart badges to show less when partially estimated

### DIFF
--- a/web/src/features/charts/CarbonChart.tsx
+++ b/web/src/features/charts/CarbonChart.tsx
@@ -30,7 +30,7 @@ function CarbonChart({ datetimes, timeAverage }: CarbonChartProps) {
 
   const hasEnoughDataToDisplay = datetimes?.length > 2;
 
-  const { text, icon } = getBadgeTextAndIcon(chartData, t);
+  const { text, icon } = getBadgeTextAndIcon(chartData, t, timeAverage);
   const badge = <EstimationBadge text={text} Icon={icon} />;
 
   if (!hasEnoughDataToDisplay) {

--- a/web/src/features/charts/EmissionChart.tsx
+++ b/web/src/features/charts/EmissionChart.tsx
@@ -28,7 +28,7 @@ function EmissionChart({ timeAverage, datetimes }: EmissionChartProps) {
   const maxEmissions = Math.max(...chartData.map((o) => o.layerData.emissions));
   const formatAxisTick = (t: number) => formatCo2({ value: t, total: maxEmissions });
 
-  const { text, icon } = getBadgeTextAndIcon(chartData, t);
+  const { text, icon } = getBadgeTextAndIcon(chartData, t, timeAverage);
   const badge = <EstimationBadge text={text} Icon={icon} />;
 
   return (

--- a/web/src/features/charts/OriginChart.tsx
+++ b/web/src/features/charts/OriginChart.tsx
@@ -89,7 +89,7 @@ function OriginChart({ displayByEmissions, datetimes, timeAverage }: OriginChart
 
   const hasEnoughDataToDisplay = datetimes?.length > 2;
 
-  const { text, icon } = getBadgeTextAndIcon(chartData, t);
+  const { text, icon } = getBadgeTextAndIcon(chartData, t, timeAverage);
 
   const badge = <EstimationBadge text={text} Icon={icon} />;
 

--- a/web/src/features/charts/graphUtils.ts
+++ b/web/src/features/charts/graphUtils.ts
@@ -274,3 +274,13 @@ export function extractLinkFromSource(
   // We on purpose don't use https due to some sources not supporting it (and the majority that does will automatically redirect anyway)
   return `http://${source}`;
 }
+
+export function hasSignificantEstimation(
+  estimationMethod: EstimationMethods | undefined,
+  estimatedPercentage: number | undefined
+) {
+  return (
+    Boolean(estimationMethod) ||
+    (estimatedPercentage != undefined && estimatedPercentage > 1)
+  );
+}

--- a/web/src/features/charts/tooltips/BreakdownChartTooltip.tsx
+++ b/web/src/features/charts/tooltips/BreakdownChartTooltip.tsx
@@ -16,7 +16,11 @@ import {
   timeAverageAtom,
 } from 'utils/state/atoms';
 
-import { getGenerationTypeKey, getRatioPercent } from '../graphUtils';
+import {
+  getGenerationTypeKey,
+  getRatioPercent,
+  hasSignificantEstimation,
+} from '../graphUtils';
 import { getExchangeTooltipData, getProductionTooltipData } from '../tooltipCalculations';
 import { InnerAreaGraphTooltipProps, LayerKey } from '../types';
 import AreaGraphToolTipHeader from './AreaGraphTooltipHeader';
@@ -124,7 +128,10 @@ export default function BreakdownChartTooltip({
   );
 
   const { estimationMethod, stateDatetime, estimatedPercentage } = zoneDetail;
-  const hasEstimationPill = estimationMethod != undefined || Boolean(estimatedPercentage);
+  const hasEstimationPill = hasSignificantEstimation(
+    estimationMethod,
+    estimatedPercentage
+  );
 
   return (
     <BreakdownChartTooltipContent

--- a/web/src/features/charts/tooltips/CarbonChartTooltip.tsx
+++ b/web/src/features/charts/tooltips/CarbonChartTooltip.tsx
@@ -6,6 +6,7 @@ import { useTranslation } from 'react-i18next';
 import { getCarbonIntensity } from 'utils/helpers';
 import { isConsumptionAtom, timeAverageAtom } from 'utils/state/atoms';
 
+import { hasSignificantEstimation } from '../graphUtils';
 import { InnerAreaGraphTooltipProps } from '../types';
 import AreaGraphToolTipHeader from './AreaGraphTooltipHeader';
 
@@ -29,7 +30,10 @@ export default function CarbonChartTooltip({ zoneDetail }: InnerAreaGraphTooltip
     { c: { ci: co2intensity }, p: { ci: co2intensityProduction } },
     isConsumption
   );
-  const hasEstimationPill = Boolean(estimationMethod) || Boolean(estimatedPercentage);
+  const hasEstimationPill = hasSignificantEstimation(
+    estimationMethod,
+    estimatedPercentage
+  );
   return (
     <div
       data-test-id="carbon-chart-tooltip"

--- a/web/src/features/charts/tooltips/EmissionChartTooltip.tsx
+++ b/web/src/features/charts/tooltips/EmissionChartTooltip.tsx
@@ -3,7 +3,7 @@ import { useTranslation } from 'react-i18next';
 import { formatCo2 } from 'utils/formatting';
 import { isConsumptionAtom, timeAverageAtom } from 'utils/state/atoms';
 
-import { getTotalEmissionsAvailable } from '../graphUtils';
+import { getTotalEmissionsAvailable, hasSignificantEstimation } from '../graphUtils';
 import { InnerAreaGraphTooltipProps } from '../types';
 import AreaGraphToolTipHeader from './AreaGraphTooltipHeader';
 
@@ -18,7 +18,10 @@ export default function EmissionChartTooltip({ zoneDetail }: InnerAreaGraphToolt
 
   const totalEmissions = getTotalEmissionsAvailable(zoneDetail, isConsumption);
   const { stateDatetime, estimationMethod, estimatedPercentage } = zoneDetail;
-  const hasEstimationPill = Boolean(estimationMethod) || Boolean(estimatedPercentage);
+  const hasEstimationPill = hasSignificantEstimation(
+    estimationMethod,
+    estimatedPercentage
+  );
 
   return (
     <div className="w-full rounded-md bg-white p-3 shadow-xl dark:border dark:border-gray-700 dark:bg-gray-800 sm:w-[410px]">

--- a/web/src/features/map/MapTooltip.tsx
+++ b/web/src/features/map/MapTooltip.tsx
@@ -79,7 +79,7 @@ function DataValidityBadge({
       />
     );
   }
-  if (estimated && estimated > 0) {
+  if (estimated && estimated > 1) {
     return (
       <EstimationBadge
         text={t(`estimation-card.aggregated_estimated.pill`, {

--- a/web/src/features/panels/zone/EstimationCard.tsx
+++ b/web/src/features/panels/zone/EstimationCard.tsx
@@ -153,9 +153,7 @@ function BaseCard({
     estimationMethod,
     estimatedPercentage
   );
-  const showBadge = Boolean(
-    estimationMethod == 'aggregated' ? estimatedPercentage : pillType
-  );
+  const showBadge = shouldShowBadge(pillType, estimationMethod, estimatedPercentage);
 
   return (
     <div
@@ -311,4 +309,15 @@ function ZoneMessageBlock({ zoneMessage }: { zoneMessage?: ZoneMessage }) {
       )}
     </span>
   );
+}
+
+function shouldShowBadge(
+  pillType: PillType | undefined,
+  estimationMethod: EstimationMethods | undefined,
+  estimatedPercentage: number | undefined
+) {
+  if (estimationMethod == EstimationMethods.AGGREGATED) {
+    return estimatedPercentage != undefined && estimatedPercentage > 1;
+  }
+  return Boolean(pillType);
 }

--- a/web/src/features/panels/zone/ZoneDetails.tsx
+++ b/web/src/features/panels/zone/ZoneDetails.tsx
@@ -3,6 +3,7 @@ import useGetZone from 'api/getZone';
 import { CommercialApiButton } from 'components/buttons/CommercialApiButton';
 import LoadingSpinner from 'components/LoadingSpinner';
 import BarBreakdownChart from 'features/charts/bar-breakdown/BarBreakdownChart';
+import { hasSignificantEstimation } from 'features/charts/graphUtils';
 import { useAtomValue, useSetAtom } from 'jotai';
 import { useEffect } from 'react';
 import { Navigate, useLocation, useParams } from 'react-router-dom';
@@ -73,7 +74,11 @@ export default function ZoneDetails(): JSX.Element {
   const { estimationMethod, estimatedPercentage } = selectedData || {};
   const zoneMessage = data?.zoneMessage;
   const cardType = getCardType({ estimationMethod, zoneMessage, isHourly });
-  const hasEstimationPill = Boolean(estimationMethod) || Boolean(estimatedPercentage);
+  const hasEstimationPill = hasSignificantEstimation(
+    estimationMethod,
+    estimatedPercentage
+  );
+
   const isIosCapacitor =
     Capacitor.isNativePlatform() && Capacitor.getPlatform() === 'ios';
   return (


### PR DESCRIPTION
## Issue

<!-- If you want to close an issue automatically when your PR is merged, write "Closes X" where X is the issue number. For example: Closes #000 -->
[AVO-620](https://linear.app/electricitymaps/issue/AVO-620/change-chart-badges-to-show-less-when-partially-estimated)

## Description

<!-- Explains the goal of this PR -->
This PR:
1. Removes estimated badge when less than 1 %
2. Removes partially estimated badge in hourly view. Only show estimated badge if all hours are estimated
3. Show 'partially estimated' instead of 'estimated' on aggregated views if the graph contains some measured data.

### Preview

<!-- Please add screenshots and/or gif that shows visual changes (if applicable) -->
1 Before:
![image](https://github.com/user-attachments/assets/7467d925-d8ff-4c1e-9f08-23c63a10e2a3)
1 Now: 
![image](https://github.com/user-attachments/assets/c9103b0f-d0b2-4edc-a26f-b9488ddafd28)

2 Before:
![image](https://github.com/user-attachments/assets/f031e5ce-eb07-4250-a436-c4312e04dbcf)
2 After:
![image](https://github.com/user-attachments/assets/3249ad53-4880-418f-9bf9-47eb98f52759)

3 Before:
![image](https://github.com/user-attachments/assets/2195554e-3a66-4876-8327-0602183c262f)
3 After:
![image](https://github.com/user-attachments/assets/22e5194c-aeca-40ec-a5ae-eda6e51d1a3e)

### Double check

- [ ] I have tested my parser changes locally with `poetry run test_parser "zone_key"`
- [x] I have run `pnpx prettier@2 --write .` and `poetry run format` in the top level directory to format my changes.
