### PR TITLE
chore(deps): Update i18next to v24

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -88,7 +88,7 @@
     "d3-shape": "^3.2.0",
     "date-fns": "^3.6.0",
     "geojson": "^0.5.0",
-    "i18next": "^23.16.8",
+    "i18next": "^24.0.2",
     "i18next-browser-languagedetector": "^8.0.0",
     "i18next-resources-to-backend": "^1.2.1",
     "jotai": "^2.10.3",

--- a/web/pnpm-lock.yaml
+++ b/web/pnpm-lock.yaml
@@ -114,8 +114,8 @@ importers:
         specifier: ^0.5.0
         version: 0.5.0
       i18next:
-        specifier: ^23.16.8
-        version: 23.16.8
+        specifier: ^24.0.2
+        version: 24.0.2(typescript@5.5.4)
       i18next-browser-languagedetector:
         specifier: ^8.0.0
         version: 8.0.0
@@ -145,7 +145,7 @@ importers:
         version: 2.0.5(react@18.3.1)
       react-i18next:
         specifier: ^15.1.3
-        version: 15.1.3(i18next@23.16.8)(react-dom@18.3.1(react@18.3.1))(react-native@0.73.6(@babel/core@7.25.7)(@babel/preset-env@7.25.4(@babel/core@7.25.7))(react@18.3.1))(react@18.3.1)
+        version: 15.1.3(i18next@24.0.2(typescript@5.5.4))(react-dom@18.3.1(react@18.3.1))(react-native@0.73.6(@babel/core@7.25.7)(@babel/preset-env@7.25.4(@babel/core@7.25.7))(react@18.3.1))(react@18.3.1)
       react-icons:
         specifier: ^5.3.0
         version: 5.3.0(react@18.3.1)
@@ -5474,8 +5474,13 @@ packages:
   i18next-resources-to-backend@1.2.1:
     resolution: {integrity: sha512-okHbVA+HZ7n1/76MsfhPqDou0fptl2dAlhRDu2ideXloRRduzHsqDOznJBef+R3DFZnbvWoBW+KxJ7fnFjd6Yw==}
 
-  i18next@23.16.8:
-    resolution: {integrity: sha512-06r/TitrM88Mg5FdUXAKL96dJMzgqLE5dv3ryBAra4KCwD9mJ4ndOTS95ZuymIGoE+2hzfdaMak2X11/es7ZWg==}
+  i18next@24.0.2:
+    resolution: {integrity: sha512-D88xyIGcWAKwBTAs4RSqASi8NXR/NhCVSTM4LDbdoU8qb/5dcEZjNCLDhtQBB7Epw/Cp1w2vH/3ujoTbqLSs5g==}
+    peerDependencies:
+      typescript: ^5
+    peerDependenciesMeta:
+      typescript:
+        optional: true
 
   iconv-lite@0.6.3:
     resolution: {integrity: sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==}
@@ -14887,9 +14892,11 @@ snapshots:
     dependencies:
       '@babel/runtime': 7.25.6
 
-  i18next@23.16.8:
+  i18next@24.0.2(typescript@5.5.4):
     dependencies:
       '@babel/runtime': 7.25.7
+    optionalDependencies:
+      typescript: 5.5.4
 
   iconv-lite@0.6.3:
     dependencies:
@@ -16450,11 +16457,11 @@ snapshots:
       react-fast-compare: 3.2.2
       shallowequal: 1.1.0
 
-  react-i18next@15.1.3(i18next@23.16.8)(react-dom@18.3.1(react@18.3.1))(react-native@0.73.6(@babel/core@7.25.7)(@babel/preset-env@7.25.4(@babel/core@7.25.7))(react@18.3.1))(react@18.3.1):
+  react-i18next@15.1.3(i18next@24.0.2(typescript@5.5.4))(react-dom@18.3.1(react@18.3.1))(react-native@0.73.6(@babel/core@7.25.7)(@babel/preset-env@7.25.4(@babel/core@7.25.7))(react@18.3.1))(react@18.3.1):
     dependencies:
       '@babel/runtime': 7.25.7
       html-parse-stringify: 3.0.1
-      i18next: 23.16.8
+      i18next: 24.0.2(typescript@5.5.4)
       react: 18.3.1
     optionalDependencies:
       react-dom: 18.3.1(react@18.3.1)


### PR DESCRIPTION
## Description

i18next has released a new major version that drops support for some of their oldest backwards compatibility features, we don't use any of these so for us this will be pure gains in terms of performance and bundle size.

### Double check

- [x] I have run `pnpx prettier@2 --write .` and `poetry run format` in the top level directory to format my changes.
