### PR TITLE
AVO-669: Quick Fix: Center date between Time Header nav arrows

### DIFF
--- a/web/src/features/time/HistoricalTimeHeader.tsx
+++ b/web/src/features/time/HistoricalTimeHeader.tsx
@@ -77,8 +77,8 @@ export default function HistoricalTimeHeader() {
   }
 
   return (
-    <div className="flex min-h-6 flex-row items-center justify-between">
-      {startDatetime && endDatetime && (
+    <div className="flex min-h-6 flex-row items-center">
+      {!isHourly && startDatetime && endDatetime && (
         <Badge
           pillText={
             <FormattedTime
@@ -91,46 +91,57 @@ export default function HistoricalTimeHeader() {
         />
       )}
       {isHourly && (
-        <div className="flex h-6 flex-row items-center gap-x-3">
-          <NewFeaturePopover
-            side="top"
-            content={<NewFeaturePopoverContent />}
-            isOpenByDefault={isNewFeaturePopoverEnabled}
-          >
+        <div className="relative flex h-6 w-full items-center">
+          <div className="absolute flex w-full items-center justify-between px-10">
+            <NewFeaturePopover
+              side="top"
+              content={<NewFeaturePopoverContent />}
+              isOpenByDefault={isNewFeaturePopoverEnabled}
+            >
+              <Button
+                backgroundClasses="bg-transparent"
+                onClick={handleLeftClick}
+                size="sm"
+                type="tertiary"
+                isDisabled={!isWithinHistoricalLimit}
+                icon={
+                  <ChevronLeft
+                    size={22}
+                    className={twMerge(
+                      'text-brand-green dark:text-success-dark',
+                      !isWithinHistoricalLimit && 'opacity-50'
+                    )}
+                  />
+                }
+              />
+            </NewFeaturePopover>
+            {startDatetime && endDatetime && (
+              <FormattedTime
+                datetime={startDatetime}
+                language={i18n.languages[0]}
+                endDatetime={endDatetime}
+                className="text-sm font-semibold"
+              />
+            )}
             <Button
               backgroundClasses="bg-transparent"
-              onClick={handleLeftClick}
               size="sm"
+              onClick={handleRightClick}
               type="tertiary"
-              isDisabled={!isWithinHistoricalLimit}
+              isDisabled={!urlDatetime}
               icon={
-                <ChevronLeft
-                  size={22}
+                <ChevronRight
                   className={twMerge(
                     'text-brand-green dark:text-success-dark',
-                    !isWithinHistoricalLimit && 'opacity-50'
+                    !urlDatetime && 'opacity-50'
                   )}
+                  size={22}
                 />
               }
             />
-          </NewFeaturePopover>
+          </div>
           <Button
-            backgroundClasses="bg-transparent"
-            size="sm"
-            onClick={handleRightClick}
-            type="tertiary"
-            isDisabled={!urlDatetime}
-            icon={
-              <ChevronRight
-                className={twMerge(
-                  'text-brand-green dark:text-success-dark',
-                  !urlDatetime && 'opacity-50'
-                )}
-                size={22}
-              />
-            }
-          />
-          <Button
+            backgroundClasses="absolute z-1 right-2"
             size="sm"
             type="tertiary"
             onClick={() => {

--- a/web/src/features/time/HistoricalTimeHeader.tsx
+++ b/web/src/features/time/HistoricalTimeHeader.tsx
@@ -1,4 +1,3 @@
-import Badge from 'components/Badge';
 import { Button } from 'components/Button';
 import {
   NewFeaturePopover,
@@ -76,93 +75,90 @@ export default function HistoricalTimeHeader() {
     navigate({ datetime: newDate.toISOString() });
   }
 
-  return (
-    <div className="flex min-h-6 flex-row items-center">
-      {!isHourly && startDatetime && endDatetime && (
-        <Badge
-          pillText={
-            <FormattedTime
-              datetime={startDatetime}
-              language={i18n.languages[0]}
-              endDatetime={endDatetime}
-            />
-          }
-          type="success"
+  if (!isHourly && startDatetime && endDatetime) {
+    return (
+      <div className="flex min-h-6 flex-row items-center justify-center">
+        <FormattedTime
+          datetime={startDatetime}
+          language={i18n.languages[0]}
+          endDatetime={endDatetime}
+          className="text-sm font-semibold"
         />
-      )}
-      {isHourly && (
-        <div className="relative flex h-6 w-full items-center">
-          <div className="absolute flex w-full items-center justify-between px-10">
-            <NewFeaturePopover
-              side="top"
-              content={<NewFeaturePopoverContent />}
-              isOpenByDefault={isNewFeaturePopoverEnabled}
-            >
-              <Button
-                backgroundClasses="bg-transparent"
-                onClick={handleLeftClick}
-                size="sm"
-                type="tertiary"
-                isDisabled={!isWithinHistoricalLimit}
-                icon={
-                  <ChevronLeft
-                    size={22}
-                    className={twMerge(
-                      'text-brand-green dark:text-success-dark',
-                      !isWithinHistoricalLimit && 'opacity-50'
-                    )}
-                  />
-                }
-              />
-            </NewFeaturePopover>
-            {startDatetime && endDatetime && (
-              <FormattedTime
-                datetime={startDatetime}
-                language={i18n.languages[0]}
-                endDatetime={endDatetime}
-                className="text-sm font-semibold"
-              />
-            )}
-            <Button
-              backgroundClasses="bg-transparent"
-              size="sm"
-              onClick={handleRightClick}
-              type="tertiary"
-              isDisabled={!urlDatetime}
-              icon={
-                <ChevronRight
-                  className={twMerge(
-                    'text-brand-green dark:text-success-dark',
-                    !urlDatetime && 'opacity-50'
-                  )}
-                  size={22}
-                />
-              }
-            />
-          </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="relative flex h-6 w-full items-center">
+      <div className="absolute flex w-full items-center justify-between px-10">
+        <NewFeaturePopover
+          side="top"
+          content={<NewFeaturePopoverContent />}
+          isOpenByDefault={isNewFeaturePopoverEnabled}
+        >
           <Button
-            backgroundClasses="absolute z-1 right-2"
+            backgroundClasses="bg-transparent"
+            onClick={handleLeftClick}
             size="sm"
             type="tertiary"
-            onClick={() => {
-              trackEvent(TrackEvent.HISTORICAL_NAVIGATION, {
-                direction: 'latest',
-              });
-              navigate({ datetime: '' });
-            }}
-            isDisabled={!urlDatetime}
+            isDisabled={!isWithinHistoricalLimit}
             icon={
-              <ArrowRightToLine
+              <ChevronLeft
+                size={22}
                 className={twMerge(
                   'text-brand-green dark:text-success-dark',
-                  !urlDatetime && 'opacity-50'
+                  !isWithinHistoricalLimit && 'opacity-50'
                 )}
-                size={22}
               />
             }
           />
-        </div>
-      )}
+        </NewFeaturePopover>
+        {startDatetime && endDatetime && (
+          <FormattedTime
+            datetime={startDatetime}
+            language={i18n.languages[0]}
+            endDatetime={endDatetime}
+            className="text-sm font-semibold"
+          />
+        )}
+        <Button
+          backgroundClasses="bg-transparent"
+          size="sm"
+          onClick={handleRightClick}
+          type="tertiary"
+          isDisabled={!urlDatetime}
+          icon={
+            <ChevronRight
+              className={twMerge(
+                'text-brand-green dark:text-success-dark',
+                !urlDatetime && 'opacity-50'
+              )}
+              size={22}
+            />
+          }
+        />
+      </div>
+      <Button
+        backgroundClasses="absolute z-1 right-2"
+        size="sm"
+        type="tertiary"
+        onClick={() => {
+          trackEvent(TrackEvent.HISTORICAL_NAVIGATION, {
+            direction: 'latest',
+          });
+          navigate({ datetime: '' });
+        }}
+        isDisabled={!urlDatetime}
+        icon={
+          <ArrowRightToLine
+            className={twMerge(
+              'text-brand-green dark:text-success-dark',
+              !urlDatetime && 'opacity-50'
+            )}
+            size={22}
+          />
+        }
+      />
     </div>
   );
 }


### PR DESCRIPTION
## Description

[AVO-669](https://linear.app/electricitymaps/issue/AVO-669/quick-fixes-for-launch-make-navigation-more-intuitive): Quick Fix: Center date between Time Header nav arrows

### Preview
Mobile + light mode:
<img width="279" alt="Screenshot 2024-12-02 at 21 52 31" src="https://github.com/user-attachments/assets/d29f67a2-025d-4e38-bb63-155150f24679">

Desktop + dark mode:
<img width="367" alt="Screenshot 2024-12-02 at 21 52 06" src="https://github.com/user-attachments/assets/f4fda8e3-d835-4d9e-8645-432fac7b5998">

Desktop + aggregate view:
<img width="352" alt="Screenshot 2024-12-02 at 22 25 13" src="https://github.com/user-attachments/assets/60b3e94e-ad60-4eab-91c4-8c0748c39f00">

### Double check

- [ ] I have tested my parser changes locally with `poetry run test_parser "zone_key"`
- [ ] I have run `pnpx prettier@2 --write .` and `poetry run format` in the top level directory to format my changes.
