### PR TITLE
chore(config): Switch SE internal exchanges to Nordpool

### DIFF
--- a/config/exchanges/SE-SE1_SE-SE2.yaml
+++ b/config/exchanges/SE-SE1_SE-SE2.yaml
@@ -5,6 +5,6 @@ lonlat:
   - 17.869
   - 65.469
 parsers:
-  exchange: ENTSOE.fetch_exchange
+  exchange: NORDPOOL.fetch_exchange
   exchangeForecast: ENTSOE.fetch_exchange_forecast
 rotation: 205

--- a/config/exchanges/SE-SE2_SE-SE3.yaml
+++ b/config/exchanges/SE-SE2_SE-SE3.yaml
@@ -5,6 +5,6 @@ lonlat:
   - 14.804
   - 61.42
 parsers:
-  exchange: ENTSOE.fetch_exchange
+  exchange: NORDPOOL.fetch_exchange
   exchangeForecast: ENTSOE.fetch_exchange_forecast
 rotation: 180

--- a/config/exchanges/SE-SE3_SE-SE4.yaml
+++ b/config/exchanges/SE-SE3_SE-SE4.yaml
@@ -5,6 +5,6 @@ lonlat:
   - 14.5
   - 57.2
 parsers:
-  exchange: ENTSOE.fetch_exchange
+  exchange: NORDPOOL.fetch_exchange
   exchangeForecast: ENTSOE.fetch_exchange_forecast
 rotation: 180


### PR DESCRIPTION
## Description

Switch the internal SE exchanges to Nordpool to avoid ENTSO-E downtime and reduce the amount of API calls we make.

This is only the internal SE exchanges for now to be on the safe side but it does support all of the nordic + baltic.

### Preview
```
[{'datetime': datetime.datetime(2024, 12, 1, 23, 0, tzinfo=datetime.timezone.utc),
  'netFlow': 4391.0,
  'sortedZoneKeys': 'SE-SE3->SE-SE4',
  'source': 'nordpool.com',
  'sourceType': <EventSourceType.measured: 'measured'>},
 {'datetime': datetime.datetime(2024, 12, 1, 23, 15, tzinfo=datetime.timezone.utc),
  'netFlow': 4391.0,
  'sortedZoneKeys': 'SE-SE3->SE-SE4',
  'source': 'nordpool.com',
  'sourceType': <EventSourceType.measured: 'measured'>},
 {'datetime': datetime.datetime(2024, 12, 1, 23, 30, tzinfo=datetime.timezone.utc),
  'netFlow': 4391.0,
  'sortedZoneKeys': 'SE-SE3->SE-SE4',
  'source': 'nordpool.com',
  'sourceType': <EventSourceType.measured: 'measured'>},
 {'datetime': datetime.datetime(2024, 12, 1, 23, 45, tzinfo=datetime.timezone.utc),
  'netFlow': 4391.0,
  'sortedZoneKeys': 'SE-SE3->SE-SE4',
  'source': 'nordpool.com',
  'sourceType': <EventSourceType.measured: 'measured'>},
 {'datetime': datetime.datetime(2024, 12, 2, 0, 0, tzinfo=datetime.timezone.utc),
  'netFlow': 4185.0,
  'sortedZoneKeys': 'SE-SE3->SE-SE4',
  'source': 'nordpool.com',
  'sourceType': <EventSourceType.measured: 'measured'>},
 {'datetime': datetime.datetime(2024, 12, 2, 0, 15, tzinfo=datetime.timezone.utc),
  'netFlow': 4185.0,
  'sortedZoneKeys': 'SE-SE3->SE-SE4',
  'source': 'nordpool.com',
  'sourceType': <EventSourceType.measured: 'measured'>},
 {'datetime': datetime.datetime(2024, 12, 2, 0, 30, tzinfo=datetime.timezone.utc),
  'netFlow': 4185.0,
  'sortedZoneKeys': 'SE-SE3->SE-SE4',
  'source': 'nordpool.com',
  'sourceType': <EventSourceType.measured: 'measured'>},
 {'datetime': datetime.datetime(2024, 12, 2, 0, 45, tzinfo=datetime.timezone.utc),
  'netFlow': 4185.0,
  'sortedZoneKeys': 'SE-SE3->SE-SE4',
  'source': 'nordpool.com',
  'sourceType': <EventSourceType.measured: 'measured'>},
 {'datetime': datetime.datetime(2024, 12, 2, 1, 0, tzinfo=datetime.timezone.utc),
  'netFlow': 3997.0,
  'sortedZoneKeys': 'SE-SE3->SE-SE4',
  'source': 'nordpool.com',
  'sourceType': <EventSourceType.measured: 'measured'>},
 {'datetime': datetime.datetime(2024, 12, 2, 1, 15, tzinfo=datetime.timezone.utc),
  'netFlow': 3997.0,
  'sortedZoneKeys': 'SE-SE3->SE-SE4',
  'source': 'nordpool.com',
  'sourceType': <EventSourceType.measured: 'measured'>},
 {'datetime': datetime.datetime(2024, 12, 2, 1, 30, tzinfo=datetime.timezone.utc),
  'netFlow': 3997.0,
  'sortedZoneKeys': 'SE-SE3->SE-SE4',
  'source': 'nordpool.com',
  'sourceType': <EventSourceType.measured: 'measured'>},
 {'datetime': datetime.datetime(2024, 12, 2, 1, 45, tzinfo=datetime.timezone.utc),
  'netFlow': 3997.0,
  'sortedZoneKeys': 'SE-SE3->SE-SE4',
  'source': 'nordpool.com',
  'sourceType': <EventSourceType.measured: 'measured'>},
 {'datetime': datetime.datetime(2024, 12, 2, 2, 0, tzinfo=datetime.timezone.utc),
  'netFlow': 3990.0,
  'sortedZoneKeys': 'SE-SE3->SE-SE4',
  'source': 'nordpool.com',
  'sourceType': <EventSourceType.measured: 'measured'>},
 {'datetime': datetime.datetime(2024, 12, 2, 2, 15, tzinfo=datetime.timezone.utc),
  'netFlow': 3990.0,
  'sortedZoneKeys': 'SE-SE3->SE-SE4',
  'source': 'nordpool.com',
  'sourceType': <EventSourceType.measured: 'measured'>},
 {'datetime': datetime.datetime(2024, 12, 2, 2, 30, tzinfo=datetime.timezone.utc),
  'netFlow': 3990.0,
  'sortedZoneKeys': 'SE-SE3->SE-SE4',
  'source': 'nordpool.com',
  'sourceType': <EventSourceType.measured: 'measured'>},
 {'datetime': datetime.datetime(2024, 12, 2, 2, 45, tzinfo=datetime.timezone.utc),
  'netFlow': 3990.0,
  'sortedZoneKeys': 'SE-SE3->SE-SE4',
  'source': 'nordpool.com',
  'sourceType': <EventSourceType.measured: 'measured'>},
 {'datetime': datetime.datetime(2024, 12, 2, 3, 0, tzinfo=datetime.timezone.utc),
  'netFlow': 4018.0,
  'sortedZoneKeys': 'SE-SE3->SE-SE4',
  'source': 'nordpool.com',
  'sourceType': <EventSourceType.measured: 'measured'>},
 {'datetime': datetime.datetime(2024, 12, 2, 3, 15, tzinfo=datetime.timezone.utc),
  'netFlow': 4018.0,
  'sortedZoneKeys': 'SE-SE3->SE-SE4',
  'source': 'nordpool.com',
  'sourceType': <EventSourceType.measured: 'measured'>},
 {'datetime': datetime.datetime(2024, 12, 2, 3, 30, tzinfo=datetime.timezone.utc),
  'netFlow': 4018.0,
  'sortedZoneKeys': 'SE-SE3->SE-SE4',
  'source': 'nordpool.com',
  'sourceType': <EventSourceType.measured: 'measured'>},
 {'datetime': datetime.datetime(2024, 12, 2, 3, 45, tzinfo=datetime.timezone.utc),
  'netFlow': 4018.0,
  'sortedZoneKeys': 'SE-SE3->SE-SE4',
  'source': 'nordpool.com',
  'sourceType': <EventSourceType.measured: 'measured'>},
 {'datetime': datetime.datetime(2024, 12, 2, 4, 0, tzinfo=datetime.timezone.utc),
  'netFlow': 4171.0,
  'sortedZoneKeys': 'SE-SE3->SE-SE4',
  'source': 'nordpool.com',
  'sourceType': <EventSourceType.measured: 'measured'>},
 {'datetime': datetime.datetime(2024, 12, 2, 4, 15, tzinfo=datetime.timezone.utc),
  'netFlow': 4171.0,
  'sortedZoneKeys': 'SE-SE3->SE-SE4',
  'source': 'nordpool.com',
  'sourceType': <EventSourceType.measured: 'measured'>},
 {'datetime': datetime.datetime(2024, 12, 2, 4, 30, tzinfo=datetime.timezone.utc),
  'netFlow': 4171.0,
  'sortedZoneKeys': 'SE-SE3->SE-SE4',
  'source': 'nordpool.com',
  'sourceType': <EventSourceType.measured: 'measured'>},
 {'datetime': datetime.datetime(2024, 12, 2, 4, 45, tzinfo=datetime.timezone.utc),
  'netFlow': 4171.0,
  'sortedZoneKeys': 'SE-SE3->SE-SE4',
  'source': 'nordpool.com',
  'sourceType': <EventSourceType.measured: 'measured'>},
 {'datetime': datetime.datetime(2024, 12, 2, 5, 0, tzinfo=datetime.timezone.utc),
  'netFlow': 4820.0,
  'sortedZoneKeys': 'SE-SE3->SE-SE4',
  'source': 'nordpool.com',
  'sourceType': <EventSourceType.measured: 'measured'>},
 {'datetime': datetime.datetime(2024, 12, 2, 5, 15, tzinfo=datetime.timezone.utc),
  'netFlow': 4820.0,
  'sortedZoneKeys': 'SE-SE3->SE-SE4',
  'source': 'nordpool.com',
  'sourceType': <EventSourceType.measured: 'measured'>},
 {'datetime': datetime.datetime(2024, 12, 2, 5, 30, tzinfo=datetime.timezone.utc),
  'netFlow': 4820.0,
  'sortedZoneKeys': 'SE-SE3->SE-SE4',
  'source': 'nordpool.com',
  'sourceType': <EventSourceType.measured: 'measured'>},
 {'datetime': datetime.datetime(2024, 12, 2, 5, 45, tzinfo=datetime.timezone.utc),
  'netFlow': 4820.0,
  'sortedZoneKeys': 'SE-SE3->SE-SE4',
  'source': 'nordpool.com',
  'sourceType': <EventSourceType.measured: 'measured'>},
 {'datetime': datetime.datetime(2024, 12, 2, 6, 0, tzinfo=datetime.timezone.utc),
  'netFlow': 5258.0,
  'sortedZoneKeys': 'SE-SE3->SE-SE4',
  'source': 'nordpool.com',
  'sourceType': <EventSourceType.measured: 'measured'>},
 {'datetime': datetime.datetime(2024, 12, 2, 6, 15, tzinfo=datetime.timezone.utc),
  'netFlow': 5258.0,
  'sortedZoneKeys': 'SE-SE3->SE-SE4',
  'source': 'nordpool.com',
  'sourceType': <EventSourceType.measured: 'measured'>},
 {'datetime': datetime.datetime(2024, 12, 2, 6, 30, tzinfo=datetime.timezone.utc),
  'netFlow': 5258.0,
  'sortedZoneKeys': 'SE-SE3->SE-SE4',
  'source': 'nordpool.com',
  'sourceType': <EventSourceType.measured: 'measured'>},
 {'datetime': datetime.datetime(2024, 12, 2, 6, 45, tzinfo=datetime.timezone.utc),
  'netFlow': 5258.0,
  'sortedZoneKeys': 'SE-SE3->SE-SE4',
  'source': 'nordpool.com',
  'sourceType': <EventSourceType.measured: 'measured'>},
 {'datetime': datetime.datetime(2024, 12, 2, 7, 0, tzinfo=datetime.timezone.utc),
  'netFlow': 5472.0,
  'sortedZoneKeys': 'SE-SE3->SE-SE4',
  'source': 'nordpool.com',
  'sourceType': <EventSourceType.measured: 'measured'>},
 {'datetime': datetime.datetime(2024, 12, 2, 7, 15, tzinfo=datetime.timezone.utc),
  'netFlow': 5472.0,
  'sortedZoneKeys': 'SE-SE3->SE-SE4',
  'source': 'nordpool.com',
  'sourceType': <EventSourceType.measured: 'measured'>},
 {'datetime': datetime.datetime(2024, 12, 2, 7, 30, tzinfo=datetime.timezone.utc),
  'netFlow': 5472.0,
  'sortedZoneKeys': 'SE-SE3->SE-SE4',
  'source': 'nordpool.com',
  'sourceType': <EventSourceType.measured: 'measured'>},
 {'datetime': datetime.datetime(2024, 12, 2, 7, 45, tzinfo=datetime.timezone.utc),
  'netFlow': 5472.0,
  'sortedZoneKeys': 'SE-SE3->SE-SE4',
  'source': 'nordpool.com',
  'sourceType': <EventSourceType.measured: 'measured'>},
 {'datetime': datetime.datetime(2024, 12, 2, 8, 0, tzinfo=datetime.timezone.utc),
  'netFlow': 5466.0,
  'sortedZoneKeys': 'SE-SE3->SE-SE4',
  'source': 'nordpool.com',
  'sourceType': <EventSourceType.measured: 'measured'>},
 {'datetime': datetime.datetime(2024, 12, 2, 8, 15, tzinfo=datetime.timezone.utc),
  'netFlow': 5466.0,
  'sortedZoneKeys': 'SE-SE3->SE-SE4',
  'source': 'nordpool.com',
  'sourceType': <EventSourceType.measured: 'measured'>},
 {'datetime': datetime.datetime(2024, 12, 2, 8, 30, tzinfo=datetime.timezone.utc),
  'netFlow': 5466.0,
  'sortedZoneKeys': 'SE-SE3->SE-SE4',
  'source': 'nordpool.com',
  'sourceType': <EventSourceType.measured: 'measured'>},
 {'datetime': datetime.datetime(2024, 12, 2, 8, 45, tzinfo=datetime.timezone.utc),
  'netFlow': 5466.0,
  'sortedZoneKeys': 'SE-SE3->SE-SE4',
  'source': 'nordpool.com',
  'sourceType': <EventSourceType.measured: 'measured'>},
 {'datetime': datetime.datetime(2024, 12, 2, 9, 0, tzinfo=datetime.timezone.utc),
  'netFlow': 5428.0,
  'sortedZoneKeys': 'SE-SE3->SE-SE4',
  'source': 'nordpool.com',
  'sourceType': <EventSourceType.measured: 'measured'>},
 {'datetime': datetime.datetime(2024, 12, 2, 9, 15, tzinfo=datetime.timezone.utc),
  'netFlow': 5428.0,
  'sortedZoneKeys': 'SE-SE3->SE-SE4',
  'source': 'nordpool.com',
  'sourceType': <EventSourceType.measured: 'measured'>},
 {'datetime': datetime.datetime(2024, 12, 2, 9, 30, tzinfo=datetime.timezone.utc),
  'netFlow': 5428.0,
  'sortedZoneKeys': 'SE-SE3->SE-SE4',
  'source': 'nordpool.com',
  'sourceType': <EventSourceType.measured: 'measured'>},
 {'datetime': datetime.datetime(2024, 12, 2, 9, 45, tzinfo=datetime.timezone.utc),
  'netFlow': 5428.0,
  'sortedZoneKeys': 'SE-SE3->SE-SE4',
  'source': 'nordpool.com',
  'sourceType': <EventSourceType.measured: 'measured'>},
 {'datetime': datetime.datetime(2024, 12, 2, 10, 0, tzinfo=datetime.timezone.utc),
  'netFlow': 5517.0,
  'sortedZoneKeys': 'SE-SE3->SE-SE4',
  'source': 'nordpool.com',
  'sourceType': <EventSourceType.measured: 'measured'>},
 {'datetime': datetime.datetime(2024, 12, 2, 10, 15, tzinfo=datetime.timezone.utc),
  'netFlow': 5517.0,
  'sortedZoneKeys': 'SE-SE3->SE-SE4',
  'source': 'nordpool.com',
  'sourceType': <EventSourceType.measured: 'measured'>},
 {'datetime': datetime.datetime(2024, 12, 2, 10, 30, tzinfo=datetime.timezone.utc),
  'netFlow': 5517.0,
  'sortedZoneKeys': 'SE-SE3->SE-SE4',
  'source': 'nordpool.com',
  'sourceType': <EventSourceType.measured: 'measured'>},
 {'datetime': datetime.datetime(2024, 12, 2, 10, 45, tzinfo=datetime.timezone.utc),
  'netFlow': 5517.0,
  'sortedZoneKeys': 'SE-SE3->SE-SE4',
  'source': 'nordpool.com',
  'sourceType': <EventSourceType.measured: 'measured'>},
 {'datetime': datetime.datetime(2024, 12, 2, 11, 0, tzinfo=datetime.timezone.utc),
  'netFlow': 5521.0,
  'sortedZoneKeys': 'SE-SE3->SE-SE4',
  'source': 'nordpool.com',
  'sourceType': <EventSourceType.measured: 'measured'>},
 {'datetime': datetime.datetime(2024, 12, 2, 11, 15, tzinfo=datetime.timezone.utc),
  'netFlow': 5521.0,
  'sortedZoneKeys': 'SE-SE3->SE-SE4',
  'source': 'nordpool.com',
  'sourceType': <EventSourceType.measured: 'measured'>},
 {'datetime': datetime.datetime(2024, 12, 2, 11, 30, tzinfo=datetime.timezone.utc),
  'netFlow': 5521.0,
  'sortedZoneKeys': 'SE-SE3->SE-SE4',
  'source': 'nordpool.com',
  'sourceType': <EventSourceType.measured: 'measured'>},
 {'datetime': datetime.datetime(2024, 12, 2, 11, 45, tzinfo=datetime.timezone.utc),
  'netFlow': 5521.0,
  'sortedZoneKeys': 'SE-SE3->SE-SE4',
  'source': 'nordpool.com',
  'sourceType': <EventSourceType.measured: 'measured'>},
 {'datetime': datetime.datetime(2024, 12, 2, 12, 0, tzinfo=datetime.timezone.utc),
  'netFlow': 5588.0,
  'sortedZoneKeys': 'SE-SE3->SE-SE4',
  'source': 'nordpool.com',
  'sourceType': <EventSourceType.measured: 'measured'>},
 {'datetime': datetime.datetime(2024, 12, 2, 12, 15, tzinfo=datetime.timezone.utc),
  'netFlow': 5588.0,
  'sortedZoneKeys': 'SE-SE3->SE-SE4',
  'source': 'nordpool.com',
  'sourceType': <EventSourceType.measured: 'measured'>},
 {'datetime': datetime.datetime(2024, 12, 2, 12, 30, tzinfo=datetime.timezone.utc),
  'netFlow': 5588.0,
  'sortedZoneKeys': 'SE-SE3->SE-SE4',
  'source': 'nordpool.com',
  'sourceType': <EventSourceType.measured: 'measured'>},
 {'datetime': datetime.datetime(2024, 12, 2, 12, 45, tzinfo=datetime.timezone.utc),
  'netFlow': 5588.0,
  'sortedZoneKeys': 'SE-SE3->SE-SE4',
  'source': 'nordpool.com',
  'sourceType': <EventSourceType.measured: 'measured'>},
 {'datetime': datetime.datetime(2024, 12, 2, 13, 0, tzinfo=datetime.timezone.utc),
  'netFlow': 5395.0,
  'sortedZoneKeys': 'SE-SE3->SE-SE4',
  'source': 'nordpool.com',
  'sourceType': <EventSourceType.measured: 'measured'>},
 {'datetime': datetime.datetime(2024, 12, 2, 13, 15, tzinfo=datetime.timezone.utc),
  'netFlow': 5395.0,
  'sortedZoneKeys': 'SE-SE3->SE-SE4',
  'source': 'nordpool.com',
  'sourceType': <EventSourceType.measured: 'measured'>},
 {'datetime': datetime.datetime(2024, 12, 2, 13, 30, tzinfo=datetime.timezone.utc),
  'netFlow': 5395.0,
  'sortedZoneKeys': 'SE-SE3->SE-SE4',
  'source': 'nordpool.com',
  'sourceType': <EventSourceType.measured: 'measured'>},
 {'datetime': datetime.datetime(2024, 12, 2, 13, 45, tzinfo=datetime.timezone.utc),
  'netFlow': 5395.0,
  'sortedZoneKeys': 'SE-SE3->SE-SE4',
  'source': 'nordpool.com',
  'sourceType': <EventSourceType.measured: 'measured'>},
 {'datetime': datetime.datetime(2024, 12, 2, 14, 0, tzinfo=datetime.timezone.utc),
  'netFlow': 5380.0,
  'sortedZoneKeys': 'SE-SE3->SE-SE4',
  'source': 'nordpool.com',
  'sourceType': <EventSourceType.measured: 'measured'>},
 {'datetime': datetime.datetime(2024, 12, 2, 14, 15, tzinfo=datetime.timezone.utc),
  'netFlow': 5380.0,
  'sortedZoneKeys': 'SE-SE3->SE-SE4',
  'source': 'nordpool.com',
  'sourceType': <EventSourceType.measured: 'measured'>},
 {'datetime': datetime.datetime(2024, 12, 2, 14, 30, tzinfo=datetime.timezone.utc),
  'netFlow': 5380.0,
  'sortedZoneKeys': 'SE-SE3->SE-SE4',
  'source': 'nordpool.com',
  'sourceType': <EventSourceType.measured: 'measured'>},
 {'datetime': datetime.datetime(2024, 12, 2, 14, 45, tzinfo=datetime.timezone.utc),
  'netFlow': 5380.0,
  'sortedZoneKeys': 'SE-SE3->SE-SE4',
  'source': 'nordpool.com',
  'sourceType': <EventSourceType.measured: 'measured'>},
 {'datetime': datetime.datetime(2024, 12, 2, 15, 0, tzinfo=datetime.timezone.utc),
  'netFlow': 4804.0,
  'sortedZoneKeys': 'SE-SE3->SE-SE4',
  'source': 'nordpool.com',
  'sourceType': <EventSourceType.measured: 'measured'>},
 {'datetime': datetime.datetime(2024, 12, 2, 15, 15, tzinfo=datetime.timezone.utc),
  'netFlow': 4804.0,
  'sortedZoneKeys': 'SE-SE3->SE-SE4',
  'source': 'nordpool.com',
  'sourceType': <EventSourceType.measured: 'measured'>},
 {'datetime': datetime.datetime(2024, 12, 2, 15, 30, tzinfo=datetime.timezone.utc),
  'netFlow': 4804.0,
  'sortedZoneKeys': 'SE-SE3->SE-SE4',
  'source': 'nordpool.com',
  'sourceType': <EventSourceType.measured: 'measured'>},
 {'datetime': datetime.datetime(2024, 12, 2, 15, 45, tzinfo=datetime.timezone.utc),
  'netFlow': 4804.0,
  'sortedZoneKeys': 'SE-SE3->SE-SE4',
  'source': 'nordpool.com',
  'sourceType': <EventSourceType.measured: 'measured'>},
 {'datetime': datetime.datetime(2024, 12, 2, 16, 0, tzinfo=datetime.timezone.utc),
  'netFlow': 4467.0,
  'sortedZoneKeys': 'SE-SE3->SE-SE4',
  'source': 'nordpool.com',
  'sourceType': <EventSourceType.measured: 'measured'>},
 {'datetime': datetime.datetime(2024, 12, 2, 16, 15, tzinfo=datetime.timezone.utc),
  'netFlow': 4467.0,
  'sortedZoneKeys': 'SE-SE3->SE-SE4',
  'source': 'nordpool.com',
  'sourceType': <EventSourceType.measured: 'measured'>},
 {'datetime': datetime.datetime(2024, 12, 2, 16, 30, tzinfo=datetime.timezone.utc),
  'netFlow': 4467.0,
  'sortedZoneKeys': 'SE-SE3->SE-SE4',
  'source': 'nordpool.com',
  'sourceType': <EventSourceType.measured: 'measured'>},
 {'datetime': datetime.datetime(2024, 12, 2, 16, 45, tzinfo=datetime.timezone.utc),
  'netFlow': 4467.0,
  'sortedZoneKeys': 'SE-SE3->SE-SE4',
  'source': 'nordpool.com',
  'sourceType': <EventSourceType.measured: 'measured'>},
 {'datetime': datetime.datetime(2024, 12, 2, 17, 0, tzinfo=datetime.timezone.utc),
  'netFlow': 4282.0,
  'sortedZoneKeys': 'SE-SE3->SE-SE4',
  'source': 'nordpool.com',
  'sourceType': <EventSourceType.measured: 'measured'>},
 {'datetime': datetime.datetime(2024, 12, 2, 17, 15, tzinfo=datetime.timezone.utc),
  'netFlow': 4282.0,
  'sortedZoneKeys': 'SE-SE3->SE-SE4',
  'source': 'nordpool.com',
  'sourceType': <EventSourceType.measured: 'measured'>},
 {'datetime': datetime.datetime(2024, 12, 2, 17, 30, tzinfo=datetime.timezone.utc),
  'netFlow': 4282.0,
  'sortedZoneKeys': 'SE-SE3->SE-SE4',
  'source': 'nordpool.com',
  'sourceType': <EventSourceType.measured: 'measured'>},
 {'datetime': datetime.datetime(2024, 12, 2, 17, 45, tzinfo=datetime.timezone.utc),
  'netFlow': 4282.0,
  'sortedZoneKeys': 'SE-SE3->SE-SE4',
  'source': 'nordpool.com',
  'sourceType': <EventSourceType.measured: 'measured'>},
 {'datetime': datetime.datetime(2024, 12, 2, 18, 0, tzinfo=datetime.timezone.utc),
  'netFlow': 4324.0,
  'sortedZoneKeys': 'SE-SE3->SE-SE4',
  'source': 'nordpool.com',
  'sourceType': <EventSourceType.measured: 'measured'>},
 {'datetime': datetime.datetime(2024, 12, 2, 18, 15, tzinfo=datetime.timezone.utc),
  'netFlow': 4324.0,
  'sortedZoneKeys': 'SE-SE3->SE-SE4',
  'source': 'nordpool.com',
  'sourceType': <EventSourceType.measured: 'measured'>},
 {'datetime': datetime.datetime(2024, 12, 2, 18, 30, tzinfo=datetime.timezone.utc),
  'netFlow': 4324.0,
  'sortedZoneKeys': 'SE-SE3->SE-SE4',
  'source': 'nordpool.com',
  'sourceType': <EventSourceType.measured: 'measured'>},
 {'datetime': datetime.datetime(2024, 12, 2, 18, 45, tzinfo=datetime.timezone.utc),
  'netFlow': 4324.0,
  'sortedZoneKeys': 'SE-SE3->SE-SE4',
  'source': 'nordpool.com',
  'sourceType': <EventSourceType.measured: 'measured'>},
 {'datetime': datetime.datetime(2024, 12, 2, 19, 0, tzinfo=datetime.timezone.utc),
  'netFlow': 4485.0,
  'sortedZoneKeys': 'SE-SE3->SE-SE4',
  'source': 'nordpool.com',
  'sourceType': <EventSourceType.measured: 'measured'>},
 {'datetime': datetime.datetime(2024, 12, 2, 19, 15, tzinfo=datetime.timezone.utc),
  'netFlow': 4485.0,
  'sortedZoneKeys': 'SE-SE3->SE-SE4',
  'source': 'nordpool.com',
  'sourceType': <EventSourceType.measured: 'measured'>},
 {'datetime': datetime.datetime(2024, 12, 2, 19, 30, tzinfo=datetime.timezone.utc),
  'netFlow': 4485.0,
  'sortedZoneKeys': 'SE-SE3->SE-SE4',
  'source': 'nordpool.com',
  'sourceType': <EventSourceType.measured: 'measured'>},
 {'datetime': datetime.datetime(2024, 12, 2, 19, 45, tzinfo=datetime.timezone.utc),
  'netFlow': 4485.0,
  'sortedZoneKeys': 'SE-SE3->SE-SE4',
  'source': 'nordpool.com',
  'sourceType': <EventSourceType.measured: 'measured'>},
 {'datetime': datetime.datetime(2024, 12, 2, 20, 0, tzinfo=datetime.timezone.utc),
  'netFlow': 4348.0,
  'sortedZoneKeys': 'SE-SE3->SE-SE4',
  'source': 'nordpool.com',
  'sourceType': <EventSourceType.measured: 'measured'>},
 {'datetime': datetime.datetime(2024, 12, 2, 20, 15, tzinfo=datetime.timezone.utc),
  'netFlow': 4348.0,
  'sortedZoneKeys': 'SE-SE3->SE-SE4',
  'source': 'nordpool.com',
  'sourceType': <EventSourceType.measured: 'measured'>},
 {'datetime': datetime.datetime(2024, 12, 2, 20, 30, tzinfo=datetime.timezone.utc),
  'netFlow': 4348.0,
  'sortedZoneKeys': 'SE-SE3->SE-SE4',
  'source': 'nordpool.com',
  'sourceType': <EventSourceType.measured: 'measured'>},
 {'datetime': datetime.datetime(2024, 12, 2, 20, 45, tzinfo=datetime.timezone.utc),
  'netFlow': 4348.0,
  'sortedZoneKeys': 'SE-SE3->SE-SE4',
  'source': 'nordpool.com',
  'sourceType': <EventSourceType.measured: 'measured'>},
 {'datetime': datetime.datetime(2024, 12, 2, 21, 0, tzinfo=datetime.timezone.utc),
  'netFlow': 3969.0,
  'sortedZoneKeys': 'SE-SE3->SE-SE4',
  'source': 'nordpool.com',
  'sourceType': <EventSourceType.measured: 'measured'>},
 {'datetime': datetime.datetime(2024, 12, 2, 21, 15, tzinfo=datetime.timezone.utc),
  'netFlow': 3969.0,
  'sortedZoneKeys': 'SE-SE3->SE-SE4',
  'source': 'nordpool.com',
  'sourceType': <EventSourceType.measured: 'measured'>},
 {'datetime': datetime.datetime(2024, 12, 2, 21, 30, tzinfo=datetime.timezone.utc),
  'netFlow': 3969.0,
  'sortedZoneKeys': 'SE-SE3->SE-SE4',
  'source': 'nordpool.com',
  'sourceType': <EventSourceType.measured: 'measured'>},
 {'datetime': datetime.datetime(2024, 12, 2, 21, 45, tzinfo=datetime.timezone.utc),
  'netFlow': 3969.0,
  'sortedZoneKeys': 'SE-SE3->SE-SE4',
  'source': 'nordpool.com',
  'sourceType': <EventSourceType.measured: 'measured'>},
 {'datetime': datetime.datetime(2024, 12, 2, 22, 0, tzinfo=datetime.timezone.utc),
  'netFlow': 4235.0,
  'sortedZoneKeys': 'SE-SE3->SE-SE4',
  'source': 'nordpool.com',
  'sourceType': <EventSourceType.measured: 'measured'>},
 {'datetime': datetime.datetime(2024, 12, 2, 22, 15, tzinfo=datetime.timezone.utc),
  'netFlow': 4235.0,
  'sortedZoneKeys': 'SE-SE3->SE-SE4',
  'source': 'nordpool.com',
  'sourceType': <EventSourceType.measured: 'measured'>},
 {'datetime': datetime.datetime(2024, 12, 2, 22, 30, tzinfo=datetime.timezone.utc),
  'netFlow': 4235.0,
  'sortedZoneKeys': 'SE-SE3->SE-SE4',
  'source': 'nordpool.com',
  'sourceType': <EventSourceType.measured: 'measured'>},
 {'datetime': datetime.datetime(2024, 12, 2, 22, 45, tzinfo=datetime.timezone.utc),
  'netFlow': 4235.0,
  'sortedZoneKeys': 'SE-SE3->SE-SE4',
  'source': 'nordpool.com',
  'sourceType': <EventSourceType.measured: 'measured'>},
 {'datetime': datetime.datetime(2024, 12, 2, 23, 0, tzinfo=datetime.timezone.utc),
  'netFlow': 4155.0,
  'sortedZoneKeys': 'SE-SE3->SE-SE4',
  'source': 'nordpool.com',
  'sourceType': <EventSourceType.measured: 'measured'>},
 {'datetime': datetime.datetime(2024, 12, 2, 23, 15, tzinfo=datetime.timezone.utc),
  'netFlow': 4155.0,
  'sortedZoneKeys': 'SE-SE3->SE-SE4',
  'source': 'nordpool.com',
  'sourceType': <EventSourceType.measured: 'measured'>},
 {'datetime': datetime.datetime(2024, 12, 2, 23, 30, tzinfo=datetime.timezone.utc),
  'netFlow': 4155.0,
  'sortedZoneKeys': 'SE-SE3->SE-SE4',
  'source': 'nordpool.com',
  'sourceType': <EventSourceType.measured: 'measured'>},
 {'datetime': datetime.datetime(2024, 12, 2, 23, 45, tzinfo=datetime.timezone.utc),
  'netFlow': 4155.0,
  'sortedZoneKeys': 'SE-SE3->SE-SE4',
  'source': 'nordpool.com',
  'sourceType': <EventSourceType.measured: 'measured'>},
 {'datetime': datetime.datetime(2024, 12, 3, 0, 0, tzinfo=datetime.timezone.utc),
  'netFlow': 4255.0,
  'sortedZoneKeys': 'SE-SE3->SE-SE4',
  'source': 'nordpool.com',
  'sourceType': <EventSourceType.measured: 'measured'>},
 {'datetime': datetime.datetime(2024, 12, 3, 0, 15, tzinfo=datetime.timezone.utc),
  'netFlow': 4255.0,
  'sortedZoneKeys': 'SE-SE3->SE-SE4',
  'source': 'nordpool.com',
  'sourceType': <EventSourceType.measured: 'measured'>},
 {'datetime': datetime.datetime(2024, 12, 3, 0, 30, tzinfo=datetime.timezone.utc),
  'netFlow': 4255.0,
  'sortedZoneKeys': 'SE-SE3->SE-SE4',
  'source': 'nordpool.com',
  'sourceType': <EventSourceType.measured: 'measured'>},
 {'datetime': datetime.datetime(2024, 12, 3, 0, 45, tzinfo=datetime.timezone.utc),
  'netFlow': 4255.0,
  'sortedZoneKeys': 'SE-SE3->SE-SE4',
  'source': 'nordpool.com',
  'sourceType': <EventSourceType.measured: 'measured'>},
 {'datetime': datetime.datetime(2024, 12, 3, 1, 0, tzinfo=datetime.timezone.utc),
  'netFlow': 4118.0,
  'sortedZoneKeys': 'SE-SE3->SE-SE4',
  'source': 'nordpool.com',
  'sourceType': <EventSourceType.measured: 'measured'>},
 {'datetime': datetime.datetime(2024, 12, 3, 1, 15, tzinfo=datetime.timezone.utc),
  'netFlow': 4118.0,
  'sortedZoneKeys': 'SE-SE3->SE-SE4',
  'source': 'nordpool.com',
  'sourceType': <EventSourceType.measured: 'measured'>},
 {'datetime': datetime.datetime(2024, 12, 3, 1, 30, tzinfo=datetime.timezone.utc),
  'netFlow': 4118.0,
  'sortedZoneKeys': 'SE-SE3->SE-SE4',
  'source': 'nordpool.com',
  'sourceType': <EventSourceType.measured: 'measured'>},
 {'datetime': datetime.datetime(2024, 12, 3, 1, 45, tzinfo=datetime.timezone.utc),
  'netFlow': 4118.0,
  'sortedZoneKeys': 'SE-SE3->SE-SE4',
  'source': 'nordpool.com',
  'sourceType': <EventSourceType.measured: 'measured'>},
 {'datetime': datetime.datetime(2024, 12, 3, 2, 0, tzinfo=datetime.timezone.utc),
  'netFlow': 4249.0,
  'sortedZoneKeys': 'SE-SE3->SE-SE4',
  'source': 'nordpool.com',
  'sourceType': <EventSourceType.measured: 'measured'>},
 {'datetime': datetime.datetime(2024, 12, 3, 2, 15, tzinfo=datetime.timezone.utc),
  'netFlow': 4249.0,
  'sortedZoneKeys': 'SE-SE3->SE-SE4',
  'source': 'nordpool.com',
  'sourceType': <EventSourceType.measured: 'measured'>},
 {'datetime': datetime.datetime(2024, 12, 3, 2, 30, tzinfo=datetime.timezone.utc),
  'netFlow': 4249.0,
  'sortedZoneKeys': 'SE-SE3->SE-SE4',
  'source': 'nordpool.com',
  'sourceType': <EventSourceType.measured: 'measured'>},
 {'datetime': datetime.datetime(2024, 12, 3, 2, 45, tzinfo=datetime.timezone.utc),
  'netFlow': 4249.0,
  'sortedZoneKeys': 'SE-SE3->SE-SE4',
  'source': 'nordpool.com',
  'sourceType': <EventSourceType.measured: 'measured'>},
 {'datetime': datetime.datetime(2024, 12, 3, 3, 0, tzinfo=datetime.timezone.utc),
  'netFlow': 3973.0,
  'sortedZoneKeys': 'SE-SE3->SE-SE4',
  'source': 'nordpool.com',
  'sourceType': <EventSourceType.measured: 'measured'>},
 {'datetime': datetime.datetime(2024, 12, 3, 3, 15, tzinfo=datetime.timezone.utc),
  'netFlow': 3973.0,
  'sortedZoneKeys': 'SE-SE3->SE-SE4',
  'source': 'nordpool.com',
  'sourceType': <EventSourceType.measured: 'measured'>},
 {'datetime': datetime.datetime(2024, 12, 3, 3, 30, tzinfo=datetime.timezone.utc),
  'netFlow': 3973.0,
  'sortedZoneKeys': 'SE-SE3->SE-SE4',
  'source': 'nordpool.com',
  'sourceType': <EventSourceType.measured: 'measured'>},
 {'datetime': datetime.datetime(2024, 12, 3, 3, 45, tzinfo=datetime.timezone.utc),
  'netFlow': 3973.0,
  'sortedZoneKeys': 'SE-SE3->SE-SE4',
  'source': 'nordpool.com',
  'sourceType': <EventSourceType.measured: 'measured'>},
 {'datetime': datetime.datetime(2024, 12, 3, 4, 0, tzinfo=datetime.timezone.utc),
  'netFlow': 4625.0,
  'sortedZoneKeys': 'SE-SE3->SE-SE4',
  'source': 'nordpool.com',
  'sourceType': <EventSourceType.measured: 'measured'>},
 {'datetime': datetime.datetime(2024, 12, 3, 4, 15, tzinfo=datetime.timezone.utc),
  'netFlow': 4625.0,
  'sortedZoneKeys': 'SE-SE3->SE-SE4',
  'source': 'nordpool.com',
  'sourceType': <EventSourceType.measured: 'measured'>},
 {'datetime': datetime.datetime(2024, 12, 3, 4, 30, tzinfo=datetime.timezone.utc),
  'netFlow': 4625.0,
  'sortedZoneKeys': 'SE-SE3->SE-SE4',
  'source': 'nordpool.com',
  'sourceType': <EventSourceType.measured: 'measured'>},
 {'datetime': datetime.datetime(2024, 12, 3, 4, 45, tzinfo=datetime.timezone.utc),
  'netFlow': 4625.0,
  'sortedZoneKeys': 'SE-SE3->SE-SE4',
  'source': 'nordpool.com',
  'sourceType': <EventSourceType.measured: 'measured'>},
 {'datetime': datetime.datetime(2024, 12, 3, 5, 0, tzinfo=datetime.timezone.utc),
  'netFlow': 4896.0,
  'sortedZoneKeys': 'SE-SE3->SE-SE4',
  'source': 'nordpool.com',
  'sourceType': <EventSourceType.measured: 'measured'>},
 {'datetime': datetime.datetime(2024, 12, 3, 5, 15, tzinfo=datetime.timezone.utc),
  'netFlow': 4896.0,
  'sortedZoneKeys': 'SE-SE3->SE-SE4',
  'source': 'nordpool.com',
  'sourceType': <EventSourceType.measured: 'measured'>},
 {'datetime': datetime.datetime(2024, 12, 3, 5, 30, tzinfo=datetime.timezone.utc),
  'netFlow': 4896.0,
  'sortedZoneKeys': 'SE-SE3->SE-SE4',
  'source': 'nordpool.com',
  'sourceType': <EventSourceType.measured: 'measured'>},
 {'datetime': datetime.datetime(2024, 12, 3, 5, 45, tzinfo=datetime.timezone.utc),
  'netFlow': 4896.0,
  'sortedZoneKeys': 'SE-SE3->SE-SE4',
  'source': 'nordpool.com',
  'sourceType': <EventSourceType.measured: 'measured'>},
 {'datetime': datetime.datetime(2024, 12, 3, 6, 0, tzinfo=datetime.timezone.utc),
  'netFlow': 4999.0,
  'sortedZoneKeys': 'SE-SE3->SE-SE4',
  'source': 'nordpool.com',
  'sourceType': <EventSourceType.measured: 'measured'>},
 {'datetime': datetime.datetime(2024, 12, 3, 6, 15, tzinfo=datetime.timezone.utc),
  'netFlow': 4999.0,
  'sortedZoneKeys': 'SE-SE3->SE-SE4',
  'source': 'nordpool.com',
  'sourceType': <EventSourceType.measured: 'measured'>},
 {'datetime': datetime.datetime(2024, 12, 3, 6, 30, tzinfo=datetime.timezone.utc),
  'netFlow': 4999.0,
  'sortedZoneKeys': 'SE-SE3->SE-SE4',
  'source': 'nordpool.com',
  'sourceType': <EventSourceType.measured: 'measured'>},
 {'datetime': datetime.datetime(2024, 12, 3, 6, 45, tzinfo=datetime.timezone.utc),
  'netFlow': 4999.0,
  'sortedZoneKeys': 'SE-SE3->SE-SE4',
  'source': 'nordpool.com',
  'sourceType': <EventSourceType.measured: 'measured'>}]
---------------------
took 0.75s
min returned datetime: 2024-12-01 23:00:00+00:00 UTC
max returned datetime: 2024-12-03 06:45:00+00:00 UTC  -- OK, <2h from now :) (now=2024-12-03T08:17:56+00:00 UTC)
```

### Double check

- [x] I have tested my parser changes locally with `poetry run test_parser "zone_key"`
- [x] I have run `pnpx prettier@2 --write .` and `poetry run format` in the top level directory to format my changes.
