### PR TITLE
chore(web): use consistent testid naming

### DIFF
--- a/web/cypress/e2e/countrypanel.spec.ts
+++ b/web/cypress/e2e/countrypanel.spec.ts
@@ -14,57 +14,53 @@ describe('Country Panel', () => {
         delete win.navigator.__proto__.serviceWorker;
       },
     });
-    cy.get('[data-test-id=close-modal]').click();
+    cy.get('[data-testid=close-modal]').click();
     cy.waitForAPISuccess('v9/state/hourly');
     cy.waitForAPISuccess('v9/details/hourly/DK-DK2');
-    cy.get('[data-test-id=loading-overlay]').should('not.exist');
+    cy.get('[data-testid=loading-overlay]').should('not.exist');
     cy.contains('East Denmark');
     cy.contains('Carbon Intensity');
-    cy.get('[data-test-id=left-panel] [data-test-id=co2-square-value]').contains('73');
-    // cy.get('[data-test-id=zone-header-lowcarbon-gauge]').trigger('mouseover');
+    cy.get('[data-testid=left-panel] [data-testid=co2-square-value]').contains('73');
+    // cy.get('[data-testid=zone-header-lowcarbon-gauge]').trigger('mouseover');
     // cy.contains('Includes renewables and nuclear');
-    cy.get('[data-test-id=zone-header-lowcarbon-gauge]').trigger('mouseout');
+    cy.get('[data-testid=zone-header-lowcarbon-gauge]').trigger('mouseout');
 
-    cy.get('[data-test-id=toggle-button-emissions]').should(
+    cy.get('[data-testid=toggle-button-emissions]').should(
       'have.attr',
       'aria-checked',
       'false'
     );
-    cy.get('[data-test-id=toggle-button-emissions]')
+    cy.get('[data-testid=toggle-button-emissions]')
       .click()
       .should('have.attr', 'aria-checked', 'true');
     cy.contains('0 t');
-    cy.get('[data-test-id=toggle-button-electricity]').click();
+    cy.get('[data-testid=toggle-button-electricity]').click();
 
     // // test graph tooltip
-    // cy.get('[data-test-id=details-carbon-graph]').trigger('mousemove', 'left');
+    // cy.get('[data-testid=details-carbon-graph]').trigger('mousemove', 'left');
     // // ensure hovering the graph does not change underlying data
-    // cy.get('[data-test-id=left-panel] [data-test-id=co2-square-value]').should(
+    // cy.get('[data-testid=left-panel] [data-testid=co2-square-value]').should(
     //   'have.text',
     //   '232'
     // );
-    cy.get('[data-test-id=time-slider-input] ').should(
-      'have.attr',
-      'aria-valuenow',
-      '24'
-    );
+    cy.get('[data-testid=time-slider-input] ').should('have.attr', 'aria-valuenow', '24');
     // ensure tooltip is shown and changes depending on where on the graph is being hovered
-    cy.get('[data-test-id=details-carbon-graph]').trigger('mousemove', 'left');
-    cy.get('[data-test-id=carbon-chart-tooltip]').should('be.visible');
-    cy.get('[data-test-id=carbon-chart-tooltip] ').should('contain.text', '72');
+    cy.get('[data-testid=details-carbon-graph]').trigger('mousemove', 'left');
+    cy.get('[data-testid=carbon-chart-tooltip]').should('be.visible');
+    cy.get('[data-testid=carbon-chart-tooltip] ').should('contain.text', '72');
 
-    cy.get('[data-test-id=details-carbon-graph]').trigger('mouseout');
-    cy.get('[data-test-id=details-carbon-graph]').trigger('mousemove', 'center');
-    cy.get('[data-test-id=carbon-chart-tooltip]').should('contain.text', '64');
-    cy.get('[data-test-id=details-carbon-graph]').trigger('mouseout');
+    cy.get('[data-testid=details-carbon-graph]').trigger('mouseout');
+    cy.get('[data-testid=details-carbon-graph]').trigger('mousemove', 'center');
+    cy.get('[data-testid=carbon-chart-tooltip]').should('contain.text', '64');
+    cy.get('[data-testid=details-carbon-graph]').trigger('mouseout');
 
-    // cy.get('[data-test-id=time-slider-input] ').setSliderValue(1_661_306_400_000);
-    cy.get('[data-test-id=left-panel] [data-test-id=co2-square-value]').should(
+    // cy.get('[data-testid=time-slider-input] ').setSliderValue(1_661_306_400_000);
+    cy.get('[data-testid=left-panel] [data-testid=co2-square-value]').should(
       'contain.text',
       '73'
     );
 
-    cy.get('[data-test-id=left-panel-back-button]').click();
+    cy.get('[data-testid=left-panel-back-button]').click();
   });
 
   // TODO bring back when we have a no recent data message
@@ -78,7 +74,7 @@ describe('Country Panel', () => {
     cy.waitForAPISuccess('v9/state/hourly');
     cy.waitForAPISuccess('v9/details/hourly/UA');
 
-    cy.get('[data-test-id=no-data-overlay-message]')
+    cy.get('[data-testid=no-data-overlay-message]')
       .should('exist')
       .contains('Data is temporarily unavailable for the selected time');
   });
@@ -98,7 +94,7 @@ describe('Country Panel', () => {
     cy.waitForAPISuccess('v9/state/hourly');
     cy.waitForAPISuccess('v9/details/hourly/CN');
 
-    cy.get('[data-test-id=no-parser-message]').should('exist');
+    cy.get('[data-testid=no-parser-message]').should('exist');
   });
 
   // TODO(AVO-659): fix flaky tests
@@ -110,7 +106,7 @@ describe('Country Panel', () => {
         delete win.navigator.__proto__.serviceWorker;
       },
     });
-    cy.get('[data-test-id=close-modal]').click();
+    cy.get('[data-testid=close-modal]').click();
     cy.waitForAPISuccess('v9/state/hourly');
     cy.waitForAPISuccess('v9/details/hourly/DK-DK2');
     // eslint-disable-next-line cypress/require-data-selectors
@@ -125,7 +121,7 @@ describe('Country Panel', () => {
         delete win.navigator.__proto__.serviceWorker;
       },
     });
-    cy.get('[data-test-id=close-modal]').click();
+    cy.get('[data-testid=close-modal]').click();
     cy.waitForAPISuccess('v9/state/hourly');
     cy.waitForAPISuccess('v9/details/hourly/DK-DK2');
     // eslint-disable-next-line cypress/require-data-selectors
@@ -140,10 +136,10 @@ describe('Country Panel', () => {
         delete win.navigator.__proto__.serviceWorker;
       },
     });
-    cy.get('[data-test-id=close-modal]').click();
+    cy.get('[data-testid=close-modal]').click();
     cy.waitForAPISuccess('v9/state/hourly');
     cy.waitForAPISuccess('v9/details/hourly/DK-DK2');
-    cy.get('[data-test-id=left-panel] [data-test-id=co2-square-value]').should(
+    cy.get('[data-testid=left-panel] [data-testid=co2-square-value]').should(
       'be.visible'
     );
   });

--- a/web/cypress/e2e/map.spec.ts
+++ b/web/cypress/e2e/map.spec.ts
@@ -4,33 +4,33 @@ describe('Map', () => {
   it('interacts with the map', () => {
     cy.interceptAPI('v9/state/hourly');
     cy.visit('/?lang=en-GB');
-    cy.get('[data-test-id=close-modal]').click();
+    cy.get('[data-testid=close-modal]').click();
     cy.waitForAPISuccess(`v9/state/hourly`);
-    cy.get('[data-test-id=loading-overlay]').should('not.exist');
+    cy.get('[data-testid=loading-overlay]').should('not.exist');
 
     // test map
-    cy.get('[data-test-id=exchange-layer]').should('exist');
-    cy.get('[data-test-id=wind-layer]').should('exist');
+    cy.get('[data-testid=exchange-layer]').should('exist');
+    cy.get('[data-testid=wind-layer]').should('exist');
     // eslint-disable-next-line cypress/require-data-selectors
     cy.get('.maplibregl-map').should('be.visible');
 
     // Close the info according on the ranking panel
-    cy.get('[data-test-id=collapse-button]').click();
+    cy.get('[data-testid=collapse-button]').click();
 
-    cy.get('[data-test-id=zone-search-bar]').type('Denmark');
+    cy.get('[data-testid=zone-search-bar]').type('Denmark');
     cy.get('[data-index="0"] > .group').click();
     // Check that the page title contains the zone name
     cy.title().should('contain', 'Bornholm');
 
-    cy.get('[data-test-id=left-panel-back-button]').click();
+    cy.get('[data-testid=left-panel-back-button]').click();
 
     // closes left panel
-    cy.get('[data-test-id=left-panel-collapse-button]').click();
+    cy.get('[data-testid=left-panel-collapse-button]').click();
 
     // tests toggle
-    cy.get('[data-test-id=toggle-button-production-toggle]').click();
-    cy.get('[data-test-id=exchange-arrow-DK-DK2-\\>SE-SE4]').should('not.exist');
-    cy.get('[data-test-id=toggle-button-consumption-toggle]').click();
+    cy.get('[data-testid=toggle-button-production-toggle]').click();
+    cy.get('[data-testid=exchange-arrow-DK-DK2-\\>SE-SE4]').should('not.exist');
+    cy.get('[data-testid=toggle-button-consumption-toggle]').click();
 
     // TODO: functionality has changed to be an onhover trigger
     // rather than a click trigger for the tooltip. This may cause issues for mobile?
@@ -47,47 +47,47 @@ describe('Map', () => {
     // );
 
     // test language selector
-    cy.get('[data-test-id=language-selector-open-button]').click();
+    cy.get('[data-testid=language-selector-open-button]').click();
     cy.contains('English');
     cy.contains('Dansk').click();
     cy.contains('forbrug');
-    // cy.get('[data-test-id=language-selector]').click();
+    // cy.get('[data-testid=language-selector]').click();
     // cy.contains('English').click();
     // cy.contains('consumption');
 
     // test layers
 
-    cy.get('[data-test-id=wind-layer-button]').should('be.visible').click();
+    cy.get('[data-testid=wind-layer-button]').should('be.visible').click();
     // cy.contains('Wind power potential');
 
-    cy.get('[data-test-id=solar-layer-button]').should('be.visible').click();
+    cy.get('[data-testid=solar-layer-button]').should('be.visible').click();
     // cy.contains('Solar power potential');
 
     // test dark mode
-    // cy.get('[data-test-id=dark-mode-button]').click().click();
+    // cy.get('[data-testid=dark-mode-button]').click().click();
 
     // test zoom buttons
     // eslint-disable-next-line cypress/require-data-selectors
     cy.get('.maplibregl-ctrl-zoom-in.maplibregl-ctrl-zoom-in').click();
 
     // test exchange arrows
-    cy.get('[data-test-id=exchange-arrow-DK-DK2-\\>SE-SE4]').should('be.visible');
+    cy.get('[data-testid=exchange-arrow-DK-DK2-\\>SE-SE4]').should('be.visible');
 
     // toggle to country view
-    cy.get('[data-test-id=toggle-button-country-toggle]').click();
+    cy.get('[data-testid=toggle-button-country-toggle]').click();
 
     // test exchange arrows
-    cy.get('[data-test-id=exchange-arrow-DK-\\>SE]').should('be.visible');
+    cy.get('[data-testid=exchange-arrow-DK-\\>SE]').should('be.visible');
 
     // toggle back to zone view
-    cy.get('[data-test-id=toggle-button-zone-toggle]').click();
+    cy.get('[data-testid=toggle-button-zone-toggle]').click();
 
     // closes left panel
-    cy.get('[data-test-id=left-panel-collapse-button]').click();
+    cy.get('[data-testid=left-panel-collapse-button]').click();
 
-    cy.get('[data-test-id=zone-search-bar]').type('Japan');
+    cy.get('[data-testid=zone-search-bar]').type('Japan');
     cy.get('[data-index="0"] > .group').click();
 
-    cy.get('[data-test-id=exchange-arrow-JP-TH-\\>JP-TK]').should('be.visible');
+    cy.get('[data-testid=exchange-arrow-JP-TH-\\>JP-TK]').should('be.visible');
   });
 });

--- a/web/cypress/e2e/ranking.spec.ts
+++ b/web/cypress/e2e/ranking.spec.ts
@@ -5,34 +5,34 @@ describe('Ranking Panel', () => {
     cy.interceptAPI('v9/state/hourly');
     cy.interceptAPI('v9/details/hourly/DK-DK2');
     cy.visit('/?lang=en-GB');
-    cy.get('[data-test-id=close-modal]').click();
+    cy.get('[data-testid=close-modal]').click();
     cy.waitForAPISuccess(`v9/meta`);
     cy.waitForAPISuccess(`v9/state/hourly`);
-    cy.get('[data-test-id=loading-overlay]').should('not.exist');
+    cy.get('[data-testid=loading-overlay]').should('not.exist');
 
     // Close the ranking panel accordion
-    cy.get('[data-test-id=collapse-button]').click();
+    cy.get('[data-testid=collapse-button]').click();
 
     // See more than X countries on the list by default
-    cy.get('[data-test-id=zone-list-link]').should('have.length.above', 3);
+    cy.get('[data-testid=zone-list-link]').should('have.length.above', 3);
 
     // Search for a country
-    cy.get('[data-test-id=zone-search-bar]').type('east denm');
-    cy.get('[data-test-id=zone-list-link]').should('have.length', 1);
+    cy.get('[data-testid=zone-search-bar]').type('east denm');
+    cy.get('[data-testid=zone-list-link]').should('have.length', 1);
 
     // Click a country and return the the ranking panel
-    cy.get('[data-test-id=zone-list-link]').click();
-    cy.get('[data-test-id=zone-name]').should('exist');
-    cy.get('[data-test-id=left-panel-back-button]').click();
+    cy.get('[data-testid=zone-list-link]').click();
+    cy.get('[data-testid=zone-name]').should('exist');
+    cy.get('[data-testid=left-panel-back-button]').click();
 
     // TODO: Ideally the search result should either be reset or the typed value stay in the input
 
     // enable colorblind mode
-    // cy.get('[data-test-id=colorblind-checkbox]').check({ force: true });
+    // cy.get('[data-testid=colorblind-checkbox]').check({ force: true });
 
     // open faq
-    // cy.get('[data-test-id=faq-link]').click();
+    // cy.get('[data-testid=faq-link]').click();
     // cy.contains('Frequently Asked Questions');
-    // cy.get('[data-test-id=left-panel-back-button]').click();
+    // cy.get('[data-testid=left-panel-back-button]').click();
   });
 });

--- a/web/cypress/e2e/timeslider.spec.ts
+++ b/web/cypress/e2e/timeslider.spec.ts
@@ -51,88 +51,88 @@ describe('TimeController', () => {
 
     // Note that we force language here as CI and local machines might display dates differently otherwise
     cy.visit('/zone/DK-DK2?lang=en-GB');
-    cy.get('[data-test-id=loading-overlay]').should('not.exist');
-    cy.get('[data-test-id=close-modal]').click();
+    cy.get('[data-testid=loading-overlay]').should('not.exist');
+    cy.get('[data-testid=close-modal]').click();
     // Hourly
     cy.waitForAPISuccess(`v9/state/hourly`);
     cy.waitForAPISuccess(`v9/details/hourly/DK-DK2`);
     cy.contains('LIVE');
-    cy.get('[data-test-id=co2-square-value').should(
+    cy.get('[data-testid=co2-square-value').should(
       'contain.text',
       getco2intensity(24, hourlyData)
     );
-    // cy.get('[data-test-id=date-display').should(
+    // cy.get('[data-testid=date-display').should(
     //   'have.text',
     //   getFormattedDate(24, hourlyData, 'hourly')
     // );
     // cy.get('input.time-slider-input').setSliderValue(getTime(5, hourlyData));
-    // cy.get('[data-test-id=co2-square-value').should(
+    // cy.get('[data-testid=co2-square-value').should(
     //   'have.text',
     //   getco2intensity(5, hourlyData)
     // );
 
     // Monthly
-    cy.get('[data-test-id="time-controller-daily"]').click();
+    cy.get('[data-testid="time-controller-daily"]').click();
     cy.waitForAPISuccess(`v9/state/daily`);
     cy.waitForAPISuccess(`v9/details/daily/DK-DK2`);
-    // cy.get('[data-test-id=co2-square-value').should(
+    // cy.get('[data-testid=co2-square-value').should(
     //   'contain.text',
     //   getco2intensity(30, dailyData)
     // );
-    // cy.get('[data-test-id=date-display').should(
+    // cy.get('[data-testid=date-display').should(
     //   'have.text',
     //   getFormattedDate(30, dailyData, 'daily')
     // );
     //cy.get('input.time-slider-input').setSliderValue(getTime(16, dailyData));
-    // cy.get('[data-test-id=date-display').should(
+    // cy.get('[data-testid=date-display').should(
     //   'have.text',
     //   getFormattedDate(16, dailyData, 'daily')
     // );
-    // cy.get('[data-test-id=co2-square-value').should(
+    // cy.get('[data-testid=co2-square-value').should(
     //   'have.text',
     //   getco2intensity(16, dailyData)
     // );
 
     // Yearly
-    cy.get('[data-test-id="time-controller-monthly"]').click();
+    cy.get('[data-testid="time-controller-monthly"]').click();
     cy.waitForAPISuccess(`v9/state/monthly`);
     cy.waitForAPISuccess(`v9/details/monthly/DK-DK2`);
-    cy.get('[data-test-id=co2-square-value').should(
+    cy.get('[data-testid=co2-square-value').should(
       'contain.text',
       getco2intensity(12, monthlyData)
     );
-    // cy.get('[data-test-id=date-display').should(
+    // cy.get('[data-testid=date-display').should(
     //   'have.text',
     //   getFormattedDate(11, monthlyData, 'monthly')
     // );
     // //cy.get('input.time-slider-input').setSliderValue(getTime(5, monthlyData));
-    // cy.get('[data-test-id=date-display').should(
+    // cy.get('[data-testid=date-display').should(
     //   'have.text',
     //   getFormattedDate(5, monthlyData, 'monthly')
     // );
-    // cy.get('[data-test-id=co2-square-value').should(
+    // cy.get('[data-testid=co2-square-value').should(
     //   'have.text',
     //   getco2intensity(5, monthlyData)
     // );
 
     // 5 Years
-    cy.get('[data-test-id="time-controller-yearly"]').click();
+    cy.get('[data-testid="time-controller-yearly"]').click();
     cy.waitForAPISuccess(`v9/state/yearly`);
     cy.waitForAPISuccess(`v9/details/yearly/DK-DK2`);
-    cy.get('[data-test-id=co2-square-value').should(
+    cy.get('[data-testid=co2-square-value').should(
       'contain.text',
       getco2intensity(-1, yearlyData)
     );
-    // cy.get('[data-test-id=date-display').should(
+    // cy.get('[data-testid=date-display').should(
     //   'have.text',
     //   getFormattedDate(4, yearlyData, 'yearly')
     // );
     // //cy.get('input.time-slider-input').setSliderValue(getTime(2, yearlyData));
-    // cy.get('[data-test-id=date-display').should(
+    // cy.get('[data-testid=date-display').should(
     //   'have.text',
     //   getFormattedDate(2, yearlyData, 'yearly')
     // );
-    // cy.get('[data-test-id=co2-square-value').should(
+    // cy.get('[data-testid=co2-square-value').should(
     //   'have.text',
     //   getco2intensity(2, yearlyData)
     // );

--- a/web/src/components/Accordion.tsx
+++ b/web/src/components/Accordion.tsx
@@ -89,26 +89,26 @@ export default function Accordion({
   return (
     <section className="flex flex-col overflow-hidden py-1">
       <button
-        data-test-id="collapse-button"
+        data-testid="collapse-button"
         onClick={handleToggleCollapse}
         className={twMerge('flex flex-row items-center gap-1.5', className)}
       >
         {icon}
-        <h3 className="grow text-left" data-test-id="title">
+        <h3 className="grow text-left" data-testid="title">
           {(expandedTitle && !isCollapsed ? expandedTitle : title) || title}
         </h3>
         {badge}
         {collapsedIcon && expandedIcon ? (
           <Icon
             className={twMerge('text-black dark:text-white', iconClassName)}
-            data-test-id={isCollapsed ? 'collapse-down' : 'collapse-up'}
+            data-testid={isCollapsed ? 'collapse-down' : 'collapse-up'}
             size={iconSize}
           />
         ) : (
           <AnimatedIcon
             className={twMerge('text-black dark:text-white', iconClassName)}
             style={{ rotate: spring.rotate.to((r) => `${r}deg`) }}
-            data-test-id={isCollapsed ? 'collapse-down' : 'collapse-up'}
+            data-testid={isCollapsed ? 'collapse-down' : 'collapse-up'}
             size={iconSize}
           />
         )}

--- a/web/src/components/Badge.tsx
+++ b/web/src/components/Badge.tsx
@@ -30,7 +30,7 @@ export default function Badge({ pillText, type, icon }: BadgeProps) {
   return (
     <span
       className={`flex h-6 flex-row items-center gap-1 whitespace-nowrap rounded-full px-2 py-1 text-xs font-semibold ${classes}`}
-      data-test-id="badge"
+      data-testid="badge"
     >
       {icon}
       {pillText}

--- a/web/src/components/Button.tsx
+++ b/web/src/components/Button.tsx
@@ -65,7 +65,7 @@ export function Button({
         target="_blank"
         // Used to prevent browser translation crashes on edge, see #6809
         translate="no"
-        data-test-id={dataTestId}
+        data-testid={dataTestId}
       >
         {icon}
         {children}

--- a/web/src/components/CarbonIntensitySquare.tsx
+++ b/web/src/components/CarbonIntensitySquare.tsx
@@ -60,7 +60,7 @@ function CarbonIntensitySquare({
             >
               <p
                 className="select-none text-base leading-none"
-                data-test-id="co2-square-value"
+                data-testid="co2-square-value"
               >
                 <span className="font-semibold">{Math.round(intensity) || '?'}</span>
                 <span className="text-xs font-semibold">g</span>

--- a/web/src/components/CircularGauge.tsx
+++ b/web/src/components/CircularGauge.tsx
@@ -86,7 +86,7 @@ export function CircularGauge({
   return (
     <div className="flex flex-col items-center gap-2">
       <TooltipWrapper tooltipContent={tooltipContent} side="bottom" sideOffset={8}>
-        <div data-test-id={testId} className="relative flex flex-col items-center">
+        <div data-testid={testId} className="relative flex flex-col items-center">
           <svg height={height} width={width}>
             <Group top={centerY} left={centerX} height={height} width={width}>
               <BackgroundArc radius={radius} />

--- a/web/src/components/LoadingOverlay.tsx
+++ b/web/src/components/LoadingOverlay.tsx
@@ -39,7 +39,7 @@ function FadingOverlay({ isVisible }: { isVisible: boolean }) {
         <animated.div
           className="fixed z-50 h-full w-full bg-gray-100 dark:bg-gray-900"
           style={styles}
-          data-test-id="loading-overlay"
+          data-testid="loading-overlay"
         >
           <LoadingSpinner showReloadButton={showButton} />
         </animated.div>

--- a/web/src/components/Modal.tsx
+++ b/web/src/components/Modal.tsx
@@ -25,7 +25,7 @@ export default function Modal({
         <Dialog.Content
           // Avoid close button being auto-focused initially, as pressing space will otherwise close the modal
           onOpenAutoFocus={(event: Event) => event.preventDefault()}
-          data-test-id={testId}
+          data-testid={testId}
           className={`fixed left-1/2 top-1/2 z-40 max-h-full w-[98vw] max-w-2xl -translate-x-1/2 -translate-y-1/2 rounded-xl bg-white/90 shadow-md backdrop-blur-sm dark:bg-gray-800/90 sm:w-[90vw] ${
             fullWidth ? 'p-0' : 'p-4'
           }`}
@@ -38,7 +38,7 @@ export default function Modal({
           <Dialog.Close
             className="absolute right-2 top-2 rounded-full bg-gray-100 p-1.5 hover:bg-gray-200 dark:bg-gray-900 dark:hover:bg-gray-700"
             aria-label="Close"
-            data-test-id="close-modal-button"
+            data-testid="close-modal-button"
           >
             <X size="18" />
           </Dialog.Close>

--- a/web/src/components/MoreOptionsDropdown.cy.tsx
+++ b/web/src/components/MoreOptionsDropdown.cy.tsx
@@ -107,7 +107,7 @@ describe('MoreOptionsDropdown', () => {
     cy.get('Share via').should('not.exist');
 
     cy.contains('Share on X (Twitter)').should('be.visible');
-    cy.get('[data-test-id=twitter-chart-share]')
+    cy.get('[data-testid=twitter-chart-share]')
       .should('have.attr', 'href')
       .and(
         'equal',
@@ -115,12 +115,12 @@ describe('MoreOptionsDropdown', () => {
       );
 
     cy.contains('Share on LinkedIn').should('be.visible');
-    cy.get('[data-test-id=linkedin-chart-share]')
+    cy.get('[data-testid=linkedin-chart-share]')
       .should('have.attr', 'href')
       .and('equal', 'https://www.linkedin.com/shareArticle?mini=true&url=hello');
 
     cy.contains('Share on Facebook').should('be.visible');
-    cy.get('[data-test-id=facebook-chart-share]')
+    cy.get('[data-testid=facebook-chart-share]')
       .should('have.attr', 'href')
       .and(
         'equal',
@@ -128,7 +128,7 @@ describe('MoreOptionsDropdown', () => {
       );
 
     cy.contains('Share on Reddit').should('be.visible');
-    cy.get('[data-test-id=reddit-chart-share]')
+    cy.get('[data-testid=reddit-chart-share]')
       .should('have.attr', 'href')
       .and('equal', 'https://www.reddit.com/web/submit?url=hello');
   });
@@ -165,7 +165,7 @@ describe('MoreOptionsDropdown', () => {
     );
     cy.get('button').click();
     cy.contains('Copy link to chart').should('exist');
-    cy.get('[data-test-id="toast"]').should('not.exist');
+    cy.get('[data-testid="toast"]').should('not.exist');
     cy.contains('Copy link to chart').click();
     cy.get('[data-testid="toast"]').should('exist');
   });

--- a/web/src/components/MoreOptionsDropdown.tsx
+++ b/web/src/components/MoreOptionsDropdown.tsx
@@ -123,7 +123,7 @@ export function MoreOptionsDropdown({
               {!hasMobileUserAgent && (
                 <>
                   <a
-                    data-test-id="twitter-chart-share"
+                    data-testid="twitter-chart-share"
                     target="_blank"
                     rel="noopener"
                     onClick={handleTrackShares[ShareType.TWITTER]}
@@ -137,7 +137,7 @@ export function MoreOptionsDropdown({
                     </DropdownMenu.Item>
                   </a>
                   <a
-                    data-test-id="facebook-chart-share"
+                    data-testid="facebook-chart-share"
                     target="_blank"
                     rel="noopener"
                     onClick={handleTrackShares[ShareType.FACEBOOK]}
@@ -151,7 +151,7 @@ export function MoreOptionsDropdown({
                     </DropdownMenu.Item>
                   </a>
                   <a
-                    data-test-id="linkedin-chart-share"
+                    data-testid="linkedin-chart-share"
                     href={`https://www.linkedin.com/shareArticle?mini=true&url=${shareUrl}`}
                     target="_blank"
                     rel="noopener"
@@ -163,7 +163,7 @@ export function MoreOptionsDropdown({
                     </DropdownMenu.Item>
                   </a>
                   <a
-                    data-test-id="reddit-chart-share"
+                    data-testid="reddit-chart-share"
                     href={`https://www.reddit.com/web/submit?url=${shareUrl}`}
                     target="_blank"
                     rel="noopener"

--- a/web/src/components/NewFeaturePopover/NewFeaturePopover.cy.tsx
+++ b/web/src/components/NewFeaturePopover/NewFeaturePopover.cy.tsx
@@ -27,7 +27,7 @@ describe('New Feature Popover', () => {
       </NewFeaturePopover>
     );
     cy.contains('anchor');
-    cy.get('[data-test-id=dismiss]').click();
+    cy.get('[data-testid=dismiss]').click();
     cy.contains('content').should('not.exist');
   });
 });

--- a/web/src/components/NewFeaturePopover/NewFeaturePopover.tsx
+++ b/web/src/components/NewFeaturePopover/NewFeaturePopover.tsx
@@ -45,7 +45,7 @@ export function NewFeaturePopover({
     >
       {content}
       <Popover.Close
-        data-test-id="dismiss"
+        data-testid="dismiss"
         onClick={onDismiss}
         className="self-start text-white"
       >

--- a/web/src/components/Pill.tsx
+++ b/web/src/components/Pill.tsx
@@ -11,7 +11,7 @@ export default function Pill({
     <button
       className={`flex h-9 w-full flex-row items-center justify-center rounded-full border border-black text-black hover:bg-neutral-200 disabled:border-neutral-200 disabled:text-neutral-200 dark:border-white dark:text-white dark:hover:bg-gray-700 disabled:dark:border-gray-700 disabled:dark:text-gray-700 ${classes}`}
       onClick={onClick}
-      data-test-id="pill"
+      data-testid="pill"
     >
       <div className={`text-sm font-semibold`}>{text}</div>
     </button>

--- a/web/src/components/ShareIcon.tsx
+++ b/web/src/components/ShareIcon.tsx
@@ -11,9 +11,9 @@ export function ShareIcon({
   iconSize?: number;
 }) {
   return showIosIcon ? (
-    <Share data-test-id="iosShareIcon" size={iconSize} />
+    <Share data-testid="iosShareIcon" size={iconSize} />
   ) : (
-    <Share2 data-test-id="defaultShareIcon" size={iconSize} />
+    <Share2 data-testid="defaultShareIcon" size={iconSize} />
   );
 }
 

--- a/web/src/components/TimeAverageToggle.tsx
+++ b/web/src/components/TimeAverageToggle.tsx
@@ -47,7 +47,7 @@ function TimeAverageToggle({ timeAverage, onToggleGroupClick }: TimeAverageToggl
       {options.map(({ value, label, dataTestId }) => (
         <ToggleGroupItem
           key={`group-item-${value}-${label}`}
-          data-test-id={dataTestId}
+          data-testid={dataTestId}
           value={value}
           aria-label={label}
           onClick={() => onToggleGroupClick(value)}

--- a/web/src/components/TimeSlider.tsx
+++ b/web/src/components/TimeSlider.tsx
@@ -112,7 +112,7 @@ export function TimeSliderBasic({
         <SliderPrimitive.Range />
       </SliderPrimitive.Track>
       <SliderPrimitive.Thumb
-        data-test-id="time-slider-input"
+        data-testid="time-slider-input"
         className="flex h-7 w-7 items-center justify-center rounded-full bg-white outline
            outline-1 outline-neutral-200 hover:outline-2 focus-visible:outline-2 dark:bg-gray-900 dark:outline-gray-700"
       >

--- a/web/src/components/ToggleButton.tsx
+++ b/web/src/components/ToggleButton.tsx
@@ -62,7 +62,7 @@ export default function ToggleButton({
             key={`group-item-${key}`}
             value={value}
             onClick={() => onToggle(value)}
-            data-test-id={`toggle-button-${dataTestId ?? value}`}
+            data-testid={`toggle-button-${dataTestId ?? value}`}
             className={twMerge(
               'inline-flex h-7 w-full items-center whitespace-nowrap rounded-full bg-gray-100/0 px-3 text-xs dark:border dark:border-gray-400/0 dark:bg-transparent',
               value === selectedOption

--- a/web/src/components/ZoneGauges.tsx
+++ b/web/src/components/ZoneGauges.tsx
@@ -24,7 +24,7 @@ export default function ZoneGaugesWithCO2Square({
   return (
     <div className="flex w-full flex-row justify-evenly">
       <CarbonIntensitySquare
-        data-test-id="co2-square-value"
+        data-testid="co2-square-value"
         intensity={intensity}
         tooltipContent={
           withTooltips ? <p>{t('tooltips.zoneHeader.carbonIntensity')}</p> : undefined

--- a/web/src/components/app-survey/FeedbackCard.tsx
+++ b/web/src/components/app-survey/FeedbackCard.tsx
@@ -109,7 +109,7 @@ export default function FeedbackCard({
 
   return (
     <div
-      data-test-id="feedback-card"
+      data-testid="feedback-card"
       className="flex w-full flex-col gap-2 rounded-lg border border-neutral-200 bg-zinc-50 px-3 py-4 transition-all dark:border-gray-700 dark:bg-gray-900"
       ref={feedbackCardReference}
     >
@@ -120,12 +120,12 @@ export default function FeedbackCard({
           />
           <h2
             className={`self-center text-left text-sm font-semibold text-black dark:text-white`}
-            data-test-id="title"
+            data-testid="title"
           >
             {isFeedbackSubmitted ? successSubtitle : title}
           </h2>
         </div>
-        <button data-test-id="close-button" onClick={handleClose}>
+        <button data-testid="close-button" onClick={handleClose}>
           <X />
         </button>
       </div>
@@ -134,7 +134,7 @@ export default function FeedbackCard({
           className={`pb-1 ${
             isFeedbackSubmitted ? 'text-sm' : 'text-xs'
           } font-medium text-neutral-400`}
-          data-test-id="subtitle"
+          data-testid="subtitle"
         >
           {isFeedbackSubmitted ? successMessage : subtitle}
         </div>
@@ -178,11 +178,11 @@ function InputField({
       <div className="flex flex-wrap justify-start">
         <span className="text-sm font-normal text-black dark:text-white">
           {!isRequired && <span className="pr-1 font-semibold">{optional}</span>}
-          <span data-test-id="input-title">{inputQuestion}</span>
+          <span data-testid="input-title">{inputQuestion}</span>
         </span>
       </div>
       <textarea
-        data-test-id="feedback-input"
+        data-testid="feedback-input"
         value={inputText}
         onChange={(event) => {
           handleInputChange(event);
@@ -269,7 +269,7 @@ function FeedbackFields({
           </div>
         </div>
       )}
-      <div data-test-id="feedback-question" className="text-sm">
+      <div data-testid="feedback-question" className="text-sm">
         {primaryQuestion}
       </div>
       <ActionPills
@@ -328,10 +328,10 @@ function ActionPills({
         currentPillNumber={currentPillNumber}
       />
       <div className="flex flex-row items-center justify-between pt-1">
-        <div data-test-id="disagree-text" className="text-xs font-bold">
+        <div data-testid="disagree-text" className="text-xs font-bold">
           {disagreeText}
         </div>
-        <div data-test-id="agree-text" className="text-xs font-bold">
+        <div data-testid="agree-text" className="text-xs font-bold">
           {agreeText}
         </div>
       </div>
@@ -355,7 +355,7 @@ function PillContent({
     >
       {pillContent.map((content) => (
         <ToggleGroupPrimitive.Item
-          data-test-id={`feedback-pill-${content}`}
+          data-testid={`feedback-pill-${content}`}
           key={content}
           value={content}
           aria-label={content}

--- a/web/src/components/modals/OnboardingModal.tsx
+++ b/web/src/components/modals/OnboardingModal.tsx
@@ -90,7 +90,7 @@ export function OnboardingModal() {
   return (
     <Modal
       modalName="onboarding"
-      data-test-id="onboarding"
+      data-testid="onboarding"
       visible={visible}
       onDismiss={handleDismiss}
       views={onboardingViews}

--- a/web/src/components/modals/OnboardingModalInner.tsx
+++ b/web/src/components/modals/OnboardingModalInner.tsx
@@ -64,7 +64,7 @@ function Modal({
       <div
         className="px-auto absolute top-auto z-50 mx-auto flex w-full items-center justify-center
        self-center sm:top-20 sm:min-w-[500px]"
-        data-test-id={modalName}
+        data-testid={modalName}
       >
         <div className="z-10 -mr-4 flex w-full max-w-[35px] flex-col items-start pl-1 sm:mr-0 sm:max-w-[60px] sm:items-end sm:px-2">
           {!isOnFirstView() && (

--- a/web/src/features/charts/FuturePrice.cy.tsx
+++ b/web/src/features/charts/FuturePrice.cy.tsx
@@ -17,28 +17,28 @@ describe('FuturePrice only positive values', () => {
   });
 
   it('Opens when accordion clicked', () => {
-    cy.get('[data-test-id="future-price"]').should('not.exist');
-    cy.get('[data-test-id="collapse-button"]').click();
-    cy.get('[data-test-id="future-price"]').should('be.visible');
+    cy.get('[data-testid="future-price"]').should('not.exist');
+    cy.get('[data-testid="collapse-button"]').click();
+    cy.get('[data-testid="future-price"]').should('be.visible');
   });
 
   it('Tomorrow label is visible', () => {
-    cy.get('[data-test-id="tomorrow-label"]').should('be.visible');
+    cy.get('[data-testid="tomorrow-label"]').should('be.visible');
   });
 
   it('Price data is visible', () => {
-    cy.get('[data-test-id="negative-price"]').should('not.exist');
-    cy.get('[data-test-id="price-bar"]').should('be.visible');
-    cy.get('[data-test-id="positive-price"]').should('be.visible');
+    cy.get('[data-testid="negative-price"]').should('not.exist');
+    cy.get('[data-testid="price-bar"]').should('be.visible');
+    cy.get('[data-testid="positive-price"]').should('be.visible');
   });
 
   it('Disclaimers are visible', () => {
-    cy.get('[data-test-id="time-disclaimer"]').should('be.visible');
-    cy.get('[data-test-id="price-disclaimer"]').should('be.visible');
+    cy.get('[data-testid="time-disclaimer"]').should('be.visible');
+    cy.get('[data-testid="price-disclaimer"]').should('be.visible');
   });
 
   it('now label is visible', () => {
-    cy.get('[data-test-id="now-label"]').should('be.visible');
+    cy.get('[data-testid="now-label"]').should('be.visible');
   });
 });
 
@@ -60,10 +60,10 @@ describe('FuturePrice negative values', () => {
   });
 
   it('Price data is visible', () => {
-    cy.get('[data-test-id="collapse-button"]').click();
-    cy.get('[data-test-id="collapse-button"]').click();
-    cy.get('[data-test-id="negative-price"]').should('be.visible');
-    cy.get('[data-test-id="price-bar"]').should('be.visible');
-    cy.get('[data-test-id="positive-price"]').should('be.visible');
+    cy.get('[data-testid="collapse-button"]').click();
+    cy.get('[data-testid="collapse-button"]').click();
+    cy.get('[data-testid="negative-price"]').should('be.visible');
+    cy.get('[data-testid="price-bar"]').should('be.visible');
+    cy.get('[data-testid="positive-price"]').should('be.visible');
   });
 });

--- a/web/src/features/charts/FuturePrice.tsx
+++ b/web/src/features/charts/FuturePrice.tsx
@@ -66,7 +66,7 @@ export function FuturePrice({ futurePrice }: { futurePrice: FuturePriceData | nu
         setState={setIsCollapsed}
         onOpen={() => trackEvent(TrackEvent.FUTURE_PRICE_EXPANDED)}
       >
-        <div data-test-id="future-price">
+        <div data-testid="future-price">
           <PriceDisclaimer />
           <TimeDisclaimer />
           {futurePrice?.priceData && (
@@ -83,7 +83,7 @@ export function FuturePrice({ futurePrice }: { futurePrice: FuturePriceData | nu
                   >
                     <div>
                       {dateIsFirstHourOfTomorrow(new Date(date)) && (
-                        <div className="flex flex-col py-1" data-test-id="tomorrow-label">
+                        <div className="flex flex-col py-1" data-testid="tomorrow-label">
                           <HorizontalDivider />
                           <TommorowLabel date={date} t={t} i18n={i18n} />
                         </div>
@@ -104,7 +104,7 @@ export function FuturePrice({ futurePrice }: { futurePrice: FuturePriceData | nu
                                   negativePercentage / 100
                                 } + 12px - 12px * ${negativePercentage / 100})`,
                               }}
-                              data-test-id="negative-price"
+                              data-testid="negative-price"
                             >
                               <PriceBar
                                 price={price}
@@ -121,7 +121,7 @@ export function FuturePrice({ futurePrice }: { futurePrice: FuturePriceData | nu
                           )}
                           {price >= 0 && (
                             <div
-                              data-test-id="positive-price"
+                              data-testid="positive-price"
                               style={{
                                 width: `calc(100% * ${
                                   (100 - negativePercentage) / 100
@@ -186,7 +186,7 @@ export function PriceBar({
       style={{
         width: `calc(calc(${nonNegativePrice / maxPrice} * (100% - 12px)) + 12px)`,
       }}
-      data-test-id="price-bar"
+      data-testid="price-bar"
     />
   );
 }
@@ -224,7 +224,7 @@ function TimeDisplay({ date, granularity }: { date: string; granularity: number 
 
   if (isNow(date, granularity)) {
     return (
-      <p className={`min-w-18 pl-1 text-sm font-semibold`} data-test-id="now-label">
+      <p className={`min-w-18 pl-1 text-sm font-semibold`} data-testid="now-label">
         {t(`country-panel.price-chart.now`)}
       </p>
     );
@@ -279,7 +279,7 @@ function Disclaimer({
   text: string;
 }) {
   return (
-    <div className={className} data-test-id={testId}>
+    <div className={className} data-testid={testId}>
       {Icon}
       <p className="pl-1 text-xs font-semibold">{text}</p>
     </div>

--- a/web/src/features/charts/elements/AreaGraph.tsx
+++ b/web/src/features/charts/elements/AreaGraph.tsx
@@ -259,7 +259,7 @@ function AreaGraph({
   return (
     <div ref={reference}>
       <svg
-        data-test-id={testId}
+        data-testid={testId}
         height={height}
         className={`w-full overflow-visible ${
           isDisabled ? 'pointer-events-none blur' : ''

--- a/web/src/features/charts/tooltips/CarbonChartTooltip.tsx
+++ b/web/src/features/charts/tooltips/CarbonChartTooltip.tsx
@@ -32,7 +32,7 @@ export default function CarbonChartTooltip({ zoneDetail }: InnerAreaGraphTooltip
   const hasEstimationPill = Boolean(estimationMethod) || Boolean(estimatedPercentage);
   return (
     <div
-      data-test-id="carbon-chart-tooltip"
+      data-testid="carbon-chart-tooltip"
       className="w-full rounded-md bg-white p-3 shadow-xl dark:border dark:border-gray-700 dark:bg-gray-800 sm:w-[410px]"
     >
       <AreaGraphToolTipHeader

--- a/web/src/features/exchanges/ExchangeArrow.tsx
+++ b/web/src/features/exchanges/ExchangeArrow.tsx
@@ -105,7 +105,7 @@ function ExchangeArrow({
           top: '-41px',
         }}
         onWheel={() => setIsMoving(true)}
-        data-test-id={`exchange-arrow-${key}`}
+        data-testid={`exchange-arrow-${key}`}
       >
         <source srcSet={`${imageSource}.webp`} type="image/webp" />
         <img src={`${imageSource}.gif`} alt="" draggable={false} />

--- a/web/src/features/exchanges/ExchangeLayer.tsx
+++ b/web/src/features/exchanges/ExchangeLayer.tsx
@@ -18,7 +18,7 @@ function ExchangeLayer({ map }: { map?: maplibregl.Map }) {
 
   return (
     <div
-      data-test-id="exchange-layer"
+      data-testid="exchange-layer"
       id="exchange-layer"
       className="h-full w-full"
       ref={ref}

--- a/web/src/features/exchanges/ExchangeTooltip.tsx
+++ b/web/src/features/exchanges/ExchangeTooltip.tsx
@@ -27,7 +27,7 @@ export default function ExchangeTooltip({
 
   const divClass = `${isMobile ? 'flex-col' : 'flex'} items-center pb-2`;
   return (
-    <div className="text-start text-base font-medium" data-test-id="exchange-tooltip">
+    <div className="text-start text-base font-medium" data-testid="exchange-tooltip">
       {t('tooltips.crossborderexport')}:
       <div>
         <div className={divClass}>

--- a/web/src/features/map-controls/LanguageSelector.cy.tsx
+++ b/web/src/features/map-controls/LanguageSelector.cy.tsx
@@ -9,7 +9,7 @@ it('mounts', () => {
       <LanguageSelector />
     </I18nextProvider>
   );
-  cy.get('[data-test-id=language-selector-open-button]').click();
+  cy.get('[data-testid=language-selector-open-button]').click();
   cy.contains('English');
   cy.contains('Français');
   cy.contains('Deutsch');
@@ -25,7 +25,7 @@ it('mounts', () => {
 
   cy.get('button').contains('Italiano').click();
 
-  cy.get('[data-test-id=language-selector-open-button]').trigger('mouseover');
+  cy.get('[data-testid=language-selector-open-button]').trigger('mouseover');
 
   cy.get('.relative').contains('Seleziona la lingua');
 });

--- a/web/src/features/map-controls/MapButton.tsx
+++ b/web/src/features/map-controls/MapButton.tsx
@@ -33,7 +33,7 @@ export default function MapButton({
           asToggle && 'pointer-events-auto'
         )}
         aria-label={ariaLabel}
-        data-test-id={dataTestId}
+        data-testid={dataTestId}
         role="button"
       >
         <div>{icon}</div>

--- a/web/src/features/map-controls/MapControls.cy.tsx
+++ b/web/src/features/map-controls/MapControls.cy.tsx
@@ -22,23 +22,23 @@ describe('MapControls', () => {
         </I18nextProvider>
       </QueryClientProvider>
     );
-    cy.get('[data-test-id=language-selector-open-button]').click();
+    cy.get('[data-testid=language-selector-open-button]').click();
     cy.contains('English').click();
     cy.contains('country');
     cy.contains('zone');
     cy.contains('production');
     cy.contains('consumption');
-    cy.get('[data-test-id=language-selector-open-button]').click();
+    cy.get('[data-testid=language-selector-open-button]').click();
     cy.contains('Deutsch').click();
     cy.contains('Produktion');
     cy.contains('Verbrauch');
-    cy.get('[data-test-id=language-selector-open-button]').click();
+    cy.get('[data-testid=language-selector-open-button]').click();
     cy.contains('Svenska').click();
     cy.contains('produktion');
     cy.contains('konsumtion');
     cy.contains('land');
     cy.contains('zon');
-    cy.get('[data-test-id=language-selector-open-button]').click();
+    cy.get('[data-testid=language-selector-open-button]').click();
     cy.contains('English').click();
   });
 
@@ -49,14 +49,14 @@ describe('MapControls', () => {
         <MapControls />
       </QueryClientProvider>
     );
-    cy.get('[data-test-id=theme-selector-open-button]').click();
+    cy.get('[data-testid=theme-selector-open-button]').click();
     cy.contains('System');
     cy.contains('Light')
       .click()
       .should(() => {
         expect(localStorage.getItem('theme')).to.eq('"light"');
       });
-    cy.get('[data-test-id=theme-selector-open-button]').click();
+    cy.get('[data-testid=theme-selector-open-button]').click();
     cy.contains('Dark')
       .click()
       .should(() => {

--- a/web/src/features/map-controls/MapOptionSelector.tsx
+++ b/web/src/features/map-controls/MapOptionSelector.tsx
@@ -25,7 +25,7 @@ export default function MapOptionSelector({
           isOpen ? 'pointer-events-none' : 'pointer-events-auto',
           isMobile && 'rounded-full transition duration-200 focus-visible:outline-none '
         )}
-        data-test-id={testId}
+        data-testid={testId}
         onClick={toggleTooltip}
         type={undefined}
       >

--- a/web/src/features/map-controls/MobileButtons.tsx
+++ b/web/src/features/map-controls/MobileButtons.tsx
@@ -26,7 +26,7 @@ export default function MobileButtons() {
         onClick={handleOpenSettingsModal}
         backgroundClasses="bg-white/80 backdrop-blur dark:bg-gray-800/80 pointer-events-auto"
         icon={<Settings size={20} />}
-        data-test-id="settings-button-mobile"
+        data-testid="settings-button-mobile"
       />
     </div>
   );

--- a/web/src/features/map/Map.cy.tsx
+++ b/web/src/features/map/Map.cy.tsx
@@ -194,8 +194,8 @@ describe('Map Component', () => {
     );
 
     cy.mount(<RouterProvider router={router} />);
-    cy.get('[data-test-id=exchange-layer]').should('be.visible');
-    cy.get('[data-test-id=wind-layer]').should('exist');
+    cy.get('[data-testid=exchange-layer]').should('be.visible');
+    cy.get('[data-testid=wind-layer]').should('exist');
     cy.get('.maplibregl-map').should('be.visible');
   });
 });

--- a/web/src/features/modals/SettingsModal.cy.tsx
+++ b/web/src/features/modals/SettingsModal.cy.tsx
@@ -18,23 +18,23 @@ describe('SettingsModalContent', () => {
     );
     cy.contains('Wind data is currently unavailable');
     cy.contains('Solar data is currently unavailable');
-    cy.get('[data-test-id=language-selector-open-button]').click();
+    cy.get('[data-testid=language-selector-open-button]').click();
     cy.contains('English').click();
     cy.contains('country');
     cy.contains('zone');
     cy.contains('production');
     cy.contains('consumption');
-    cy.get('[data-test-id=language-selector-open-button]').click();
+    cy.get('[data-testid=language-selector-open-button]').click();
     cy.contains('Deutsch').click();
     cy.contains('Produktion');
     cy.contains('Verbrauch');
-    cy.get('[data-test-id=language-selector-open-button]').click();
+    cy.get('[data-testid=language-selector-open-button]').click();
     cy.contains('Svenska').click();
     cy.contains('produktion');
     cy.contains('konsumtion');
     cy.contains('land');
     cy.contains('zon');
-    cy.get('[data-test-id=language-selector-open-button]').click();
+    cy.get('[data-testid=language-selector-open-button]').click();
     cy.contains('English').click();
   });
 
@@ -47,14 +47,14 @@ describe('SettingsModalContent', () => {
         </I18nextProvider>
       </QueryClientProvider>
     );
-    cy.get('[data-test-id=theme-selector-open-button]').click();
+    cy.get('[data-testid=theme-selector-open-button]').click();
     cy.contains('System');
     cy.contains('Light')
       .click()
       .should(() => {
         expect(localStorage.getItem('theme')).to.eq('"light"');
       });
-    cy.get('[data-test-id=theme-selector-open-button]').click();
+    cy.get('[data-testid=theme-selector-open-button]').click();
     cy.contains('Dark')
       .click()
       .should(() => {

--- a/web/src/features/panels/LeftPanel.tsx
+++ b/web/src/features/panels/LeftPanel.tsx
@@ -18,7 +18,7 @@ function CollapseButton({ isCollapsed, onCollapse }: CollapseButtonProps) {
   const { t } = useTranslation();
   return (
     <button
-      data-test-id="left-panel-collapse-button"
+      data-testid="left-panel-collapse-button"
       className={
         'absolute left-full top-2 z-[21] mt-[env(safe-area-inset-top)] h-12 w-6 cursor-pointer rounded-r bg-zinc-50 shadow-[6px_2px_10px_-3px_rgba(0,0,0,0.1)] hover:bg-zinc-100 dark:bg-gray-900 dark:text-gray-400 dark:hover:bg-gray-800'
       }
@@ -50,7 +50,7 @@ function OuterPanel({ children }: { children: React.ReactNode }) {
 
   return (
     <div
-      data-test-id="left-panel"
+      data-testid="left-panel"
       className={twMerge(
         'absolute left-0 top-0 z-[21] h-full w-full bg-zinc-50 pt-[env(safe-area-inset-top)] shadow-xl transition-all duration-500 dark:bg-gray-900 dark:[color-scheme:dark] sm:w-[calc(14vw_+_16rem)]',
         location.pathname.startsWith('/map') ? 'hidden sm:flex' : 'block sm:flex',

--- a/web/src/features/panels/ranking-panel/SearchBar.tsx
+++ b/web/src/features/panels/ranking-panel/SearchBar.tsx
@@ -21,7 +21,7 @@ function SearchBar({
     <div className="mb-2 mr-[14px] flex h-11 flex-row items-center gap-3 rounded border border-gray-400/10 bg-gray-100 p-3 transition hover:bg-gray-200/70 dark:border dark:border-gray-400/10 dark:bg-gray-800 dark:hover:bg-gray-700/70">
       <Search />
       <input
-        data-test-id="zone-search-bar"
+        data-testid="zone-search-bar"
         className="font h-8 w-full bg-transparent text-base placeholder-gray-500 focus:border-b-2 focus:border-gray-300 focus:outline-none dark:focus:border-gray-600"
         placeholder={placeholder}
         onChange={onHandleInput}

--- a/web/src/features/panels/ranking-panel/ZoneList.tsx
+++ b/web/src/features/panels/ranking-panel/ZoneList.tsx
@@ -25,7 +25,7 @@ function ZoneRow({ zoneId, color, ranking, countryName, zoneName }: ZoneRowType)
       className="group my-1 flex h-11 w-full items-center gap-2 rounded bg-gray-100 px-3 hover:bg-gray-200 focus:border focus:border-gray-400/60 focus-visible:outline-none dark:border dark:border-gray-400/10 dark:bg-gray-800 dark:hover:bg-gray-700/70 dark:focus:border-gray-500/80"
       key={ranking}
       to={`/zone/${zoneId}`}
-      data-test-id="zone-list-link"
+      data-testid="zone-list-link"
     >
       <span className="flex w-4 justify-end text-xs">{ranking}</span>
       <div className="h-4 w-4 min-w-4 rounded-sm" style={{ backgroundColor: color }} />

--- a/web/src/features/panels/zone/EstimationCard.cy.tsx
+++ b/web/src/features/panels/zone/EstimationCard.cy.tsx
@@ -27,20 +27,20 @@ describe('EstimationCard with FeedbackCard', () => {
     cy.intercept('/feature-flags', {
       body: { 'feedback-estimation-labels': true },
     });
-    cy.get('[data-test-id=feedback-card]').should('not.exist');
-    cy.get('[data-test-id=collapse-button]').click();
-    cy.get('[data-test-id=feedback-card]').should('exist');
-    cy.get('[data-test-id=collapse-button]').click();
-    cy.get('[data-test-id=feedback-card]').should('exist');
+    cy.get('[data-testid=feedback-card]').should('not.exist');
+    cy.get('[data-testid=collapse-button]').click();
+    cy.get('[data-testid=feedback-card]').should('exist');
+    cy.get('[data-testid=collapse-button]').click();
+    cy.get('[data-testid=feedback-card]').should('exist');
   });
 
   it.skip('feedback card should only be visible if feature-flag is enabled', () => {
     cy.intercept('/feature-flags', {
       body: { 'feedback-estimation-labels': false },
     });
-    cy.get('[data-test-id=feedback-card]').should('not.exist');
-    cy.get('[data-test-id=collapse-button]').click();
-    cy.get('[data-test-id=feedback-card]').should('exist');
+    cy.get('[data-testid=feedback-card]').should('not.exist');
+    cy.get('[data-testid=collapse-button]').click();
+    cy.get('[data-testid=feedback-card]').should('exist');
   });
 });
 
@@ -60,24 +60,24 @@ describe('EstimationCard with known estimation method', () => {
   });
 
   it('Estimation card contains expected information', () => {
-    cy.get('[data-test-id=title]').contains('Data is always estimated');
-    cy.get('[data-test-id=badge]').contains('Not realtime');
-    cy.get('[data-test-id="collapse-button"]').click();
-    cy.get('[data-test-id="body-text"]').contains(
+    cy.get('[data-testid=title]').contains('Data is always estimated');
+    cy.get('[data-testid=badge]').contains('Not realtime');
+    cy.get('[data-testid="collapse-button"]').click();
+    cy.get('[data-testid="body-text"]').contains(
       'The data for this zone is not published in realtime and only provides the total production. Both hourly production and production sources are estimated based on historical data for each production source.'
     );
   });
 
   it('Toggles when collapse button is clicked', () => {
-    cy.get('[data-test-id="collapse-up"]').should('not.exist');
-    cy.get('[data-test-id="collapse-down"]').should('exist');
-    cy.get('[data-test-id="body-text"]').should('not.exist');
-    cy.get('[data-test-id="methodology-link"]').should('not.exist');
-    cy.get('[data-test-id="collapse-button"]').click();
-    cy.get('[data-test-id="collapse-up"]').should('exist');
-    cy.get('[data-test-id="collapse-down"]').should('not.exist');
-    cy.get('[data-test-id="body-text"]').should('exist');
-    cy.get('[data-test-id="methodology-link"]').should('exist');
+    cy.get('[data-testid="collapse-up"]').should('not.exist');
+    cy.get('[data-testid="collapse-down"]').should('exist');
+    cy.get('[data-testid="body-text"]').should('not.exist');
+    cy.get('[data-testid="methodology-link"]').should('not.exist');
+    cy.get('[data-testid="collapse-button"]').click();
+    cy.get('[data-testid="collapse-up"]').should('exist');
+    cy.get('[data-testid="collapse-down"]').should('not.exist');
+    cy.get('[data-testid="body-text"]').should('exist');
+    cy.get('[data-testid="methodology-link"]').should('exist');
   });
 });
 
@@ -90,10 +90,10 @@ describe('EstimationCard', () => {
         </QueryClientProvider>
       </I18nextProvider>
     );
-    cy.get('[data-test-id=title]').contains('Data is estimated');
-    cy.get('[data-test-id=badge]').contains('Imprecise');
-    cy.get('[data-test-id="collapse-button"]').click();
-    cy.get('[data-test-id="body-text"]').contains(
+    cy.get('[data-testid=title]').contains('Data is estimated');
+    cy.get('[data-testid=badge]').contains('Imprecise');
+    cy.get('[data-testid="collapse-button"]').click();
+    cy.get('[data-testid="body-text"]').contains(
       'The published data for this zone is unavailable or incomplete. The data shown on the map is estimated using our best effort, but might differ from the actual values.'
     );
   });
@@ -106,7 +106,7 @@ describe('EstimationCard', () => {
         </QueryClientProvider>
       </I18nextProvider>
     );
-    cy.get('[data-test-id=title]').should('not.exist');
+    cy.get('[data-testid=title]').should('not.exist');
   });
 });
 
@@ -126,16 +126,16 @@ describe('OutageCard', () => {
   });
 
   it('Outage message contains expected information', () => {
-    cy.get('[data-test-id=title]').contains('Ongoing issues');
-    cy.get('[data-test-id=badge]').contains('Unavailable');
+    cy.get('[data-testid=title]').contains('Ongoing issues');
+    cy.get('[data-testid=badge]').contains('Unavailable');
   });
 
   it('For outage start as expanded and toggles collapse when collapse button is clicked', () => {
-    cy.get('[data-test-id="collapse-up"]').should('exist');
-    cy.get('[data-test-id="collapse-down"]').should('not.exist');
-    cy.get('[data-test-id="collapse-button"]').click();
-    cy.get('[data-test-id="collapse-up"]').should('not.exist');
-    cy.get('[data-test-id="collapse-down"]').should('exist');
+    cy.get('[data-testid="collapse-up"]').should('exist');
+    cy.get('[data-testid="collapse-down"]').should('not.exist');
+    cy.get('[data-testid="collapse-button"]').click();
+    cy.get('[data-testid="collapse-up"]').should('not.exist');
+    cy.get('[data-testid="collapse-down"]').should('exist');
   });
 });
 
@@ -152,10 +152,10 @@ describe('AggregatedCard', () => {
         </QueryClientProvider>
       </I18nextProvider>
     );
-    cy.get('[data-test-id=title]').contains('Data is aggregated');
-    cy.get('[data-test-id=badge]').contains('50% estimated');
-    cy.get('[data-test-id="collapse-button"]').click();
-    cy.get('[data-test-id="body-text"]').contains(
+    cy.get('[data-testid=title]').contains('Data is aggregated');
+    cy.get('[data-testid=badge]').contains('50% estimated');
+    cy.get('[data-testid="collapse-button"]').click();
+    cy.get('[data-testid="body-text"]').contains(
       'The data consists of an aggregation of hourly values. 50% of the production values are estimated.'
     );
   });
@@ -172,10 +172,10 @@ describe('AggregatedCard', () => {
         </QueryClientProvider>
       </I18nextProvider>
     );
-    cy.get('[data-test-id=title]').contains('Data is aggregated');
-    cy.get('[data-test-id=badge]').should('not.exist');
-    cy.get('[data-test-id="collapse-button"]').click();
-    cy.get('[data-test-id="body-text"]').contains(
+    cy.get('[data-testid=title]').contains('Data is aggregated');
+    cy.get('[data-testid=badge]').should('not.exist');
+    cy.get('[data-testid="collapse-button"]').click();
+    cy.get('[data-testid="body-text"]').contains(
       'The data consists of an aggregation of hourly values.'
     );
   });

--- a/web/src/features/panels/zone/EstimationCard.tsx
+++ b/web/src/features/panels/zone/EstimationCard.tsx
@@ -178,7 +178,7 @@ function BaseCard({
       >
         <div className="flex flex-col gap-2">
           <div
-            data-test-id="body-text"
+            data-testid="body-text"
             className={`text-sm font-normal text-neutral-600 dark:text-neutral-400`}
           >
             {estimationMethod != 'outage' && bodyText}
@@ -191,7 +191,7 @@ function BaseCard({
               href="https://www.electricitymaps.com/methodology#missing-data"
               target="_blank"
               rel="noreferrer"
-              data-test-id="methodology-link"
+              data-testid="methodology-link"
               className={`text-sm font-semibold text-black underline dark:text-white`}
               onClick={() => {
                 trackEvent(TrackEvent.ESTIMATION_CARD_METHODOLOGY_LINK_CLICKED, {

--- a/web/src/features/panels/zone/FeedbackCard.cy.tsx
+++ b/web/src/features/panels/zone/FeedbackCard.cy.tsx
@@ -24,39 +24,39 @@ describe('FeedbackCard', () => {
   });
 
   it('renders correctly', () => {
-    cy.get('[data-test-id=feedback-card]').should('be.visible');
-    cy.get('[data-test-id=title]').should('contain.text', 'Help us improve!');
-    cy.get('[data-test-id=subtitle]').should(
+    cy.get('[data-testid=feedback-card]').should('be.visible');
+    cy.get('[data-testid=title]').should('contain.text', 'Help us improve!');
+    cy.get('[data-testid=subtitle]').should(
       'contain.text',
       'Please rate the following statement.'
     );
-    cy.get('[data-test-id=feedback-question]').should(
+    cy.get('[data-testid=feedback-question]').should(
       'contain.text',
       'The description of the data estimation was easy to understand:'
     );
-    cy.get('[data-test-id=feedback-pill-1]').should('contain.text', '1');
-    cy.get('[data-test-id=feedback-pill-5]').should('contain.text', '5');
-    cy.get('[data-test-id=agree-text]').should('contain.text', 'Strongly agree');
-    cy.get('[data-test-id=disagree-text]').should('contain.text', 'Strongly disagree');
+    cy.get('[data-testid=feedback-pill-1]').should('contain.text', '1');
+    cy.get('[data-testid=feedback-pill-5]').should('contain.text', '5');
+    cy.get('[data-testid=agree-text]').should('contain.text', 'Strongly agree');
+    cy.get('[data-testid=disagree-text]').should('contain.text', 'Strongly disagree');
   });
 
   it('closes when the close button is clicked', () => {
-    cy.get('[data-test-id=close-button]').click();
-    cy.get('[data-test-id=feedback-card]').should('not.exist');
+    cy.get('[data-testid=close-button]').click();
+    cy.get('[data-testid=feedback-card]').should('not.exist');
   });
 
   it('changes state when pill is clicked', () => {
-    cy.get('[data-test-id=feedback-pill-4]').click();
-    cy.get('[data-test-id=input-title]').should(
+    cy.get('[data-testid=feedback-pill-4]').click();
+    cy.get('[data-testid=input-title]').should(
       'contain.text',
       'Anything we can do to improve it?'
     );
   });
 
   it('changes state when the submit button is clicked', () => {
-    cy.get('[data-test-id=feedback-pill-1]').click();
-    cy.get('[data-test-id=feedback-input]').type('Test comment');
-    cy.get('[data-test-id=pill]').click();
-    cy.get('[data-test-id=title]').should('contain.text', 'Thank you for your feedback!');
+    cy.get('[data-testid=feedback-pill-1]').click();
+    cy.get('[data-testid=feedback-input]').type('Test comment');
+    cy.get('[data-testid=pill]').click();
+    cy.get('[data-testid=title]').should('contain.text', 'Thank you for your feedback!');
   });
 });

--- a/web/src/features/panels/zone/NoInformationMessage.tsx
+++ b/web/src/features/panels/zone/NoInformationMessage.tsx
@@ -33,7 +33,7 @@ export default function NoInformationMessage({ status }: { status: ZoneDataStatu
     translations[ZoneDataStatus.NO_INFORMATION];
 
   return (
-    <div data-test-id="no-parser-message" className="pt-4 text-center text-base">
+    <div data-testid="no-parser-message" className="pt-4 text-center text-base">
       <span
         className="prose text-sm dark:prose-invert prose-a:text-sky-600 prose-a:no-underline hover:prose-a:underline"
         dangerouslySetInnerHTML={{

--- a/web/src/features/panels/zone/ShareButton.cy.tsx
+++ b/web/src/features/panels/zone/ShareButton.cy.tsx
@@ -22,9 +22,9 @@ describe('Share Button', () => {
         </ToastProvider>
       </QueryClientProvider>
     );
-    cy.get('[data-test-id="linkIcon"]').should('be.visible');
-    cy.get('[data-test-id="iosShareIcon"]').should('not.exist');
-    cy.get('[data-test-id="defaultShareIcon"]').should('not.exist');
+    cy.get('[data-testid="linkIcon"]').should('be.visible');
+    cy.get('[data-testid="iosShareIcon"]').should('not.exist');
+    cy.get('[data-testid="defaultShareIcon"]').should('not.exist');
   });
 
   it('should display share icon for iOS native app', () => {
@@ -36,9 +36,9 @@ describe('Share Button', () => {
         </ToastProvider>
       </QueryClientProvider>
     );
-    cy.get('[data-test-id="iosShareIcon"]').should('be.visible');
-    cy.get('[data-test-id="defaultShareIcon"]').should('not.exist');
-    cy.get('[data-test-id="linkIcon"]').should('not.exist');
+    cy.get('[data-testid="iosShareIcon"]').should('be.visible');
+    cy.get('[data-testid="defaultShareIcon"]').should('not.exist');
+    cy.get('[data-testid="linkIcon"]').should('not.exist');
   });
 
   it('should display share icon for iOS mobile web', () => {
@@ -50,9 +50,9 @@ describe('Share Button', () => {
         </ToastProvider>
       </QueryClientProvider>
     );
-    cy.get('[data-test-id="iosShareIcon"]').should('be.visible');
-    cy.get('[data-test-id="defaultShareIcon"]').should('not.exist');
-    cy.get('[data-test-id="linkIcon"]').should('not.exist');
+    cy.get('[data-testid="iosShareIcon"]').should('be.visible');
+    cy.get('[data-testid="defaultShareIcon"]').should('not.exist');
+    cy.get('[data-testid="linkIcon"]').should('not.exist');
   });
 
   it('should display default share icon for non-iOS native app', () => {
@@ -64,9 +64,9 @@ describe('Share Button', () => {
         </ToastProvider>
       </QueryClientProvider>
     );
-    cy.get('[data-test-id="defaultShareIcon"]').should('be.visible');
-    cy.get('[data-test-id="iosShareIcon"]').should('not.exist');
-    cy.get('[data-test-id="linkIcon"]').should('not.exist');
+    cy.get('[data-testid="defaultShareIcon"]').should('be.visible');
+    cy.get('[data-testid="iosShareIcon"]').should('not.exist');
+    cy.get('[data-testid="linkIcon"]').should('not.exist');
   });
 
   it('should display default share icon for non-iOS mobile web', () => {
@@ -78,9 +78,9 @@ describe('Share Button', () => {
         </ToastProvider>
       </QueryClientProvider>
     );
-    cy.get('[data-test-id="defaultShareIcon"]').should('be.visible');
-    cy.get('[data-test-id="iosShareIcon"]').should('not.exist');
-    cy.get('[data-test-id="linkIcon"]').should('not.exist');
+    cy.get('[data-testid="defaultShareIcon"]').should('be.visible');
+    cy.get('[data-testid="iosShareIcon"]').should('not.exist');
+    cy.get('[data-testid="linkIcon"]').should('not.exist');
   });
 
   it('should trigger toast on click', () => {
@@ -91,9 +91,9 @@ describe('Share Button', () => {
         </ToastProvider>
       </QueryClientProvider>
     );
-    cy.get('[data-test-id="share-btn"]').should('exist');
-    cy.get('[data-test-id="toast"]').should('not.exist');
-    cy.get('[data-test-id="share-btn"]').click();
+    cy.get('[data-testid="share-btn"]').should('exist');
+    cy.get('[data-testid="toast"]').should('not.exist');
+    cy.get('[data-testid="share-btn"]').click();
     cy.get('[data-testid="toast"]').should('exist');
   });
 
@@ -105,7 +105,7 @@ describe('Share Button', () => {
         </ToastProvider>
       </QueryClientProvider>
     );
-    cy.get('[data-test-id="share-btn"]').click();
+    cy.get('[data-testid="share-btn"]').click();
     cy.get('[data-testid="toast"]').should('be.visible');
     cy.get('[data-testid="toast-dismiss"]').click();
     cy.get('[data-testid="toast"]').should('not.exist');

--- a/web/src/features/panels/zone/ShareButton.tsx
+++ b/web/src/features/panels/zone/ShareButton.tsx
@@ -63,7 +63,7 @@ export function ShareButton({
     trackShareClick();
   }, [reference, hasMobileUserAgent, copyToClipboard, share, shareUrl]);
 
-  let shareIcon = <Link data-test-id="linkIcon" size={iconSize} />;
+  let shareIcon = <Link data-testid="linkIcon" size={iconSize} />;
   if (hasMobileUserAgent || Capacitor.isNativePlatform()) {
     shareIcon = <MemoizedShareIcon showIosIcon={showIosIcon} />;
   }

--- a/web/src/features/panels/zone/ZoneDetails.tsx
+++ b/web/src/features/panels/zone/ZoneDetails.tsx
@@ -172,7 +172,7 @@ function ZoneDetailsContent({
   if (isError) {
     return (
       <div
-        data-test-id="no-parser-message"
+        data-testid="no-parser-message"
         className={`flex h-full w-full items-center justify-center text-sm`}
       >
         🤖 Unknown server error 🤖

--- a/web/src/features/panels/zone/ZoneHeaderTitle.tsx
+++ b/web/src/features/panels/zone/ZoneHeaderTitle.tsx
@@ -65,7 +65,7 @@ export default function ZoneHeaderTitle({ zoneId, isEstimated }: ZoneHeaderTitle
       </Helmet>
       <div
         className="self-center py-4 pr-4 text-xl"
-        data-test-id="left-panel-back-button"
+        data-testid="left-panel-back-button"
         onClick={onNavigateBack}
         role="button"
         tabIndex={0}
@@ -89,7 +89,7 @@ export default function ZoneHeaderTitle({ zoneId, isEstimated }: ZoneHeaderTitle
             tooltipContent={showTooltip ? zoneNameFull : undefined}
             side="bottom"
           >
-            <h1 className="truncate" data-test-id="zone-name">
+            <h1 className="truncate" data-testid="zone-name">
               {zoneName}
             </h1>
           </TooltipWrapper>

--- a/web/src/features/weather-layers/wind-layer/WindLayer.tsx
+++ b/web/src/features/weather-layers/wind-layer/WindLayer.tsx
@@ -93,7 +93,7 @@ export default function WindLayer({ map }: { map?: maplibregl.Map }) {
         isVisible ? 'opacity-100' : 'opacity-0'
       }`}
       id="wind"
-      data-test-id="wind-layer"
+      data-testid="wind-layer"
       width={width}
       height={height}
       ref={reference}


### PR DESCRIPTION
## Issue

userEvent.click(screen.getByTestId('dismiss-btn')) works only when the attribute is named data-testid and not data-test-id is due to how the testing library is configured to query elements.
Explanation:
Testing Library Convention:
The @testing-library/react library, which includes screen.getByTestId, is designed to work with the data-testid attribute by default. This is a convention used by the library to identify elements for testing purposes.

## Description
This PR renames all `data-test-id` attributes to `data-testid`

