### PR TITLE
bug(web): wrong query key on zone request

### DIFF
--- a/web/src/api/getZone.ts
+++ b/web/src/api/getZone.ts
@@ -58,7 +58,7 @@ const useGetZone = (): UseQueryResult<ZoneDetails> => {
       QUERY_KEYS.ZONE,
       {
         zone: zoneId,
-        aggregate: urlTimeAverage,
+        aggregate: timeAverage,
         targetDatetime: urlDatetime,
       },
     ],


### PR DESCRIPTION
## Issue
Out of sync state and zone data

## Description
I was still seeing the annoying out of sync data issue, after some debugging I found the query key was set to "24h" instead of "hourly" this fixes the issue. It would be nice to align on one standard to aggregations in the future.