### PR TITLE
Pumping storage fix for CZ parser

### DIFF
--- a/parsers/CZ.py
+++ b/parsers/CZ.py
@@ -2,11 +2,16 @@ from datetime import datetime, timedelta
 from logging import Logger, getLogger
 
 from bs4 import BeautifulSoup
+
 # The request library is used to fetch content through HTTP
 from requests import Response, Session
 
 from electricitymap.contrib.lib.models.event_lists import (
-    ExchangeList, ProductionBreakdownList, ProductionMix, StorageMix)
+    ExchangeList,
+    ProductionBreakdownList,
+    ProductionMix,
+    StorageMix,
+)
 from electricitymap.contrib.lib.types import ZoneKey
 from parsers.lib.config import refetch_frequency
 from parsers.lib.exceptions import ParserException
@@ -284,7 +289,7 @@ if __name__ == "__main__":
     """Main method, never used by the Electricity Map backend, but handy for testing."""
 
     # print("fetch_production() ->")
-    fetch_production()
+    print(fetch_production())
     # print(fetch_production())
     # print(get_pumping_load())
     # print("fetch_price() ->")

--- a/parsers/CZ.py
+++ b/parsers/CZ.py
@@ -238,7 +238,7 @@ def fetch_production(
                     pumping_storage = float(values[v]) * -1
                     if values["date"] in pumping_load_at_time:
                         pumping_storage += pumping_load_at_time[values["date"]]
-                    storage.add_value(mode=generator, value=float(values[v]))
+                    storage.add_value(mode=generator, value=float(pumping_storage))
 
             # # sum production to get
 
@@ -290,6 +290,9 @@ if __name__ == "__main__":
 
     # print("fetch_production() ->")
     print(fetch_production())
+    # temp = fetch_production()
+    # for i in temp:
+    #     print(i['storage'], i['datetime'])
     # print(fetch_production())
     # print(get_pumping_load())
     # print("fetch_price() ->")


### PR DESCRIPTION
## Issue

Closes #5426

## Description

Creates get_pumping_load function which fetches pumping load data from ceps.cz and computes the current load at each timestamp that is being used for pumping. 

Modifies fetch_production to call get_pumping_load, whose dictionary is then used to add the amount of energy being stored to hydro at each timestamp.

### Preview

The hydro storage values from fetch_production() showing the new positive values calculated from load_including_pumping-load
<img width="356" alt="image" src="https://github.com/user-attachments/assets/d56f522f-13f4-4d81-8ff5-70496202f90a">

### Double check

- [ ] I have tested my parser changes locally with `poetry run test_parser "zone_key"` - I got the error marking ":( >2h from now !!!" but the original CZ parser code produces the exact same error locally. I tried to see if it was a time conversion issue but didn't have any luck locating the source of the issue
- [X] I have run `pnpx prettier@2 --write .` and `poetry run format` in the top level directory to format my changes.
