### PR TITLE
fix(web): round estimation percentage to 0 decimals

### DIFF
--- a/web/src/features/charts/graphUtils.ts
+++ b/web/src/features/charts/graphUtils.ts
@@ -231,10 +231,10 @@ function analyzeChartData(chartData: AreaGraphElement[]) {
   }
   const calculatedTotal = round(
     estimatedTotal / total || ((estimatedCount || tsaCount) / total) * 100,
-    2
+    0
   );
   return {
-    estimatedTotal: calculatedTotal > 1 ? calculatedTotal : Number.NaN,
+    estimatedTotal: calculatedTotal,
     allTimeSlicerAverageMethod: tsaCount === total,
     allEstimated: estimatedCount === total,
     hasEstimation: estimatedCount > 0,
@@ -248,8 +248,7 @@ export function getBadgeTextAndIcon(
   const { allTimeSlicerAverageMethod, allEstimated, hasEstimation, estimatedTotal } =
     analyzeChartData(chartData);
 
-  // If the total is NaN, it means that the estimation percentage is too low to be displayed
-  if (Number.isNaN(estimatedTotal)) {
+  if (estimatedTotal === 0) {
     return {};
   }
 

--- a/web/src/features/charts/tooltips/BreakdownChartTooltip.tsx
+++ b/web/src/features/charts/tooltips/BreakdownChartTooltip.tsx
@@ -9,6 +9,7 @@ import { getZoneName } from 'translation/translation';
 import { ElectricityModeType, Maybe, ZoneDetail } from 'types';
 import { EstimationMethods, modeColor, TimeAverages } from 'utils/constants';
 import { formatCo2, formatEnergy, formatPower } from 'utils/formatting';
+import { round } from 'utils/helpers';
 import {
   displayByEmissionsAtom,
   isConsumptionAtom,
@@ -124,7 +125,9 @@ export default function BreakdownChartTooltip({
   );
 
   const { estimationMethod, stateDatetime, estimatedPercentage } = zoneDetail;
-  const hasEstimationPill = estimationMethod != undefined || Boolean(estimatedPercentage);
+  const roundedEstimatedPercentage = round(estimatedPercentage ?? 0, 0);
+  const hasEstimationPill =
+    estimationMethod != undefined || Boolean(roundedEstimatedPercentage);
 
   return (
     <BreakdownChartTooltipContent
@@ -134,7 +137,7 @@ export default function BreakdownChartTooltip({
       selectedLayerKey={selectedLayerKey}
       timeAverage={timeAverage}
       hasEstimationPill={hasEstimationPill}
-      estimatedPercentage={estimatedPercentage}
+      estimatedPercentage={roundedEstimatedPercentage}
       estimationMethod={estimationMethod}
     ></BreakdownChartTooltipContent>
   );

--- a/web/src/features/charts/tooltips/CarbonChartTooltip.tsx
+++ b/web/src/features/charts/tooltips/CarbonChartTooltip.tsx
@@ -3,7 +3,7 @@ import { CarbonIntensityDisplay } from 'components/CarbonIntensityDisplay';
 import { useCo2ColorScale } from 'hooks/theme';
 import { useAtom, useAtomValue } from 'jotai';
 import { useTranslation } from 'react-i18next';
-import { getCarbonIntensity } from 'utils/helpers';
+import { getCarbonIntensity, round } from 'utils/helpers';
 import { isConsumptionAtom, timeAverageAtom } from 'utils/state/atoms';
 
 import { InnerAreaGraphTooltipProps } from '../types';
@@ -29,7 +29,9 @@ export default function CarbonChartTooltip({ zoneDetail }: InnerAreaGraphTooltip
     { c: { ci: co2intensity }, p: { ci: co2intensityProduction } },
     isConsumption
   );
-  const hasEstimationPill = Boolean(estimationMethod) || Boolean(estimatedPercentage);
+  const roundedEstimatedPercentage = round(estimatedPercentage ?? 0, 0);
+  const hasEstimationPill =
+    Boolean(estimationMethod) || Boolean(roundedEstimatedPercentage);
   return (
     <div
       data-testid="carbon-chart-tooltip"
@@ -41,7 +43,7 @@ export default function CarbonChartTooltip({ zoneDetail }: InnerAreaGraphTooltip
         squareColor={co2ColorScale(intensity)}
         title={t('tooltips.carbonintensity')}
         hasEstimationPill={hasEstimationPill}
-        estimatedPercentage={estimatedPercentage}
+        estimatedPercentage={roundedEstimatedPercentage}
         estimationMethod={estimationMethod}
       />
       <CarbonIntensityDisplay

--- a/web/src/features/charts/tooltips/EmissionChartTooltip.tsx
+++ b/web/src/features/charts/tooltips/EmissionChartTooltip.tsx
@@ -1,6 +1,7 @@
 import { useAtomValue } from 'jotai';
 import { useTranslation } from 'react-i18next';
 import { formatCo2 } from 'utils/formatting';
+import { round } from 'utils/helpers';
 import { isConsumptionAtom, timeAverageAtom } from 'utils/state/atoms';
 
 import { getTotalEmissionsAvailable } from '../graphUtils';
@@ -18,7 +19,9 @@ export default function EmissionChartTooltip({ zoneDetail }: InnerAreaGraphToolt
 
   const totalEmissions = getTotalEmissionsAvailable(zoneDetail, isConsumption);
   const { stateDatetime, estimationMethod, estimatedPercentage } = zoneDetail;
-  const hasEstimationPill = Boolean(estimationMethod) || Boolean(estimatedPercentage);
+  const roundedEstimatedPercentage = round(estimatedPercentage ?? 0, 0);
+  const hasEstimationPill =
+    Boolean(estimationMethod) || Boolean(roundedEstimatedPercentage);
 
   return (
     <div className="w-full rounded-md bg-white p-3 shadow-xl dark:border dark:border-gray-700 dark:bg-gray-800 sm:w-[410px]">
@@ -28,7 +31,7 @@ export default function EmissionChartTooltip({ zoneDetail }: InnerAreaGraphToolt
         squareColor="#a5292a"
         title={t('country-panel.emissions')}
         hasEstimationPill={hasEstimationPill}
-        estimatedPercentage={estimatedPercentage}
+        estimatedPercentage={roundedEstimatedPercentage}
         estimationMethod={estimationMethod}
       />
       <p className="flex justify-center text-base">

--- a/web/src/features/map/MapTooltip.tsx
+++ b/web/src/features/map/MapTooltip.tsx
@@ -11,6 +11,7 @@ import { useAtomValue } from 'jotai';
 import { TrendingUpDown } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import { StateZoneData } from 'types';
+import { round } from 'utils/helpers';
 import { selectedDatetimeStringAtom } from 'utils/state/atoms';
 
 import { hoveredZoneAtom, mapMovingAtom, mousePositionAtom } from './mapAtoms';
@@ -37,12 +38,18 @@ export function TooltipInner({
   };
   const { e, o } = zoneData;
 
+  const estimated = typeof e === 'number' ? round(e ?? 0, 0) : e;
+
   return (
     <div className="flex w-full flex-col gap-2 py-3 text-center">
       <div className="flex flex-col px-3">
         <div className="flex w-full flex-row justify-between">
           <ZoneName zone={zoneId} textStyle="font-medium text-base font-poppins" />
-          <DataValidityBadge hasOutage={o} estimated={e} hasZoneData={hasZoneData} />
+          <DataValidityBadge
+            hasOutage={o}
+            estimated={estimated}
+            hasZoneData={hasZoneData}
+          />
         </div>
         <TimeDisplay
           zoneId={zoneId}
@@ -79,7 +86,7 @@ function DataValidityBadge({
       />
     );
   }
-  if (estimated && estimated > 0) {
+  if (estimated && estimated > 0.5) {
     return (
       <EstimationBadge
         text={t(`estimation-card.aggregated_estimated.pill`, {

--- a/web/src/features/panels/zone/ZoneDetails.tsx
+++ b/web/src/features/panels/zone/ZoneDetails.tsx
@@ -9,6 +9,7 @@ import { Navigate, useLocation, useParams } from 'react-router-dom';
 import { twMerge } from 'tailwind-merge';
 import { RouteParameters, ZoneMessage } from 'types';
 import { Charts, EstimationMethods, SpatialAggregate } from 'utils/constants';
+import { round } from 'utils/helpers';
 import {
   displayByEmissionsAtom,
   isHourlyAtom,
@@ -73,7 +74,9 @@ export default function ZoneDetails(): JSX.Element {
   const { estimationMethod, estimatedPercentage } = selectedData || {};
   const zoneMessage = data?.zoneMessage;
   const cardType = getCardType({ estimationMethod, zoneMessage, isHourly });
-  const hasEstimationPill = Boolean(estimationMethod) || Boolean(estimatedPercentage);
+  const roundedEstimatedPercentage = round(estimatedPercentage ?? 0, 0);
+  const hasEstimationPill =
+    Boolean(estimationMethod) || Boolean(roundedEstimatedPercentage);
   const isIosCapacitor =
     Capacitor.isNativePlatform() && Capacitor.getPlatform() === 'ios';
   return (
@@ -93,7 +96,7 @@ export default function ZoneDetails(): JSX.Element {
               cardType={cardType}
               estimationMethod={estimationMethod}
               zoneMessage={zoneMessage}
-              estimatedPercentage={selectedData?.estimatedPercentage}
+              estimatedPercentage={roundedEstimatedPercentage}
             />
           )}
         <ZoneHeaderGauges zoneKey={zoneId} />

--- a/web/src/hooks/getEstimationTranslation.ts
+++ b/web/src/hooks/getEstimationTranslation.ts
@@ -1,5 +1,6 @@
 import { useTranslation } from 'react-i18next';
 import { EstimationMethods } from 'utils/constants';
+import { round } from 'utils/helpers';
 
 export function useGetEstimationTranslation(
   field: 'title' | 'pill' | 'body',
@@ -7,9 +8,10 @@ export function useGetEstimationTranslation(
   estimatedPercentage?: number
 ) {
   const { t } = useTranslation();
-  const exactTranslation = estimatedPercentage
+  const roundedEstimatedPercentage = round(estimatedPercentage ?? 0, 0);
+  const exactTranslation = roundedEstimatedPercentage
     ? t(`estimation-card.aggregated_estimated.${field}`, {
-        percentage: estimatedPercentage,
+        percentage: roundedEstimatedPercentage,
       })
     : t(`estimation-card.${estimationMethod}.${field}`);
 


### PR DESCRIPTION
## Issue

<!-- If you want to close an issue automatically when your PR is merged, write "Closes X" where X is the issue number. For example: Closes #000 -->

## Description

<!-- Explains the goal of this PR -->
This PR rounds estimation percentages to 0 decimals.

### Preview

<!-- Please add screenshots and/or gif that shows visual changes (if applicable) -->
<img width="977" alt="image" src="https://github.com/user-attachments/assets/212a316e-ff30-41b1-9a9c-f9adb133e5d7">
<img width="761" alt="image" src="https://github.com/user-attachments/assets/2b380b2d-790d-4b22-92f5-f9b0ddbc2f45">


### Double check

- [ ] I have tested my parser changes locally with `poetry run test_parser "zone_key"`
- [x] I have run `pnpx prettier@2 --write .` and `poetry run format` in the top level directory to format my changes.
