### PR TITLE
chore(SEO): Use useMatches to get the correct pathname with urlTimeRange

### DIFF
--- a/web/src/hooks/useGetCanonicalUrl.tsx
+++ b/web/src/hooks/useGetCanonicalUrl.tsx
@@ -1,5 +1,5 @@
 import { useTranslation } from 'react-i18next';
-import { useMatch } from 'react-router-dom';
+import { useMatches } from 'react-router-dom';
 import { baseUrl } from 'utils/constants';
 
 /**
@@ -7,14 +7,13 @@ import { baseUrl } from 'utils/constants';
  */
 export const useGetCanonicalUrl = () => {
   const { i18n } = useTranslation();
-  // TODO: Replace with useMatches once we have migrated to react routers data routing
-  const mapMatch = useMatch('/map');
-  const zoneMatch = useMatch('/zone/:zoneId');
 
-  const pathname = mapMatch?.pathname ?? zoneMatch?.pathname;
+  const matches = useMatches();
+
+  const pathname = matches?.[1]?.pathname;
 
   const currentLanguageKey = i18n.languages[0];
-  return `${baseUrl}${pathname ?? '/map'}${
+  return `${baseUrl}${pathname}${
     currentLanguageKey.startsWith('en') ? '' : `?lang=${currentLanguageKey}`
   }`;
 };

--- a/web/src/hooks/useGetCanonicalUrl.tsx
+++ b/web/src/hooks/useGetCanonicalUrl.tsx
@@ -10,7 +10,7 @@ export const useGetCanonicalUrl = () => {
 
   const matches = useMatches();
 
-  const pathname = matches?.at(-1)?.pathname;
+  const pathname = matches?.at(-1)?.pathname ?? '/';
 
   const currentLanguageKey = i18n.languages[0];
   return `${baseUrl}${pathname}${

--- a/web/src/hooks/useGetCanonicalUrl.tsx
+++ b/web/src/hooks/useGetCanonicalUrl.tsx
@@ -10,7 +10,7 @@ export const useGetCanonicalUrl = () => {
 
   const matches = useMatches();
 
-  const pathname = matches?.[1]?.pathname;
+  const pathname = matches?.at(-1)?.pathname;
 
   const currentLanguageKey = i18n.languages[0];
   return `${baseUrl}${pathname}${


### PR DESCRIPTION
## Issue

We had a todo we could fix + SEO didn't pick up the `urlTimeRange`.

## Description

Uses the useMatches hook to get the pathname.


### Double check

- [x] I have run `pnpx prettier@2 --write .` and `poetry run format` in the top level directory to format my changes.
