### PR TITLE
chore(parsers): Archive the Statnett parser

### DIFF
--- a/config/exchanges/NO-NO4_RU-1.yaml
+++ b/config/exchanges/NO-NO4_RU-1.yaml
@@ -1,6 +1,4 @@
 lonlat:
   - 30.1437
   - 69.52
-parsers:
-  exchange: statnett.fetch_exchange
 rotation: 120

--- a/parsers/archived/statnett.py
+++ b/parsers/archived/statnett.py
@@ -1,6 +1,5 @@
-#!/usr/bin/env python3
-# Note: This parser is only used for the NO-NO4->RU-1 exchange
-# and should be archived if this data becomes available on ENTSO-E.
+# Archived because the parser was only used for NO-NO4 to RU-1 exchange, which has since been removed from the source.
+# This exchange is no longer active.
 
 from datetime import datetime, timedelta
 from logging import Logger, getLogger


### PR DESCRIPTION
## Issue
The exchange this parser was used for has been removed at the source so we can archive it without any further issues.

## Description

Archives the Statnett parser and removes the references to it.

### Double check

- [x] I have run `pnpx prettier@2 --write .` and `poetry run format` in the top level directory to format my changes.
