### PR TITLE
feat(zones):Update capacity value for CH and add unknown capacity value

### DIFF
--- a/config/zones/CH.yaml
+++ b/config/zones/CH.yaml
@@ -5,18 +5,69 @@ bounding_box:
     - 47.808380127
 
 capacity:
-  biomass: 648.4
-  coal: 0
-  gas: 304.7
-  geothermal: 0
-  hydro: 10438.1
-  hydro storage: 6697
-  nuclear: 3014.6
-  oil: 0
-  solar: 6357.9
-  wind: 102.2
-  unkown: 15860
-  
+  biomass:
+    - datetime: '2023-01-01'
+      source: SFOE
+      value: 542.9
+    - datetime: '2024-01-01'
+      source: SFOE
+      value: 648.4
+  coal:
+    - datetime: '2023-01-01'
+      source: SFOE
+      value: 0
+  gas:
+    - datetime: '2023-01-01'
+      source: SFOE
+      value: 216.5
+    - datetime: '2024-01-01'
+      source: SFOE
+      value: 304.7
+  geothermal:
+    - datetime: '2023-01-01'
+      source: SFOE
+      value: 0
+  hydro:
+    - datetime: '2023-01-01'
+      source: SFOE
+      value: 12885.3
+    - datetime: '2024-01-01'
+      source: SFOE
+      value: 10438.1
+  hydro storage:
+    - datetime: '2024-01-01'
+      source: entsoe
+      value: 6697
+  nuclear:
+    - datetime: '2023-01-01'
+      source: SFOE
+      value: 3014.6
+  oil:
+    - datetime: '2023-01-01'
+      source: SFOE
+      value: 0.4
+    - datetime: '2024-01-01'
+      source: SFOE
+      value: 0
+  solar:
+    - datetime: '2023-01-01'
+      source: SFOE
+      value: 4736.7
+    - datetime: '2024-01-01'
+      source: SFOE
+      value: 6357.9
+  wind:
+    - datetime: '2023-01-01'
+      source: SFOE
+      value: 88.4
+    - datetime: '2024-01-01'
+      source: SFOE
+      value: 102.2
+  unknown:
+    - datetime: '2024-01-01'
+      source: SFOE
+      value: 15860
+
 contributors:
   - corradio
   - postronium

--- a/config/zones/CH.yaml
+++ b/config/zones/CH.yaml
@@ -3,17 +3,20 @@ bounding_box:
     - 45.8179931641
   - - 10.4920501709
     - 47.808380127
+
 capacity:
-  biomass: 542.9
+  biomass: 648.4
   coal: 0
-  gas: 216.5
+  gas: 304.7
   geothermal: 0
-  hydro: 12885.3
-  hydro storage: 4605
+  hydro: 10438.1
+  hydro storage: 6697
   nuclear: 3014.6
-  oil: 0.4
-  solar: 4736.7
-  wind: 88.4
+  oil: 0
+  solar: 6357.9
+  wind: 102.2
+  unkown: 15860
+  
 contributors:
   - corradio
   - postronium


### PR DESCRIPTION
## Issue
No unknown capacity value for CH. The unknown production value is calculated as the difference in total_production and the sum of consumption, exchange and storage, so we do not have a capacity value for this production mode. Unknown capacity production value is here added as the total production capacity. 

Other values are updated: 
https://www.uvek-gis.admin.ch/BFE/storymaps/EE_Elektrizitaetsproduktionsanlagen/?lang=en 
ENTSOE

### Double check

- [ ] I have tested my parser changes locally with `poetry run test_parser "zone_key"`
- [x] I have run `pnpx prettier@2 --write .` and `poetry run format` in the top level directory to format my changes.
