### PR TITLE
chore(web): set CSP headers in a single place

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -3,7 +3,6 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, viewport-fit=cover" />
-    <meta http-equiv="Content-Security-Policy" content="default-src * 'self' 'unsafe-inline' data: gap: https://ssl.gstatic.com 'unsafe-eval' blob:; style-src * 'unsafe-inline'; media-src *;" />
     <meta name="description" content="Electricity Maps is a live 24/7 visualization of where your electricity comes from and how much CO2 was emitted to produce it." />
     <meta property="og:description" content="Electricity Maps is a live 24/7 visualization of where your electricity comes from and how much CO2 was emitted to produce it." />
     <meta property="og:image" content="https://app.electricitymaps.com/images/electricitymap_social_image.png" />

--- a/web/public/_headers
+++ b/web/public/_headers
@@ -8,4 +8,4 @@
   Link:  <https://o192958.ingest.sentry.io>; rel=preconnect
   Link:  <https://plausible.io>; rel=preconnect
 # === Disallow iframes from external domains
-  Content-Security-Policy: frame-ancestors 'self' https://*.electricitymaps.com;
+  Content-Security-Policy: frame-ancestors 'self' https://*.electricitymaps.com; default-src * 'self' 'unsafe-inline' data: gap: https://ssl.gstatic.com 'unsafe-eval' blob:; style-src * 'unsafe-inline'; media-src *;


### PR DESCRIPTION
## Description

Follow-up to https://github.com/electricitymaps/electricitymaps-contrib/pull/7551

### Double check

- [x] I have tested my parser changes locally with `poetry run test_parser "zone_key"`
- [x] I have run `pnpx prettier@2 --write .` and `poetry run format` in the top level directory to format my changes.
