### PR TITLE
chore(exchanges): Switch internal nordic exchanges to Nordpool

### DIFF
--- a/config/exchanges/DK-DK1_SE-SE3.yaml
+++ b/config/exchanges/DK-DK1_SE-SE3.yaml
@@ -5,6 +5,6 @@ lonlat:
   - 11.556268
   - 56.857802
 parsers:
-  exchange: ENTSOE.fetch_exchange
+  exchange: NORDPOOL.fetch_exchange
   exchangeForecast: ENTSOE.fetch_exchange_forecast
 rotation: 70

--- a/config/exchanges/DK-DK2_SE-SE4.yaml
+++ b/config/exchanges/DK-DK2_SE-SE4.yaml
@@ -5,6 +5,6 @@ lonlat:
   - 12.704418
   - 55.952282
 parsers:
-  exchange: ENTSOE.fetch_exchange
+  exchange: NORDPOOL.fetch_exchange
   exchangeForecast: ENTSOE.fetch_exchange_forecast
 rotation: 70

--- a/config/exchanges/FI_NO-NO4.yaml
+++ b/config/exchanges/FI_NO-NO4.yaml
@@ -5,6 +5,6 @@ lonlat:
   - 25.35158
   - 68.862684
 parsers:
-  exchange: ENTSOE.fetch_exchange
+  exchange: NORDPOOL.fetch_exchange
   exchangeForecast: ENTSOE.fetch_exchange_forecast
 rotation: -30

--- a/config/exchanges/FI_SE-SE1.yaml
+++ b/config/exchanges/FI_SE-SE1.yaml
@@ -5,6 +5,6 @@ lonlat:
   - 23.857
   - 66.921
 parsers:
-  exchange: ENTSOE.fetch_exchange
+  exchange: NORDPOOL.fetch_exchange
   exchangeForecast: ENTSOE.fetch_exchange_forecast
 rotation: -90

--- a/config/exchanges/FI_SE-SE3.yaml
+++ b/config/exchanges/FI_SE-SE3.yaml
@@ -5,6 +5,6 @@ lonlat:
   - 19.797
   - 60.628
 parsers:
-  exchange: ENTSOE.fetch_exchange
+  exchange: NORDPOOL.fetch_exchange
   exchangeForecast: ENTSOE.fetch_exchange_forecast
 rotation: -110

--- a/config/exchanges/NO-NO1_NO-NO2.yaml
+++ b/config/exchanges/NO-NO1_NO-NO2.yaml
@@ -5,6 +5,6 @@ lonlat:
   - 9.3
   - 59.844429
 parsers:
-  exchange: ENTSOE.fetch_exchange
+  exchange: NORDPOOL.fetch_exchange
   exchangeForecast: ENTSOE.fetch_exchange_forecast
 rotation: -110

--- a/config/exchanges/NO-NO1_NO-NO3.yaml
+++ b/config/exchanges/NO-NO1_NO-NO3.yaml
@@ -5,6 +5,6 @@ lonlat:
   - 9.533218
   - 61.731596
 parsers:
-  exchange: ENTSOE.fetch_exchange
+  exchange: NORDPOOL.fetch_exchange
   exchangeForecast: ENTSOE.fetch_exchange_forecast
 rotation: -45

--- a/config/exchanges/NO-NO1_NO-NO5.yaml
+++ b/config/exchanges/NO-NO1_NO-NO5.yaml
@@ -5,6 +5,6 @@ lonlat:
   - 8.3
   - 61.132896
 parsers:
-  exchange: ENTSOE.fetch_exchange
+  exchange: NORDPOOL.fetch_exchange
   exchangeForecast: ENTSOE.fetch_exchange_forecast
 rotation: -90

--- a/config/exchanges/NO-NO1_SE-SE3.yaml
+++ b/config/exchanges/NO-NO1_SE-SE3.yaml
@@ -5,6 +5,6 @@ lonlat:
   - 12.254138
   - 61.008235
 parsers:
-  exchange: ENTSOE.fetch_exchange
+  exchange: NORDPOOL.fetch_exchange
   exchangeForecast: ENTSOE.fetch_exchange_forecast
 rotation: 90

--- a/config/exchanges/NO-NO2_NO-NO5.yaml
+++ b/config/exchanges/NO-NO2_NO-NO5.yaml
@@ -5,6 +5,6 @@ lonlat:
   - 7.461
   - 60.0
 parsers:
-  exchange: ENTSOE.fetch_exchange
+  exchange: NORDPOOL.fetch_exchange
   exchangeForecast: ENTSOE.fetch_exchange_forecast
 rotation: -10

--- a/config/exchanges/NO-NO3_NO-NO4.yaml
+++ b/config/exchanges/NO-NO3_NO-NO4.yaml
@@ -5,6 +5,6 @@ lonlat:
   - 12.465132
   - 64.745638
 parsers:
-  exchange: ENTSOE.fetch_exchange
+  exchange: NORDPOOL.fetch_exchange
   exchangeForecast: ENTSOE.fetch_exchange_forecast
 rotation: 30

--- a/config/exchanges/NO-NO3_NO-NO5.yaml
+++ b/config/exchanges/NO-NO3_NO-NO5.yaml
@@ -6,6 +6,6 @@ lonlat:
   - 7.1
   - 61.194118
 parsers:
-  exchange: ENTSOE.fetch_exchange
+  exchange: NORDPOOL.fetch_exchange
   exchangeForecast: ENTSOE.fetch_exchange_forecast
 rotation: 140

--- a/config/exchanges/NO-NO3_SE-SE2.yaml
+++ b/config/exchanges/NO-NO3_SE-SE2.yaml
@@ -5,6 +5,6 @@ lonlat:
   - 12.24842
   - 63.462916
 parsers:
-  exchange: ENTSOE.fetch_exchange
+  exchange: NORDPOOL.fetch_exchange
   exchangeForecast: ENTSOE.fetch_exchange_forecast
 rotation: 90

--- a/config/exchanges/NO-NO4_SE-SE1.yaml
+++ b/config/exchanges/NO-NO4_SE-SE1.yaml
@@ -5,6 +5,6 @@ lonlat:
   - 15.656
   - 66.609
 parsers:
-  exchange: ENTSOE.fetch_exchange
+  exchange: NORDPOOL.fetch_exchange
   exchangeForecast: ENTSOE.fetch_exchange_forecast
 rotation: 130

--- a/config/exchanges/NO-NO4_SE-SE2.yaml
+++ b/config/exchanges/NO-NO4_SE-SE2.yaml
@@ -5,6 +5,6 @@ lonlat:
   - 14.051
   - 64.913
 parsers:
-  exchange: ENTSOE.fetch_exchange
+  exchange: NORDPOOL.fetch_exchange
   exchangeForecast: ENTSOE.fetch_exchange_forecast
 rotation: 130


### PR DESCRIPTION
## Issue

Currently it seems like data is delayed in ENTSO-E for Swedish exchanges:
<img width="529" alt="image" src="https://github.com/user-attachments/assets/ba199a77-3caa-49a2-8c5e-0e7aed0c4e53" />

The internal swedish exchanges has already been switched to NORDPOOL.

## Description

Switches the rest of the Nordic internal exchanges to ENTSO-E.

I have validated that the volume of the exchanges are the same between the two sources.

### Double check

- [x] I have tested my parser changes locally with `poetry run test_parser "zone_key"`
- [x] I have run `pnpx prettier@2 --write .` and `poetry run format` in the top level directory to format my changes.
