### PR TITLE
Add exports+storage to origin charts

### DIFF
--- a/web/src/features/charts/elements/AreaGraphLayers.tsx
+++ b/web/src/features/charts/elements/AreaGraphLayers.tsx
@@ -53,7 +53,7 @@ function AreaGraphLayers({
     .x((d: any) => timeScale(d.data.datetime))
     .y0((d) => valueScale(d[0]))
     .y1((d) => valueScale(d[1]))
-    .defined((d) => (shouldHideEmptyData ? d[1] > 0 : Number.isFinite(d[1])));
+    .defined((d) => Number.isFinite(d[1]));
 
   // Mouse hover events
   let mouseOutTimeout: string | number | NodeJS.Timeout | undefined;

--- a/web/src/features/charts/elements/AreaGraphLayers.tsx
+++ b/web/src/features/charts/elements/AreaGraphLayers.tsx
@@ -53,7 +53,16 @@ function AreaGraphLayers({
     .x((d: any) => timeScale(d.data.datetime))
     .y0((d) => valueScale(d[0]))
     .y1((d) => valueScale(d[1]))
-    .defined((d) => (shouldHideEmptyData ? d[1] != 0 : Number.isFinite(d[1])));
+    .defined((d) => {
+      if (!Number.isFinite(d[0]) || !Number.isFinite(d[1])) {
+        return false;
+      }
+      if (shouldHideEmptyData && d[0] == d[1]) {
+        // zero area height
+        return false;
+      }
+      return true;
+    });
 
   // Mouse hover events
   let mouseOutTimeout: string | number | NodeJS.Timeout | undefined;

--- a/web/src/features/charts/elements/AreaGraphLayers.tsx
+++ b/web/src/features/charts/elements/AreaGraphLayers.tsx
@@ -53,7 +53,7 @@ function AreaGraphLayers({
     .x((d: any) => timeScale(d.data.datetime))
     .y0((d) => valueScale(d[0]))
     .y1((d) => valueScale(d[1]))
-    .defined((d) => Number.isFinite(d[1]));
+    .defined((d) => (shouldHideEmptyData ? d[1] != 0 : Number.isFinite(d[1])));
 
   // Mouse hover events
   let mouseOutTimeout: string | number | NodeJS.Timeout | undefined;

--- a/web/src/features/charts/hooks/useOriginChartData.ts
+++ b/web/src/features/charts/hooks/useOriginChartData.ts
@@ -93,7 +93,7 @@ export default function useOriginChartData() {
       // Add exchanges
       for (const [key, exchangeValue] of Object.entries(value.exchange)) {
         // in GW or MW
-        entry.layerData[key] = Math.max(0, exchangeValue / valueFactor);
+        entry.layerData[key] = exchangeValue / valueFactor;
         if (displayByEmissions) {
           // in gCO₂eq/hour
           entry.layerData[key] =
@@ -143,7 +143,7 @@ function getStorageValue(
     return Number.NaN;
   }
 
-  const invertedValue = -1 * Math.min(0, storageValue);
+  const invertedValue = -1 * storageValue;
 
   return displayByEmissions
     ? invertedValue * value.dischargeCo2Intensities[storageKey] * valueFactor


### PR DESCRIPTION
## Issue

This PR adds storage and exports to the origin chart by showing them as negative.

## Description

@lav-julien and myself discussed the following graph and were unsure if the wind drop was curtailment.

<img width="730" alt="image" src="https://github.com/user-attachments/assets/9927c1c6-97df-4300-906f-06ede9c21c1c" />

We wanted to check if the load stayed constant (indicating no missing data), and realised the exports were not visible here.
It reminded me of [this debate](https://github.com/electricitymaps/electricitymaps-contrib/issues/1030) from 2018 where a similar issue was discussed.

Important point: by adding exports and storage to the origin graph, we actually bring back more consistency with the top bar chart (which is supposed to represent a slice of the origin graph at a particular point) by visualising the bars that are negative.

### Preview

![image](https://github.com/user-attachments/assets/771e5d80-9163-4c0b-b1c0-5765e1f8825f)
![image](https://github.com/user-attachments/assets/80f96e5d-6094-4442-962e-97f40ef6c154)

Tooltips also work out of the box as they use the same system as the bar chart at the top:

![image](https://github.com/user-attachments/assets/6f64f703-fcc9-4f99-8e96-f3550c3ef4a4)


### Double check

- [ ] ~I have tested my parser changes locally with `poetry run test_parser "zone_key"`~
- [x] I have run `pnpx prettier@2 --write .` and `poetry run format` in the top level directory to format my changes.
