### PR TITLE
Fix storage tooltip intensity

### DIFF
--- a/web/src/components/CarbonIntensityDisplay.tsx
+++ b/web/src/components/CarbonIntensityDisplay.tsx
@@ -28,7 +28,7 @@ export function CarbonIntensityDisplay({
     <>
       {withSquare && <Square co2Intensity={intensityAsNumber} />}
       <p className={className}>
-        <b>{Math.round(intensityAsNumber) || '?'}</b>&nbsp;
+        <b>{co2Intensity == null ? '?' : Math.round(intensityAsNumber)}</b>&nbsp;
         {CarbonUnits.GRAMS_CO2EQ_PER_KILOWATT_HOUR}
       </p>
     </>

--- a/web/src/features/charts/tooltips/BreakdownChartTooltip.tsx
+++ b/web/src/features/charts/tooltips/BreakdownChartTooltip.tsx
@@ -280,7 +280,6 @@ export function BreakdownChartTooltipContent({
       {!displayByEmissions && (Number.isFinite(co2Intensity) || usage !== 0) && (
         <>
           <br />
-          <br />
           {t('tooltips.withcarbonintensity')}
           <br />
           <div className="flex-wrap">


### PR DESCRIPTION
## Issue

Tooltip says "?" carbon intensity when highlighting a storage moment. Also, there's an additional line break:

<img width="659" alt="image" src="https://github.com/user-attachments/assets/f03077c1-3a2f-4650-aa3f-c832e07aec4a" />


## Description

Fixed!

### Preview

<img width="624" alt="image" src="https://github.com/user-attachments/assets/57da41d0-fc5c-47a2-9d0f-b5d81c025939" />


### Double check

- [ ] ~I have tested my parser changes locally with `poetry run test_parser "zone_key"`~
- [x] I have run `pnpx prettier@2 --write .` and `poetry run format` in the top level directory to format my changes.
