### PR TITLE
Fix formatting of unit for 72hrs

### DIFF
--- a/web/src/features/charts/hooks/useNetExchangeChartData.ts
+++ b/web/src/features/charts/hooks/useNetExchangeChartData.ts
@@ -83,7 +83,7 @@ function getValuesInfo(
   displayByEmissions: boolean,
   timeRange: string
 ): ValuesInfo {
-  const isHourly = timeRange === TimeRange.H24;
+  const isHourly = timeRange === TimeRange.H24 || timeRange === TimeRange.H72;
   const maxTotalValue = d3Max(historyData, (d: ZoneDetail) =>
     Math.abs(getNetExchange(d, displayByEmissions))
   );


### PR DESCRIPTION
## Issue

Raised on LinkedIn and by @VIKTORVAV99 

### Preview

<img width="468" alt="image" src="https://github.com/user-attachments/assets/21b36fce-ae1e-415e-b8bd-51899ea0e940" />


### Double check

- [ ] ~I have tested my parser changes locally with `poetry run test_parser "zone_key"`~
- [x] I have run `pnpx prettier@2 --write .` and `poetry run format` in the top level directory to format my changes.
