### PR TITLE
Minor style changes to area graphs

### DIFF
--- a/web/src/features/charts/elements/AreaGraph.tsx
+++ b/web/src/features/charts/elements/AreaGraph.tsx
@@ -150,7 +150,6 @@ function AreaGraph({
 
   const containerWidth = Math.max(observerWidth - Y_AXIS_WIDTH, 0);
   const containerHeight = Math.max(observerHeight - X_AXIS_HEIGHT, 0);
-  const barWidth = containerWidth / datetimes.length;
 
   // Build layers
   const layers = useMemo(

--- a/web/src/features/charts/elements/AreaGraph.tsx
+++ b/web/src/features/charts/elements/AreaGraph.tsx
@@ -295,7 +295,7 @@ function AreaGraph({
           selectedTimeRange={selectedTimeRange}
           datetimes={datetimesWithNext}
           scaleWidth={containerWidth}
-          transform={`translate(${barWidth / 2} ${containerHeight})`}
+          transform={`translate(0 ${containerHeight})`}
           className="h-[22px] w-full overflow-visible opacity-50"
           timezone={zoneTimezone}
           chartHeight={containerHeight}

--- a/web/src/features/charts/elements/ValueAxis.tsx
+++ b/web/src/features/charts/elements/ValueAxis.tsx
@@ -12,28 +12,27 @@ function ValueAxis({ scale, width, formatTick }: ValueAxisProps) {
   const [y1, y2] = scale.range();
   return (
     <g
-      transform={`translate(${width - 1} -1)`}
+      transform={`translate(${width} 0)`}
       fill="none"
       fontSize="10"
       fontFamily="sans-serif"
       textAnchor="start"
       className="opacity-50"
-      strokeWidth={0.5}
       style={{ pointerEvents: 'none' }}
     >
       <path
         className="domain"
         stroke="currentColor"
-        d={`M6,${y1 + 0.5}H0.5V${y2 + 0.5}H6`}
+        strokeWidth={0.5}
+        d={`M0,${y1}V${y2}H0`}
       />
       {scale.ticks(5).map((v) => (
         <g
           key={`valueaxis-tick-${v}`}
           className="tick"
-          opacity={1}
           transform={`translate(0,${scale(v)})`}
         >
-          <line stroke="currentColor" x2="6" />
+          <line stroke="currentColor" x2="6" opacity={0.5} />
           <text fill="currentColor" x="6" y="3" dx="0.32em">
             {formatTick(v)}
           </text>

--- a/web/src/features/time/TimeAxis.tsx
+++ b/web/src/features/time/TimeAxis.tsx
@@ -44,7 +44,7 @@ const renderTick = (
     IS_MAJOR_TICK_CALLABLE[selectedTimeRange](localHours, localMinutes, index);
   const isLastTick = index === HOURLY_TIME_INDEX[selectedTimeRange];
   const overlapsWithLive = scale(value) + 40 >= scale.range()[1]; // the "LIVE" labels takes ~30px
-  const shouldShowTick = displayLive
+  const shouldShowValue = displayLive
     ? (isMajorTick && !overlapsWithLive) || isLastTick
     : isMajorTick;
 
@@ -68,7 +68,7 @@ const renderTick = (
           />
         )}
       <line stroke="currentColor" y2="6" opacity={isMajorTick ? 0.5 : 0.2} />
-      {shouldShowTick &&
+      {shouldShowValue &&
         renderTickValue(value, index, displayLive, lang, selectedTimeRange, timezone)}
     </g>
   );

--- a/web/src/features/time/TimeAxis.tsx
+++ b/web/src/features/time/TimeAxis.tsx
@@ -22,10 +22,7 @@ const getMajorTick = (
       return index % 6 === 0;
     }
     case TimeRange.H72: {
-      return (
-        ((localHours === 12 || localHours === 0) && localMinutes === 0) ||
-        ((localHours === 12 || localHours === 0) && localMinutes === 30)
-      );
+      return localHours === 12 || localHours === 0;
     }
     case TimeRange.M12:
     case TimeRange.ALL: {

--- a/web/src/features/time/TimeAxis.tsx
+++ b/web/src/features/time/TimeAxis.tsx
@@ -42,6 +42,11 @@ const renderTick = (
   const isMajorTick =
     !isLoading &&
     IS_MAJOR_TICK_CALLABLE[selectedTimeRange](localHours, localMinutes, index);
+  const isLastTick = index === HOURLY_TIME_INDEX[selectedTimeRange];
+  const overlapsWithLive = scale(value) + 40 >= scale.range()[1]; // the "LIVE" labels takes ~30px
+  const shouldShowTick = displayLive
+    ? (isMajorTick && !overlapsWithLive) || isLastTick
+    : isMajorTick;
 
   return (
     <g
@@ -63,7 +68,7 @@ const renderTick = (
           />
         )}
       <line stroke="currentColor" y2="6" opacity={isMajorTick ? 0.5 : 0.2} />
-      {isMajorTick &&
+      {shouldShowTick &&
         renderTickValue(value, index, displayLive, lang, selectedTimeRange, timezone)}
     </g>
   );

--- a/web/src/features/time/TimeAxis.tsx
+++ b/web/src/features/time/TimeAxis.tsx
@@ -22,7 +22,10 @@ const getMajorTick = (
       return index % 6 === 0;
     }
     case TimeRange.H72: {
-      return (localHours === 12 || localHours === 0) && localMinutes === 0;
+      return (
+        ((localHours === 12 || localHours === 0) && localMinutes === 0) ||
+        ((localHours === 12 || localHours === 0) && localMinutes === 30)
+      );
     }
     case TimeRange.M12:
     case TimeRange.ALL: {

--- a/web/src/features/time/TimeAxis.tsx
+++ b/web/src/features/time/TimeAxis.tsx
@@ -10,18 +10,18 @@ import { formatDateTick } from '../../utils/formatting';
 // The following represents a list of methods, indexed by time range, that depict
 // if a datetime should be a major tick, where we will display the date value.
 type MajorTickCallable = (
-  localHours: number,
-  localMinutes: number,
-  index: number
+  _localHours: number,
+  _localMinutes: number,
+  _index: number
 ) => boolean;
 type IsMajorTickCallableType = { [key: string]: MajorTickCallable };
 const IS_MAJOR_TICK_CALLABLE: IsMajorTickCallableType = {
-  '24h': (localHours, localMinutes, index) => index % 6 === 0,
-  '72h': (localHours, localMinutes, index) =>
-    (localHours === 12 || localHours === 0) && localMinutes === 0,
-  '30d': (localHours, localMinutes, index) => index % 6 === 0,
-  '12mo': (localHours, localMinutes, index) => true,
-  all: (localHours, localMinutes, index) => true,
+  '24h': (_localHours, _localMinutes, _index) => _index % 6 === 0,
+  '72h': (_localHours, _localMinutes, _index) =>
+    (_localHours === 12 || _localHours === 0) && _localMinutes === 0,
+  '30d': (_localHours, _localMinutes, _index) => _index % 6 === 0,
+  '12mo': (_localHours, _localMinutes, _index) => true,
+  all: (_localHours, _localMinutes, _index) => true,
 };
 
 const renderTick = (

--- a/web/src/features/time/TimeAxis.tsx
+++ b/web/src/features/time/TimeAxis.tsx
@@ -47,7 +47,7 @@ const renderTick = (
   isTimeController?: boolean
 ) => {
   const { localHours, localMinutes } = getLocalTime(value, timezone);
-  const isMidnightTime = localHours === 0 && localMinutes === 0;
+  const isMidnightTime = localHours === 0;
 
   const isMajorTick =
     !isLoading && getMajorTick(selectedTimeRange, localHours, localMinutes, index);

--- a/web/src/features/time/TimeAxis.tsx
+++ b/web/src/features/time/TimeAxis.tsx
@@ -9,7 +9,13 @@ import { formatDateTick } from '../../utils/formatting';
 
 // The following represents a list of methods, indexed by time range, that depict
 // if a datetime should be a major tick, where we will display the date value.
-const IS_MAJOR_TICK_CALLABLE = {
+type MajorTickCallable = (
+  localHours: number,
+  localMinutes: number,
+  index: number
+) => boolean;
+type IsMajorTickCallableType = { [key: string]: MajorTickCallable };
+const IS_MAJOR_TICK_CALLABLE: IsMajorTickCallableType = {
   '24h': (localHours, localMinutes, index) => index % 6 === 0,
   '72h': (localHours, localMinutes, index) =>
     (localHours === 12 || localHours === 0) && localMinutes === 0,

--- a/web/src/features/time/TimeAxis.tsx
+++ b/web/src/features/time/TimeAxis.tsx
@@ -3,7 +3,7 @@ import { useTranslation } from 'react-i18next';
 import PulseLoader from 'react-spinners/PulseLoader';
 import useResizeObserver from 'use-resize-observer/polyfilled';
 import { HOURLY_TIME_INDEX, TimeRange } from 'utils/constants';
-import { getLocalTime,isValidHistoricalTimeRange } from 'utils/helpers';
+import { getLocalTime, isValidHistoricalTimeRange } from 'utils/helpers';
 
 import { formatDateTick } from '../../utils/formatting';
 

--- a/web/src/utils/formatting.test.ts
+++ b/web/src/utils/formatting.test.ts
@@ -615,6 +615,28 @@ describe('formatDateTick', () => {
     expect(consoleSpy).toHaveBeenCalledWith('UNIMPLEMENTED is not implemented');
     consoleSpy.mockRestore();
   });
+
+  it('should format date correctly for 72-hour time aggregate at midnight', () => {
+    const date = new Date('2023-01-01T00:00:00Z');
+    const result = formatDateTick(date, 'en', TimeRange.H72);
+    expect(result).toBe(
+      new Intl.DateTimeFormat('en', {
+        month: 'short',
+        day: 'numeric',
+        timeZone: 'UTC',
+      }).format(date)
+    );
+  });
+
+  it('should format date correctly for 72-hour time aggregate not at midnight', () => {
+    const date = new Date('2023-01-01T12:00:00Z');
+    const result = formatDateTick(date, 'en', TimeRange.H72);
+    expect(result).toBe(
+      new Intl.DateTimeFormat('en', {
+        timeStyle: 'short',
+      }).format(date)
+    );
+  });
 });
 
 describe('formatDataSources', () => {

--- a/web/src/utils/formatting.ts
+++ b/web/src/utils/formatting.ts
@@ -208,7 +208,7 @@ const formatDateTick = (
 
   switch (timeRange) {
     case TimeRange.H72: {
-      const [localHours, localMinutes] = getLocalTime(date, timezone);
+      const { localHours, localMinutes } = getLocalTime(date, timezone);
       if (localHours === 0 && localMinutes === 0) {
         // Display date name when midnight
         return new Intl.DateTimeFormat(lang, {

--- a/web/src/utils/formatting.ts
+++ b/web/src/utils/formatting.ts
@@ -1,6 +1,7 @@
 import * as d3 from 'd3-format';
 
 import { TimeRange } from './constants';
+import { getLocalTime } from './helpers';
 import { EnergyUnits, PowerUnits } from './units';
 
 const DEFAULT_NUM_DIGITS = 3;
@@ -206,7 +207,21 @@ const formatDateTick = (
   }
 
   switch (timeRange) {
-    case TimeRange.H72:
+    case TimeRange.H72: {
+      const [localHours, localMinutes] = getLocalTime(date, timezone);
+      if (localHours === 0 && localMinutes === 0) {
+        // Display date name when midnight
+        return new Intl.DateTimeFormat(lang, {
+          month: 'short',
+          day: 'numeric',
+          timeZone: 'UTC',
+        }).format(date);
+      }
+      return new Intl.DateTimeFormat(lang, {
+        timeStyle: 'short',
+        timeZone: timezone,
+      }).format(date);
+    }
     case TimeRange.H24: {
       return new Intl.DateTimeFormat(lang, {
         timeStyle: 'short',

--- a/web/src/utils/helpers.test.ts
+++ b/web/src/utils/helpers.test.ts
@@ -15,6 +15,7 @@ import {
   getCarbonIntensity,
   getDestinationPath,
   getFossilFuelRatio,
+  getLocalTime,
   getNetExchange,
   getProductionCo2Intensity,
   getRenewableRatio,
@@ -417,5 +418,17 @@ describe('getNetExchange', () => {
     } as unknown as ZoneDetail;
     const result = getNetExchange(zoneData, true);
     expect(result).toBe(100);
+  });
+});
+
+describe('getLocalTime', () => {
+  it('should return the correct local time', () => {
+    const result = getLocalTime(new Date('2024-03-20T08:00:00Z'), 'Europe/Paris');
+    expect(result).toEqual({ localHours: 9, localMinutes: 0 });
+  });
+
+  it('should return the correct local time when timezone is not provided', () => {
+    const result = getLocalTime(new Date('2024-03-20T08:00:00Z'));
+    expect(result).toEqual({ localHours: 8, localMinutes: 0 });
   });
 });

--- a/web/src/utils/helpers.ts
+++ b/web/src/utils/helpers.ts
@@ -240,3 +240,23 @@ export const hasMobileUserAgent = () =>
 
 export const isValidHistoricalTimeRange = (timeRange: TimeRange) =>
   historicalTimeRange.includes(timeRange);
+
+export const getLocalTime = (date: Date, timezone?: string) => {
+  if (!timezone) {
+    return [date.getUTCHours(), date.getUTCMinutes()];
+  }
+
+  const formatter = new Intl.DateTimeFormat('en-US', {
+    timeZone: timezone,
+    hour: 'numeric',
+    minute: 'numeric',
+    hour12: false,
+  });
+
+  const [hours, minutes] = formatter
+    .format(date)
+    .split(':')
+    .map((n) => Number.parseInt(n, 10));
+
+  return [hours, minutes];
+};

--- a/web/src/utils/helpers.ts
+++ b/web/src/utils/helpers.ts
@@ -243,7 +243,7 @@ export const isValidHistoricalTimeRange = (timeRange: TimeRange) =>
 
 export const getLocalTime = (date: Date, timezone?: string) => {
   if (!timezone) {
-    return [date.getUTCHours(), date.getUTCMinutes()];
+    return { localHours: date.getUTCHours(), localMinutes: date.getUTCMinutes() };
   }
 
   const formatter = new Intl.DateTimeFormat('en-US', {
@@ -258,5 +258,5 @@ export const getLocalTime = (date: Date, timezone?: string) => {
     .split(':')
     .map((n) => Number.parseInt(n, 10));
 
-  return [hours, minutes];
+  return { localHours: hours, localMinutes: minutes };
 };


### PR DESCRIPTION
## Issue

I identified the following issues on the AreaGraph component:
* the horizontal x-axis line is not visible (which is inconsistent with the y-axis where it is present)
* the tick stroke width & opacity of the x-axis are not the same as the y-axis
* the time ticks are located in the middle of a bar, instead of the start. This causes some confusion when looking e.g. at a month where we expect the month to start at the beginning of the interval (not the middle). This makes sense as Electricity Maps assigns to the beginning of the interval the value from the start to the end.
* the y-axis has ticks at the beginning and the end of the scale. I suggest we remove them as they don't bring much.

<img width="438" alt="image" src="https://github.com/user-attachments/assets/48cdd5a5-2e1a-49a4-afc5-70ec435c0c9b" />

## Description

This PR fixes the above, and in addition:
* For the 72hr view, it shows ticks at midnight and at noon
* For the 72hr view, it formats the midnight tick with the date, and the noon tick with the time, making it more intuitive to see what day starts when.

Note that the tooltip highlights the value at the middle of a bar (i.e. interval), whereas the ticks start at the beginning of the bar. It makes sense as the passage of time is more accurately indicated, whereas the highlight of the *interval* is kept intact.

### Preview

<img width="439" alt="image" src="https://github.com/user-attachments/assets/4638456e-e3ad-4be0-8252-5bd0dc0bf1a7" />


### Double check

- [ ] ~I have tested my parser changes locally with `poetry run test_parser "zone_key"`~
- [x] I have run `pnpx prettier@2 --write .` and `poetry run format` in the top level directory to format my changes.
