### PR TITLE
bug(web): fix wrong graph index on tooltip close

### DIFF
--- a/web/src/features/charts/elements/AreaGraph.tsx
+++ b/web/src/features/charts/elements/AreaGraph.tsx
@@ -239,6 +239,7 @@ function AreaGraph({
   const onCloseTooltip = () => {
     setTooltipData(null);
     setHoveredLayerIndex(null);
+    setGraphIndex(null);
   };
 
   const headerHeight = useHeaderHeight();


### PR DESCRIPTION
## Issue
Mobile chart index becomes stuck after closing tooltip
## Description
This PR resets the graph index after closing mobile tooltips