### PR TITLE
perf: Extract regex patterns + more arrow functions

### DIFF
--- a/web/src/components/ShareIcon.tsx
+++ b/web/src/components/ShareIcon.tsx
@@ -3,6 +3,8 @@ import { Share, Share2 } from 'lucide-react';
 import { memo } from 'react';
 import { DEFAULT_ICON_SIZE } from 'utils/constants';
 
+const IOS_DEVICE_PATTERN: RegExp = /Mac|iPad|iPhone|iPod/;
+
 export function ShareIcon({
   showIosIcon = defaultShouldShowIosIcon(),
   iconSize = DEFAULT_ICON_SIZE,
@@ -18,6 +20,6 @@ export function ShareIcon({
 }
 
 export const defaultShouldShowIosIcon = () =>
-  /Mac|iPad|iPhone|iPod/.test(navigator.userAgent) || Capacitor.getPlatform() === 'ios';
+  IOS_DEVICE_PATTERN.test(navigator.userAgent) || Capacitor.getPlatform() === 'ios';
 
 export const MemoizedShareIcon = memo(ShareIcon);

--- a/web/src/features/charts/graphUtils.ts
+++ b/web/src/features/charts/graphUtils.ts
@@ -79,19 +79,14 @@ export const getStorageKey = (name: ElectricityStorageType): string | undefined 
   }
 };
 
-export const getGenerationTypeKey = (name: string): GenerationType | undefined => {
-  if (modeOrder.includes(name as GenerationType)) {
-    return name as GenerationType;
-  }
-
-  return undefined;
-};
+export const getGenerationTypeKey = (name: string): GenerationType | undefined =>
+  modeOrder.includes(name as GenerationType) ? (name as GenerationType) : undefined;
 
 /** Returns the total electricity that is available in the zone (e.g. production + discharge + imports) */
-export function getTotalElectricityAvailable(
+export const getTotalElectricityAvailable = (
   zoneData: ZoneDetail,
   isConsumption: boolean
-) {
+) => {
   const totalDischarge = zoneData.totalDischarge ?? 0;
   const totalImport = zoneData.totalImport ?? 0;
 
@@ -100,10 +95,13 @@ export function getTotalElectricityAvailable(
   }
 
   return zoneData.totalProduction + totalDischarge + (isConsumption ? totalImport : 0);
-}
+};
 
 /** Returns the total emissions that is available in the zone (e.g. production + discharge + imports) */
-export function getTotalEmissionsAvailable(zoneData: ZoneDetail, isConsumption: boolean) {
+export const getTotalEmissionsAvailable = (
+  zoneData: ZoneDetail,
+  isConsumption: boolean
+) => {
   const totalCo2Discharge = zoneData.totalCo2Discharge ?? 0;
   const totalCo2Import = zoneData.totalCo2Import ?? 0;
 
@@ -114,7 +112,7 @@ export function getTotalEmissionsAvailable(zoneData: ZoneDetail, isConsumption: 
   return (
     zoneData.totalCo2Production + totalCo2Discharge + (isConsumption ? totalCo2Import : 0)
   );
-}
+};
 
 export const getNextDatetime = (datetimes: Date[], currentDate: Date) => {
   const index = datetimes.findIndex((d) => d?.getTime() === currentDate?.getTime());
@@ -124,13 +122,13 @@ export const getNextDatetime = (datetimes: Date[], currentDate: Date) => {
   return datetimes[index + 1];
 };
 
-export function determineUnit(
+export const determineUnit = (
   displayByEmissions: boolean,
   currentZoneDetail: ZoneDetail,
   isConsumption: boolean,
   isHourly: boolean,
   t: TFunction
-) {
+) => {
   if (displayByEmissions) {
     return getUnit(
       formatCo2({ value: getTotalEmissionsAvailable(currentZoneDetail, isConsumption) }) +
@@ -150,18 +148,12 @@ export function determineUnit(
           value: getTotalElectricityAvailable(currentZoneDetail, isConsumption),
         })
       );
-}
+};
+const GET_UNIT_REGEX = /\s+(.+)/;
+const getUnit = (valueAndUnit: string | number) =>
+  valueAndUnit.toString().match(GET_UNIT_REGEX)?.at(1) ?? '';
 
-function getUnit(valueAndUnit: string | number) {
-  const regex = /\s+(.+)/;
-  const match = valueAndUnit.toString().match(regex);
-  if (!match) {
-    return '';
-  }
-  return match[1];
-}
-
-export function getRatioPercent(value: Maybe<number>, total: Maybe<number>) {
+export const getRatioPercent = (value: Maybe<number>, total: Maybe<number>) => {
   // If both the numerator and denominator are zeros,
   // interpret the ratio as zero instead of NaN.
   if (value === 0 && total === 0) {
@@ -179,9 +171,9 @@ export function getRatioPercent(value: Maybe<number>, total: Maybe<number>) {
     return '?';
   }
   return Math.round((value / total) * 10_000) / 100;
-}
+};
 
-export function getElectricityProductionValue({
+export const getElectricityProductionValue = ({
   generationTypeCapacity,
   isStorage,
   generationTypeProduction,
@@ -191,7 +183,7 @@ export function getElectricityProductionValue({
   isStorage: boolean;
   generationTypeProduction: Maybe<number>;
   generationTypeStorage: Maybe<number>;
-}) {
+}) => {
   const value = isStorage ? generationTypeStorage : generationTypeProduction;
 
   // If the value is not defined but the capacity
@@ -210,9 +202,9 @@ export function getElectricityProductionValue({
   }
   // Do not negate value if it is zero
   return generationTypeStorage === 0 ? 0 : -generationTypeStorage;
-}
+};
 
-function analyzeChartData(chartData: AreaGraphElement[]) {
+const analyzeChartData = (chartData: AreaGraphElement[]) => {
   let estimatedCount = 0;
   let tsaCount = 0;
   let estimatedTotal = 0;
@@ -239,12 +231,12 @@ function analyzeChartData(chartData: AreaGraphElement[]) {
     allEstimated: estimatedCount === total,
     hasEstimation: estimatedCount > 0,
   };
-}
+};
 
-export function getBadgeTextAndIcon(
+export const getBadgeTextAndIcon = (
   chartData: AreaGraphElement[],
   t: TFunction
-): { text?: string; icon?: LucideIcon } {
+): { text?: string; icon?: LucideIcon } => {
   const { allTimeSlicerAverageMethod, allEstimated, hasEstimation, estimatedTotal } =
     analyzeChartData(chartData);
 
@@ -276,14 +268,14 @@ export function getBadgeTextAndIcon(
     return { text: t('estimation-badge.partially-estimated'), icon: TrendingUpDown };
   }
   return {};
-}
+};
 
-export function extractLinkFromSource(
+export const extractLinkFromSource = (
   source: string,
   sourceToLinkMapping: {
     [key: string]: string;
   }
-) {
+) => {
   const link = sourceToLinkMapping[source];
   if (link) {
     return link;
@@ -299,4 +291,4 @@ export function extractLinkFromSource(
 
   // We on purpose don't use https due to some sources not supporting it (and the majority that does will automatically redirect anyway)
   return `http://${source}`;
-}
+};

--- a/web/src/features/weather-layers/wind-layer/util.ts
+++ b/web/src/features/weather-layers/wind-layer/util.ts
@@ -1,49 +1,41 @@
 import { Capacitor } from '@capacitor/core';
 
+const IOS_DEVICE_PATTERN: RegExp = /iPad|iPhone|iPod/;
+const MOBILE_DEVICE_PATTERN: RegExp =
+  /android|blackberry|iemobile|ipad|iphone|ipod|opera mini|webos/i;
+const ANDROID_DEVICE_PATTERN: RegExp = /android/i;
+const MAC_DEVICE_PATTERN: RegExp = /Mac/;
+
 /**
  * @returns {Boolean} true if the specified value is not null and not undefined.
  */
-export function isValue(x: unknown) {
-  return x !== null && x !== undefined;
-}
+export const isValue = (x: unknown) => x !== null && x !== undefined;
 
 /**
  * @returns {Number} returns remainder of floored division, i.e., floor(a / n). Useful for consistent modulo
  * of negative numbers. See http://en.wikipedia.org/wiki/Modulo_operation.
  */
-export function floorModulus(a: number, n: number) {
-  return a - n * Math.floor(a / n);
-}
+export const floorModulus = (a: number, n: number) => a - n * Math.floor(a / n);
 
 /**
  * @returns {Boolean} true if agent is probably a mobile device.
  */
-export function isMobile() {
-  return /android|blackberry|iemobile|ipad|iphone|ipod|opera mini|webos/i.test(
-    navigator.userAgent
-  );
-}
+export const isMobile = () => MOBILE_DEVICE_PATTERN.test(navigator.userAgent);
 
 /**
  * @returns {Boolean} true if agent is probably an iPhone.
  */
-export function isIphone() {
-  return (
-    Capacitor.getPlatform() === 'ios' || /iPad|iPhone|iPod/.test(navigator.userAgent)
-  );
-}
+export const isIphone = () =>
+  Capacitor.getPlatform() === 'ios' || IOS_DEVICE_PATTERN.test(navigator.userAgent);
 
 /**
  * @returns {Boolean} true if agent is probably an Android.
  */
-export function isAndroid() {
-  return Capacitor.getPlatform() === 'android' || /Android/.test(navigator.userAgent);
-}
+export const isAndroid = () =>
+  Capacitor.getPlatform() === 'android' ||
+  ANDROID_DEVICE_PATTERN.test(navigator.userAgent);
 
-export function isMobileWeb() {
-  return Capacitor.getPlatform() === 'web' && (isIphone() || isAndroid() || isMobile());
-}
+export const isMobileWeb = () =>
+  Capacitor.getPlatform() === 'web' && (isIphone() || isAndroid() || isMobile());
 
-export function isIos() {
-  return /Mac/.test(navigator.userAgent) || isIphone();
-}
+export const isIos = () => MAC_DEVICE_PATTERN.test(navigator.userAgent) || isIphone();

--- a/web/src/hooks/useShare.ts
+++ b/web/src/hooks/useShare.ts
@@ -5,6 +5,7 @@ import { ShareType, trackShare } from 'utils/analytics';
 
 const trackShareClick = trackShare(ShareType.SHARE);
 const trackShareCompletion = trackShare(ShareType.COMPLETED_SHARE);
+const SHARE_ERROR_PATTERN: RegExp = /AbortError|canceled/;
 
 export function useShare() {
   const { t } = useTranslation();
@@ -33,7 +34,7 @@ export function useShare() {
         }
         return result;
       } catch (error) {
-        if (error instanceof Error && !/AbortError|canceled/.test(error.toString())) {
+        if (error instanceof Error && !SHARE_ERROR_PATTERN.test(error.toString())) {
           console.error(error);
           callback?.(t('share-button.share-error'));
         }

--- a/web/src/translation/i18n.ts
+++ b/web/src/translation/i18n.ts
@@ -5,14 +5,16 @@ import resourcesToBackend from 'i18next-resources-to-backend';
 import { initReactI18next } from 'react-i18next';
 import { localeToFacebookLocale } from 'translation/locales';
 
+// Regular expression for valid language or locale strings
+const VALID_LOCALE_REGEX = /^[A-Za-z]{2}(-[A-Za-z]{2})?$/;
+
+const LOCALE_CLEANUP_PATTERN = /[^A-Za-z-]/g;
+
 export const sanitizeLocale = (locale: string): string => {
   // Get the first 5 characters and strip all non-alphabetic characters except hyphens from the locale string
-  locale = locale.slice(0, 5).replaceAll(/[^A-Za-z-]/g, '');
+  locale = locale.slice(0, 5).replaceAll(LOCALE_CLEANUP_PATTERN, '');
 
-  // Regular expression for valid language or locale strings
-  const validLocaleRegex = /^[A-Za-z]{2}(-[A-Za-z]{2})?$/;
-
-  if (validLocaleRegex.test(locale)) {
+  if (VALID_LOCALE_REGEX.test(locale)) {
     return Intl.getCanonicalLocales(locale)[0];
   }
 

--- a/web/src/utils/helpers.ts
+++ b/web/src/utils/helpers.ts
@@ -230,13 +230,13 @@ export const getZoneTimezone = (zoneId?: string) => {
   return zones[zoneId]?.timezone;
 };
 
+const MOBILE_USER_AGENT_PATTERN: RegExp =
+  /android|blackberry|iemobile|ipad|iphone|ipod|opera mini|webos/i;
 /**
  * @returns {Boolean} true if agent is probably a mobile device.
  */
 export const hasMobileUserAgent = () =>
-  /android|blackberry|iemobile|ipad|iphone|ipod|opera mini|webos/i.test(
-    navigator.userAgent
-  );
+  MOBILE_USER_AGENT_PATTERN.test(navigator.userAgent);
 
 export const isValidHistoricalTimeRange = (timeRange: TimeRange) =>
   historicalTimeRange.includes(timeRange);


### PR DESCRIPTION
## Issue

If we declare the regex inside the functions they will be recompiled every time the function is called, but if we extract them to their own constants outside the functions then they are only compiled once.

## Description

Extract the regex patterns + convert some functions to arrow functions for consistency and size.

### Double check

- [x] I have run `pnpx prettier@2 --write .` and `poetry run format` in the top level directory to format my changes.
