### PR TITLE
bug(web): drag from arrow on desktop

### DIFF
--- a/web/src/features/exchanges/ExchangeArrow.tsx
+++ b/web/src/features/exchanges/ExchangeArrow.tsx
@@ -99,7 +99,7 @@ function ExchangeArrow({
           cursor: 'pointer',
           overflow: 'hidden',
           position: 'absolute',
-          pointerEvents: 'all',
+          pointerEvents: isMobile ? 'all' : 'none',
           imageRendering: 'crisp-edges',
           left: '-25px',
           top: '-41px',

--- a/web/src/features/exchanges/ExchangeArrow.tsx
+++ b/web/src/features/exchanges/ExchangeArrow.tsx
@@ -2,7 +2,7 @@ import TooltipWrapper from 'components/tooltips/TooltipWrapper';
 import { mapMovingAtom } from 'features/map/mapAtoms';
 import { useHeaderHeight } from 'hooks/headerHeight';
 import { useSetAtom } from 'jotai';
-import { useCallback } from 'react';
+import { useCallback, useEffect } from 'react';
 import { resolvePath } from 'react-router-dom';
 import { ExchangeArrowData } from 'types';
 
@@ -29,6 +29,18 @@ function ExchangeArrow({
   const { co2intensity, lonlat, netFlow, rotation, key } = data;
   const setIsMoving = useSetAtom(mapMovingAtom);
   const headerHeight = useHeaderHeight();
+
+  useEffect(() => {
+    const cancelWheel = (event: Event) => event.preventDefault();
+    const exchangeLayer = document.querySelector('#exchange-layer');
+    if (!exchangeLayer) {
+      return;
+    }
+    exchangeLayer.addEventListener('wheel', cancelWheel, {
+      passive: true,
+    });
+    return () => exchangeLayer.removeEventListener('wheel', cancelWheel);
+  }, []);
 
   const handlePointerDown = useCallback(
     (event: React.PointerEvent) => {

--- a/web/src/features/exchanges/ExchangeArrow.tsx
+++ b/web/src/features/exchanges/ExchangeArrow.tsx
@@ -2,7 +2,7 @@ import TooltipWrapper from 'components/tooltips/TooltipWrapper';
 import { mapMovingAtom } from 'features/map/mapAtoms';
 import { useHeaderHeight } from 'hooks/headerHeight';
 import { useSetAtom } from 'jotai';
-import { useEffect } from 'react';
+import { useCallback } from 'react';
 import { resolvePath } from 'react-router-dom';
 import { ExchangeArrowData } from 'types';
 
@@ -27,25 +27,70 @@ function ExchangeArrow({
   isMobile,
 }: ExchangeArrowProps) {
   const { co2intensity, lonlat, netFlow, rotation, key } = data;
-
   const setIsMoving = useSetAtom(mapMovingAtom);
   const headerHeight = useHeaderHeight();
 
-  useEffect(() => {
-    const cancelWheel = (event: Event) => event.preventDefault();
-    const exchangeLayer = document.querySelector('#exchange-layer');
-    if (!exchangeLayer) {
-      return;
-    }
-    exchangeLayer.addEventListener('wheel', cancelWheel, {
-      passive: true,
-    });
-    return () => exchangeLayer.removeEventListener('wheel', cancelWheel);
-  }, []);
+  const handlePointerDown = useCallback(
+    (event: React.PointerEvent) => {
+      event.preventDefault();
+      event.stopPropagation();
+
+      const mapCanvas = map.getCanvas();
+
+      const mouseDown = new MouseEvent('mousedown', {
+        clientX: event.clientX,
+        clientY: event.clientY,
+        bubbles: true,
+        cancelable: true,
+        view: window,
+        button: 0,
+        buttons: 1,
+      });
+      mapCanvas.dispatchEvent(mouseDown);
+
+      const handleMove = (moveEvent: PointerEvent) => {
+        moveEvent.preventDefault();
+        moveEvent.stopPropagation();
+
+        const mouseMove = new MouseEvent('mousemove', {
+          clientX: moveEvent.clientX,
+          clientY: moveEvent.clientY,
+          bubbles: true,
+          cancelable: true,
+          view: window,
+          button: 0,
+          buttons: 1,
+        });
+        mapCanvas.dispatchEvent(mouseMove);
+      };
+
+      const handleUp = (upEvent: PointerEvent) => {
+        upEvent.preventDefault();
+        upEvent.stopPropagation();
+
+        const mouseUp = new MouseEvent('mouseup', {
+          clientX: upEvent.clientX,
+          clientY: upEvent.clientY,
+          bubbles: true,
+          cancelable: true,
+          view: window,
+          button: 0,
+          buttons: 0,
+        });
+        mapCanvas.dispatchEvent(mouseUp);
+
+        document.removeEventListener('pointermove', handleMove);
+        document.removeEventListener('pointerup', handleUp);
+      };
+
+      document.addEventListener('pointermove', handleMove);
+      document.addEventListener('pointerup', handleUp);
+    },
+    [map]
+  );
 
   const absFlow = Math.abs(netFlow ?? 0);
 
-  // Don't render if there is no position or if flow is very low ...
   if (!lonlat || absFlow < 1) {
     return null;
   }
@@ -96,14 +141,16 @@ function ExchangeArrow({
         id={key}
         style={{
           transform: `translateX(${transform.x}px) translateY(${transform.y}px) rotate(${transform.r}deg) scale(${transform.k})`,
-          cursor: 'pointer',
+          cursor: 'grab',
           overflow: 'hidden',
           position: 'absolute',
-          pointerEvents: isMobile ? 'all' : 'none',
           imageRendering: 'crisp-edges',
           left: '-25px',
           top: '-41px',
+          pointerEvents: 'all',
+          touchAction: 'none',
         }}
+        onPointerDown={handlePointerDown}
         onWheel={() => setIsMoving(true)}
         data-testid={`exchange-arrow-${key}`}
       >


### PR DESCRIPTION
## Issue
Unable to drag the map when clicking an exchange arrow

## Description
This PR updates the exchange arrows on desktop to have pointerEvents: none. This allows dragging of the map from desktop while still seeing the tooltip on hover. 

On mobile it's significantly more difficult to handle both tap to show the exchange tooltip and drag to move the map. I suggest this isn't worth the time as I believe it requires using the arrow to control the map or elaborate passing of events. 
