### PR TITLE
perf: memoize hot-paths

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -87,6 +87,7 @@
     "d3-selection": "^3.0.0",
     "d3-shape": "^3.2.0",
     "date-fns": "^3.6.0",
+    "es-toolkit": "^1.30.1",
     "geojson": "^0.5.0",
     "i18next": "^24.0.2",
     "i18next-browser-languagedetector": "^8.0.0",

--- a/web/pnpm-lock.yaml
+++ b/web/pnpm-lock.yaml
@@ -110,6 +110,9 @@ importers:
       date-fns:
         specifier: ^3.6.0
         version: 3.6.0
+      es-toolkit:
+        specifier: ^1.30.1
+        version: 1.30.1
       geojson:
         specifier: ^0.5.0
         version: 0.5.0
@@ -5117,6 +5120,9 @@ packages:
     resolution: {integrity: sha512-QCOllgZJtaUo9miYBcLChTUaHNjJF3PYs1VidD7AwiEj1kYxKeQTctLAezAOH5ZKRH0g2IgPn6KwB4IT8iRpvA==}
     engines: {node: '>= 0.4'}
 
+  es-toolkit@1.30.1:
+    resolution: {integrity: sha512-ZXflqanzH8BpHkDhFa10bBf6ONDCe84EPUm7SSICGzuuROSluT2ynTPtwn9PcRelMtorCRozSknI/U0MNYp0Uw==}
+
   esbuild-register@3.6.0:
     resolution: {integrity: sha512-H2/S7Pm8a9CL1uhp9OvjwrBh5Pvx0H8qVOxNu8Wed9Y7qv56MPtq+GGM8RJpq6glYJn9Wspr8uw7l55uyinNeg==}
     peerDependencies:
@@ -7975,6 +7981,7 @@ packages:
 
   sudo-prompt@9.2.1:
     resolution: {integrity: sha512-Mu7R0g4ig9TUuGSxJavny5Rv0egCEtpZRNMrZaYS1vxkiIxGiGUwoezU3LazIQ+KE04hTrTfNPgxU5gzi7F5Pw==}
+    deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
 
   sunrise-sunset-js@2.2.1:
     resolution: {integrity: sha512-ErsvmxoTCZRacVPtlchkrTAR8qxypBy0BDrrv9LMugLuF0AykcS5pQsP1EhQJHgumxrTTSI8N8KJkQMVJ6dEPw==}
@@ -14892,6 +14899,8 @@ snapshots:
       is-callable: 1.2.7
       is-date-object: 1.0.5
       is-symbol: 1.0.4
+
+  es-toolkit@1.30.1: {}
 
   esbuild-register@3.6.0(esbuild@0.23.1):
     dependencies:

--- a/web/src/api/getState.ts
+++ b/web/src/api/getState.ts
@@ -3,7 +3,7 @@ import { useQuery } from '@tanstack/react-query';
 import { useParams } from 'react-router-dom';
 import type { GridState, RouteParameters } from 'types';
 import { TimeRange } from 'utils/constants';
-import { isValidHistoricalTimeRange } from 'utils/helpers';
+import { memoizedIsValidHistoricalTimeRange } from 'utils/helpers';
 import { getStaleTime } from 'utils/refetching';
 
 import {
@@ -22,7 +22,7 @@ const getState = async (
   const shouldQueryHistorical =
     targetDatetime &&
     isValidDate(targetDatetime) &&
-    isValidHistoricalTimeRange(timeRange);
+    memoizedIsValidHistoricalTimeRange(timeRange);
 
   const path: URL = new URL(
     `v9/state/${TIME_RANGE_TO_TIME_AVERAGE[timeRange]}${

--- a/web/src/api/getZone.ts
+++ b/web/src/api/getZone.ts
@@ -5,7 +5,7 @@ import invariant from 'tiny-invariant';
 import type { ZoneDetails } from 'types';
 import { RouteParameters } from 'types';
 import { TimeRange } from 'utils/constants';
-import { isValidHistoricalTimeRange } from 'utils/helpers';
+import { memoizedIsValidHistoricalTimeRange } from 'utils/helpers';
 import { getStaleTime } from 'utils/refetching';
 
 import {
@@ -27,7 +27,7 @@ const getZone = async (
   const shouldQueryHistorical =
     targetDatetime &&
     isValidDate(targetDatetime) &&
-    isValidHistoricalTimeRange(timeRange);
+    memoizedIsValidHistoricalTimeRange(timeRange);
 
   const path: URL = new URL(
     `v9/details/${TIME_RANGE_TO_TIME_AVERAGE[timeRange]}/${zoneId}${

--- a/web/src/features/time/TimeAxis.tsx
+++ b/web/src/features/time/TimeAxis.tsx
@@ -3,7 +3,7 @@ import { useTranslation } from 'react-i18next';
 import PulseLoader from 'react-spinners/PulseLoader';
 import useResizeObserver from 'use-resize-observer/polyfilled';
 import { HOURLY_TIME_INDEX, TimeRange } from 'utils/constants';
-import { getLocalTime, isValidHistoricalTimeRange } from 'utils/helpers';
+import { memoizedGetLocalTime, memoizedIsValidHistoricalTimeRange } from 'utils/helpers';
 
 import { formatDateTick } from '../../utils/formatting';
 
@@ -46,7 +46,7 @@ const renderTick = (
   chartHeight?: number,
   isTimeController?: boolean
 ) => {
-  const { localHours, localMinutes } = getLocalTime(value, timezone);
+  const { localHours, localMinutes } = memoizedGetLocalTime(value, timezone);
   const isMidnightTime = localHours === 0;
 
   const isMajorTick =
@@ -65,7 +65,7 @@ const renderTick = (
       transform={`translate(${scale(value)},0)`}
     >
       {isMidnightTime &&
-        isValidHistoricalTimeRange(selectedTimeRange) &&
+        memoizedIsValidHistoricalTimeRange(selectedTimeRange) &&
         !isTimeController && (
           <line
             stroke="currentColor"
@@ -94,7 +94,9 @@ const renderTickValue = (
   const shouldDisplayLive = displayLive && index === HOURLY_TIME_INDEX[selectedTimeRange];
   const dateText = formatDateTick(v, lang, selectedTimeRange, timezone);
   const textOffset =
-    isValidHistoricalTimeRange(selectedTimeRange) && dateText && dateText.length > 5
+    memoizedIsValidHistoricalTimeRange(selectedTimeRange) &&
+    dateText &&
+    dateText.length > 5
       ? 5
       : 0;
 

--- a/web/src/utils/formatting.ts
+++ b/web/src/utils/formatting.ts
@@ -1,7 +1,7 @@
 import * as d3 from 'd3-format';
 
 import { TimeRange } from './constants';
-import { getLocalTime } from './helpers';
+import { memoizedGetLocalTime } from './helpers';
 import { EnergyUnits, PowerUnits } from './units';
 
 const DEFAULT_NUM_DIGITS = 3;
@@ -208,7 +208,7 @@ const formatDateTick = (
 
   switch (timeRange) {
     case TimeRange.H72: {
-      const { localHours, localMinutes } = getLocalTime(date, timezone);
+      const { localHours, localMinutes } = memoizedGetLocalTime(date, timezone);
       if (localHours === 0 && localMinutes === 0) {
         // Display date name when midnight
         return new Intl.DateTimeFormat(lang, {

--- a/web/src/utils/helpers.ts
+++ b/web/src/utils/helpers.ts
@@ -1,4 +1,5 @@
 import { callerLocation, useMeta } from 'api/getMeta';
+import { memoize } from 'es-toolkit';
 import {
   useLocation,
   useMatch,
@@ -43,9 +44,10 @@ export function useUserLocation(): callerLocation {
 /**
  * Converts date to format returned by API
  */
-export function dateToDatetimeString(date: Date) {
-  return date.toISOString().split('.')[0] + 'Z';
-}
+export const dateToDatetimeString = (date: Date) =>
+  date.toISOString().split('.')[0] + 'Z';
+export const memoizedDateToDatetimeString = memoize(dateToDatetimeString);
+
 export function getProductionCo2Intensity(
   mode: ElectricityModeType,
   zoneData: ZoneDetail
@@ -240,6 +242,7 @@ export const hasMobileUserAgent = () =>
 
 export const isValidHistoricalTimeRange = (timeRange: TimeRange) =>
   historicalTimeRange.includes(timeRange);
+export const memoizedIsValidHistoricalTimeRange = memoize(isValidHistoricalTimeRange);
 
 export const getLocalTime = (date: Date, timezone?: string) => {
   if (!timezone) {
@@ -260,3 +263,7 @@ export const getLocalTime = (date: Date, timezone?: string) => {
 
   return { localHours: hours, localMinutes: minutes };
 };
+
+export const memoizedGetLocalTime = memoize(getLocalTime, {
+  getCacheKey: (date: Date, timezone?: string) => `${date.toISOString()}+${timezone}`,
+});

--- a/web/src/utils/refetching.ts
+++ b/web/src/utils/refetching.ts
@@ -2,7 +2,7 @@ import type { QueryClient } from '@tanstack/react-query';
 import { ONE_MINUTE, QUERY_KEYS } from 'api/helpers';
 
 import { TimeRange } from './constants';
-import { isValidHistoricalTimeRange } from './helpers';
+import { memoizedIsValidHistoricalTimeRange } from './helpers';
 
 /**
  * Refetches data when the hour changes to show fresh data.
@@ -45,7 +45,7 @@ export function refetchDataOnHourChange(queryClient: QueryClient) {
 }
 
 export function getStaleTime(timeRange: TimeRange, urlDatetime?: string) {
-  if (!isValidHistoricalTimeRange(timeRange) || urlDatetime) {
+  if (!memoizedIsValidHistoricalTimeRange(timeRange) || urlDatetime) {
     return 0;
   }
   const now = new Date();

--- a/web/src/utils/state/atoms.ts
+++ b/web/src/utils/state/atoms.ts
@@ -3,7 +3,7 @@ import { atomWithStorage } from 'jotai/utils';
 import { useEffect } from 'react';
 import { useParams } from 'react-router-dom';
 import { RouteParameters } from 'types';
-import { dateToDatetimeString, useNavigateWithParameters } from 'utils/helpers';
+import { memoizedDateToDatetimeString, useNavigateWithParameters } from 'utils/helpers';
 
 import {
   HOURLY_TIME_INDEX,
@@ -47,7 +47,7 @@ export const endDatetimeAtom = atom<Date | undefined>(undefined);
 export const startDatetimeAtom = atom<Date | undefined>(undefined);
 export const selectedDatetimeStringAtom = atom<string>((get) => {
   const { datetime } = get(selectedDatetimeIndexAtom);
-  return dateToDatetimeString(datetime);
+  return memoizedDateToDatetimeString(datetime);
 });
 
 export const spatialAggregateAtom = atomWithStorage(


### PR DESCRIPTION
## Issue
We have some functions that are called hundred if not even thousands of times while a normal user is using the app.

On of these functions, `getLocalTime` is called 72 times per timeAxis, of which there is normally at least 5 on every zone view. This means it's called 360 times at just startup when visiting a zone.

It is also called 360 times more every time the date changes using the slider or 288 times every time the hover state changes on a AreaGraph.

## Description

Clearly there is some logic optimizations that can be done here to prevent it from being called as many times (up to 9720 times if you just use the slider to go back 72 hours) but in the meantime we can memoize the function at least so it returning cached results. This means that only the first 72 calls (for the 72 hour view) will actually go though to the internal logic and after that they will all be cached.

This PR enables such optimizations for 3 identified hot-paths that are called often with deterministic results.

> [!WARNING]
> Technically there is a risk of a memory leak here if the app never restarts as the caches will grow to infinity with new dates. But I think this risk is pretty low in reality.

> [!NOTE]
> This is a hard PR to test as nothing should have changed visually if it was done right. But I suggest checking out the branch locally and adding a `console.log()` statement for either one of the source functions and then checking how many times it was called. It should be at most 72 hours if you use the `getLocalTime` one and only use the 72 hour view.

### Double check

- [x] I have run `pnpx prettier@2 --write .` and `poetry run format` in the top level directory to format my changes.
