### PR TITLE
perf: memoize MapTooltip internals

### DIFF
--- a/web/src/components/CarbonIntensitySquare.tsx
+++ b/web/src/components/CarbonIntensitySquare.tsx
@@ -1,4 +1,5 @@
 import { animated, useSpring } from '@react-spring/web';
+import { memo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { CarbonUnits } from 'utils/units';
 
@@ -80,4 +81,4 @@ function CarbonIntensitySquare({
   );
 }
 
-export default CarbonIntensitySquare;
+export default memo(CarbonIntensitySquare);

--- a/web/src/components/CircularGauge.stories.tsx
+++ b/web/src/components/CircularGauge.stories.tsx
@@ -1,6 +1,6 @@
 import type { Meta, StoryObj } from '@storybook/react';
 
-import { CircularGauge } from './CircularGauge';
+import CircularGauge from './CircularGauge';
 
 const meta: Meta<typeof CircularGauge> = {
   title: 'Basics/CircularGauge',

--- a/web/src/components/CircularGauge.tsx
+++ b/web/src/components/CircularGauge.tsx
@@ -71,12 +71,7 @@ const SpringAnimatedArc = memo(function SpringAnimatedArc({
   );
 });
 
-export function CircularGauge({
-  ratio,
-  name,
-  testId,
-  tooltipContent,
-}: CircularGaugeProps) {
+function CircularGauge({ ratio, name, testId, tooltipContent }: CircularGaugeProps) {
   const height = 80;
   const width = 80;
   const radius = Math.min(width, height) / 2;
@@ -110,3 +105,5 @@ export function CircularGauge({
     </div>
   );
 }
+
+export default memo(CircularGauge);

--- a/web/src/components/ZoneGauges.tsx
+++ b/web/src/components/ZoneGauges.tsx
@@ -1,18 +1,19 @@
 import { useAtomValue } from 'jotai';
+import { memo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { StateZoneData } from 'types';
 import { getCarbonIntensity, getFossilFuelRatio, getRenewableRatio } from 'utils/helpers';
 import { isConsumptionAtom } from 'utils/state/atoms';
 
 import CarbonIntensitySquare from './CarbonIntensitySquare';
-import { CircularGauge } from './CircularGauge';
+import CircularGauge from './CircularGauge';
 
 interface ZoneGaugesWithCO2SquareProps {
   zoneData: StateZoneData;
   withTooltips?: boolean;
 }
 
-export default function ZoneGaugesWithCO2Square({
+function ZoneGaugesWithCO2Square({
   zoneData,
   withTooltips = false,
 }: ZoneGaugesWithCO2SquareProps) {
@@ -49,3 +50,10 @@ export default function ZoneGaugesWithCO2Square({
     </div>
   );
 }
+
+export default memo(
+  ZoneGaugesWithCO2Square,
+  (prevProps, nextProps) =>
+    JSON.stringify(prevProps.zoneData) === JSON.stringify(nextProps.zoneData) &&
+    prevProps.withTooltips === nextProps.withTooltips
+);

--- a/web/src/components/ZoneGauges.tsx
+++ b/web/src/components/ZoneGauges.tsx
@@ -51,9 +51,4 @@ function ZoneGaugesWithCO2Square({
   );
 }
 
-export default memo(
-  ZoneGaugesWithCO2Square,
-  (prevProps, nextProps) =>
-    JSON.stringify(prevProps.zoneData) === JSON.stringify(nextProps.zoneData) &&
-    prevProps.withTooltips === nextProps.withTooltips
-);
+export default memo(ZoneGaugesWithCO2Square);

--- a/web/src/features/map/MapTooltip.tsx
+++ b/web/src/features/map/MapTooltip.tsx
@@ -9,6 +9,7 @@ import ZoneGaugesWithCO2Square from 'components/ZoneGauges';
 import { ZoneName } from 'components/ZoneName';
 import { useAtomValue } from 'jotai';
 import { TrendingUpDown } from 'lucide-react';
+import { memo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { StateZoneData } from 'types';
 import { round } from 'utils/helpers';
@@ -16,7 +17,7 @@ import { selectedDatetimeStringAtom } from 'utils/state/atoms';
 
 import { hoveredZoneAtom, mapMovingAtom, mousePositionAtom } from './mapAtoms';
 
-export function TooltipInner({
+export const TooltipInner = memo(function TooltipInner({
   zoneData,
   zoneId,
 }: {
@@ -59,9 +60,11 @@ export function TooltipInner({
       <ZoneGaugesWithCO2Square zoneData={zoneData} />
     </div>
   );
-}
+});
 
-function DataValidityBadge({
+TooltipInner.displayName = 'TooltipInner';
+
+export const DataValidityBadge = memo(function DataValidityBadge({
   hasOutage,
   estimated,
   hasZoneData,
@@ -97,7 +100,9 @@ function DataValidityBadge({
     );
   }
   return null;
-}
+});
+
+DataValidityBadge.displayName = 'DataValidityBadge';
 
 export default function MapTooltip() {
   const mousePosition = useAtomValue(mousePositionAtom);

--- a/web/src/features/map/MapTooltip.tsx
+++ b/web/src/features/map/MapTooltip.tsx
@@ -17,6 +17,11 @@ import { selectedDatetimeStringAtom } from 'utils/state/atoms';
 
 import { hoveredZoneAtom, mapMovingAtom, mousePositionAtom } from './mapAtoms';
 
+const emptyZoneData: StateZoneData = {
+  p: {},
+  c: {},
+};
+
 export const TooltipInner = memo(function TooltipInner({
   zoneData,
   zoneId,
@@ -25,18 +30,7 @@ export const TooltipInner = memo(function TooltipInner({
   zoneData?: StateZoneData;
 }) {
   const hasZoneData = Boolean(zoneData);
-  zoneData ??= {
-    p: {
-      ci: null,
-      fr: null,
-      rr: null,
-    },
-    c: {
-      ci: null,
-      fr: null,
-      rr: null,
-    },
-  };
+  zoneData ??= emptyZoneData;
   const { e, o } = zoneData;
 
   const estimated = typeof e === 'number' ? round(e ?? 0, 0) : e;
@@ -47,7 +41,7 @@ export const TooltipInner = memo(function TooltipInner({
         <div className="flex w-full flex-row justify-between">
           <ZoneName zone={zoneId} textStyle="font-medium text-base font-poppins" />
           <DataValidityBadge
-            hasOutage={o}
+            hasOutage={Boolean(o)}
             estimated={estimated}
             hasZoneData={hasZoneData}
           />
@@ -69,7 +63,7 @@ export const DataValidityBadge = memo(function DataValidityBadge({
   estimated,
   hasZoneData,
 }: {
-  hasOutage?: boolean | null;
+  hasOutage: boolean;
   estimated?: number | boolean | null;
   hasZoneData: boolean;
 }) {


### PR DESCRIPTION
## Issue

The internals of the tooltips re-render when you move the mouse even if it's on the same zone.

## Description

Memoizes the internal components of the map tooltip so they are stable, also memoizes the gauges, co2 square and estimated badge to be stable even between zones. This helps especially on zones which are fully estimated or have no data at all.

### Double check

- [x] I have run `pnpx prettier@2 --write .` and `poetry run format` in the top level directory to format my changes.
