### PR TITLE
fix(parsers): make validate_reasonable_time relate to utc dates

### DIFF
--- a/parsers/lib/quality.py
+++ b/parsers/lib/quality.py
@@ -40,14 +40,14 @@ def validate_datapoint_format(datapoint: dict[str, Any], kind: str, zone_key: Zo
 
 
 def validate_reasonable_time(item, k):
-    data_time = arrow.get(item["datetime"])
+    data_time = arrow.get(item["datetime"]).astimezone(timezone.utc)
     if data_time.year < 2000:
         raise ValidationError(
             f"Data from {k} can't be before year 2000, it was from: {data_time}"
         )
 
     arrow_now = arrow.utcnow()
-    if data_time.astimezone(timezone.utc) > arrow_now:
+    if data_time > arrow_now:
         raise ValidationError(
             f"Data from {k} can't be in the future, data was {data_time}, now is {arrow_now}"
         )


### PR DESCRIPTION
## Issue

Actual issue fixed: A log message was provided with two dates logged but without timezone details, making the comparison hard when it could have been made easy by using UTC systematically.

A bundled edge case change:
Via https://github.com/electricitymaps/electricitymaps-contrib/issues/1168#issuecomment-369597354 we got a course check to ensure data imported was in the right milennia. This course check will now check the year using UTC datetime which probably won't matter. Maybe it shouldn't been changed at all as it wasn't what I looked to fix and could muddy this PR - happy to revert and not change it.

### Double check

- [ ] I have tested my parser changes locally with `poetry run test_parser "zone_key"`
  _Comment_: This could impact all parsers, and I have not run them all.
- [x] I have run `pnpx prettier@2 --write .` and `poetry run format` in the top level directory to format my changes.
