### PR TITLE
fix(locales): make sv.json's net exchange translation consistent

### DIFF
--- a/web/src/locales/sv.json
+++ b/web/src/locales/sv.json
@@ -277,11 +277,11 @@
       "all": "Årliga elpriser"
     },
     "netExchange": {
-      "24h": "Timvis nettohandel",
-      "72h": "Timvis nettohandel",
-      "30d": "Daglig nettohandel",
-      "12mo": "Månadsvis nettohandel",
-      "all": "Årlig nettohandel"
+      "24h": "Timvis nettoöverföring",
+      "72h": "Timvis nettoöverföring",
+      "30d": "Daglig nettoöverföring",
+      "12mo": "Månadsvis nettoöverföring",
+      "all": "Årlig nettoöverföring"
     },
     "not-enough-data": "Inte tillräckligt med data för att visa diagrammet"
   },


### PR DESCRIPTION
The swedish translation of "net exchange" occur in two places, where the initial one was translated as "nettoöverföring", while the one added later was translated as "nettohandel".

My take is that the initial translation of "nettoöverföring" better conveys that this chart is about net import/export than "nettohandel" does. No matter what is decided, I think we should make the translations consistent to be one way or the other.