### PR TITLE
fix(parser): JP price parser fixed by updating API url

### DIFF
--- a/DATA_SOURCES.md
+++ b/DATA_SOURCES.md
@@ -536,7 +536,7 @@ A ⇉ B: unidirectional operation, only with power flow "from A to B"
 ### Electricity prices (day-ahead) data sources
 
 - France: [RTE](https://www.rte-france.com/en/eco2mix/market-data)
-- Japan: [JEPX](http://www.jepx.org)
+- Japan: [JEPX](http://www.jepx.jp)
 - Nicaragua: [CNDC](http://www.cndc.org.ni/)
 - Singapore: [EMC](https://www.emcsg.com)
 - Turkey: [EPIAS](https://seffaflik.epias.com.tr/transparency/piyasalar/gop/ptf.xhtml)

--- a/parsers/JP.py
+++ b/parsers/JP.py
@@ -282,7 +282,7 @@ def fetch_price(
         fiscal_year = target_datetime.year - 1
     else:
         fiscal_year = target_datetime.year
-    url = f"http://www.jepx.org/market/excel/spot_{fiscal_year}.csv"
+    url = f"http://www.jepx.jp/market/excel/spot_{fiscal_year}.csv"
     df = pd.read_csv(url, encoding="shift-jis")
 
     df = df.iloc[:, [0, 1, 6, 7, 8, 9, 10, 11, 12, 13, 14]]
@@ -324,7 +324,7 @@ def fetch_price(
                 "price": round(
                     int(1000 * row[1][zone_key]), -1
                 ),  # Convert from JPY/kWh to JPY/MWh
-                "source": "jepx.org",
+                "source": "jepx.jp",
             }
         )
 


### PR DESCRIPTION
## Issue

This fixes known price parser issues for JP reported in the wiki page, _except for JP-ON_. JP-ON wasn't functional before either, because it didn't have a price data source mapped out like the other regions.

![image](https://github.com/user-attachments/assets/65b533f6-95ac-4681-9824-0281786277ad)

### Double check

- [x] I have tested my parser changes locally with `poetry run test_parser "zone_key"`
  ```
  poetry run test_parser "JP-CB" price && echo 1
  poetry run test_parser "JP-CG" price && echo 2
  poetry run test_parser "JP-HKD" price && echo 3
  poetry run test_parser "JP-HR" price && echo 4
  poetry run test_parser "JP-KN" price && echo 5
  poetry run test_parser "JP-KY" price && echo 6
  poetry run test_parser "JP-ON" price && echo 7
  poetry run test_parser "JP-SK" price && echo 8
  poetry run test_parser "JP-TH" price && echo 9
  poetry run test_parser "JP-TK" price && echo 10
  ```
- [x] I have run `pnpx prettier@2 --write .` and `poetry run format` in the top level directory to format my changes.
