### PR TITLE
refactor/fix(parser): swap arrow in favour of datetime in IN_WE, and etc.

### DIFF
--- a/parsers/IN_WE.py
+++ b/parsers/IN_WE.py
@@ -156,7 +156,6 @@ def format_exchanges_data(
 
 def format_consumption_data(
     data: dict,
-    zone_key: str,
     target_datetime: datetime,
 ) -> float:
     """format consumption data:
@@ -242,9 +241,7 @@ def fetch_consumption(
 
     consumption_list = TotalConsumptionList(logger)
     for dt in get_date_range(target_datetime):
-        consumption_data_point = format_consumption_data(
-            zone_key=zone_key, data=data, target_datetime=dt
-        )
+        consumption_data_point = format_consumption_data(data=data, target_datetime=dt)
         consumption_list.append(
             zoneKey=zone_key,
             datetime=dt,

--- a/parsers/IN_WE.py
+++ b/parsers/IN_WE.py
@@ -45,12 +45,10 @@ KIND_MAPPING = {
 
 def get_date_range(dt: datetime):
     """Returns 24 datetime objects for a given datetime's date, one for each hour."""
-    now_date_as_dt = datetime.combine(
-        datetime.now(ZONE_INFO).date(), datetime.min.time()
-    ).replace(tzinfo=ZONE_INFO)
+    date_dt = datetime.combine(dt.date(), datetime.min.time()).replace(tzinfo=ZONE_INFO)
     return pd.date_range(
-        now_date_as_dt,
-        now_date_as_dt + timedelta(hours=23),
+        date_dt,
+        date_dt + timedelta(hours=23),
         freq="H",
     ).to_pydatetime()
 

--- a/parsers/IN_WE.py
+++ b/parsers/IN_WE.py
@@ -43,17 +43,6 @@ KIND_MAPPING = {
 }
 
 
-def is_expected_downtime() -> bool:
-    """
-    Details about this expected downtime is currently being clarified via
-    https://github.com/electricitymaps/electricitymaps-contrib/pull/6184#issuecomment-2564302911.
-    """
-    expected_outage_days = [5, 6, 0]  # Saturday, Sunday and Monday
-    if datetime.now(ZONE_INFO).weekday() in expected_outage_days:
-        return True
-    return False
-
-
 def get_date_range(dt: datetime):
     """Returns 24 datetime objects for a given datetime's date, one for each hour."""
     now_date_as_dt = datetime.combine(
@@ -83,15 +72,10 @@ def fetch_data(
     try:
         data = json.loads(resp.json().get("d", {}))
     except Exception as e:
-        if is_expected_downtime(target_datetime):
-            raise ValueError(
-                "IN_WE Parser cannot get latest data during the expected downtime (Saturday to Monday)."
-            ) from e
-        else:
-            raise ParserException(
-                parser="IN_WE.py",
-                message=f"{target_datetime}: {kind} data is not available",
-            ) from e
+        raise ParserException(
+            parser="IN_WE.py",
+            message=f"{target_datetime}: {kind} data is not available",
+        ) from e
 
     for item in data:
         # replace datetime string with datetime object

--- a/parsers/IN_WE.py
+++ b/parsers/IN_WE.py
@@ -45,14 +45,18 @@ KIND_MAPPING = {
 
 def _get_hour_dts(dt: datetime):
     """
-    Returns 24 datetime objects for a given datetime's date, one for each hour.
+    Returns up to 24 datetime objects for a given datetime's date, one for each
+    hour, excluding future hours.
     """
     date_dt = datetime.combine(dt.date(), datetime.min.time()).replace(tzinfo=ZONE_INFO)
-    return pd.date_range(
+    dts = pd.date_range(
         date_dt,
         date_dt + timedelta(hours=23),
         freq="H",
     ).to_pydatetime()
+
+    now_dt = datetime.now(ZONE_INFO)
+    return [dt for dt in dts if dt < now_dt]
 
 
 def _fetch_data(


### PR DESCRIPTION
## Issue

Resolves subtask of https://github.com/electricitymaps/electricitymaps-contrib/issues/6135.

## Description

I ended up doing a lot of other refactoring in this PR as well =/ I aim not to do that to reduce the complexity of code review and keep PRs minimalistic, but I went for it anyhow this time as I struggled a while to get it to run correctly and had to understand the code better.

My gained code comprehension ended up making me fix a bug, where fetching could lead getting old data even though there was new data available.

I also fixed what I think is a bug that could have led to a bit incorrect data by mixing a few data points from an AM hour (like 04) into an PM hour (like 16:00) or vice versa.

## `is_expected_downtime` removed

I asked about this in https://github.com/electricitymaps/electricitymaps-contrib/pull/6184#issuecomment-2564564977, but since I've got fresh data from the API during this expected downtime, I went with removing it for now. I'll look to see if the API is actually providing data regularly going forward, and will be ready to add back exception handling if needed.

## Double check

- [x] I have tested my parser changes locally with `poetry run test_parser "zone_key"`
  ```
  poetry run test_parser "IN-WE" consumption
  poetry run test_parser "IN-WE" consumption --target_datetime="2024-12-27 00:00 +05:30"
  poetry run test_parser "IN-SO->IN-WE"
  poetry run test_parser "IN-SO->IN-WE" --target_datetime="2024-12-27 00:00 +05:30"
  poetry run test_parser "IN-EA->IN-WE"
  poetry run test_parser "IN-NO->IN-WE"
  ```
- [x] I have run `pnpx prettier@2 --write .` and `poetry run format` in the top level directory to format my changes.
