### PR TITLE
cleanup: remove arrow and backports-datetime-fromisoformat parser deps

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -124,20 +124,6 @@ files = [
 frozenlist = ">=1.1.0"
 
 [[package]]
-name = "arrow"
-version = "0.16.0"
-description = "Better dates & times for Python"
-optional = true
-python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
-files = [
-    {file = "arrow-0.16.0-py2.py3-none-any.whl", hash = "sha256:98184d8dd3e5d30b96c2df4596526f7de679ccb467f358b82b0f686436f3a6b8"},
-    {file = "arrow-0.16.0.tar.gz", hash = "sha256:92aac856ea5175c804f7ccb96aca4d714d936f1c867ba59d747a8096ec30e90a"},
-]
-
-[package.dependencies]
-python-dateutil = ">=2.7.0"
-
-[[package]]
 name = "async-timeout"
 version = "5.0.1"
 description = "Timeout context manager for asyncio programs"
@@ -1920,10 +1906,10 @@ test = ["coverage[toml]", "zope.event", "zope.testing"]
 testing = ["coverage[toml]", "zope.event", "zope.testing"]
 
 [extras]
-parsers = ["Pillow", "arrow", "beautifulsoup4", "demjson3", "freezegun", "html5lib", "imageio", "lxml", "mock", "odfpy", "opencv-python", "openpyxl", "pandas", "pycountry", "pydataxm", "pytesseract", "requests", "signalr-client-threads", "tqdm", "xlrd"]
+parsers = ["Pillow", "beautifulsoup4", "demjson3", "freezegun", "html5lib", "imageio", "lxml", "mock", "odfpy", "opencv-python", "openpyxl", "pandas", "pycountry", "pydataxm", "pytesseract", "requests", "signalr-client-threads", "tqdm", "xlrd"]
 scripts = ["xmltodict"]
 
 [metadata]
 lock-version = "2.0"
 python-versions = ">= 3.10, < 3.11"
-content-hash = "42f5d366463e01ee3dbca6be90d417f29d77509d310ab720f55d6b380847073e"
+content-hash = "f33ae1a662462cababd0102226fc8dc9592730f6ff000f48b2c066f5bb1ab1a0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,6 @@ include = ["config/*.json"]
 [tool.poetry.dependencies]
 python = '>= 3.10, < 3.11'
 pydantic = "^1.9.0"
-arrow = { version = "0.16.0", optional = true }
 beautifulsoup4 = { version = "~4.6.0", optional = true }
 demjson3 = { version = "^3.0.5", optional = true }
 freezegun = { version = "^0.3.15", optional = true }
@@ -49,8 +48,6 @@ test = 'scripts.tooling:test'
 
 [tool.poetry.extras]
 parsers = [
-    "arrow",
-    "backports-datetime-fromisoformat",
     "beautifulsoup4",
     "demjson3",
     "eiapy",


### PR DESCRIPTION
## Issue

- Fixes #6135 
- Removes mistakenly introduced dependency `backports-datetime-fromisoformat` in #7650. It was introduced temporarily by me before I decided it wasn't worth introducing a dependency and instead did https://github.com/electricitymaps/electricitymaps-contrib/pull/7650/files#diff-b3b0e852a383691bf7d2424c5df072905b16e6758451306a15e2f9ef10c4c37aR126-R129.

## Description

Requires a few PRs to land first:
- https://github.com/electricitymaps/electricitymaps-contrib/pull/7627
- https://github.com/electricitymaps/electricitymaps-contrib/pull/7629
- https://github.com/electricitymaps/electricitymaps-contrib/pull/7630
- https://github.com/electricitymaps/electricitymaps-contrib/pull/7636