### PR TITLE
fix(tests): make CH parser test independent on test runner timezone

### DIFF
--- a/parsers/test/test_CH.py
+++ b/parsers/test/test_CH.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import datetime, timezone
 
 import pytest
 
@@ -19,5 +19,5 @@ from parsers.CH import get_solar_capacity_at
     ],
 )
 def test_get_solar_capacity(dt, expected):
-    target_datetime = datetime.fromisoformat(dt)
+    target_datetime = datetime.fromisoformat(dt).replace(tzinfo=timezone.utc)
     assert get_solar_capacity_at(target_datetime) == expected


### PR DESCRIPTION
## Issue

`poetry run test` had test_CH fail locally for me in my UTC+1 timezone - this fixes it.

### Double check

- [x] I have run `pnpx prettier@2 --write .` and `poetry run format` in the top level directory to format my changes.
