### PR TITLE
chore(config): Remove other forecast keys

### DIFF
--- a/electricitymap/contrib/config/constants.py
+++ b/electricitymap/contrib/config/constants.py
@@ -13,11 +13,6 @@ WEATHER_DATABASE_KEYS = [
     "dewpoint",
     "precipitation",
 ]
-OTHER_FORECAST_KEYS = [
-    "price",
-    "production",
-    "consumption",
-]
 
 # Note: this is sorted for plotting purposes
 PRODUCTION_MODES = [


### PR DESCRIPTION
## Description

Deletes the unused constant OTHER_FORECAST_KEYS

### Double check

- [ ] I have tested my parser changes locally with `poetry run test_parser "zone_key"`
- [ ] I have run `pnpx prettier@2 --write .` and `poetry run format` in the top level directory to format my changes.
