### PR TITLE
perf/fix: Remove trans component from RankingPanel.tsx

### DIFF
--- a/web/src/features/panels/ranking-panel/RankingPanel.tsx
+++ b/web/src/features/panels/ranking-panel/RankingPanel.tsx
@@ -5,7 +5,7 @@ import { useGetCanonicalUrl } from 'hooks/useGetCanonicalUrl';
 import { useAtomValue } from 'jotai';
 import { ReactElement, useCallback, useState } from 'react';
 import { Helmet } from 'react-helmet-async';
-import { Trans, useTranslation } from 'react-i18next';
+import { useTranslation } from 'react-i18next';
 import { metaTitleSuffix } from 'utils/constants';
 import {
   isConsumptionAtom,
@@ -63,7 +63,7 @@ export default function RankingPanel(): ReactElement {
       <div className="flex flex-grow flex-col overflow-hidden pr-2">
         <div className="pb-5">
           <h1>{t('ranking-panel.title')}</h1>
-          <p className="text-sm">{<Trans i18nKey="ranking-panel.subtitle" />}</p>
+          <p className="text-sm">{t('ranking-panel.subtitle')}</p>
         </div>
 
         <SearchBar


### PR DESCRIPTION
## Issue

A innocent little change introduced in #7568 caused our bundle size to increase by 7.3 kb and the subtitle to constantly re-render when the datetime changes.
## Description
Switches back to using the `t()` function instead to fix this regression


### Double check

- [x] I have run `pnpx prettier@2 --write .` and `poetry run format` in the top level directory to format my changes.
