### PR TITLE
chore(tests): prefer use of requests_mock over unittest.mock

### DIFF
--- a/parsers/test/__snapshots__/test_ES.ambr
+++ b/parsers/test/__snapshots__/test_ES.ambr
@@ -1,0 +1,144 @@
+# serializer version: 1
+# name: test_fetch_consumption
+  list([
+    dict({
+      'consumption': 5.5,
+      'datetime': datetime.datetime(2023, 9, 4, 0, 55, tzinfo=zoneinfo.ZoneInfo(key='Atlantic/Canary')),
+      'source': 'demanda.ree.es',
+      'sourceType': <EventSourceType.measured: 'measured'>,
+      'zoneKey': 'ES-CN-HI',
+    }),
+  ])
+# ---
+# name: test_fetch_exchange
+  list([
+    dict({
+      'datetime': datetime.datetime(2023, 9, 3, 19, 5, tzinfo=zoneinfo.ZoneInfo(key='Europe/Madrid')),
+      'netFlow': 309.8,
+      'sortedZoneKeys': 'ES->ES-IB-MA',
+      'source': 'demanda.ree.es',
+      'sourceType': <EventSourceType.measured: 'measured'>,
+    }),
+  ])
+# ---
+# name: test_fetch_production
+  list([
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2023, 9, 2, 21, 0, tzinfo=zoneinfo.ZoneInfo(key='Europe/Madrid')),
+      'production': dict({
+        'biomass': 0.0,
+        'coal': 0.0,
+        'gas': 0.0,
+        'oil': 81.9,
+        'solar': 1.1,
+        'unknown': 0.0,
+        'wind': 0.2,
+      }),
+      'source': 'demanda.ree.es',
+      'sourceType': <EventSourceType.measured: 'measured'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'ES-IB-ME',
+    }),
+  ])
+# ---
+# name: test_fetch_production_storage
+  list([
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2023, 9, 4, 0, 55, tzinfo=zoneinfo.ZoneInfo(key='Atlantic/Canary')),
+      'production': dict({
+        'oil': 3.2,
+        'solar': 0.0,
+        'wind': 3.0,
+      }),
+      'source': 'demanda.ree.es',
+      'sourceType': <EventSourceType.measured: 'measured'>,
+      'storage': dict({
+        'hydro': 0.5,
+      }),
+      'zoneKey': 'ES-CN-HI',
+    }),
+  ])
+# ---
+# name: test_production_DST_CN
+  list([
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2021, 10, 31, 1, 55, tzinfo=datetime.timezone(datetime.timedelta(seconds=3600))),
+      'production': dict({
+        'oil': 2.8,
+        'solar': 0.0,
+        'wind': 3.3,
+      }),
+      'source': 'demanda.ree.es',
+      'sourceType': <EventSourceType.measured: 'measured'>,
+      'storage': dict({
+        'hydro': 1.2,
+      }),
+      'zoneKey': 'ES-CN-HI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2021, 10, 31, 1, 0, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'oil': 2.5,
+        'solar': 0.0,
+        'wind': 3.2,
+      }),
+      'source': 'demanda.ree.es',
+      'sourceType': <EventSourceType.measured: 'measured'>,
+      'storage': dict({
+        'hydro': 1.2,
+      }),
+      'zoneKey': 'ES-CN-HI',
+    }),
+  ])
+# ---
+# name: test_production_DST_IB
+  list([
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2020, 10, 25, 2, 55, tzinfo=datetime.timezone(datetime.timedelta(seconds=7200))),
+      'production': dict({
+        'biomass': 19.2,
+        'coal': 73.3,
+        'gas': 127.1,
+        'oil': 0.0,
+        'solar': 0.0,
+        'unknown': 2.9,
+        'wind': 0.0,
+      }),
+      'source': 'demanda.ree.es',
+      'sourceType': <EventSourceType.measured: 'measured'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'ES-IB-MA',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2020, 10, 25, 2, 0, tzinfo=datetime.timezone(datetime.timedelta(seconds=3600))),
+      'production': dict({
+        'biomass': 18.5,
+        'coal': 73.3,
+        'gas': 128.0,
+        'oil': 0.0,
+        'solar': 0.0,
+        'unknown': 2.9,
+        'wind': 0.0,
+      }),
+      'source': 'demanda.ree.es',
+      'sourceType': <EventSourceType.measured: 'measured'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'ES-IB-MA',
+    }),
+  ])
+# ---

--- a/parsers/test/test_ES.py
+++ b/parsers/test/test_ES.py
@@ -1,5 +1,6 @@
-from datetime import datetime, timezone
-from unittest.mock import patch
+from datetime import datetime
+
+from requests_mock import ANY
 
 from electricitymap.contrib.lib.types import ZoneKey
 from parsers import ES
@@ -7,182 +8,74 @@ from parsers import ES
 
 ### El Hierro
 # Consumption
-@patch("requests.Response")
-@patch("parsers.ES.Session.get")
-def test_fetch_consumption(mocked_session_get, mocked_response, session):
-    mocked_response.ok = True
-    mocked_response.text = r'null({"valoresHorariosGeneracion":[{"ts":"2023-09-04 00:55","dem":5.5,"die":3.2,"gas":0.0,"eol":3.0,"cc":0.0,"vap":0.0,"fot":0.0,"hid":-0.5}]}'
-    mocked_session_get.return_value = mocked_response
-    data_list = ES.fetch_consumption(
+def test_fetch_consumption(adapter, session, snapshot):
+    mock_data = b'null({"valoresHorariosGeneracion":[{"ts":"2023-09-04 00:55","dem":5.5,"die":3.2,"gas":0.0,"eol":3.0,"cc":0.0,"vap":0.0,"fot":0.0,"hid":-0.5}]}'
+    adapter.register_uri(ANY, ANY, content=mock_data)
+
+    assert snapshot == ES.fetch_consumption(
         ZoneKey("ES-CN-HI"), session, datetime.fromisoformat("2023-09-04")
     )
-
-    # Test "get" function has been called correctly
-    assert (
-        mocked_session_get.call_args[0][0]
-        == "https://demanda.ree.es/WSvisionaMovilesCanariasRest/resources/demandaGeneracionCanarias?curva=EL_HIERRO5M&fecha=2023-09-04"
-    )
-
-    # Test that the data is parsed correctly afterwards
-    assert len(data_list) == 1
-    assert data_list[0]["zoneKey"] == "ES-CN-HI"
-    assert data_list[0]["source"] == "demanda.ree.es"
-    assert data_list[0]["consumption"] == 5.5
-    assert isinstance(data_list[0]["datetime"], datetime)
-    assert data_list[0]["datetime"] == datetime(2023, 9, 3, 23, 55, tzinfo=timezone.utc)
 
 
 ### El Hierro
 # Production
-@patch("requests.Response")
-@patch("parsers.ES.Session.get")
-def test_fetch_production_storage(mocked_session_get, mocked_response, session):
-    mocked_response.ok = True
-    mocked_response.text = r'null({"valoresHorariosGeneracion":[{"ts":"2023-09-04 00:55","dem":5.5,"die":3.2,"gas":0.0,"eol":3.0,"cc":0.0,"vap":0.0,"fot":0.0,"hid":-0.5}]}'
-    mocked_session_get.return_value = mocked_response
-    data_list = ES.fetch_production(
-        ZoneKey("ES-CN-HI"), session, datetime.fromisoformat("2023-09-04")
-    )
+def test_fetch_production_storage(adapter, session, snapshot):
+    mock_data = b'null({"valoresHorariosGeneracion":[{"ts":"2023-09-04 00:55","dem":5.5,"die":3.2,"gas":0.0,"eol":3.0,"cc":0.0,"vap":0.0,"fot":0.0,"hid":-0.5}]}'
+    adapter.register_uri(ANY, ANY, content=mock_data)
 
-    # Test "get" function has been called correctly
-    assert (
-        mocked_session_get.call_args[0][0]
-        == "https://demanda.ree.es/WSvisionaMovilesCanariasRest/resources/demandaGeneracionCanarias?curva=EL_HIERRO5M&fecha=2023-09-04"
+    assert snapshot == ES.fetch_production(
+        ZoneKey("ES-CN-HI"),
+        session,
+        datetime.fromisoformat("2023-09-04"),
     )
-
-    # Test that the data is parsed correctly afterwards
-    assert len(data_list) == 1
-    assert data_list[0]["zoneKey"] == "ES-CN-HI"
-    assert data_list[0]["source"] == "demanda.ree.es"
-    assert data_list[0]["production"] == {
-        "oil": 3.2,
-        "solar": 0.0,
-        "wind": 3.0,
-    }
-    assert data_list[0]["storage"], {"hydro": 0.5}
-    assert isinstance(data_list[0]["datetime"], datetime)
-    assert data_list[0]["datetime"] == datetime(2023, 9, 3, 23, 55, tzinfo=timezone.utc)
 
 
 # Test for DST change days
-@patch("requests.Response")
-@patch("parsers.ES.Session.get")
-def test_production_DST_CN(mocked_session_get, mocked_response, session):
-    mocked_response.ok = True
-    mocked_response.text = r'null({"valoresHorariosGeneracion":[{"ts":"2021-10-31 1A:55","dem":4.8,"die":2.8,"gas":0.0,"eol":3.3,"cc":0.0,"vap":0.0,"fot":0.0,"hid":-1.2},{"ts":"2021-10-31 1B:00","dem":4.5,"die":2.5,"gas":0.0,"eol":3.2,"cc":0.0,"vap":0.0,"fot":0.0,"hid":-1.2}]}'
-    mocked_session_get.return_value = mocked_response
-    data_list = ES.fetch_production(
-        ZoneKey("ES-CN-HI"), session, datetime.fromisoformat("2021-10-31")
-    )
+def test_production_DST_CN(adapter, session, snapshot):
+    mock_data = b'null({"valoresHorariosGeneracion":[{"ts":"2021-10-31 1A:55","dem":4.8,"die":2.8,"gas":0.0,"eol":3.3,"cc":0.0,"vap":0.0,"fot":0.0,"hid":-1.2},{"ts":"2021-10-31 1B:00","dem":4.5,"die":2.5,"gas":0.0,"eol":3.2,"cc":0.0,"vap":0.0,"fot":0.0,"hid":-1.2}]}'
+    adapter.register_uri(ANY, ANY, content=mock_data)
 
-    # Test "get" function has been called correctly
-    assert (
-        mocked_session_get.call_args[0][0]
-        == "https://demanda.ree.es/WSvisionaMovilesCanariasRest/resources/demandaGeneracionCanarias?curva=EL_HIERRO5M&fecha=2021-10-31"
-    )
-
-    # Test that the data is parsed correctly afterwards
-    assert len(data_list) == 2
-    assert isinstance(data_list[0]["datetime"], datetime)
-    assert data_list[0]["datetime"].astimezone(timezone.utc) == datetime(
-        2021, 10, 31, 0, 55, tzinfo=timezone.utc
-    )
-    assert isinstance(data_list[1]["datetime"], datetime)
-    assert data_list[1]["datetime"].astimezone(timezone.utc) == datetime(
-        2021, 10, 31, 1, 0, tzinfo=timezone.utc
+    assert snapshot == ES.fetch_production(
+        ZoneKey("ES-CN-HI"),
+        session,
+        datetime.fromisoformat("2021-10-31"),
     )
 
 
 ### Menorca
 # Production
-@patch("requests.Response")
-@patch("parsers.ES.Session.get")
-def test_fetch_production(mocked_session_get, mocked_response, session):
-    mocked_response.ok = True
-    mocked_response.text = r'null({"valoresHorariosGeneracion":[{"ts":"2023-09-02 21:00","dem":85.9,"car":0.0,"die":22.6,"gas":59.3,"cc":0.0,"cb":0.0,"fot":1.1,"tnr":0.0,"trn":0.0,"eol":0.2,"emm":2.7,"emi":-0.0,"otrRen":0.0,"resid":0.0,"genAux":0.0,"cogen":0.0,"eif":-0.0}]}'
-    mocked_session_get.return_value = mocked_response
-    data_list = ES.fetch_production(
-        ZoneKey("ES-IB-ME"), session, datetime.fromisoformat("2023-09-03")
-    )
+def test_fetch_production(adapter, session, snapshot):
+    mock_data = b'null({"valoresHorariosGeneracion":[{"ts":"2023-09-02 21:00","dem":85.9,"car":0.0,"die":22.6,"gas":59.3,"cc":0.0,"cb":0.0,"fot":1.1,"tnr":0.0,"trn":0.0,"eol":0.2,"emm":2.7,"emi":-0.0,"otrRen":0.0,"resid":0.0,"genAux":0.0,"cogen":0.0,"eif":-0.0}]}'
+    adapter.register_uri(ANY, ANY, content=mock_data)
 
-    # Test "get" function has been called correctly
-    assert (
-        mocked_session_get.call_args[0][0]
-        == "https://demanda.ree.es/WSvisionaMovilesBalearesRest/resources/demandaGeneracionBaleares?curva=MENORCA5M&fecha=2023-09-03"
+    assert snapshot == ES.fetch_production(
+        ZoneKey("ES-IB-ME"),
+        session,
+        datetime.fromisoformat("2023-09-03"),
     )
-
-    # Test that the data is parsed correctly afterwards
-    assert len(data_list) == 1
-    assert data_list[0]["zoneKey"] == "ES-IB-ME"
-    assert data_list[0]["source"] == "demanda.ree.es"
-    assert data_list[0]["production"] == {
-        "biomass": 0.0,
-        "coal": 0.0,
-        "gas": 0.0,
-        "oil": 81.9,
-        "solar": 1.1,
-        "unknown": 0.0,
-        "wind": 0.2,
-    }
-    assert isinstance(data_list[0]["datetime"], datetime)
-    assert data_list[0]["datetime"] == datetime(2023, 9, 2, 19, 0, tzinfo=timezone.utc)
 
 
 ### Mallorca
 # Exchange
-@patch("requests.Response")
-@patch("parsers.ES.Session.get")
-def test_fetch_exchange(mocked_session_get, mocked_response, session):
-    mocked_response.ok = True
-    mocked_response.text = r'null({"valoresHorariosGeneracion":[{"ts":"2023-09-03 19:05","dem":670.3,"car":0.0,"die":0.0,"gas":0.0,"cc":416.4,"cb":309.8,"fot":19.7,"tnr":0.0,"trn":0.0,"eol":0.0,"emm":-20.6,"emi":-91.3,"otrRen":0.0,"resid":34.6,"genAux":0.0,"cogen":1.7,"eif":-0.0}]}'
-    mocked_session_get.return_value = mocked_response
-    data_list = ES.fetch_exchange(
+def test_fetch_exchange(adapter, session, snapshot):
+    mock_data = b'null({"valoresHorariosGeneracion":[{"ts":"2023-09-03 19:05","dem":670.3,"car":0.0,"die":0.0,"gas":0.0,"cc":416.4,"cb":309.8,"fot":19.7,"tnr":0.0,"trn":0.0,"eol":0.0,"emm":-20.6,"emi":-91.3,"otrRen":0.0,"resid":34.6,"genAux":0.0,"cogen":1.7,"eif":-0.0}]}'
+    adapter.register_uri(ANY, ANY, content=mock_data)
+
+    assert snapshot == ES.fetch_exchange(
         ZoneKey("ES"),
         ZoneKey("ES-IB-MA"),
         session,
         datetime.fromisoformat("2023-09-03"),
     )
 
-    # Test "get" function has been called correctly
-    assert (
-        mocked_session_get.call_args[0][0]
-        == "https://demanda.ree.es/WSvisionaMovilesBalearesRest/resources/demandaGeneracionBaleares?curva=MALLORCA5M&fecha=2023-09-03"
-    )
-
-    # Test that the data is parsed correctly afterwards
-    assert len(data_list) == 1
-    assert data_list[0]["sortedZoneKeys"] == "ES->ES-IB-MA"
-    assert data_list[0]["source"] == "demanda.ree.es"
-    assert data_list[0]["netFlow"] is not None
-    assert data_list[0]["netFlow"] == 309.8
-    assert isinstance(data_list[0]["datetime"], datetime)
-    assert data_list[0]["datetime"] == datetime(2023, 9, 3, 17, 5, tzinfo=timezone.utc)
-
 
 # Test for DST change days
-@patch("requests.Response")
-@patch("parsers.ES.Session.get")
-def test_production_DST_IB(mocked_session_get, mocked_response, session):
-    mocked_response.ok = True
-    mocked_response.text = r'null({"valoresHorariosGeneracion":[{"ts":"2020-10-25 2A:55","dem":261.3,"car":73.3,"die":0.0,"gas":0.0,"cc":127.1,"cb":100.4,"fot":0.0,"tnr":0.0,"trn":0.0,"eol":0.0,"emm":-3.5,"emi":-58.1,"otrRen":0.0,"resid":19.2,"genAux":0.0,"cogen":2.9,"eif":-0.0},{"ts":"2020-10-25 2B:00","dem":261.7,"car":73.3,"die":0.0,"gas":0.0,"cc":128.0,"cb":100.4,"fot":0.0,"tnr":0.0,"trn":0.0,"eol":0.0,"emm":-3.3,"emi":-58.1,"otrRen":0.0,"resid":18.5,"genAux":0.0,"cogen":2.9,"eif":-0.0}]}'
-    mocked_session_get.return_value = mocked_response
-    data_list = ES.fetch_production(
-        ZoneKey("ES-IB-MA"), session, datetime.fromisoformat("2020-10-25")
-    )
+def test_production_DST_IB(adapter, session, snapshot):
+    mock_data = b'null({"valoresHorariosGeneracion":[{"ts":"2020-10-25 2A:55","dem":261.3,"car":73.3,"die":0.0,"gas":0.0,"cc":127.1,"cb":100.4,"fot":0.0,"tnr":0.0,"trn":0.0,"eol":0.0,"emm":-3.5,"emi":-58.1,"otrRen":0.0,"resid":19.2,"genAux":0.0,"cogen":2.9,"eif":-0.0},{"ts":"2020-10-25 2B:00","dem":261.7,"car":73.3,"die":0.0,"gas":0.0,"cc":128.0,"cb":100.4,"fot":0.0,"tnr":0.0,"trn":0.0,"eol":0.0,"emm":-3.3,"emi":-58.1,"otrRen":0.0,"resid":18.5,"genAux":0.0,"cogen":2.9,"eif":-0.0}]}'
+    adapter.register_uri(ANY, ANY, content=mock_data)
 
-    # Test "get" function has been called correctly
-    assert (
-        mocked_session_get.call_args[0][0]
-        == "https://demanda.ree.es/WSvisionaMovilesBalearesRest/resources/demandaGeneracionBaleares?curva=MALLORCA5M&fecha=2020-10-25"
-    )
-
-    # Test that the data is parsed correctly afterwards
-    assert len(data_list) == 2
-    assert isinstance(data_list[0]["datetime"], datetime)
-    assert data_list[0]["datetime"].astimezone(timezone.utc) == datetime(
-        2020, 10, 25, 0, 55, tzinfo=timezone.utc
-    )
-    assert isinstance(data_list[1]["datetime"], datetime)
-    assert data_list[1]["datetime"].astimezone(timezone.utc) == datetime(
-        2020, 10, 25, 1, 0, tzinfo=timezone.utc
+    assert snapshot == ES.fetch_production(
+        ZoneKey("ES-IB-MA"),
+        session,
+        datetime.fromisoformat("2020-10-25"),
     )


### PR DESCRIPTION
## Description

Changes are triggered by the observation and discussion in https://github.com/electricitymaps/electricitymaps-contrib/pull/7672#discussion_r1902172671, where test_ES.py was the sole test file using unittest.mock's patch decorator, where all others used requests_mock.

I figure requests_mock is cleaner for us to use as we specifically mock requests, but its also nice to be consistent so that understanding one test leads to understanding other tests.

### Double check

- [x] I have tested my parser changes locally with `poetry run test_parser "zone_key"`
  The parser wasn't changed, only tests.
- [x] I have run `pnpx prettier@2 --write .` and `poetry run format` in the top level directory to format my changes.
