### PR TITLE
fix: correct California exchange arrow positions

### DIFF
--- a/config/exchanges/US-CAL-BANC_US-CAL-CISO.yaml
+++ b/config/exchanges/US-CAL-BANC_US-CAL-CISO.yaml
@@ -1,6 +1,6 @@
 lonlat:
-  - -121.300708327
-  - 38.806317855
+  - -121.41
+  - 38.776
 parsers:
   exchange: EIA.fetch_exchange
-rotation: -44
+rotation: -15

--- a/config/exchanges/US-CAL-BANC_US-CAL-TIDC.yaml
+++ b/config/exchanges/US-CAL-BANC_US-CAL-TIDC.yaml
@@ -1,6 +1,6 @@
 lonlat:
-  - -120.584803325
-  - 37.632077092
+  - -121.25
+  - 37.48
 parsers:
   exchange: EIA.fetch_exchange
-rotation: -33
+rotation: 165

--- a/config/exchanges/US-CAL-BANC_US-NW-BPAT.yaml
+++ b/config/exchanges/US-CAL-BANC_US-NW-BPAT.yaml
@@ -1,6 +1,6 @@
 lonlat:
-  - -122.568137
-  - 41.367034
+  - -122.75
+  - 41.28
 parsers:
   exchange: EIA.fetch_exchange
-rotation: -122
+rotation: 145

--- a/config/exchanges/US-CAL-CISO_US-CAL-IID.yaml
+++ b/config/exchanges/US-CAL-CISO_US-CAL-IID.yaml
@@ -1,6 +1,6 @@
 lonlat:
-  - -114.67096252242025
-  - 33.20594911251957
+  - -116
+  - 34
 parsers:
   exchange: EIA.fetch_exchange
-rotation: -48
+rotation: 180

--- a/config/exchanges/US-CAL-CISO_US-CAL-LDWP.yaml
+++ b/config/exchanges/US-CAL-CISO_US-CAL-LDWP.yaml
@@ -1,6 +1,6 @@
 lonlat:
-  - -118.584465341
-  - 37.123240455
+  - -118.23
+  - 36.6
 parsers:
   exchange: EIA.fetch_exchange
-rotation: -87
+rotation: -90

--- a/config/exchanges/US-CAL-CISO_US-CAL-TIDC.yaml
+++ b/config/exchanges/US-CAL-CISO_US-CAL-TIDC.yaml
@@ -1,6 +1,6 @@
 lonlat:
-  - -120.369765245
-  - 37.628431424
+  - -114.3
+  - 34.39
 parsers:
   exchange: EIA.fetch_exchange
-rotation: -58
+rotation: 40

--- a/config/exchanges/US-CAL-CISO_US-NW-BPAT.yaml
+++ b/config/exchanges/US-CAL-CISO_US-NW-BPAT.yaml
@@ -1,6 +1,6 @@
 lonlat:
-  - -124.06497455924251
-  - 41.4636574822466
+  - -123.7
+  - 41.42
 parsers:
   exchange: EIA.fetch_exchange
-rotation: -158
+rotation: 160

--- a/config/exchanges/US-CAL-CISO_US-NW-NEVP.yaml
+++ b/config/exchanges/US-CAL-CISO_US-NW-NEVP.yaml
@@ -1,6 +1,6 @@
 lonlat:
-  - -118.334372766
-  - 37.3916303460001
+  - -118.7
+  - 38.1
 parsers:
   exchange: EIA.fetch_exchange
 rotation: -135

--- a/config/exchanges/US-CAL-CISO_US-SW-AZPS.yaml
+++ b/config/exchanges/US-CAL-CISO_US-SW-AZPS.yaml
@@ -1,6 +1,6 @@
 lonlat:
-  - -114.14771926876867
-  - 34.26236586541118
+  - -114.2
+  - 34.18
 parsers:
   exchange: EIA.fetch_exchange
-rotation: -71
+rotation: -50

--- a/config/exchanges/US-CAL-CISO_US-SW-SRP.yaml
+++ b/config/exchanges/US-CAL-CISO_US-SW-SRP.yaml
@@ -1,6 +1,6 @@
 lonlat:
-  - -114.15123583543954
-  - 34.24653998229242
+  - -114.5
+  - 33.7
 parsers:
   exchange: EIA.fetch_exchange
 rotation: -67

--- a/config/exchanges/US-CAL-CISO_US-SW-WALC.yaml
+++ b/config/exchanges/US-CAL-CISO_US-SW-WALC.yaml
@@ -1,6 +1,6 @@
 lonlat:
-  - -118.584465341
-  - 37.123240455
+  - -114.6
+  - 33.42
 parsers:
   exchange: EIA.fetch_exchange
-rotation: -103
+rotation: -35

--- a/config/exchanges/US-CAL-IID_US-SW-AZPS.yaml
+++ b/config/exchanges/US-CAL-IID_US-SW-AZPS.yaml
@@ -1,6 +1,6 @@
 lonlat:
-  - -114.48204066696128
-  - 32.83826436542124
+  - -114.53
+  - 32.88
 parsers:
   exchange: EIA.fetch_exchange
-rotation: -100
+rotation: -80

--- a/config/exchanges/US-CAL-IID_US-SW-WALC.yaml
+++ b/config/exchanges/US-CAL-IID_US-SW-WALC.yaml
@@ -1,6 +1,6 @@
 lonlat:
-  - -114.475390609
-  - 32.839163816
+  - -114.62
+  - 33.12
 parsers:
   exchange: EIA.fetch_exchange
-rotation: -176
+rotation: -125

--- a/config/exchanges/US-CAL-LDWP_US-NW-BPAT.yaml
+++ b/config/exchanges/US-CAL-LDWP_US-NW-BPAT.yaml
@@ -1,6 +1,6 @@
 lonlat:
-  - -118.239371804
-  - 37.462786265
+  - -118.43
+  - 37.18
 parsers:
   exchange: EIA.fetch_exchange
-rotation: -163
+rotation: 140

--- a/config/exchanges/US-CAL-LDWP_US-NW-NEVP.yaml
+++ b/config/exchanges/US-CAL-LDWP_US-NW-NEVP.yaml
@@ -1,6 +1,6 @@
 lonlat:
-  - -118.576569
-  - 37.463081
+  - -117.98
+  - 36.755
 parsers:
   exchange: EIA.fetch_exchange
-rotation: -145
+rotation: 40

--- a/config/exchanges/US-CAL-LDWP_US-NW-PACE.yaml
+++ b/config/exchanges/US-CAL-LDWP_US-NW-PACE.yaml
@@ -1,6 +1,6 @@
 lonlat:
-  - -117.604019502
-  - 36.292071642
+  - -117.65
+  - 36.4
 parsers:
   exchange: EIA.fetch_exchange
 rotation: -121

--- a/config/exchanges/US-CAL-LDWP_US-SW-AZPS.yaml
+++ b/config/exchanges/US-CAL-LDWP_US-SW-AZPS.yaml
@@ -1,6 +1,6 @@
 lonlat:
-  - -118.237451
-  - 33.767594
+  - -118.235
+  - 34.05
 parsers:
   exchange: EIA.fetch_exchange
 rotation: -70

--- a/config/exchanges/US-CAL-LDWP_US-SW-WALC.yaml
+++ b/config/exchanges/US-CAL-LDWP_US-SW-WALC.yaml
@@ -1,6 +1,6 @@
 lonlat:
-  - -118.584465341
-  - 37.123240455
+  - -117.74
+  - 36.18
 parsers:
   exchange: EIA.fetch_exchange
-rotation: -107
+rotation: -45

--- a/config/exchanges/US-NW-NEVP_US-SW-WALC.yaml
+++ b/config/exchanges/US-NW-NEVP_US-SW-WALC.yaml
@@ -1,6 +1,6 @@
 lonlat:
-  - -114.895038742
-  - 35.2125988070001
+  - -114.7
+  - 35.15
 parsers:
   exchange: EIA.fetch_exchange
-rotation: -23
+rotation: 0

--- a/config/exchanges/US-SW-AZPS_US-SW-WALC.yaml
+++ b/config/exchanges/US-SW-AZPS_US-SW-WALC.yaml
@@ -1,6 +1,6 @@
 lonlat:
-  - -114.481466787
-  - 32.8340214030001
+  - -114.35
+  - 32.71
 parsers:
   exchange: EIA.fetch_exchange
-rotation: -47
+rotation: -125


### PR DESCRIPTION
## Issue

In [#7557](https://github.com/electricitymaps/electricitymaps-contrib/issues/7557), @madsnedergaard notes that the exchange arrow positions are off throughout California.

Closes #7557

## Description

The aim of this PR is to ensure all exchange arrows beginning with US-CAL (and a couple adjacent arrows) are positioned and angled correctly.

### Preview

![image](https://github.com/user-attachments/assets/b5336c51-e08b-4797-9747-b4df4907465f)

### Double check

- [x] I have tested my parser changes locally with `poetry run test_parser "zone_key"`
- [x] I have run `pnpx prettier@2 --write .` and `poetry run format` in the top level directory to format my changes.
