### PR TITLE
fix(web): don't allow persistant production mode

### DIFF
--- a/web/src/utils/state/atoms.ts
+++ b/web/src/utils/state/atoms.ts
@@ -54,7 +54,7 @@ export const spatialAggregateAtom = atomWithStorage(
   'country-mode',
   SpatialAggregate.ZONE
 );
-export const productionConsumptionAtom = atomWithStorage('mode', Mode.CONSUMPTION);
+export const productionConsumptionAtom = atom(Mode.CONSUMPTION);
 export const isConsumptionAtom = atom<boolean>(
   (get) => get(productionConsumptionAtom) === Mode.CONSUMPTION
 );


### PR DESCRIPTION
## Issue
We sometime receive negative feedback that the exchange arrows have been removed.

## Description

This PR removes the storage of the consumption / production mode state, when users now reload this will be reset to consumption.