### PR TITLE
chore(ci system): colorize pytest output and summarize slowest tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -83,6 +83,8 @@ click = "^8.0.0"
 
 [tool.pytest.ini_options]
 testpaths = ["tests", "parsers/test", "electricitymap/contrib/lib/tests"]
+addopts = "--color=yes --durations=10"
+
 
 [build-system]
 requires = ["poetry-core>=1.0.0,<2"]


### PR DESCRIPTION
## Description

- configures `pytest` to colorize output, even in when run via GitHub Actions as it otherwise wouldn't.
- configures `pytest` to provide a summary of the ten slowest tests

## Preview

### Colorized output

Colorized output makes the text quite a bit more readable. Here is a failure without color:

Before|After
-|-
![image](https://github.com/user-attachments/assets/196840be-0c25-4aea-be55-51e64792ce52)|![image](https://github.com/user-attachments/assets/663d7285-07b3-49d0-9577-fec11a6267b7)

### Slowest tests summarized

![image](https://github.com/user-attachments/assets/f33042e4-26b6-4cf0-93ec-050feeebae74)