### PR TITLE
fix: pin poetry to v1 pending migration to v2

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -497,7 +497,7 @@ jobs:
         uses: actions/checkout@v4
       - name: Install poetry
         run: |
-          pipx install poetry
+          pipx install "poetry==1.*"
       - name: Get poetry version
         id: get-poetry-version
         run: |
@@ -538,7 +538,7 @@ jobs:
         uses: actions/checkout@v4
       - name: Install poetry
         run: |
-          pipx install poetry
+          pipx install "poetry==1.*"
       - name: Get poetry version
         id: get-poetry-version
         run: |

--- a/Earthfile
+++ b/Earthfile
@@ -33,7 +33,7 @@ poetry-lock:
 
 prepare:
   FROM +src-files-with-parsers
-  RUN pip install poetry==1.6.1
+  RUN pip install "poetry==1.*"
   RUN apt-get update && apt-get install -y python3-opencv tesseract-ocr tesseract-ocr-jpn tesseract-ocr-eng libgl1
   RUN poetry config virtualenvs.create false
   RUN poetry install --compile -E parsers

--- a/parsers.dockerfile
+++ b/parsers.dockerfile
@@ -6,7 +6,7 @@
 FROM python:3.10
 WORKDIR /workspace
 RUN apt-get update && apt-get install -y python3-opencv tesseract-ocr tesseract-ocr-jpn tesseract-ocr-eng libgl1
-RUN pip install poetry
+RUN pip install "poetry==1.*"
 COPY . .
 RUN poetry install -E parsers
 ENTRYPOINT ["poetry", "run", "test_parser"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -85,7 +85,7 @@ click = "^8.0.0"
 testpaths = ["tests", "parsers/test", "electricitymap/contrib/lib/tests"]
 
 [build-system]
-requires = ["poetry-core>=1.0.0"]
+requires = ["poetry-core>=1.0.0,<2"]
 build-backend = "poetry.core.masonry.api"
 
 [tool.ruff]


### PR DESCRIPTION
## Issue

- Fixes #7689 

## Description

Poetry v2 was released yesterday, and it broke the CI system among other things. To use poetry v2, there is quite a bit of changes needed. Due to that, I think the best path forward short term is to pin poetry to v1 and then work the migration to v2 without time pressure.

### Double check

- [x] I have run `pnpx prettier@2 --write .` and `poetry run format` in the top level directory to format my changes.
