### PR TITLE
fix(parsers, MX): drop seldom occuring datapoints with an hour set to 25

### DIFF
--- a/config/zones/MX.yaml
+++ b/config/zones/MX.yaml
@@ -55,6 +55,7 @@ capacity:
       value: 7320.0
 contributors:
   - scriptator
+  - consideRatio
 country: MX
 emissionFactors:
   direct:


### PR DESCRIPTION
## Issue

<!-- If you want to close an issue automatically when your PR is merged, write "Closes X" where X is the issue number. For example: Closes #000 -->

## Description

<!-- Explains the goal of this PR -->

### Preview

<!-- Please add screenshots and/or gif that shows visual changes (if applicable) -->

### Double check

- [ ] I have tested my parser changes locally with `poetry run test_parser "zone_key"`
- [ ] I have run `pnpx prettier@2 --write .` and `poetry run format` in the top level directory to format my changes.
