### PR TITLE
fix(web): don't allow persistant country mode

### DIFF
--- a/web/src/utils/state/atoms.ts
+++ b/web/src/utils/state/atoms.ts
@@ -53,10 +53,7 @@ export const selectedDatetimeStringAtom = atom<string>((get) => {
   return dateToDatetimeString(datetime);
 });
 
-export const spatialAggregateAtom = atomWithStorage(
-  'country-mode',
-  SpatialAggregate.ZONE
-);
+export const spatialAggregateAtom = atom(SpatialAggregate.ZONE);
 export const productionConsumptionAtom = atom(Mode.CONSUMPTION);
 export const isConsumptionAtom = atom<boolean>(
   (get) => get(productionConsumptionAtom) === Mode.CONSUMPTION


### PR DESCRIPTION
## Issue

Users may get stuck in the country mode without know how to change

## Description

This PR removes the local storage for the country / zone selection. 