### PR TITLE
bug(web): 72h slider showing 1 day before

### DIFF
--- a/web/src/utils/formatting.ts
+++ b/web/src/utils/formatting.ts
@@ -214,7 +214,7 @@ const formatDateTick = (
         return new Intl.DateTimeFormat(lang, {
           month: 'short',
           day: 'numeric',
-          timeZone: 'UTC',
+          timeZone: timezone,
         }).format(date);
       }
       return new Intl.DateTimeFormat(lang, {


### PR DESCRIPTION
## Issue
UTC timezone shows the previous date

## Description
Before:
<img width="417" alt="image" src="https://github.com/user-attachments/assets/a1625deb-e6c1-438a-9cb8-7377f9a234bb" />

This PR updates the "Jan 8" tick to properly show at the start of the new day.