### PR TITLE
feat(parsers, ES-IB-ME): add capacity config

### DIFF
--- a/config/zones/ES-IB-ME.yaml
+++ b/config/zones/ES-IB-ME.yaml
@@ -8,7 +8,20 @@ contributors:
   - systemcatch
   - alixunderplatz
   - silimotion
+  - hectodium
 country: ES
+capacity:
+  # capacity sources described in
+  # https://github.com/electricitymaps/electricitymaps-contrib/issues/7520
+  biomass: 0
+  coal: 0
+  gas: 0
+  geothermal: 0
+  hydro: 0
+  nuclear: 0
+  oil: 271.6
+  solar: 50.8
+  wind: 0
 delays:
   production: 5
 emissionFactors:

--- a/config/zones/ES-IB-ME.yaml
+++ b/config/zones/ES-IB-ME.yaml
@@ -11,17 +11,49 @@ contributors:
   - hectodium
 country: ES
 capacity:
-  # capacity sources described in
-  # https://github.com/electricitymaps/electricitymaps-contrib/issues/7520
-  biomass: 0
-  coal: 0
-  gas: 0
-  geothermal: 0
-  hydro: 0
-  nuclear: 0
-  oil: 271.6
-  solar: 50.8
-  wind: 0
+  # capacity sources described in https://github.com/electricitymaps/electricitymaps-contrib/issues/7520
+  biomass:
+    - datetime: '2023-12-31'
+      source: ree.es
+      value: 0
+  coal:
+    - datetime: '2023-12-31'
+      source: ree.es
+      value: 0
+  gas:
+    - datetime: '2023-12-31'
+      source: ree.es
+      value: 0
+  geothermal:
+    - datetime: '2023-12-31'
+      source: ree.es
+      value: 0
+  hydro:
+    - datetime: '2023-12-31'
+      source: ree.es
+      value: 0
+  nuclear:
+    - datetime: '2023-12-31'
+      source: ree.es
+      value: 0
+  oil:
+    - datetime: '2018-05-01'
+      source: ime.cat
+      value: 271.6
+  solar:
+    - datetime: '2018-05-01'
+      source: ime.cat
+      value: 5.1
+    - datetime: '2023-05-01'
+      source: ime.cat, menorca.info
+      value: 50.8
+  wind:
+    - datetime: '2018-05-01'
+      source: ime.cat
+      value: 3.2
+    - datetime: '2023-12-31'
+      source: ree.es
+      value: 0
 delays:
   production: 5
 emissionFactors:


### PR DESCRIPTION
## Issue

- fixes #7520

## Description

@hectodium had done an great writeup about the capacities for ES-IB-ME, so I just did the simple task of adding capacity config based on @hectodium's summary.

With this, I also add @hectodium under the contributors config for ES-IB-ME!

### Double check

- [x] I have run `pnpx prettier@2 --write .` and `poetry run format` in the top level directory to format my changes.
