### PR TITLE
refactor(parsers, ENTSOE): comment document/process types systematically

### DIFF
--- a/parsers/ENTSOE.py
+++ b/parsers/ENTSOE.py
@@ -503,7 +503,12 @@ def query_consumption(
     domain: str, session: Session, target_datetime: datetime | None = None
 ) -> str | None:
     params = {
+        # System total load - Total load', including losses without power used
+        # for energy storage, is equal to generation deducted with exports,
+        # added with imports and deducted with power used for energy storage.
         "documentType": "A65",
+        # Realised - The process for the treatment of realised data as opposed
+        # to forecast data
         "processType": "A16",
         "outBiddingZone_Domain": domain,
     }
@@ -520,8 +525,12 @@ def query_production(
     in_domain: str, session: Session, target_datetime: datetime | None = None
 ) -> str | None:
     params = {
+        # Actual generation per type - A document providing the actual
+        # generation per generation type for a period.
         "documentType": "A75",
-        "processType": "A16",  # Realised
+        # Realised - The process for the treatment of realised data as opposed
+        # to forecast data
+        "processType": "A16",
         "in_Domain": in_domain,
     }
     return query_ENTSOE(
@@ -540,7 +549,11 @@ def query_production_per_units(
     target_datetime: datetime | None = None,
 ) -> str | None:
     params = {
+        # Actual generation - A document providing the actual generation for a
+        # period.
         "documentType": "A73",
+        # Realised - The process for the treatment of realised data as opposed
+        # to forecast data
         "processType": "A16",
         "psrType": psr_type,
         "in_Domain": domain,
@@ -562,6 +575,8 @@ def query_exchange(
     target_datetime: datetime | None = None,
 ) -> str | None:
     params = {
+        # Aggregated energy data report - A compilation of the time series of
+        # all the meter readings or their equivalent for a given period.
         "documentType": "A11",
         "in_Domain": in_domain,
         "out_Domain": out_domain,
@@ -584,7 +599,9 @@ def query_exchange_forecast(
     """Gets exchange forecast for 48 hours ahead and previous 24 hours."""
 
     params = {
-        "documentType": "A09",  # Finalised schedule
+        # Finalised schedule - A compilation of a set of schedules that have
+        # been finalized after a given cutoff.
+        "documentType": "A09",
         "in_Domain": in_domain,
         "out_Domain": out_domain,
     }
@@ -603,6 +620,8 @@ def query_price(
     """Gets day-ahead price for 24 hours ahead and previous 72 hours."""
 
     params = {
+        # Price Document - The document is used to provide market spot price
+        # information.
         "documentType": "A44",
         "in_Domain": domain,
         "out_Domain": domain,
@@ -623,8 +642,11 @@ def query_generation_forecast(
 
     # Note: this does not give a breakdown of the production
     params = {
-        "documentType": "A71",  # Generation Forecast
-        "processType": "A01",  # Realised
+        # Generation forecast - A document providing the generation forecast for
+        # a period.
+        "documentType": "A71",
+        # Day ahead - The information provided concerns a day ahead schedule
+        "processType": "A01",
         "in_Domain": in_domain,
     }
     return query_ENTSOE(
@@ -642,7 +664,11 @@ def query_consumption_forecast(
     """Gets consumption forecast for 48 hours ahead and previous 24 hours."""
 
     params = {
-        "documentType": "A65",  # Load Forecast
+        # System total load - Total load', including losses without power used
+        # for energy storage, is equal to generation deducted with exports,
+        # added with imports and deducted with power used for energy storage.
+        "documentType": "A65",
+        # Day ahead - The information provided concerns a day ahead schedule
         "processType": "A01",
         "outBiddingZone_Domain": in_domain,
     }
@@ -674,7 +700,9 @@ def query_wind_solar_production_forecast(
         )
 
     params = {
-        "documentType": "A69",  # Forecast
+        # Wind and solar forecast - A document providing the forecast of wind
+        # and solar generation.
+        "documentType": "A69",
         "processType": EntsoeTypeEnum(process_type).value,
         "in_Domain": in_domain,
     }


### PR DESCRIPTION
Adds comments systematically of `documentType` and `processType` values sent to the ENTSO-E API, based on "Definition" and "Description", as looked up in 
https://eepublicdownloads.entsoe.eu/clean-documents/EDI/Library/Core/entso-e-code-list-v36r0.pdf.

Comments like these became useful while debugging #5318 when I had to match whats fetched via the API and what was looked up manually using the ENTSO-E website.