### PR TITLE
Fix mobile paddings

### DIFF
--- a/web/src/features/map-controls/MobileButtons.tsx
+++ b/web/src/features/map-controls/MobileButtons.tsx
@@ -10,7 +10,7 @@ export default function MobileButtons() {
   const handleOpenInfoModal = () => setIsInfoModalOpen(true);
   const handleOpenSettingsModal = () => setIsSettingsModalOpen(true);
   return (
-    <div className="flex gap-2 p-2">
+    <div className="flex gap-2 pr-2 pt-2">
       <Button
         size="md"
         type="secondary"

--- a/web/src/features/panels/zone/ZoneHeader.tsx
+++ b/web/src/features/panels/zone/ZoneHeader.tsx
@@ -34,7 +34,7 @@ export default function ZoneHeader({ zoneId, isEstimated }: ZoneHeaderTitleProps
   const { t } = useTranslation();
 
   return (
-    <div className="flex w-full items-center pl-2 pr-3 pt-2">
+    <div className="flex w-full items-center pl-2 pr-3 sm:pt-2">
       <Helmet prioritizeSeoTags>
         <title>{seoZoneName + metaTitleSuffix}</title>
         <link rel="canonical" href={canonicalUrl} />

--- a/web/src/features/time/TimeControllerWrapper.tsx
+++ b/web/src/features/time/TimeControllerWrapper.tsx
@@ -20,7 +20,7 @@ function BottomSheetWrappedTimeController() {
   const safeAreaBottom = safeAreaBottomString
     ? Number.parseInt(safeAreaBottomString.replace('px', ''))
     : 0;
-  const SNAP_POINTS = [60 + safeAreaBottom, 160 + safeAreaBottom];
+  const SNAP_POINTS = [60 + safeAreaBottom, 170 + safeAreaBottom];
 
   // Don't show the time controller until the onboarding has been seen
   // But it still has to be rendered to avoid re-querying data and showing loading


### PR DESCRIPTION
## Issue

I got a bit annoyed seeing these paddings on my iPhone SE:
* top padding is too big and screen estate is lost
* no bottom padding on bottom drawer

![image](https://github.com/user-attachments/assets/45b8c2bc-a4ad-4740-8387-16f078bedd0e)

## Description

8px at the top of the country header needs to be removed (but only on mobile)
<img width="374" alt="image" src="https://github.com/user-attachments/assets/f0716d8a-0270-42b7-9da7-206f2da90e72" />

..and 8px additional needs to be removed from the padding of the mobile buttons
<img width="387" alt="image" src="https://github.com/user-attachments/assets/ce2663f3-1cf8-458b-86f6-97f122f81269" />

The result is much more balanced and we won 16px of vertical space:
<img width="358" alt="image" src="https://github.com/user-attachments/assets/a405e503-efd5-434a-ad6e-5f0dbc03f3bb" />

Note the logo has some padding inconsistencies, but that's because the padding is built into the svg :/

The bottom drawer padding is fixed by simply changing the snap points.

<img width="467" alt="image" src="https://github.com/user-attachments/assets/e7f6e27a-b9b3-400d-bfe1-db4389c7c3d4" />

### Double check

- [ ] ~I have tested my parser changes locally with `poetry run test_parser "zone_key"`~
- [x] I have run `pnpx prettier@2 --write .` and `poetry run format` in the top level directory to format my changes.
