### PR TITLE
chore(NG.py): Adjust re-fetch frequency for NG.py

### DIFF
--- a/parsers/NG.py
+++ b/parsers/NG.py
@@ -75,12 +75,7 @@ def get_data(session: Session, logger: Logger, timestamp: datetime):
     return production_dict
 
 
-# The data is hourly, but it takes a few minutes after the turn of each hour
-# for the server to populate it. Setting the re-fetch frequency to 45 min will
-# ensure that if the live data is missing for a given hour when it's first
-# fetched, it will be fetched again during the same hour. (As far as I can
-# tell, the table is always populated within 15 min of the turn of the hour).
-@config.refetch_frequency(timedelta(minutes=45))
+@config.refetch_frequency(timedelta(hours=24))
 def fetch_production(
     zone_key: ZoneKey = ZoneKey("NG"),
     session: Session | None = None,


### PR DESCRIPTION
## Issue

I tried re-fetching the data for NG but it created one event for every 45 min instead of one per day. So instead of 2920 re-fetch events it would have created 87600 of them if I didn't kill it.

## Description

Adjust the ratio as the parsers returns a full 24 hours of data.

### Double check

- [x] I have tested my parser changes locally with `poetry run test_parser "zone_key"`
- [x] I have run `pnpx prettier@2 --write .` and `poetry run format` in the top level directory to format my changes.
