### PR TITLE
fix: Fix capacity update script

### DIFF
--- a/capacity_update.py
+++ b/capacity_update.py
@@ -41,7 +41,6 @@ def capacity_update(
     assert not (zone is None and source is None), "Zone and source cannot be both set"
 
     session = Session()
-    update_aggregate = eval(update_aggregate)
     parsed_target_datetime = None
     if target_datetime is None:
         raise ValueError("target_datetime must be specified")


### PR DESCRIPTION
## Issue

This started to fail for some reason and the eval is throwing a type issue.

## Description

Removes the eval as it should not be needed.

### Double check

- [x] I have tested my parser changes locally with `poetry run test_parser "zone_key"`
- [x] I have run `pnpx prettier@2 --write .` and `poetry run format` in the top level directory to format my changes.
