### PR TITLE
fix/feat(parsers, MN): fix json parsing error and add coal data

### DIFF
--- a/config/zones/MN.yaml
+++ b/config/zones/MN.yaml
@@ -24,6 +24,7 @@ contributors:
   - q--
   - alixunderplatz
   - MuffinCompiler
+  - consideRatio
 country: MN
 emissionFactors:
   direct:


### PR DESCRIPTION
## Issue

For #5906 that should resolve after a while if it works by its own.

## Description

The JSON API used had a new format which broke the parser.

- I made it so that wind data is now collected from another key clearly for the wind data based on seeing a wind power icon used to represent it.
  ![image](https://github.com/user-attachments/assets/7479464a-ac26-43d7-8c85-20d27dcbcc30)
- I ignored the JSON API key `Songino` as it wasn't obvious enough what to do about it, but it could be battery storage perhaps based on the icon, see discussion following https://github.com/electricitymaps/electricitymaps-contrib/issues/5906#issuecomment-2161197001.
- See also highlighted decision below

## Highlighted decision

- I mapped `dts` to `coal`, even without understanding what `dts` refers to.
  - It seems that the previous parser's `unknown` calculation was calculating the same value `dts` is set to
  - It seems that it's a coal, oil, or gas plant `dts` represents based on the icon for it in https://ndc.energy.mn/
  - It seems that Mongolia's electricity production is dominated by coal (https://en.wikipedia.org/wiki/Energy_in_Mongolia).

### Double check

- [x] I have tested my parser changes locally with `poetry run test_parser "zone_key"`
- [x] I have run `pnpx prettier@2 --write .` and `poetry run format` in the top level directory to format my changes.
