### PR TITLE
fix(parsers, KW): update regexp and workaround legacy connect issue

### DIFF
--- a/config/zones/KW.yaml
+++ b/config/zones/KW.yaml
@@ -53,6 +53,7 @@ capacity:
 contributors:
   - alixunderplatz
   - nessie2013
+  - consideRatio
 country: KW
 emissionFactors:
   direct:

--- a/parsers/KW.py
+++ b/parsers/KW.py
@@ -1,6 +1,5 @@
-#!/usr/bin/env python3
 """
-This parser returns Kuwait's electricity system load (assumed to be equal to electricity production)
+This parser returns Kuwait's electricity system load
 Source: Ministry of Electricity and Water / State of Kuwait
 URL: https://www.mew.gov.kw/en/
 Scroll down to see the system load gauge
@@ -8,11 +7,44 @@ Shares of Electricity production in 2017: 65.6% oil, 34.4% gas (source: IEA; htt
 """
 
 import re
+import ssl
 from datetime import datetime
 from logging import Logger, getLogger
 from zoneinfo import ZoneInfo
 
+import requests
+import urllib3
 from requests import Session
+
+
+# A workaround is required to connect to the API as of 2025-01-14, to avoid the
+# following error:
+#
+#     SSLError(1, '[SSL: UNSAFE_LEGACY_RENEGOTIATION_DISABLED] unsafe legacy renegotiation disabled (_ssl.c:1007)')
+#
+# The workaround is based on https://stackoverflow.com/a/73519818/2220152.
+#
+class _CustomHttpAdapter(requests.adapters.HTTPAdapter):
+    # "Transport adapter" that allows us to use custom ssl_context.
+
+    def __init__(self, ssl_context=None, **kwargs):
+        self.ssl_context = ssl_context
+        super().__init__(**kwargs)
+
+    def init_poolmanager(self, connections, maxsize, block=False):
+        self.poolmanager = urllib3.poolmanager.PoolManager(
+            num_pools=connections,
+            maxsize=maxsize,
+            block=block,
+            ssl_context=self.ssl_context,
+        )
+
+
+def _patch_session_for_legacy_connect(session):
+    ctx = ssl.create_default_context(ssl.Purpose.SERVER_AUTH)
+    ctx.options |= 0x4  # OP_LEGACY_SERVER_CONNECT
+    session.mount("https://", _CustomHttpAdapter(ctx))
+    return session
 
 
 def fetch_consumption(
@@ -23,11 +55,15 @@ def fetch_consumption(
 ):
     if target_datetime:
         raise NotImplementedError("This parser is not yet able to parse past dates")
+    r = _patch_session_for_legacy_connect(session or Session())
 
-    r = session or Session()
     url = "https://www.mew.gov.kw/en"
     response = r.get(url)
-    load = re.findall(r"\((\d{4,5})\)", response.text)
+    # The regexp gets the load value from a line looking like this:
+    #
+    # var obj= {"maxValue":10865,"currentValue":7285,"highlights":[{"from":0,"to":10179,"color":"#83e043"},{"from":10179,"to":10604,"color":"#ff6a00"},{"from":10604,"to":10865,"color":"#f12828"}]};
+    #
+    load = re.findall(r'"currentValue":(\d+)', response.text)
     load = int(load[0])
     consumption = load
 


### PR DESCRIPTION
## Issue

The KW consumption parser is down, but this fixes it.

There were two issues:
- A HTML response regexp no longer managed to identify the system load and was updated
- `requests.Session().get()` no longer worked due to an issue, which could be worked around in a way that I assume is fine because I assume no sensitive traffic is being sent when making a request to fetch this data.

### Double check

- [x] I have tested my parser changes locally with `poetry run test_parser "zone_key"`
- [x] I have run `pnpx prettier@2 --write .` and `poetry run format` in the top level directory to format my changes.
