### PR TITLE
Suppress production parser for CA-NB, CA-SK, CA-YT

### DIFF
--- a/config/zones/CA-NB.yaml
+++ b/config/zones/CA-NB.yaml
@@ -192,8 +192,6 @@ isRenewable:
     - _comment: Sum of renewable sources
       datetime: '2019-01-01'
       value: 0.3284
-parsers:
-  production: CA_NB.fetch_production
 region: Americas
 sources:
   Government of Canada 2019:

--- a/config/zones/CA-SK.yaml
+++ b/config/zones/CA-SK.yaml
@@ -194,6 +194,5 @@ fallbackZoneMixes:
         wind: 0.08756286656629877
 parsers:
   consumption: CA_SK.fetch_consumption
-  production: CA_SK.fetch_production
 region: Americas
 timezone: America/Regina

--- a/config/zones/CA-YT.yaml
+++ b/config/zones/CA-YT.yaml
@@ -195,7 +195,5 @@ fallbackZoneMixes:
         solar: 0.0
         unknown: 0.08804942933376388
         wind: 0.0
-parsers:
-  production: YUKONENERGY.fetch_production
 region: Americas
 timezone: America/Whitehorse


### PR DESCRIPTION
## Issue

Suppress bad parser -> Will be replaced by GPZD (https://github.com/electricitymaps/electricitymaps/pull/6348)

- [x] I have tested my parser changes locally with `poetry run test_parser "zone_key"`
- [x] I have run `pnpx prettier@2 --write .` and `poetry run format` in the top level directory to format my changes.
