### PR TITLE
removing AL parser since it is not working

### DIFF
--- a/config/zones/AL.yaml
+++ b/config/zones/AL.yaml
@@ -77,7 +77,6 @@ parsers:
   consumptionForecast: ENTSOE.fetch_consumption_forecast
   generationForecast: ENTSOE.fetch_generation_forecast
   price: ENTSOE.fetch_price
-  production: ENTSOE.fetch_production
   productionCapacity: ENTSOE.fetch_production_capacity
   productionPerModeForecast: ENTSOE.fetch_wind_solar_forecasts
 region: Europe


### PR DESCRIPTION
## Issue
Removing AL parser which is not working currently. AL will be a fully estimated country until we get a good parser.

- [x] I have tested my parser changes locally with `poetry run test_parser "zone_key"`
- [x] I have run `pnpx prettier@2 --write .` and `poetry run format` in the top level directory to format my changes.
