### PR TITLE
feat(parsers): remove CH production parser

### DIFF
--- a/config/zones/CH.yaml
+++ b/config/zones/CH.yaml
@@ -442,7 +442,6 @@ parsers:
   consumptionForecast: ENTSOE.fetch_consumption_forecast
   generationForecast: ENTSOE.fetch_generation_forecast
   price: ENTSOE.fetch_price
-  production: CH.fetch_production
   productionPerModeForecast: ENTSOE.fetch_wind_solar_forecasts
 price_displayed: false
 region: Europe


### PR DESCRIPTION
## Issue

<!-- If you want to close an issue automatically when your PR is merged, write "Closes X" where X is the issue number. For example: Closes #000 -->
[GMM-251](https://linear.app/electricitymaps/issue/GMM-251/ch-data-no-longer-supported-by-entsoe)

## Description

<!-- Explains the goal of this PR -->
ENTSOE has stopped reporting for Switzerland. I cannot find hourly data for CH so I have added it to the general purpose zone development (see [PR](https://github.com/electricitymaps/electricitymaps/pull/6473)). Therefore we need to remove the CH production parser, which is not getting any production data anyways. 


