### PR TITLE
feat(capacity-parsers): fix EMBER capacity parser

### DIFF
--- a/electricitymap/contrib/capacity_parsers/EMBER.py
+++ b/electricitymap/contrib/capacity_parsers/EMBER.py
@@ -59,13 +59,10 @@ def map_variable_to_mode(data: pd.Series) -> str:
 
 
 def get_data_from_url(session: Session) -> pd.DataFrame:
-    yearly_catalogue_url = EMBER_URL + "/data-catalogue/yearly-electricity-data/"
-    r: Response = session.get(yearly_catalogue_url)
-    soup = BeautifulSoup(r.text, "html.parser")
-    csv_link = soup.find("a", {"download": "yearly_full_release_long_format.csv"})[
-        "href"
-    ]
-    r_csv: Response = session.get(EMBER_URL + csv_link)
+    # The page where the link below has been found: https://ember-energy.org/data/yearly-electricity-data/
+    yearly_catalogue_url = "https://storage.googleapis.com/emb-prod-bkt-publicdata/public-downloads/yearly_full_release_long_format.csv"
+
+    r_csv: Response = session.get(yearly_catalogue_url)
     df = pd.read_csv(io.StringIO(r_csv.text))
     return df
 

--- a/electricitymap/contrib/capacity_parsers/EMBER.py
+++ b/electricitymap/contrib/capacity_parsers/EMBER.py
@@ -5,7 +5,6 @@ from typing import Any
 
 import pandas as pd
 import pycountry
-from bs4 import BeautifulSoup
 from requests import Response, Session
 
 from electricitymap.contrib.config import ZoneKey


### PR DESCRIPTION
## Issue

<!-- If you want to close an issue automatically when your PR is merged, write "Closes X" where X is the issue number. For example: Closes #000 -->

[GMM-400](https://linear.app/electricitymaps/issue/GMM-400/ember-capacity-parser-is-down)

## Description

<!-- Explains the goal of this PR --> 
This PR fixes the EMBER capacity parser.

### Testing

To test run: `poetry run capacity_update --source EMBER --target_datetime "2023-01-01"`

### Double check

- [ ] I have tested my parser changes locally with `poetry run test_parser "zone_key"`
- [ ] I have run `pnpx prettier@2 --write .` and `poetry run format` in the top level directory to format my changes.
