### PR TITLE
chore(tests): Clean up python test to use global fixtures

### DIFF
--- a/parsers/test/test_ESKOM.py
+++ b/parsers/test/test_ESKOM.py
@@ -1,16 +1,12 @@
 import freezegun
-from requests import Session
-from requests_mock import GET, Adapter
+from requests_mock import GET
 
 from electricitymap.contrib.lib.types import ZoneKey
 from parsers.ESKOM import fetch_production, get_url
 
 
 @freezegun.freeze_time("2023-09-22")
-def test_production(snapshot):
-    session = Session()
-    adapter = Adapter()
-    session.mount("https://", adapter)
+def test_production(adapter, session, snapshot):
     with open("parsers/test/mocks/ESKOM/Station_Build_Up.csv", "rb") as mock_file:
         adapter.register_uri(
             GET,

--- a/parsers/test/test_FO.py
+++ b/parsers/test/test_FO.py
@@ -3,8 +3,6 @@ from datetime import datetime, timezone
 from importlib import resources
 
 import pytest
-import requests
-import requests_mock
 from freezegun import freeze_time
 from requests_mock import ANY, GET
 
@@ -12,21 +10,10 @@ from electricitymap.contrib.lib.types import ZoneKey
 from parsers.FO import fetch_production
 
 
-@pytest.fixture()
-def fixture_session_mock() -> tuple[requests.Session, requests_mock.Adapter]:
-    session = requests.Session()
-
-    adapter = requests_mock.Adapter()
-    session.mount("https://", adapter)
-
-    return session, adapter
-
-
 @freeze_time("2024-05-16 12:04:00")
 @pytest.mark.parametrize("zone", ["FO", "FO-MI", "FO-SI"])
-def test_fetch_production_live(snapshot, fixture_session_mock, zone):
+def test_fetch_production_live(adapter, session, snapshot, zone):
     """That the parser fetches expected production values."""
-    session, adapter = fixture_session_mock
 
     adapter.register_uri(
         GET,
@@ -46,13 +33,12 @@ def test_fetch_production_live(snapshot, fixture_session_mock, zone):
 
 @pytest.mark.parametrize("zone", ["FO", "FO-MI", "FO-SI"])
 @pytest.mark.parametrize("utc_offset", ["SDT", "DST"])
-def test_fetch_production_historical(snapshot, fixture_session_mock, zone, utc_offset):
+def test_fetch_production_historical(adapter, session, snapshot, zone, utc_offset):
     """That the parser fetches expected historical values.
 
     Given that API responses differ depending on whether SDT or DST apply for the target date, we also make sure
     that we handle both cases correctly.
     """
-    session, adapter = fixture_session_mock
 
     month = 2 if utc_offset == "SDT" else 7
     target_datetime = datetime(2023, month, 16, 12, tzinfo=timezone.utc)

--- a/parsers/test/test_FR.py
+++ b/parsers/test/test_FR.py
@@ -1,17 +1,13 @@
 import os
 
-from requests import Session
-from requests_mock import GET, Adapter
+from requests_mock import GET
 
 from electricitymap.contrib.lib.types import ZoneKey
 from parsers.FR import API_ENDPOINT, fetch_production
 
 
-def test_production(snapshot):
-    session = Session()
-    adapter = Adapter()
+def test_production(adapter, session, snapshot):
     os.environ["RESEAUX_ENERGIES_TOKEN"] = "test_token"
-    session.mount("https://", adapter)
     with open("parsers/test/mocks/FR/response.json", "rb") as mock_file:
         adapter.register_uri(
             GET,

--- a/parsers/test/test_GB.py
+++ b/parsers/test/test_GB.py
@@ -2,28 +2,18 @@ from datetime import datetime, timezone
 from importlib import resources
 
 import pytest
-import requests
 from freezegun import freeze_time
-from requests_mock import ANY, GET, Adapter
+from requests_mock import ANY, GET
 
 from electricitymap.contrib.lib.types import ZoneKey
 from parsers.GB import fetch_price
-
-
-@pytest.fixture()
-def fixture_session_mock() -> tuple[requests.Session, Adapter]:
-    adapter = Adapter()
-    session = requests.Session()
-    session.mount("http://", adapter)
-    return session, adapter
 
 
 @pytest.mark.parametrize(
     "zone_key", ["BE", "CH", "AT", "ES", "FR", "GB", "IT", "NL", "PT"]
 )
 @freeze_time("2024-04-14 15:10:57")
-def test_fetch_price_live(snapshot, fixture_session_mock, zone_key):
-    session, adapter = fixture_session_mock
+def test_fetch_price_live(adapter, session, snapshot, zone_key):
     adapter.register_uri(
         GET,
         ANY,
@@ -35,8 +25,7 @@ def test_fetch_price_live(snapshot, fixture_session_mock, zone_key):
     assert snapshot == fetch_price(zone_key=ZoneKey(zone_key), session=session)
 
 
-def test_fetch_price_historical(snapshot, fixture_session_mock):
-    session, adapter = fixture_session_mock
+def test_fetch_price_historical(adapter, session, snapshot):
     adapter.register_uri(
         GET,
         ANY,

--- a/parsers/test/test_GE.py
+++ b/parsers/test/test_GE.py
@@ -3,26 +3,15 @@ from datetime import datetime, timezone
 from importlib import resources
 
 import pytest
-import requests
 from freezegun import freeze_time
-from requests_mock import ANY, GET, Adapter
+from requests_mock import ANY, GET
 
 from electricitymap.contrib.lib.types import ZoneKey
 from parsers.GE import fetch_exchange, fetch_production
 
 
-@pytest.fixture()
-def fixture_session_mock() -> tuple[requests.Session, Adapter]:
-    adapter = Adapter()
-    session = requests.Session()
-    session.mount("https://", adapter)
-    return session, adapter
-
-
 @freeze_time("2024-04-09 17:57:00")
-def test_fetch_production_live(snapshot, fixture_session_mock):
-    session, adapter = fixture_session_mock
-
+def test_fetch_production_live(adapter, session, snapshot):
     mock_asset = str(
         resources.files("parsers.test.mocks.GE").joinpath("production_live.xls")
     )
@@ -34,9 +23,7 @@ def test_fetch_production_live(snapshot, fixture_session_mock):
     assert snapshot == fetch_production(session=session)
 
 
-def test_fetch_production_historical(snapshot, fixture_session_mock):
-    session, adapter = fixture_session_mock
-
+def test_fetch_production_historical(adapter, session, snapshot):
     mock_asset = str(
         resources.files("parsers.test.mocks.GE").joinpath("production_20200101.xls")
     )
@@ -54,8 +41,7 @@ def test_fetch_production_historical(snapshot, fixture_session_mock):
 
 @pytest.mark.parametrize("neighbour", ["AM", "AZ", "RU-1", "TR"])
 @freeze_time("2024-04-08 12:00:00")
-def test_fetch_exchange_live(snapshot, fixture_session_mock, neighbour):
-    session, adapter = fixture_session_mock
+def test_fetch_exchange_live(adapter, session, snapshot, neighbour):
     adapter.register_uri(
         GET,
         ANY,

--- a/parsers/test/test_GT.py
+++ b/parsers/test/test_GT.py
@@ -2,29 +2,14 @@ import json
 from datetime import datetime
 from importlib import resources
 
-import pytest
-import requests
-import requests_mock
 from freezegun import freeze_time
 from requests_mock import ANY, GET
 
 from parsers.GT import fetch_consumption, fetch_production
 
 
-@pytest.fixture()
-def fixture_session_mock() -> tuple[requests.Session, requests_mock.Adapter]:
-    session = requests.Session()
-
-    adapter = requests_mock.Adapter()
-    session.mount("https://", adapter)
-
-    return session, adapter
-
-
 @freeze_time("2024-04-10 12:28:00")
-def test_fetch_production_live(snapshot, fixture_session_mock):
-    session, adapter = fixture_session_mock
-
+def test_fetch_production_live(adapter, session, snapshot):
     adapter.register_uri(
         GET,
         ANY,
@@ -43,9 +28,7 @@ def test_fetch_production_live(snapshot, fixture_session_mock):
     assert snapshot == fetch_production(session=session)
 
 
-def test_fetch_production_historical(snapshot, fixture_session_mock):
-    session, adapter = fixture_session_mock
-
+def test_fetch_production_historical(adapter, session, snapshot):
     adapter.register_uri(
         GET,
         ANY,
@@ -69,9 +52,7 @@ def test_fetch_production_historical(snapshot, fixture_session_mock):
 
 
 @freeze_time("2024-04-10 12:28:00")
-def test_fetch_consumption_live(snapshot, fixture_session_mock):
-    session, adapter = fixture_session_mock
-
+def test_fetch_consumption_live(adapter, session, snapshot):
     adapter.register_uri(
         GET,
         ANY,
@@ -90,9 +71,7 @@ def test_fetch_consumption_live(snapshot, fixture_session_mock):
     assert snapshot == fetch_consumption(session=session)
 
 
-def test_fetch_consumption_historical(snapshot, fixture_session_mock):
-    session, adapter = fixture_session_mock
-
+def test_fetch_consumption_historical(adapter, session, snapshot):
     adapter.register_uri(
         GET,
         ANY,

--- a/parsers/test/test_IEMOP.py
+++ b/parsers/test/test_IEMOP.py
@@ -1,8 +1,7 @@
 from datetime import datetime, timezone
 
 import pytest
-from requests import Session
-from requests_mock import GET, POST, Adapter
+from requests_mock import GET, POST
 
 from electricitymap.contrib.lib.types import ZoneKey
 from parsers.IEMOP import REPORTS_ADMIN_URL, fetch_production
@@ -11,13 +10,10 @@ zone_keys = [ZoneKey("PH-LU"), ZoneKey("PH-MI"), ZoneKey("PH-VI")]
 
 
 @pytest.mark.parametrize("zone_key", zone_keys)
-def test_production(snapshot, zone_key: ZoneKey):
+def test_production(adapter, session, snapshot, zone_key: ZoneKey):
     """
     Reports have been reduced to 14 September 2023 00:00 to 13 September 2023 22:00 for ease
     """
-    session = Session()
-    adapter = Adapter()
-    session.mount("https://", adapter)
     target_datetime = datetime(2023, 9, 14, 0, 0, tzinfo=timezone.utc)
     with open(
         "parsers/test/mocks/IEMOP/list_reports_items.json", "rb"

--- a/parsers/test/test_IN_EA.py
+++ b/parsers/test/test_IN_EA.py
@@ -2,8 +2,7 @@ from datetime import datetime
 from zoneinfo import ZoneInfo
 
 import pytest
-from requests import Session
-from requests_mock import GET, Adapter
+from requests_mock import GET
 
 from electricitymap.contrib.config import ZONE_NEIGHBOURS, ZoneKey
 from parsers import IN_EA
@@ -20,10 +19,7 @@ NETFLOWS = {
 
 
 @pytest.mark.parametrize("neighbour_zone_key", ZONE_NEIGHBOURS[ZoneKey("IN-EA")])
-def test_exchanges(neighbour_zone_key: ZoneKey):
-    session = Session()
-    adapter = Adapter()
-    session.mount("https://", adapter)
+def test_exchanges(adapter, session, neighbour_zone_key: ZoneKey):
     target_date = datetime(2023, 6, 25, 0, 0, tzinfo=ZoneInfo("Asia/Kolkata"))
     sorted_zone_keys = ZoneKey("->".join(sorted([neighbour_zone_key, "IN-EA"])))
     url, _ = IN_EA.get_fetch_function(sorted_zone_keys)

--- a/parsers/test/test_MD.py
+++ b/parsers/test/test_MD.py
@@ -107,8 +107,8 @@ def test_fetch_exchange_forecast_live(adapter, session, snapshot, neighbor):
     )
 
 
-@pytest.mark.parametrize("neighbour", ["RO", "UA"])
-def test_fetch_exchange_forecast_historical(adapter, session, snapshot, neighbour):
+@pytest.mark.parametrize("neighbor", ["RO", "UA"])
+def test_fetch_exchange_forecast_historical(adapter, session, snapshot, neighbor):
     adapter.register_uri(
         GET,
         ANY,
@@ -121,7 +121,7 @@ def test_fetch_exchange_forecast_historical(adapter, session, snapshot, neighbou
 
     assert snapshot == fetch_exchange_forecast(
         ZoneKey("MD"),
-        ZoneKey(neighbour),
+        ZoneKey(neighbor),
         target_datetime=historical_datetime,
         session=session,
     )

--- a/parsers/test/test_MD.py
+++ b/parsers/test/test_MD.py
@@ -3,9 +3,8 @@ from datetime import datetime, timezone
 from importlib import resources
 
 import pytest
-import requests
 from freezegun import freeze_time
-from requests_mock import ANY, GET, Adapter
+from requests_mock import ANY, GET
 
 from electricitymap.contrib.lib.types import ZoneKey
 from parsers.MD import (
@@ -23,18 +22,8 @@ frozen_live_time = freeze_time("2024-04-11 06:32:00")
 historical_datetime = datetime(2021, 7, 25, 12, tzinfo=timezone.utc)
 
 
-@pytest.fixture()
-def fixture_session_mock() -> tuple[requests.Session, Adapter]:
-    adapter = Adapter()
-    session = requests.Session()
-    session.mount("https://", adapter)
-    return session, adapter
-
-
 @frozen_live_time
-def test_fetch_consumption_live(snapshot, fixture_session_mock):
-    session, adapter = fixture_session_mock
-
+def test_fetch_consumption_live(adapter, session, snapshot):
     adapter.register_uri(
         GET,
         ANY,
@@ -48,9 +37,7 @@ def test_fetch_consumption_live(snapshot, fixture_session_mock):
     assert snapshot == fetch_consumption(session=session)
 
 
-def test_fetch_consumption_historical(snapshot, fixture_session_mock):
-    session, adapter = fixture_session_mock
-
+def test_fetch_consumption_historical(adapter, session, snapshot):
     adapter.register_uri(
         GET,
         ANY,
@@ -66,10 +53,9 @@ def test_fetch_consumption_historical(snapshot, fixture_session_mock):
     )
 
 
-@pytest.mark.parametrize("neighbour", ["RO", "UA"])
+@pytest.mark.parametrize("neighbor", ["RO", "UA"])
 @frozen_live_time
-def test_fetch_exchange_live(snapshot, fixture_session_mock, neighbour):
-    session, adapter = fixture_session_mock
+def test_fetch_exchange_live(adapter, session, snapshot, neighbor):
     adapter.register_uri(
         GET,
         ANY,
@@ -80,14 +66,11 @@ def test_fetch_exchange_live(snapshot, fixture_session_mock, neighbour):
         ),
     )
 
-    assert snapshot == fetch_exchange(
-        ZoneKey("MD"), ZoneKey(neighbour), session=session
-    )
+    assert snapshot == fetch_exchange(ZoneKey("MD"), ZoneKey(neighbor), session=session)
 
 
-@pytest.mark.parametrize("neighbour", ["RO", "UA"])
-def test_fetch_exchange_historical(snapshot, fixture_session_mock, neighbour):
-    session, adapter = fixture_session_mock
+@pytest.mark.parametrize("neighbor", ["RO", "UA"])
+def test_fetch_exchange_historical(adapter, session, snapshot, neighbor):
     adapter.register_uri(
         GET,
         ANY,
@@ -100,16 +83,15 @@ def test_fetch_exchange_historical(snapshot, fixture_session_mock, neighbour):
 
     assert snapshot == fetch_exchange(
         ZoneKey("MD"),
-        ZoneKey(neighbour),
+        ZoneKey(neighbor),
         target_datetime=historical_datetime,
         session=session,
     )
 
 
-@pytest.mark.parametrize("neighbour", ["RO", "UA"])
+@pytest.mark.parametrize("neighbor", ["RO", "UA"])
 @frozen_live_time
-def test_fetch_exchange_forecast_live(snapshot, fixture_session_mock, neighbour):
-    session, adapter = fixture_session_mock
+def test_fetch_exchange_forecast_live(adapter, session, snapshot, neighbor):
     adapter.register_uri(
         GET,
         ANY,
@@ -121,13 +103,12 @@ def test_fetch_exchange_forecast_live(snapshot, fixture_session_mock, neighbour)
     )
 
     assert snapshot == fetch_exchange_forecast(
-        ZoneKey("MD"), ZoneKey(neighbour), session=session
+        ZoneKey("MD"), ZoneKey(neighbor), session=session
     )
 
 
 @pytest.mark.parametrize("neighbour", ["RO", "UA"])
-def test_fetch_exchange_forecast_historical(snapshot, fixture_session_mock, neighbour):
-    session, adapter = fixture_session_mock
+def test_fetch_exchange_forecast_historical(adapter, session, snapshot, neighbour):
     adapter.register_uri(
         GET,
         ANY,
@@ -172,9 +153,7 @@ def test_fetch_price_historical(snapshot, historical_datetime):
 
 
 @frozen_live_time
-def test_fetch_production_live(snapshot, fixture_session_mock):
-    session, adapter = fixture_session_mock
-
+def test_fetch_production_live(adapter, session, snapshot):
     adapter.register_uri(
         GET,
         ANY,
@@ -188,9 +167,7 @@ def test_fetch_production_live(snapshot, fixture_session_mock):
     assert snapshot == fetch_production(session=session)
 
 
-def test_fetch_production_historical(snapshot, fixture_session_mock):
-    session, adapter = fixture_session_mock
-
+def test_fetch_production_historical(adapter, session, snapshot):
     adapter.register_uri(
         GET,
         ANY,

--- a/parsers/test/test_NTESMO.py
+++ b/parsers/test/test_NTESMO.py
@@ -11,10 +11,7 @@ australia = ZoneInfo("Australia/Darwin")
 
 
 @pytest.fixture()
-def fixture_session_mock() -> tuple[requests.Session, Adapter]:
-    adapter = Adapter()
-    session = requests.Session()
-
+def fixture_session_mock(adapter, session) -> tuple[requests.Session, Adapter]:
     # do not mount mock adapter on generic https:// prefix or the parser's @retry_policy decorator will overwrite it
     session.mount("https://ntesmo.com.au/", adapter)
 

--- a/parsers/test/test_TAIPOWER.py
+++ b/parsers/test/test_TAIPOWER.py
@@ -1,14 +1,10 @@
-from requests import Session
-from requests_mock import GET, Adapter
+from requests_mock import GET
 
 from electricitymap.contrib.lib.types import ZoneKey
 from parsers.TAIPOWER import PRODUCTION_URL, fetch_production
 
 
-def test_production(snapshot):
-    session = Session()
-    adapter = Adapter()
-    session.mount("http://", adapter)
+def test_production(adapter, session, snapshot):
     with open("parsers/test/mocks/TAIPOWER/genary.json", "rb") as mock_file:
         adapter.register_uri(
             GET,


### PR DESCRIPTION
## Description

We added global fixtures in #7672, this PR just takes advantage of that and removes un-needed code in the test files.


### Double check

- [x] I have run `pnpx prettier@2 --write .` and `poetry run format` in the top level directory to format my changes.
