### PR TITLE
chore(PJM parser): Use parser classes and add tests.

### DIFF
--- a/config/zones/US-MIDA-PJM.yaml
+++ b/config/zones/US-MIDA-PJM.yaml
@@ -177,6 +177,7 @@ contributors:
   - systemcatch
   - robertahunt
   - KabelWlan
+  - VIKTORVAV99
 country: US
 delays:
   production: 7

--- a/parsers/US_CA.py
+++ b/parsers/US_CA.py
@@ -62,15 +62,6 @@ def get_target_url(target_datetime: datetime | None, kind: str) -> str:
     return target_url
 
 
-def add_production_to_dict(mode: str, value: float, production_dict: dict) -> dict:
-    """Add production to production_dict, if mode is in PRODUCTION_MODES."""
-    if PRODUCTION_MODES_MAPPING[mode] not in production_dict:
-        production_dict[PRODUCTION_MODES_MAPPING[mode]] = value
-    else:
-        production_dict[PRODUCTION_MODES_MAPPING[mode]] += value
-    return production_dict
-
-
 @refetch_frequency(timedelta(days=1))
 def fetch_production(
     zone_key: ZoneKey = ZoneKey("US-CAL-CISO"),

--- a/parsers/test/__snapshots__/test_US_PJM.ambr
+++ b/parsers/test/__snapshots__/test_US_PJM.ambr
@@ -1,0 +1,167 @@
+# serializer version: 1
+# name: test_production
+  list([
+    dict({
+      'datetime': datetime.datetime(2025, 2, 9, 0, 0, tzinfo=zoneinfo.ZoneInfo(key='America/New_York')),
+      'production': dict({
+        'coal': 15849.0,
+        'gas': 41727.0,
+        'hydro': 521.0,
+        'nuclear': 33001.0,
+        'oil': 206.0,
+        'solar': 28.0,
+        'unknown': 665.0,
+        'wind': 5096.0,
+      }),
+      'source': 'pjm.com',
+      'storage': dict({
+        'battery': 0.0,
+      }),
+      'zoneKey': 'US-MIDA-PJM',
+    }),
+    dict({
+      'datetime': datetime.datetime(2025, 2, 9, 1, 0, tzinfo=zoneinfo.ZoneInfo(key='America/New_York')),
+      'production': dict({
+        'coal': 15450.0,
+        'gas': 40800.0,
+        'hydro': 452.0,
+        'nuclear': 33011.0,
+        'oil': 206.0,
+        'solar': 28.0,
+        'unknown': 663.0,
+        'wind': 5070.0,
+      }),
+      'source': 'pjm.com',
+      'storage': dict({
+        'battery': 0.0,
+      }),
+      'zoneKey': 'US-MIDA-PJM',
+    }),
+    dict({
+      'datetime': datetime.datetime(2025, 2, 9, 2, 0, tzinfo=zoneinfo.ZoneInfo(key='America/New_York')),
+      'production': dict({
+        'coal': 14787.0,
+        'gas': 40089.0,
+        'hydro': 412.0,
+        'nuclear': 33027.0,
+        'oil': 206.0,
+        'solar': 28.0,
+        'unknown': 664.0,
+        'wind': 4624.0,
+      }),
+      'source': 'pjm.com',
+      'storage': dict({
+        'battery': 0.0,
+      }),
+      'zoneKey': 'US-MIDA-PJM',
+    }),
+    dict({
+      'datetime': datetime.datetime(2025, 2, 9, 3, 0, tzinfo=zoneinfo.ZoneInfo(key='America/New_York')),
+      'production': dict({
+        'coal': 14447.0,
+        'gas': 39422.0,
+        'hydro': 445.0,
+        'nuclear': 33054.0,
+        'oil': 207.0,
+        'solar': 28.0,
+        'unknown': 668.0,
+        'wind': 4225.0,
+      }),
+      'source': 'pjm.com',
+      'storage': dict({
+        'battery': 0.0,
+      }),
+      'zoneKey': 'US-MIDA-PJM',
+    }),
+    dict({
+      'datetime': datetime.datetime(2025, 2, 9, 4, 0, tzinfo=zoneinfo.ZoneInfo(key='America/New_York')),
+      'production': dict({
+        'coal': 14471.0,
+        'gas': 39989.0,
+        'hydro': 442.0,
+        'nuclear': 33076.0,
+        'oil': 209.0,
+        'solar': 28.0,
+        'unknown': 671.0,
+        'wind': 3883.0,
+      }),
+      'source': 'pjm.com',
+      'storage': dict({
+        'battery': 0.0,
+      }),
+      'zoneKey': 'US-MIDA-PJM',
+    }),
+    dict({
+      'datetime': datetime.datetime(2025, 2, 9, 5, 0, tzinfo=zoneinfo.ZoneInfo(key='America/New_York')),
+      'production': dict({
+        'coal': 14664.0,
+        'gas': 40113.0,
+        'hydro': 435.0,
+        'nuclear': 33177.0,
+        'oil': 211.0,
+        'solar': 28.0,
+        'unknown': 670.0,
+        'wind': 3144.0,
+      }),
+      'source': 'pjm.com',
+      'storage': dict({
+        'battery': 0.0,
+      }),
+      'zoneKey': 'US-MIDA-PJM',
+    }),
+    dict({
+      'datetime': datetime.datetime(2025, 2, 9, 6, 0, tzinfo=zoneinfo.ZoneInfo(key='America/New_York')),
+      'production': dict({
+        'coal': 15121.0,
+        'gas': 40844.0,
+        'hydro': 470.0,
+        'nuclear': 33293.0,
+        'oil': 212.0,
+        'solar': 28.0,
+        'unknown': 671.0,
+        'wind': 2900.0,
+      }),
+      'source': 'pjm.com',
+      'storage': dict({
+        'battery': 0.0,
+      }),
+      'zoneKey': 'US-MIDA-PJM',
+    }),
+    dict({
+      'datetime': datetime.datetime(2025, 2, 9, 7, 0, tzinfo=zoneinfo.ZoneInfo(key='America/New_York')),
+      'production': dict({
+        'coal': 15494.0,
+        'gas': 41543.0,
+        'hydro': 934.0,
+        'nuclear': 33392.0,
+        'oil': 210.0,
+        'solar': 148.0,
+        'unknown': 668.0,
+        'wind': 2861.0,
+      }),
+      'source': 'pjm.com',
+      'storage': dict({
+        'battery': 0.0,
+      }),
+      'zoneKey': 'US-MIDA-PJM',
+    }),
+    dict({
+      'datetime': datetime.datetime(2025, 2, 9, 8, 0, tzinfo=zoneinfo.ZoneInfo(key='America/New_York')),
+      'production': dict({
+        'coal': 15427.0,
+        'gas': 41516.0,
+        'hydro': 1015.0,
+        'nuclear': 33499.0,
+        'oil': 211.0,
+        'solar': 2022.0,
+        'unknown': 666.0,
+        'wind': 2575.0,
+      }),
+      'source': 'pjm.com',
+      'storage': dict({
+        'battery': 0.0,
+      }),
+      'zoneKey': 'US-MIDA-PJM',
+    }),
+  ])
+# ---

--- a/parsers/test/__snapshots__/test_US_PJM.ambr
+++ b/parsers/test/__snapshots__/test_US_PJM.ambr
@@ -2,6 +2,8 @@
 # name: test_production
   list([
     dict({
+      'correctedModes': list([
+      ]),
       'datetime': datetime.datetime(2025, 2, 9, 0, 0, tzinfo=zoneinfo.ZoneInfo(key='America/New_York')),
       'production': dict({
         'coal': 15849.0,
@@ -10,16 +12,19 @@
         'nuclear': 33001.0,
         'oil': 206.0,
         'solar': 28.0,
-        'unknown': 665.0,
+        'unknown': 666.0,
         'wind': 5096.0,
       }),
       'source': 'pjm.com',
+      'sourceType': <EventSourceType.measured: 'measured'>,
       'storage': dict({
         'battery': 0.0,
       }),
       'zoneKey': 'US-MIDA-PJM',
     }),
     dict({
+      'correctedModes': list([
+      ]),
       'datetime': datetime.datetime(2025, 2, 9, 1, 0, tzinfo=zoneinfo.ZoneInfo(key='America/New_York')),
       'production': dict({
         'coal': 15450.0,
@@ -28,16 +33,19 @@
         'nuclear': 33011.0,
         'oil': 206.0,
         'solar': 28.0,
-        'unknown': 663.0,
+        'unknown': 664.0,
         'wind': 5070.0,
       }),
       'source': 'pjm.com',
+      'sourceType': <EventSourceType.measured: 'measured'>,
       'storage': dict({
         'battery': 0.0,
       }),
       'zoneKey': 'US-MIDA-PJM',
     }),
     dict({
+      'correctedModes': list([
+      ]),
       'datetime': datetime.datetime(2025, 2, 9, 2, 0, tzinfo=zoneinfo.ZoneInfo(key='America/New_York')),
       'production': dict({
         'coal': 14787.0,
@@ -46,16 +54,19 @@
         'nuclear': 33027.0,
         'oil': 206.0,
         'solar': 28.0,
-        'unknown': 664.0,
+        'unknown': 665.0,
         'wind': 4624.0,
       }),
       'source': 'pjm.com',
+      'sourceType': <EventSourceType.measured: 'measured'>,
       'storage': dict({
         'battery': 0.0,
       }),
       'zoneKey': 'US-MIDA-PJM',
     }),
     dict({
+      'correctedModes': list([
+      ]),
       'datetime': datetime.datetime(2025, 2, 9, 3, 0, tzinfo=zoneinfo.ZoneInfo(key='America/New_York')),
       'production': dict({
         'coal': 14447.0,
@@ -64,16 +75,19 @@
         'nuclear': 33054.0,
         'oil': 207.0,
         'solar': 28.0,
-        'unknown': 668.0,
+        'unknown': 669.0,
         'wind': 4225.0,
       }),
       'source': 'pjm.com',
+      'sourceType': <EventSourceType.measured: 'measured'>,
       'storage': dict({
         'battery': 0.0,
       }),
       'zoneKey': 'US-MIDA-PJM',
     }),
     dict({
+      'correctedModes': list([
+      ]),
       'datetime': datetime.datetime(2025, 2, 9, 4, 0, tzinfo=zoneinfo.ZoneInfo(key='America/New_York')),
       'production': dict({
         'coal': 14471.0,
@@ -82,16 +96,19 @@
         'nuclear': 33076.0,
         'oil': 209.0,
         'solar': 28.0,
-        'unknown': 671.0,
+        'unknown': 672.0,
         'wind': 3883.0,
       }),
       'source': 'pjm.com',
+      'sourceType': <EventSourceType.measured: 'measured'>,
       'storage': dict({
         'battery': 0.0,
       }),
       'zoneKey': 'US-MIDA-PJM',
     }),
     dict({
+      'correctedModes': list([
+      ]),
       'datetime': datetime.datetime(2025, 2, 9, 5, 0, tzinfo=zoneinfo.ZoneInfo(key='America/New_York')),
       'production': dict({
         'coal': 14664.0,
@@ -100,16 +117,19 @@
         'nuclear': 33177.0,
         'oil': 211.0,
         'solar': 28.0,
-        'unknown': 670.0,
+        'unknown': 671.0,
         'wind': 3144.0,
       }),
       'source': 'pjm.com',
+      'sourceType': <EventSourceType.measured: 'measured'>,
       'storage': dict({
         'battery': 0.0,
       }),
       'zoneKey': 'US-MIDA-PJM',
     }),
     dict({
+      'correctedModes': list([
+      ]),
       'datetime': datetime.datetime(2025, 2, 9, 6, 0, tzinfo=zoneinfo.ZoneInfo(key='America/New_York')),
       'production': dict({
         'coal': 15121.0,
@@ -118,16 +138,19 @@
         'nuclear': 33293.0,
         'oil': 212.0,
         'solar': 28.0,
-        'unknown': 671.0,
+        'unknown': 672.0,
         'wind': 2900.0,
       }),
       'source': 'pjm.com',
+      'sourceType': <EventSourceType.measured: 'measured'>,
       'storage': dict({
         'battery': 0.0,
       }),
       'zoneKey': 'US-MIDA-PJM',
     }),
     dict({
+      'correctedModes': list([
+      ]),
       'datetime': datetime.datetime(2025, 2, 9, 7, 0, tzinfo=zoneinfo.ZoneInfo(key='America/New_York')),
       'production': dict({
         'coal': 15494.0,
@@ -136,16 +159,19 @@
         'nuclear': 33392.0,
         'oil': 210.0,
         'solar': 148.0,
-        'unknown': 668.0,
+        'unknown': 669.0,
         'wind': 2861.0,
       }),
       'source': 'pjm.com',
+      'sourceType': <EventSourceType.measured: 'measured'>,
       'storage': dict({
         'battery': 0.0,
       }),
       'zoneKey': 'US-MIDA-PJM',
     }),
     dict({
+      'correctedModes': list([
+      ]),
       'datetime': datetime.datetime(2025, 2, 9, 8, 0, tzinfo=zoneinfo.ZoneInfo(key='America/New_York')),
       'production': dict({
         'coal': 15427.0,
@@ -154,10 +180,11 @@
         'nuclear': 33499.0,
         'oil': 211.0,
         'solar': 2022.0,
-        'unknown': 666.0,
+        'unknown': 667.0,
         'wind': 2575.0,
       }),
       'source': 'pjm.com',
+      'sourceType': <EventSourceType.measured: 'measured'>,
       'storage': dict({
         'battery': 0.0,
       }),

--- a/parsers/test/mocks/US_PJM/gen_by_fuel.json
+++ b/parsers/test/mocks/US_PJM/gen_by_fuel.json
@@ -1,0 +1,481 @@
+{
+  "links": [
+    {
+      "rel": "self",
+      "href": "https://api.pjm.com/api/v1/gen_by_fuel?RowCount=500&Order=Asc&StartRow=1&IsActiveMetadata=True&Fields=datetime_beginning_ept%2Cfuel_type%2Cmw&datetime_beginning_ept=2025-02-09T00%3A00%3A00.0000000"
+    },
+    {
+      "rel": "metadata",
+      "href": "https://api.pjm.com/api/v1/gen_by_fuel/metadata"
+    }
+  ],
+  "items": [
+    {
+      "datetime_beginning_ept": "2025-02-09T00:00:00",
+      "fuel_type": "Coal",
+      "mw": 15849.0
+    },
+    {
+      "datetime_beginning_ept": "2025-02-09T00:00:00",
+      "fuel_type": "Gas",
+      "mw": 41727.0
+    },
+    {
+      "datetime_beginning_ept": "2025-02-09T00:00:00",
+      "fuel_type": "Hydro",
+      "mw": 521.0
+    },
+    {
+      "datetime_beginning_ept": "2025-02-09T00:00:00",
+      "fuel_type": "Multiple Fuels",
+      "mw": 1.0
+    },
+    {
+      "datetime_beginning_ept": "2025-02-09T00:00:00",
+      "fuel_type": "Nuclear",
+      "mw": 33001.0
+    },
+    {
+      "datetime_beginning_ept": "2025-02-09T00:00:00",
+      "fuel_type": "Oil",
+      "mw": 206.0
+    },
+    {
+      "datetime_beginning_ept": "2025-02-09T00:00:00",
+      "fuel_type": "Other Renewables",
+      "mw": 665.0
+    },
+    {
+      "datetime_beginning_ept": "2025-02-09T00:00:00",
+      "fuel_type": "Solar",
+      "mw": 28.0
+    },
+    {
+      "datetime_beginning_ept": "2025-02-09T00:00:00",
+      "fuel_type": "Storage",
+      "mw": 0.0
+    },
+    {
+      "datetime_beginning_ept": "2025-02-09T00:00:00",
+      "fuel_type": "Wind",
+      "mw": 5096.0
+    },
+    {
+      "datetime_beginning_ept": "2025-02-09T01:00:00",
+      "fuel_type": "Coal",
+      "mw": 15450.0
+    },
+    {
+      "datetime_beginning_ept": "2025-02-09T01:00:00",
+      "fuel_type": "Gas",
+      "mw": 40800.0
+    },
+    {
+      "datetime_beginning_ept": "2025-02-09T01:00:00",
+      "fuel_type": "Hydro",
+      "mw": 452.0
+    },
+    {
+      "datetime_beginning_ept": "2025-02-09T01:00:00",
+      "fuel_type": "Multiple Fuels",
+      "mw": 1.0
+    },
+    {
+      "datetime_beginning_ept": "2025-02-09T01:00:00",
+      "fuel_type": "Nuclear",
+      "mw": 33011.0
+    },
+    {
+      "datetime_beginning_ept": "2025-02-09T01:00:00",
+      "fuel_type": "Oil",
+      "mw": 206.0
+    },
+    {
+      "datetime_beginning_ept": "2025-02-09T01:00:00",
+      "fuel_type": "Other Renewables",
+      "mw": 663.0
+    },
+    {
+      "datetime_beginning_ept": "2025-02-09T01:00:00",
+      "fuel_type": "Solar",
+      "mw": 28.0
+    },
+    {
+      "datetime_beginning_ept": "2025-02-09T01:00:00",
+      "fuel_type": "Storage",
+      "mw": 0.0
+    },
+    {
+      "datetime_beginning_ept": "2025-02-09T01:00:00",
+      "fuel_type": "Wind",
+      "mw": 5070.0
+    },
+    {
+      "datetime_beginning_ept": "2025-02-09T02:00:00",
+      "fuel_type": "Coal",
+      "mw": 14787.0
+    },
+    {
+      "datetime_beginning_ept": "2025-02-09T02:00:00",
+      "fuel_type": "Gas",
+      "mw": 40089.0
+    },
+    {
+      "datetime_beginning_ept": "2025-02-09T02:00:00",
+      "fuel_type": "Hydro",
+      "mw": 412.0
+    },
+    {
+      "datetime_beginning_ept": "2025-02-09T02:00:00",
+      "fuel_type": "Multiple Fuels",
+      "mw": 1.0
+    },
+    {
+      "datetime_beginning_ept": "2025-02-09T02:00:00",
+      "fuel_type": "Nuclear",
+      "mw": 33027.0
+    },
+    {
+      "datetime_beginning_ept": "2025-02-09T02:00:00",
+      "fuel_type": "Oil",
+      "mw": 206.0
+    },
+    {
+      "datetime_beginning_ept": "2025-02-09T02:00:00",
+      "fuel_type": "Other Renewables",
+      "mw": 664.0
+    },
+    {
+      "datetime_beginning_ept": "2025-02-09T02:00:00",
+      "fuel_type": "Solar",
+      "mw": 28.0
+    },
+    {
+      "datetime_beginning_ept": "2025-02-09T02:00:00",
+      "fuel_type": "Storage",
+      "mw": 0.0
+    },
+    {
+      "datetime_beginning_ept": "2025-02-09T02:00:00",
+      "fuel_type": "Wind",
+      "mw": 4624.0
+    },
+    {
+      "datetime_beginning_ept": "2025-02-09T03:00:00",
+      "fuel_type": "Coal",
+      "mw": 14447.0
+    },
+    {
+      "datetime_beginning_ept": "2025-02-09T03:00:00",
+      "fuel_type": "Gas",
+      "mw": 39422.0
+    },
+    {
+      "datetime_beginning_ept": "2025-02-09T03:00:00",
+      "fuel_type": "Hydro",
+      "mw": 445.0
+    },
+    {
+      "datetime_beginning_ept": "2025-02-09T03:00:00",
+      "fuel_type": "Multiple Fuels",
+      "mw": 1.0
+    },
+    {
+      "datetime_beginning_ept": "2025-02-09T03:00:00",
+      "fuel_type": "Nuclear",
+      "mw": 33054.0
+    },
+    {
+      "datetime_beginning_ept": "2025-02-09T03:00:00",
+      "fuel_type": "Oil",
+      "mw": 207.0
+    },
+    {
+      "datetime_beginning_ept": "2025-02-09T03:00:00",
+      "fuel_type": "Other Renewables",
+      "mw": 668.0
+    },
+    {
+      "datetime_beginning_ept": "2025-02-09T03:00:00",
+      "fuel_type": "Solar",
+      "mw": 28.0
+    },
+    {
+      "datetime_beginning_ept": "2025-02-09T03:00:00",
+      "fuel_type": "Storage",
+      "mw": 0.0
+    },
+    {
+      "datetime_beginning_ept": "2025-02-09T03:00:00",
+      "fuel_type": "Wind",
+      "mw": 4225.0
+    },
+    {
+      "datetime_beginning_ept": "2025-02-09T04:00:00",
+      "fuel_type": "Coal",
+      "mw": 14471.0
+    },
+    {
+      "datetime_beginning_ept": "2025-02-09T04:00:00",
+      "fuel_type": "Gas",
+      "mw": 39989.0
+    },
+    {
+      "datetime_beginning_ept": "2025-02-09T04:00:00",
+      "fuel_type": "Hydro",
+      "mw": 442.0
+    },
+    {
+      "datetime_beginning_ept": "2025-02-09T04:00:00",
+      "fuel_type": "Multiple Fuels",
+      "mw": 1.0
+    },
+    {
+      "datetime_beginning_ept": "2025-02-09T04:00:00",
+      "fuel_type": "Nuclear",
+      "mw": 33076.0
+    },
+    {
+      "datetime_beginning_ept": "2025-02-09T04:00:00",
+      "fuel_type": "Oil",
+      "mw": 209.0
+    },
+    {
+      "datetime_beginning_ept": "2025-02-09T04:00:00",
+      "fuel_type": "Other Renewables",
+      "mw": 671.0
+    },
+    {
+      "datetime_beginning_ept": "2025-02-09T04:00:00",
+      "fuel_type": "Solar",
+      "mw": 28.0
+    },
+    {
+      "datetime_beginning_ept": "2025-02-09T04:00:00",
+      "fuel_type": "Storage",
+      "mw": 0.0
+    },
+    {
+      "datetime_beginning_ept": "2025-02-09T04:00:00",
+      "fuel_type": "Wind",
+      "mw": 3883.0
+    },
+    {
+      "datetime_beginning_ept": "2025-02-09T05:00:00",
+      "fuel_type": "Coal",
+      "mw": 14664.0
+    },
+    {
+      "datetime_beginning_ept": "2025-02-09T05:00:00",
+      "fuel_type": "Gas",
+      "mw": 40113.0
+    },
+    {
+      "datetime_beginning_ept": "2025-02-09T05:00:00",
+      "fuel_type": "Hydro",
+      "mw": 435.0
+    },
+    {
+      "datetime_beginning_ept": "2025-02-09T05:00:00",
+      "fuel_type": "Multiple Fuels",
+      "mw": 1.0
+    },
+    {
+      "datetime_beginning_ept": "2025-02-09T05:00:00",
+      "fuel_type": "Nuclear",
+      "mw": 33177.0
+    },
+    {
+      "datetime_beginning_ept": "2025-02-09T05:00:00",
+      "fuel_type": "Oil",
+      "mw": 211.0
+    },
+    {
+      "datetime_beginning_ept": "2025-02-09T05:00:00",
+      "fuel_type": "Other Renewables",
+      "mw": 670.0
+    },
+    {
+      "datetime_beginning_ept": "2025-02-09T05:00:00",
+      "fuel_type": "Solar",
+      "mw": 28.0
+    },
+    {
+      "datetime_beginning_ept": "2025-02-09T05:00:00",
+      "fuel_type": "Storage",
+      "mw": 0.0
+    },
+    {
+      "datetime_beginning_ept": "2025-02-09T05:00:00",
+      "fuel_type": "Wind",
+      "mw": 3144.0
+    },
+    {
+      "datetime_beginning_ept": "2025-02-09T06:00:00",
+      "fuel_type": "Coal",
+      "mw": 15121.0
+    },
+    {
+      "datetime_beginning_ept": "2025-02-09T06:00:00",
+      "fuel_type": "Gas",
+      "mw": 40844.0
+    },
+    {
+      "datetime_beginning_ept": "2025-02-09T06:00:00",
+      "fuel_type": "Hydro",
+      "mw": 470.0
+    },
+    {
+      "datetime_beginning_ept": "2025-02-09T06:00:00",
+      "fuel_type": "Multiple Fuels",
+      "mw": 1.0
+    },
+    {
+      "datetime_beginning_ept": "2025-02-09T06:00:00",
+      "fuel_type": "Nuclear",
+      "mw": 33293.0
+    },
+    {
+      "datetime_beginning_ept": "2025-02-09T06:00:00",
+      "fuel_type": "Oil",
+      "mw": 212.0
+    },
+    {
+      "datetime_beginning_ept": "2025-02-09T06:00:00",
+      "fuel_type": "Other Renewables",
+      "mw": 671.0
+    },
+    {
+      "datetime_beginning_ept": "2025-02-09T06:00:00",
+      "fuel_type": "Solar",
+      "mw": 28.0
+    },
+    {
+      "datetime_beginning_ept": "2025-02-09T06:00:00",
+      "fuel_type": "Storage",
+      "mw": 0.0
+    },
+    {
+      "datetime_beginning_ept": "2025-02-09T06:00:00",
+      "fuel_type": "Wind",
+      "mw": 2900.0
+    },
+    {
+      "datetime_beginning_ept": "2025-02-09T07:00:00",
+      "fuel_type": "Coal",
+      "mw": 15494.0
+    },
+    {
+      "datetime_beginning_ept": "2025-02-09T07:00:00",
+      "fuel_type": "Gas",
+      "mw": 41543.0
+    },
+    {
+      "datetime_beginning_ept": "2025-02-09T07:00:00",
+      "fuel_type": "Hydro",
+      "mw": 934.0
+    },
+    {
+      "datetime_beginning_ept": "2025-02-09T07:00:00",
+      "fuel_type": "Multiple Fuels",
+      "mw": 1.0
+    },
+    {
+      "datetime_beginning_ept": "2025-02-09T07:00:00",
+      "fuel_type": "Nuclear",
+      "mw": 33392.0
+    },
+    {
+      "datetime_beginning_ept": "2025-02-09T07:00:00",
+      "fuel_type": "Oil",
+      "mw": 210.0
+    },
+    {
+      "datetime_beginning_ept": "2025-02-09T07:00:00",
+      "fuel_type": "Other Renewables",
+      "mw": 668.0
+    },
+    {
+      "datetime_beginning_ept": "2025-02-09T07:00:00",
+      "fuel_type": "Solar",
+      "mw": 148.0
+    },
+    {
+      "datetime_beginning_ept": "2025-02-09T07:00:00",
+      "fuel_type": "Storage",
+      "mw": 0.0
+    },
+    {
+      "datetime_beginning_ept": "2025-02-09T07:00:00",
+      "fuel_type": "Wind",
+      "mw": 2861.0
+    },
+    {
+      "datetime_beginning_ept": "2025-02-09T08:00:00",
+      "fuel_type": "Coal",
+      "mw": 15427.0
+    },
+    {
+      "datetime_beginning_ept": "2025-02-09T08:00:00",
+      "fuel_type": "Gas",
+      "mw": 41516.0
+    },
+    {
+      "datetime_beginning_ept": "2025-02-09T08:00:00",
+      "fuel_type": "Hydro",
+      "mw": 1015.0
+    },
+    {
+      "datetime_beginning_ept": "2025-02-09T08:00:00",
+      "fuel_type": "Multiple Fuels",
+      "mw": 1.0
+    },
+    {
+      "datetime_beginning_ept": "2025-02-09T08:00:00",
+      "fuel_type": "Nuclear",
+      "mw": 33499.0
+    },
+    {
+      "datetime_beginning_ept": "2025-02-09T08:00:00",
+      "fuel_type": "Oil",
+      "mw": 211.0
+    },
+    {
+      "datetime_beginning_ept": "2025-02-09T08:00:00",
+      "fuel_type": "Other Renewables",
+      "mw": 666.0
+    },
+    {
+      "datetime_beginning_ept": "2025-02-09T08:00:00",
+      "fuel_type": "Solar",
+      "mw": 2022.0
+    },
+    {
+      "datetime_beginning_ept": "2025-02-09T08:00:00",
+      "fuel_type": "Storage",
+      "mw": 0.0
+    },
+    {
+      "datetime_beginning_ept": "2025-02-09T08:00:00",
+      "fuel_type": "Wind",
+      "mw": 2575.0
+    }
+  ],
+  "searchSpecification": {
+    "rowCount": 500,
+    "order": "Asc",
+    "startRow": 1,
+    "isActiveMetadata": true,
+    "fields": [
+      "datetime_beginning_ept",
+      "fuel_type",
+      "mw"
+    ],
+    "filters": [
+      {
+        "datetime_beginning_ept": "2025-02-09T00:00:00.0000000"
+      }
+    ]
+  },
+  "totalRows": 90
+}

--- a/parsers/test/mocks/US_PJM/settings.json
+++ b/parsers/test/mocks/US_PJM/settings.json
@@ -1,0 +1,11 @@
+{
+  "baseUrl": "https://api.pjm.com/api/v1",
+  "baseAdminUrl": "http://localhost:44346/admin",
+  "baseSyndicationUrl": "https://api.pjm.com/syndication/v1",
+  "subscriptionKey": "aca459ab4b064b9ca31ca87ceaa23254",
+  "registerUrl": "https://apiportal.pjm.com/",
+  "connextUrl": "https://pjmconnext.com",
+  "feedbackUri": "https://www.pjm.com/AjaxService/FeedbackService.asmx/PostFeedback",
+  "feedbackKey": "SV_eJuz6ckkcfxzwJ7",
+  "tool": "Data Miner 2"
+}

--- a/parsers/test/test_US_PJM.py
+++ b/parsers/test/test_US_PJM.py
@@ -1,0 +1,33 @@
+from json import loads
+from pathlib import Path
+import re
+
+from requests_mock import ANY, GET
+
+from electricitymap.contrib.lib.types import ZoneKey
+from parsers.US_PJM import fetch_production
+
+base_path_to_mock = Path("parsers/test/mocks/US_PJM")
+
+
+def test_production(adapter, session, snapshot):
+    settings = Path(base_path_to_mock, "settings.json")
+    adapter.register_uri(
+        GET,
+        "https://dataminer2.pjm.com/config/settings.json",
+        json=loads(settings.read_text()),
+    )
+
+    data = Path(base_path_to_mock, "gen_by_fuel.json")
+    adapter.register_uri(
+        GET,
+        re.compile(
+            r"https://us-ca-proxy-jfnx5klx2a-uw\.a\.run\.app/api/v1/gen_by_fuel.*"
+        ),
+        json=loads(data.read_text()),
+    )
+
+    assert snapshot == fetch_production(
+        zone_key=ZoneKey("US-MIDA-PJM"),
+        session=session,
+    )

--- a/parsers/test/test_US_PJM.py
+++ b/parsers/test/test_US_PJM.py
@@ -1,8 +1,8 @@
+import re
 from json import loads
 from pathlib import Path
-import re
 
-from requests_mock import ANY, GET
+from requests_mock import GET
 
 from electricitymap.contrib.lib.types import ZoneKey
 from parsers.US_PJM import fetch_production


### PR DESCRIPTION
## Issue
#6011
## Description
This pull request includes significant changes to the `parsers/US_PJM.py` file, introducing new imports, refactoring the `fetch_production` function, and adding new test cases. The changes aim to improve the data parsing and handling of production data for the PJM zone. The most important changes are summarized below:

### Refactoring and Improvements:
* Added new imports for `groupby` and `itemgetter` from `itertools` and `operator`, respectively, and removed the unused `pandas` import.
* Introduced new models (`ProductionBreakdownList`, `ProductionMix`, `StorageMix`) and types (`ZoneKey`) from `electricitymap.contrib.lib`.
* Changed the `zone_key` parameter in `fetch_production` to use the `ZoneKey` type.
* Refactored the `fetch_production` function to use `groupby` for processing production data and replaced the previous DataFrame-based implementation with the new models.

### Configuration and Testing:
* Added a new `settings.json` file for mock settings in the `parsers/test/mocks/US_PJM` directory.
* Added a new test case `test_production` in `parsers/test/test_US_PJM.py` to verify the `fetch_production` function using the new snapshot testing approach.
* Added a new snapshot file `test_US_PJM.ambr` to store the expected results of the `test_production` test case.

### Double check

- [x] I have tested my parser changes locally with `poetry run test_parser "zone_key"`
- [x] I have run `pnpx prettier@2 --write .` and `poetry run format` in the top level directory to format my changes.
