### PR TITLE
chore(parser): simplify PJM parser + add test

### DIFF
--- a/config/zones/US-MIDA-PJM.yaml
+++ b/config/zones/US-MIDA-PJM.yaml
@@ -178,6 +178,7 @@ contributors:
   - robertahunt
   - KabelWlan
   - amv213
+  - VIKTORVAV99
 country: US
 delays:
   production: 7

--- a/parsers/US_PJM.py
+++ b/parsers/US_PJM.py
@@ -2,12 +2,13 @@
 
 import re
 from datetime import datetime, time, timedelta, timezone
+from itertools import groupby
 from logging import Logger, getLogger
+from operator import itemgetter
 from typing import Literal
 from zoneinfo import ZoneInfo
 
 import demjson3 as demjson
-import pandas as pd
 from bs4 import BeautifulSoup
 from requests import Response, Session
 
@@ -164,40 +165,34 @@ def fetch_production(
         "datetime_beginning_utc": target_datetime.strftime("%Y-%m-%dT%H:00:00.0000000"),
     }
     resp_data = _fetch_api_data(kind="gen_by_fuel", params=params, session=session)
-    print(resp_data)
 
-    data = pd.DataFrame(resp_data["items"])
-    if data.empty:
+    items = resp_data.get("items", [])
+
+    if items == []:
         raise ParserException(
             parser=PARSER,
             message=f"{target_datetime}: Production data is not available in the API",
             zone_key=zone_key,
         )
 
-    data["datetime_beginning_utc"] = pd.to_datetime(data["datetime_beginning_utc"])
-    data = data.set_index("datetime_beginning_utc")
-    data["fuel_type"] = data["fuel_type"].map(FUEL_MAPPING)
-
     production_breakdown_list = ProductionBreakdownList(logger)
-    for dt in data.index.unique():
-        production_mix = ProductionMix()
-        storage_mix = StorageMix()
-
-        data_dt = data.loc[data.index == dt]
-        for i in range(len(data_dt)):
-            row = data_dt.iloc[i]
-            if row["fuel_type"] == "battery":
-                storage_mix.add_value("battery", row.get("mw"))
+    for key, group in groupby(items, itemgetter("datetime_beginning_utc")):
+        dt = datetime.fromisoformat(key).replace(tzinfo=timezone.utc)
+        production = ProductionMix()
+        storage = StorageMix()
+        for data in group:
+            mode = FUEL_MAPPING[data["fuel_type"]]
+            value = data["mw"]
+            if mode == "battery":
+                storage.add_value(mode, value)
             else:
-                mode = row["fuel_type"]
-                production_mix.add_value(mode, row.get("mw"))
-
+                production.add_value(mode, value)
         production_breakdown_list.append(
             zoneKey=zone_key,
-            datetime=dt.to_pydatetime().replace(tzinfo=timezone.utc),
+            datetime=dt,
+            production=production,
+            storage=storage,
             source=SOURCE,
-            production=production_mix,
-            storage=storage_mix,
         )
 
     return production_breakdown_list.to_list()

--- a/parsers/test/__snapshots__/test_US_PJM.ambr
+++ b/parsers/test/__snapshots__/test_US_PJM.ambr
@@ -1,0 +1,467 @@
+# serializer version: 1
+# name: test_production
+  list([
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2025, 2, 9, 0, 0, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'coal': 16908.0,
+        'gas': 47280.0,
+        'hydro': 2971.0,
+        'nuclear': 32919.0,
+        'oil': 871.0,
+        'solar': 28.0,
+        'unknown': 1838.0,
+        'wind': 2782.0,
+      }),
+      'source': 'pjm.com',
+      'sourceType': <EventSourceType.measured: 'measured'>,
+      'storage': dict({
+        'battery': 8.0,
+      }),
+      'zoneKey': 'US-MIDA-PJM',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2025, 2, 9, 1, 0, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'coal': 17147.0,
+        'gas': 46725.0,
+        'hydro': 2217.0,
+        'nuclear': 32940.0,
+        'oil': 837.0,
+        'solar': 28.0,
+        'unknown': 1641.0,
+        'wind': 3202.0,
+      }),
+      'source': 'pjm.com',
+      'sourceType': <EventSourceType.measured: 'measured'>,
+      'storage': dict({
+        'battery': 3.0,
+      }),
+      'zoneKey': 'US-MIDA-PJM',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2025, 2, 9, 2, 0, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'coal': 17055.0,
+        'gas': 45683.0,
+        'hydro': 1464.0,
+        'nuclear': 32965.0,
+        'oil': 566.0,
+        'solar': 28.0,
+        'unknown': 1551.0,
+        'wind': 3504.0,
+      }),
+      'source': 'pjm.com',
+      'sourceType': <EventSourceType.measured: 'measured'>,
+      'storage': dict({
+        'battery': 1.0,
+      }),
+      'zoneKey': 'US-MIDA-PJM',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2025, 2, 9, 3, 0, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'coal': 16889.0,
+        'gas': 43567.0,
+        'hydro': 980.0,
+        'nuclear': 32987.0,
+        'oil': 206.0,
+        'solar': 28.0,
+        'unknown': 1540.0,
+        'wind': 4030.0,
+      }),
+      'source': 'pjm.com',
+      'sourceType': <EventSourceType.measured: 'measured'>,
+      'storage': dict({
+        'battery': 0.0,
+      }),
+      'zoneKey': 'US-MIDA-PJM',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2025, 2, 9, 4, 0, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'coal': 16373.0,
+        'gas': 42175.0,
+        'hydro': 638.0,
+        'nuclear': 32994.0,
+        'oil': 209.0,
+        'solar': 28.0,
+        'unknown': 841.0,
+        'wind': 4468.0,
+      }),
+      'source': 'pjm.com',
+      'sourceType': <EventSourceType.measured: 'measured'>,
+      'storage': dict({
+        'battery': 0.0,
+      }),
+      'zoneKey': 'US-MIDA-PJM',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2025, 2, 9, 5, 0, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'coal': 15849.0,
+        'gas': 41727.0,
+        'hydro': 521.0,
+        'nuclear': 33001.0,
+        'oil': 206.0,
+        'solar': 28.0,
+        'unknown': 666.0,
+        'wind': 5096.0,
+      }),
+      'source': 'pjm.com',
+      'sourceType': <EventSourceType.measured: 'measured'>,
+      'storage': dict({
+        'battery': 0.0,
+      }),
+      'zoneKey': 'US-MIDA-PJM',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2025, 2, 9, 6, 0, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'coal': 15450.0,
+        'gas': 40800.0,
+        'hydro': 452.0,
+        'nuclear': 33011.0,
+        'oil': 206.0,
+        'solar': 28.0,
+        'unknown': 664.0,
+        'wind': 5070.0,
+      }),
+      'source': 'pjm.com',
+      'sourceType': <EventSourceType.measured: 'measured'>,
+      'storage': dict({
+        'battery': 0.0,
+      }),
+      'zoneKey': 'US-MIDA-PJM',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2025, 2, 9, 7, 0, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'coal': 14787.0,
+        'gas': 40089.0,
+        'hydro': 412.0,
+        'nuclear': 33027.0,
+        'oil': 206.0,
+        'solar': 28.0,
+        'unknown': 665.0,
+        'wind': 4624.0,
+      }),
+      'source': 'pjm.com',
+      'sourceType': <EventSourceType.measured: 'measured'>,
+      'storage': dict({
+        'battery': 0.0,
+      }),
+      'zoneKey': 'US-MIDA-PJM',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2025, 2, 9, 8, 0, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'coal': 14447.0,
+        'gas': 39422.0,
+        'hydro': 445.0,
+        'nuclear': 33054.0,
+        'oil': 207.0,
+        'solar': 28.0,
+        'unknown': 669.0,
+        'wind': 4225.0,
+      }),
+      'source': 'pjm.com',
+      'sourceType': <EventSourceType.measured: 'measured'>,
+      'storage': dict({
+        'battery': 0.0,
+      }),
+      'zoneKey': 'US-MIDA-PJM',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2025, 2, 9, 9, 0, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'coal': 14471.0,
+        'gas': 39989.0,
+        'hydro': 442.0,
+        'nuclear': 33076.0,
+        'oil': 209.0,
+        'solar': 28.0,
+        'unknown': 672.0,
+        'wind': 3883.0,
+      }),
+      'source': 'pjm.com',
+      'sourceType': <EventSourceType.measured: 'measured'>,
+      'storage': dict({
+        'battery': 0.0,
+      }),
+      'zoneKey': 'US-MIDA-PJM',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2025, 2, 9, 10, 0, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'coal': 14664.0,
+        'gas': 40113.0,
+        'hydro': 435.0,
+        'nuclear': 33177.0,
+        'oil': 211.0,
+        'solar': 28.0,
+        'unknown': 671.0,
+        'wind': 3144.0,
+      }),
+      'source': 'pjm.com',
+      'sourceType': <EventSourceType.measured: 'measured'>,
+      'storage': dict({
+        'battery': 0.0,
+      }),
+      'zoneKey': 'US-MIDA-PJM',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2025, 2, 9, 11, 0, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'coal': 15121.0,
+        'gas': 40844.0,
+        'hydro': 470.0,
+        'nuclear': 33293.0,
+        'oil': 212.0,
+        'solar': 28.0,
+        'unknown': 672.0,
+        'wind': 2900.0,
+      }),
+      'source': 'pjm.com',
+      'sourceType': <EventSourceType.measured: 'measured'>,
+      'storage': dict({
+        'battery': 0.0,
+      }),
+      'zoneKey': 'US-MIDA-PJM',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2025, 2, 9, 12, 0, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'coal': 15494.0,
+        'gas': 41543.0,
+        'hydro': 934.0,
+        'nuclear': 33392.0,
+        'oil': 210.0,
+        'solar': 148.0,
+        'unknown': 669.0,
+        'wind': 2861.0,
+      }),
+      'source': 'pjm.com',
+      'sourceType': <EventSourceType.measured: 'measured'>,
+      'storage': dict({
+        'battery': 0.0,
+      }),
+      'zoneKey': 'US-MIDA-PJM',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2025, 2, 9, 13, 0, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'coal': 15427.0,
+        'gas': 41516.0,
+        'hydro': 1015.0,
+        'nuclear': 33499.0,
+        'oil': 211.0,
+        'solar': 2022.0,
+        'unknown': 667.0,
+        'wind': 2575.0,
+      }),
+      'source': 'pjm.com',
+      'sourceType': <EventSourceType.measured: 'measured'>,
+      'storage': dict({
+        'battery': 0.0,
+      }),
+      'zoneKey': 'US-MIDA-PJM',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2025, 2, 9, 14, 0, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'coal': 15530.0,
+        'gas': 41489.0,
+        'hydro': 1080.0,
+        'nuclear': 33581.0,
+        'oil': 210.0,
+        'solar': 4579.0,
+        'unknown': 669.0,
+        'wind': 2100.0,
+      }),
+      'source': 'pjm.com',
+      'sourceType': <EventSourceType.measured: 'measured'>,
+      'storage': dict({
+        'battery': 0.0,
+      }),
+      'zoneKey': 'US-MIDA-PJM',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2025, 2, 9, 15, 0, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'coal': 15649.0,
+        'gas': 42431.0,
+        'hydro': 675.0,
+        'nuclear': 33599.0,
+        'oil': 211.0,
+        'solar': 5452.0,
+        'unknown': 668.0,
+        'wind': 1630.0,
+      }),
+      'source': 'pjm.com',
+      'sourceType': <EventSourceType.measured: 'measured'>,
+      'storage': dict({
+        'battery': 5.0,
+      }),
+      'zoneKey': 'US-MIDA-PJM',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2025, 2, 9, 16, 0, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'coal': 16072.0,
+        'gas': 43125.0,
+        'hydro': 475.0,
+        'nuclear': 33613.0,
+        'oil': 210.0,
+        'solar': 5622.0,
+        'unknown': 666.0,
+        'wind': 1221.0,
+      }),
+      'source': 'pjm.com',
+      'sourceType': <EventSourceType.measured: 'measured'>,
+      'storage': dict({
+        'battery': 7.0,
+      }),
+      'zoneKey': 'US-MIDA-PJM',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2025, 2, 9, 17, 0, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'coal': 16384.0,
+        'gas': 42723.0,
+        'hydro': 468.0,
+        'nuclear': 33632.0,
+        'oil': 207.0,
+        'solar': 5502.0,
+        'unknown': 660.0,
+        'wind': 1061.0,
+      }),
+      'source': 'pjm.com',
+      'sourceType': <EventSourceType.measured: 'measured'>,
+      'storage': dict({
+        'battery': 4.0,
+      }),
+      'zoneKey': 'US-MIDA-PJM',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2025, 2, 9, 18, 0, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'coal': 16411.0,
+        'gas': 42256.0,
+        'hydro': 496.0,
+        'nuclear': 33641.0,
+        'oil': 206.0,
+        'solar': 5407.0,
+        'unknown': 667.0,
+        'wind': 1052.0,
+      }),
+      'source': 'pjm.com',
+      'sourceType': <EventSourceType.measured: 'measured'>,
+      'storage': dict({
+        'battery': 0.0,
+      }),
+      'zoneKey': 'US-MIDA-PJM',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2025, 2, 9, 19, 0, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'coal': 16010.0,
+        'gas': 42027.0,
+        'hydro': 457.0,
+        'nuclear': 33640.0,
+        'oil': 205.0,
+        'solar': 5231.0,
+        'unknown': 724.0,
+        'wind': 1187.0,
+      }),
+      'source': 'pjm.com',
+      'sourceType': <EventSourceType.measured: 'measured'>,
+      'storage': dict({
+        'battery': 0.0,
+      }),
+      'zoneKey': 'US-MIDA-PJM',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2025, 2, 9, 20, 0, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'coal': 15907.0,
+        'gas': 41535.0,
+        'hydro': 522.0,
+        'nuclear': 33629.0,
+        'oil': 205.0,
+        'solar': 4629.0,
+        'unknown': 967.0,
+        'wind': 1221.0,
+      }),
+      'source': 'pjm.com',
+      'sourceType': <EventSourceType.measured: 'measured'>,
+      'storage': dict({
+        'battery': 0.0,
+      }),
+      'zoneKey': 'US-MIDA-PJM',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2025, 2, 9, 21, 0, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'coal': 15772.0,
+        'gas': 43252.0,
+        'hydro': 1421.0,
+        'nuclear': 33625.0,
+        'oil': 401.0,
+        'solar': 2719.0,
+        'unknown': 1082.0,
+        'wind': 1341.0,
+      }),
+      'source': 'pjm.com',
+      'sourceType': <EventSourceType.measured: 'measured'>,
+      'storage': dict({
+        'battery': 0.0,
+      }),
+      'zoneKey': 'US-MIDA-PJM',
+    }),
+  ])
+# ---

--- a/parsers/test/mocks/US_PJM/gen_by_fuel.json
+++ b/parsers/test/mocks/US_PJM/gen_by_fuel.json
@@ -1,0 +1,1131 @@
+{
+  "links": [
+    {
+      "rel": "self",
+      "href": "https://api.pjm.com/api/v1/gen_by_fuel?RowCount=500&Order=Asc&StartRow=1&IsActiveMetadata=True&Fields=datetime_beginning_utc%2Cfuel_type%2Cmw&datetime_beginning_utc=2025-02-09T00%3A00%3A00.0000000"
+    },
+    {
+      "rel": "metadata",
+      "href": "https://api.pjm.com/api/v1/gen_by_fuel/metadata"
+    }
+  ],
+  "items": [
+    {
+      "datetime_beginning_utc": "2025-02-09T00:00:00",
+      "fuel_type": "Coal",
+      "mw": 16908.0
+    },
+    {
+      "datetime_beginning_utc": "2025-02-09T00:00:00",
+      "fuel_type": "Gas",
+      "mw": 47280.0
+    },
+    {
+      "datetime_beginning_utc": "2025-02-09T00:00:00",
+      "fuel_type": "Hydro",
+      "mw": 2971.0
+    },
+    {
+      "datetime_beginning_utc": "2025-02-09T00:00:00",
+      "fuel_type": "Multiple Fuels",
+      "mw": 1179.0
+    },
+    {
+      "datetime_beginning_utc": "2025-02-09T00:00:00",
+      "fuel_type": "Nuclear",
+      "mw": 32919.0
+    },
+    {
+      "datetime_beginning_utc": "2025-02-09T00:00:00",
+      "fuel_type": "Oil",
+      "mw": 871.0
+    },
+    {
+      "datetime_beginning_utc": "2025-02-09T00:00:00",
+      "fuel_type": "Other Renewables",
+      "mw": 659.0
+    },
+    {
+      "datetime_beginning_utc": "2025-02-09T00:00:00",
+      "fuel_type": "Solar",
+      "mw": 28.0
+    },
+    {
+      "datetime_beginning_utc": "2025-02-09T00:00:00",
+      "fuel_type": "Storage",
+      "mw": 8.0
+    },
+    {
+      "datetime_beginning_utc": "2025-02-09T00:00:00",
+      "fuel_type": "Wind",
+      "mw": 2782.0
+    },
+    {
+      "datetime_beginning_utc": "2025-02-09T01:00:00",
+      "fuel_type": "Coal",
+      "mw": 17147.0
+    },
+    {
+      "datetime_beginning_utc": "2025-02-09T01:00:00",
+      "fuel_type": "Gas",
+      "mw": 46725.0
+    },
+    {
+      "datetime_beginning_utc": "2025-02-09T01:00:00",
+      "fuel_type": "Hydro",
+      "mw": 2217.0
+    },
+    {
+      "datetime_beginning_utc": "2025-02-09T01:00:00",
+      "fuel_type": "Multiple Fuels",
+      "mw": 981.0
+    },
+    {
+      "datetime_beginning_utc": "2025-02-09T01:00:00",
+      "fuel_type": "Nuclear",
+      "mw": 32940.0
+    },
+    {
+      "datetime_beginning_utc": "2025-02-09T01:00:00",
+      "fuel_type": "Oil",
+      "mw": 837.0
+    },
+    {
+      "datetime_beginning_utc": "2025-02-09T01:00:00",
+      "fuel_type": "Other Renewables",
+      "mw": 660.0
+    },
+    {
+      "datetime_beginning_utc": "2025-02-09T01:00:00",
+      "fuel_type": "Solar",
+      "mw": 28.0
+    },
+    {
+      "datetime_beginning_utc": "2025-02-09T01:00:00",
+      "fuel_type": "Storage",
+      "mw": 3.0
+    },
+    {
+      "datetime_beginning_utc": "2025-02-09T01:00:00",
+      "fuel_type": "Wind",
+      "mw": 3202.0
+    },
+    {
+      "datetime_beginning_utc": "2025-02-09T02:00:00",
+      "fuel_type": "Coal",
+      "mw": 17055.0
+    },
+    {
+      "datetime_beginning_utc": "2025-02-09T02:00:00",
+      "fuel_type": "Gas",
+      "mw": 45683.0
+    },
+    {
+      "datetime_beginning_utc": "2025-02-09T02:00:00",
+      "fuel_type": "Hydro",
+      "mw": 1464.0
+    },
+    {
+      "datetime_beginning_utc": "2025-02-09T02:00:00",
+      "fuel_type": "Multiple Fuels",
+      "mw": 902.0
+    },
+    {
+      "datetime_beginning_utc": "2025-02-09T02:00:00",
+      "fuel_type": "Nuclear",
+      "mw": 32965.0
+    },
+    {
+      "datetime_beginning_utc": "2025-02-09T02:00:00",
+      "fuel_type": "Oil",
+      "mw": 566.0
+    },
+    {
+      "datetime_beginning_utc": "2025-02-09T02:00:00",
+      "fuel_type": "Other Renewables",
+      "mw": 649.0
+    },
+    {
+      "datetime_beginning_utc": "2025-02-09T02:00:00",
+      "fuel_type": "Solar",
+      "mw": 28.0
+    },
+    {
+      "datetime_beginning_utc": "2025-02-09T02:00:00",
+      "fuel_type": "Storage",
+      "mw": 1.0
+    },
+    {
+      "datetime_beginning_utc": "2025-02-09T02:00:00",
+      "fuel_type": "Wind",
+      "mw": 3504.0
+    },
+    {
+      "datetime_beginning_utc": "2025-02-09T03:00:00",
+      "fuel_type": "Coal",
+      "mw": 16889.0
+    },
+    {
+      "datetime_beginning_utc": "2025-02-09T03:00:00",
+      "fuel_type": "Gas",
+      "mw": 43567.0
+    },
+    {
+      "datetime_beginning_utc": "2025-02-09T03:00:00",
+      "fuel_type": "Hydro",
+      "mw": 980.0
+    },
+    {
+      "datetime_beginning_utc": "2025-02-09T03:00:00",
+      "fuel_type": "Multiple Fuels",
+      "mw": 885.0
+    },
+    {
+      "datetime_beginning_utc": "2025-02-09T03:00:00",
+      "fuel_type": "Nuclear",
+      "mw": 32987.0
+    },
+    {
+      "datetime_beginning_utc": "2025-02-09T03:00:00",
+      "fuel_type": "Oil",
+      "mw": 206.0
+    },
+    {
+      "datetime_beginning_utc": "2025-02-09T03:00:00",
+      "fuel_type": "Other Renewables",
+      "mw": 655.0
+    },
+    {
+      "datetime_beginning_utc": "2025-02-09T03:00:00",
+      "fuel_type": "Solar",
+      "mw": 28.0
+    },
+    {
+      "datetime_beginning_utc": "2025-02-09T03:00:00",
+      "fuel_type": "Storage",
+      "mw": 0.0
+    },
+    {
+      "datetime_beginning_utc": "2025-02-09T03:00:00",
+      "fuel_type": "Wind",
+      "mw": 4030.0
+    },
+    {
+      "datetime_beginning_utc": "2025-02-09T04:00:00",
+      "fuel_type": "Coal",
+      "mw": 16373.0
+    },
+    {
+      "datetime_beginning_utc": "2025-02-09T04:00:00",
+      "fuel_type": "Gas",
+      "mw": 42175.0
+    },
+    {
+      "datetime_beginning_utc": "2025-02-09T04:00:00",
+      "fuel_type": "Hydro",
+      "mw": 638.0
+    },
+    {
+      "datetime_beginning_utc": "2025-02-09T04:00:00",
+      "fuel_type": "Multiple Fuels",
+      "mw": 179.0
+    },
+    {
+      "datetime_beginning_utc": "2025-02-09T04:00:00",
+      "fuel_type": "Nuclear",
+      "mw": 32994.0
+    },
+    {
+      "datetime_beginning_utc": "2025-02-09T04:00:00",
+      "fuel_type": "Oil",
+      "mw": 209.0
+    },
+    {
+      "datetime_beginning_utc": "2025-02-09T04:00:00",
+      "fuel_type": "Other Renewables",
+      "mw": 662.0
+    },
+    {
+      "datetime_beginning_utc": "2025-02-09T04:00:00",
+      "fuel_type": "Solar",
+      "mw": 28.0
+    },
+    {
+      "datetime_beginning_utc": "2025-02-09T04:00:00",
+      "fuel_type": "Storage",
+      "mw": 0.0
+    },
+    {
+      "datetime_beginning_utc": "2025-02-09T04:00:00",
+      "fuel_type": "Wind",
+      "mw": 4468.0
+    },
+    {
+      "datetime_beginning_utc": "2025-02-09T05:00:00",
+      "fuel_type": "Coal",
+      "mw": 15849.0
+    },
+    {
+      "datetime_beginning_utc": "2025-02-09T05:00:00",
+      "fuel_type": "Gas",
+      "mw": 41727.0
+    },
+    {
+      "datetime_beginning_utc": "2025-02-09T05:00:00",
+      "fuel_type": "Hydro",
+      "mw": 521.0
+    },
+    {
+      "datetime_beginning_utc": "2025-02-09T05:00:00",
+      "fuel_type": "Multiple Fuels",
+      "mw": 1.0
+    },
+    {
+      "datetime_beginning_utc": "2025-02-09T05:00:00",
+      "fuel_type": "Nuclear",
+      "mw": 33001.0
+    },
+    {
+      "datetime_beginning_utc": "2025-02-09T05:00:00",
+      "fuel_type": "Oil",
+      "mw": 206.0
+    },
+    {
+      "datetime_beginning_utc": "2025-02-09T05:00:00",
+      "fuel_type": "Other Renewables",
+      "mw": 665.0
+    },
+    {
+      "datetime_beginning_utc": "2025-02-09T05:00:00",
+      "fuel_type": "Solar",
+      "mw": 28.0
+    },
+    {
+      "datetime_beginning_utc": "2025-02-09T05:00:00",
+      "fuel_type": "Storage",
+      "mw": 0.0
+    },
+    {
+      "datetime_beginning_utc": "2025-02-09T05:00:00",
+      "fuel_type": "Wind",
+      "mw": 5096.0
+    },
+    {
+      "datetime_beginning_utc": "2025-02-09T06:00:00",
+      "fuel_type": "Coal",
+      "mw": 15450.0
+    },
+    {
+      "datetime_beginning_utc": "2025-02-09T06:00:00",
+      "fuel_type": "Gas",
+      "mw": 40800.0
+    },
+    {
+      "datetime_beginning_utc": "2025-02-09T06:00:00",
+      "fuel_type": "Hydro",
+      "mw": 452.0
+    },
+    {
+      "datetime_beginning_utc": "2025-02-09T06:00:00",
+      "fuel_type": "Multiple Fuels",
+      "mw": 1.0
+    },
+    {
+      "datetime_beginning_utc": "2025-02-09T06:00:00",
+      "fuel_type": "Nuclear",
+      "mw": 33011.0
+    },
+    {
+      "datetime_beginning_utc": "2025-02-09T06:00:00",
+      "fuel_type": "Oil",
+      "mw": 206.0
+    },
+    {
+      "datetime_beginning_utc": "2025-02-09T06:00:00",
+      "fuel_type": "Other Renewables",
+      "mw": 663.0
+    },
+    {
+      "datetime_beginning_utc": "2025-02-09T06:00:00",
+      "fuel_type": "Solar",
+      "mw": 28.0
+    },
+    {
+      "datetime_beginning_utc": "2025-02-09T06:00:00",
+      "fuel_type": "Storage",
+      "mw": 0.0
+    },
+    {
+      "datetime_beginning_utc": "2025-02-09T06:00:00",
+      "fuel_type": "Wind",
+      "mw": 5070.0
+    },
+    {
+      "datetime_beginning_utc": "2025-02-09T07:00:00",
+      "fuel_type": "Coal",
+      "mw": 14787.0
+    },
+    {
+      "datetime_beginning_utc": "2025-02-09T07:00:00",
+      "fuel_type": "Gas",
+      "mw": 40089.0
+    },
+    {
+      "datetime_beginning_utc": "2025-02-09T07:00:00",
+      "fuel_type": "Hydro",
+      "mw": 412.0
+    },
+    {
+      "datetime_beginning_utc": "2025-02-09T07:00:00",
+      "fuel_type": "Multiple Fuels",
+      "mw": 1.0
+    },
+    {
+      "datetime_beginning_utc": "2025-02-09T07:00:00",
+      "fuel_type": "Nuclear",
+      "mw": 33027.0
+    },
+    {
+      "datetime_beginning_utc": "2025-02-09T07:00:00",
+      "fuel_type": "Oil",
+      "mw": 206.0
+    },
+    {
+      "datetime_beginning_utc": "2025-02-09T07:00:00",
+      "fuel_type": "Other Renewables",
+      "mw": 664.0
+    },
+    {
+      "datetime_beginning_utc": "2025-02-09T07:00:00",
+      "fuel_type": "Solar",
+      "mw": 28.0
+    },
+    {
+      "datetime_beginning_utc": "2025-02-09T07:00:00",
+      "fuel_type": "Storage",
+      "mw": 0.0
+    },
+    {
+      "datetime_beginning_utc": "2025-02-09T07:00:00",
+      "fuel_type": "Wind",
+      "mw": 4624.0
+    },
+    {
+      "datetime_beginning_utc": "2025-02-09T08:00:00",
+      "fuel_type": "Coal",
+      "mw": 14447.0
+    },
+    {
+      "datetime_beginning_utc": "2025-02-09T08:00:00",
+      "fuel_type": "Gas",
+      "mw": 39422.0
+    },
+    {
+      "datetime_beginning_utc": "2025-02-09T08:00:00",
+      "fuel_type": "Hydro",
+      "mw": 445.0
+    },
+    {
+      "datetime_beginning_utc": "2025-02-09T08:00:00",
+      "fuel_type": "Multiple Fuels",
+      "mw": 1.0
+    },
+    {
+      "datetime_beginning_utc": "2025-02-09T08:00:00",
+      "fuel_type": "Nuclear",
+      "mw": 33054.0
+    },
+    {
+      "datetime_beginning_utc": "2025-02-09T08:00:00",
+      "fuel_type": "Oil",
+      "mw": 207.0
+    },
+    {
+      "datetime_beginning_utc": "2025-02-09T08:00:00",
+      "fuel_type": "Other Renewables",
+      "mw": 668.0
+    },
+    {
+      "datetime_beginning_utc": "2025-02-09T08:00:00",
+      "fuel_type": "Solar",
+      "mw": 28.0
+    },
+    {
+      "datetime_beginning_utc": "2025-02-09T08:00:00",
+      "fuel_type": "Storage",
+      "mw": 0.0
+    },
+    {
+      "datetime_beginning_utc": "2025-02-09T08:00:00",
+      "fuel_type": "Wind",
+      "mw": 4225.0
+    },
+    {
+      "datetime_beginning_utc": "2025-02-09T09:00:00",
+      "fuel_type": "Coal",
+      "mw": 14471.0
+    },
+    {
+      "datetime_beginning_utc": "2025-02-09T09:00:00",
+      "fuel_type": "Gas",
+      "mw": 39989.0
+    },
+    {
+      "datetime_beginning_utc": "2025-02-09T09:00:00",
+      "fuel_type": "Hydro",
+      "mw": 442.0
+    },
+    {
+      "datetime_beginning_utc": "2025-02-09T09:00:00",
+      "fuel_type": "Multiple Fuels",
+      "mw": 1.0
+    },
+    {
+      "datetime_beginning_utc": "2025-02-09T09:00:00",
+      "fuel_type": "Nuclear",
+      "mw": 33076.0
+    },
+    {
+      "datetime_beginning_utc": "2025-02-09T09:00:00",
+      "fuel_type": "Oil",
+      "mw": 209.0
+    },
+    {
+      "datetime_beginning_utc": "2025-02-09T09:00:00",
+      "fuel_type": "Other Renewables",
+      "mw": 671.0
+    },
+    {
+      "datetime_beginning_utc": "2025-02-09T09:00:00",
+      "fuel_type": "Solar",
+      "mw": 28.0
+    },
+    {
+      "datetime_beginning_utc": "2025-02-09T09:00:00",
+      "fuel_type": "Storage",
+      "mw": 0.0
+    },
+    {
+      "datetime_beginning_utc": "2025-02-09T09:00:00",
+      "fuel_type": "Wind",
+      "mw": 3883.0
+    },
+    {
+      "datetime_beginning_utc": "2025-02-09T10:00:00",
+      "fuel_type": "Coal",
+      "mw": 14664.0
+    },
+    {
+      "datetime_beginning_utc": "2025-02-09T10:00:00",
+      "fuel_type": "Gas",
+      "mw": 40113.0
+    },
+    {
+      "datetime_beginning_utc": "2025-02-09T10:00:00",
+      "fuel_type": "Hydro",
+      "mw": 435.0
+    },
+    {
+      "datetime_beginning_utc": "2025-02-09T10:00:00",
+      "fuel_type": "Multiple Fuels",
+      "mw": 1.0
+    },
+    {
+      "datetime_beginning_utc": "2025-02-09T10:00:00",
+      "fuel_type": "Nuclear",
+      "mw": 33177.0
+    },
+    {
+      "datetime_beginning_utc": "2025-02-09T10:00:00",
+      "fuel_type": "Oil",
+      "mw": 211.0
+    },
+    {
+      "datetime_beginning_utc": "2025-02-09T10:00:00",
+      "fuel_type": "Other Renewables",
+      "mw": 670.0
+    },
+    {
+      "datetime_beginning_utc": "2025-02-09T10:00:00",
+      "fuel_type": "Solar",
+      "mw": 28.0
+    },
+    {
+      "datetime_beginning_utc": "2025-02-09T10:00:00",
+      "fuel_type": "Storage",
+      "mw": 0.0
+    },
+    {
+      "datetime_beginning_utc": "2025-02-09T10:00:00",
+      "fuel_type": "Wind",
+      "mw": 3144.0
+    },
+    {
+      "datetime_beginning_utc": "2025-02-09T11:00:00",
+      "fuel_type": "Coal",
+      "mw": 15121.0
+    },
+    {
+      "datetime_beginning_utc": "2025-02-09T11:00:00",
+      "fuel_type": "Gas",
+      "mw": 40844.0
+    },
+    {
+      "datetime_beginning_utc": "2025-02-09T11:00:00",
+      "fuel_type": "Hydro",
+      "mw": 470.0
+    },
+    {
+      "datetime_beginning_utc": "2025-02-09T11:00:00",
+      "fuel_type": "Multiple Fuels",
+      "mw": 1.0
+    },
+    {
+      "datetime_beginning_utc": "2025-02-09T11:00:00",
+      "fuel_type": "Nuclear",
+      "mw": 33293.0
+    },
+    {
+      "datetime_beginning_utc": "2025-02-09T11:00:00",
+      "fuel_type": "Oil",
+      "mw": 212.0
+    },
+    {
+      "datetime_beginning_utc": "2025-02-09T11:00:00",
+      "fuel_type": "Other Renewables",
+      "mw": 671.0
+    },
+    {
+      "datetime_beginning_utc": "2025-02-09T11:00:00",
+      "fuel_type": "Solar",
+      "mw": 28.0
+    },
+    {
+      "datetime_beginning_utc": "2025-02-09T11:00:00",
+      "fuel_type": "Storage",
+      "mw": 0.0
+    },
+    {
+      "datetime_beginning_utc": "2025-02-09T11:00:00",
+      "fuel_type": "Wind",
+      "mw": 2900.0
+    },
+    {
+      "datetime_beginning_utc": "2025-02-09T12:00:00",
+      "fuel_type": "Coal",
+      "mw": 15494.0
+    },
+    {
+      "datetime_beginning_utc": "2025-02-09T12:00:00",
+      "fuel_type": "Gas",
+      "mw": 41543.0
+    },
+    {
+      "datetime_beginning_utc": "2025-02-09T12:00:00",
+      "fuel_type": "Hydro",
+      "mw": 934.0
+    },
+    {
+      "datetime_beginning_utc": "2025-02-09T12:00:00",
+      "fuel_type": "Multiple Fuels",
+      "mw": 1.0
+    },
+    {
+      "datetime_beginning_utc": "2025-02-09T12:00:00",
+      "fuel_type": "Nuclear",
+      "mw": 33392.0
+    },
+    {
+      "datetime_beginning_utc": "2025-02-09T12:00:00",
+      "fuel_type": "Oil",
+      "mw": 210.0
+    },
+    {
+      "datetime_beginning_utc": "2025-02-09T12:00:00",
+      "fuel_type": "Other Renewables",
+      "mw": 668.0
+    },
+    {
+      "datetime_beginning_utc": "2025-02-09T12:00:00",
+      "fuel_type": "Solar",
+      "mw": 148.0
+    },
+    {
+      "datetime_beginning_utc": "2025-02-09T12:00:00",
+      "fuel_type": "Storage",
+      "mw": 0.0
+    },
+    {
+      "datetime_beginning_utc": "2025-02-09T12:00:00",
+      "fuel_type": "Wind",
+      "mw": 2861.0
+    },
+    {
+      "datetime_beginning_utc": "2025-02-09T13:00:00",
+      "fuel_type": "Coal",
+      "mw": 15427.0
+    },
+    {
+      "datetime_beginning_utc": "2025-02-09T13:00:00",
+      "fuel_type": "Gas",
+      "mw": 41516.0
+    },
+    {
+      "datetime_beginning_utc": "2025-02-09T13:00:00",
+      "fuel_type": "Hydro",
+      "mw": 1015.0
+    },
+    {
+      "datetime_beginning_utc": "2025-02-09T13:00:00",
+      "fuel_type": "Multiple Fuels",
+      "mw": 1.0
+    },
+    {
+      "datetime_beginning_utc": "2025-02-09T13:00:00",
+      "fuel_type": "Nuclear",
+      "mw": 33499.0
+    },
+    {
+      "datetime_beginning_utc": "2025-02-09T13:00:00",
+      "fuel_type": "Oil",
+      "mw": 211.0
+    },
+    {
+      "datetime_beginning_utc": "2025-02-09T13:00:00",
+      "fuel_type": "Other Renewables",
+      "mw": 666.0
+    },
+    {
+      "datetime_beginning_utc": "2025-02-09T13:00:00",
+      "fuel_type": "Solar",
+      "mw": 2022.0
+    },
+    {
+      "datetime_beginning_utc": "2025-02-09T13:00:00",
+      "fuel_type": "Storage",
+      "mw": 0.0
+    },
+    {
+      "datetime_beginning_utc": "2025-02-09T13:00:00",
+      "fuel_type": "Wind",
+      "mw": 2575.0
+    },
+    {
+      "datetime_beginning_utc": "2025-02-09T14:00:00",
+      "fuel_type": "Coal",
+      "mw": 15530.0
+    },
+    {
+      "datetime_beginning_utc": "2025-02-09T14:00:00",
+      "fuel_type": "Gas",
+      "mw": 41489.0
+    },
+    {
+      "datetime_beginning_utc": "2025-02-09T14:00:00",
+      "fuel_type": "Hydro",
+      "mw": 1080.0
+    },
+    {
+      "datetime_beginning_utc": "2025-02-09T14:00:00",
+      "fuel_type": "Multiple Fuels",
+      "mw": 1.0
+    },
+    {
+      "datetime_beginning_utc": "2025-02-09T14:00:00",
+      "fuel_type": "Nuclear",
+      "mw": 33581.0
+    },
+    {
+      "datetime_beginning_utc": "2025-02-09T14:00:00",
+      "fuel_type": "Oil",
+      "mw": 210.0
+    },
+    {
+      "datetime_beginning_utc": "2025-02-09T14:00:00",
+      "fuel_type": "Other Renewables",
+      "mw": 668.0
+    },
+    {
+      "datetime_beginning_utc": "2025-02-09T14:00:00",
+      "fuel_type": "Solar",
+      "mw": 4579.0
+    },
+    {
+      "datetime_beginning_utc": "2025-02-09T14:00:00",
+      "fuel_type": "Storage",
+      "mw": 0.0
+    },
+    {
+      "datetime_beginning_utc": "2025-02-09T14:00:00",
+      "fuel_type": "Wind",
+      "mw": 2100.0
+    },
+    {
+      "datetime_beginning_utc": "2025-02-09T15:00:00",
+      "fuel_type": "Coal",
+      "mw": 15649.0
+    },
+    {
+      "datetime_beginning_utc": "2025-02-09T15:00:00",
+      "fuel_type": "Gas",
+      "mw": 42431.0
+    },
+    {
+      "datetime_beginning_utc": "2025-02-09T15:00:00",
+      "fuel_type": "Hydro",
+      "mw": 675.0
+    },
+    {
+      "datetime_beginning_utc": "2025-02-09T15:00:00",
+      "fuel_type": "Multiple Fuels",
+      "mw": 1.0
+    },
+    {
+      "datetime_beginning_utc": "2025-02-09T15:00:00",
+      "fuel_type": "Nuclear",
+      "mw": 33599.0
+    },
+    {
+      "datetime_beginning_utc": "2025-02-09T15:00:00",
+      "fuel_type": "Oil",
+      "mw": 211.0
+    },
+    {
+      "datetime_beginning_utc": "2025-02-09T15:00:00",
+      "fuel_type": "Other Renewables",
+      "mw": 667.0
+    },
+    {
+      "datetime_beginning_utc": "2025-02-09T15:00:00",
+      "fuel_type": "Solar",
+      "mw": 5452.0
+    },
+    {
+      "datetime_beginning_utc": "2025-02-09T15:00:00",
+      "fuel_type": "Storage",
+      "mw": 5.0
+    },
+    {
+      "datetime_beginning_utc": "2025-02-09T15:00:00",
+      "fuel_type": "Wind",
+      "mw": 1630.0
+    },
+    {
+      "datetime_beginning_utc": "2025-02-09T16:00:00",
+      "fuel_type": "Coal",
+      "mw": 16072.0
+    },
+    {
+      "datetime_beginning_utc": "2025-02-09T16:00:00",
+      "fuel_type": "Gas",
+      "mw": 43125.0
+    },
+    {
+      "datetime_beginning_utc": "2025-02-09T16:00:00",
+      "fuel_type": "Hydro",
+      "mw": 475.0
+    },
+    {
+      "datetime_beginning_utc": "2025-02-09T16:00:00",
+      "fuel_type": "Multiple Fuels",
+      "mw": 1.0
+    },
+    {
+      "datetime_beginning_utc": "2025-02-09T16:00:00",
+      "fuel_type": "Nuclear",
+      "mw": 33613.0
+    },
+    {
+      "datetime_beginning_utc": "2025-02-09T16:00:00",
+      "fuel_type": "Oil",
+      "mw": 210.0
+    },
+    {
+      "datetime_beginning_utc": "2025-02-09T16:00:00",
+      "fuel_type": "Other Renewables",
+      "mw": 665.0
+    },
+    {
+      "datetime_beginning_utc": "2025-02-09T16:00:00",
+      "fuel_type": "Solar",
+      "mw": 5622.0
+    },
+    {
+      "datetime_beginning_utc": "2025-02-09T16:00:00",
+      "fuel_type": "Storage",
+      "mw": 7.0
+    },
+    {
+      "datetime_beginning_utc": "2025-02-09T16:00:00",
+      "fuel_type": "Wind",
+      "mw": 1221.0
+    },
+    {
+      "datetime_beginning_utc": "2025-02-09T17:00:00",
+      "fuel_type": "Coal",
+      "mw": 16384.0
+    },
+    {
+      "datetime_beginning_utc": "2025-02-09T17:00:00",
+      "fuel_type": "Gas",
+      "mw": 42723.0
+    },
+    {
+      "datetime_beginning_utc": "2025-02-09T17:00:00",
+      "fuel_type": "Hydro",
+      "mw": 468.0
+    },
+    {
+      "datetime_beginning_utc": "2025-02-09T17:00:00",
+      "fuel_type": "Multiple Fuels",
+      "mw": 1.0
+    },
+    {
+      "datetime_beginning_utc": "2025-02-09T17:00:00",
+      "fuel_type": "Nuclear",
+      "mw": 33632.0
+    },
+    {
+      "datetime_beginning_utc": "2025-02-09T17:00:00",
+      "fuel_type": "Oil",
+      "mw": 207.0
+    },
+    {
+      "datetime_beginning_utc": "2025-02-09T17:00:00",
+      "fuel_type": "Other Renewables",
+      "mw": 659.0
+    },
+    {
+      "datetime_beginning_utc": "2025-02-09T17:00:00",
+      "fuel_type": "Solar",
+      "mw": 5502.0
+    },
+    {
+      "datetime_beginning_utc": "2025-02-09T17:00:00",
+      "fuel_type": "Storage",
+      "mw": 4.0
+    },
+    {
+      "datetime_beginning_utc": "2025-02-09T17:00:00",
+      "fuel_type": "Wind",
+      "mw": 1061.0
+    },
+    {
+      "datetime_beginning_utc": "2025-02-09T18:00:00",
+      "fuel_type": "Coal",
+      "mw": 16411.0
+    },
+    {
+      "datetime_beginning_utc": "2025-02-09T18:00:00",
+      "fuel_type": "Gas",
+      "mw": 42256.0
+    },
+    {
+      "datetime_beginning_utc": "2025-02-09T18:00:00",
+      "fuel_type": "Hydro",
+      "mw": 496.0
+    },
+    {
+      "datetime_beginning_utc": "2025-02-09T18:00:00",
+      "fuel_type": "Multiple Fuels",
+      "mw": 1.0
+    },
+    {
+      "datetime_beginning_utc": "2025-02-09T18:00:00",
+      "fuel_type": "Nuclear",
+      "mw": 33641.0
+    },
+    {
+      "datetime_beginning_utc": "2025-02-09T18:00:00",
+      "fuel_type": "Oil",
+      "mw": 206.0
+    },
+    {
+      "datetime_beginning_utc": "2025-02-09T18:00:00",
+      "fuel_type": "Other Renewables",
+      "mw": 666.0
+    },
+    {
+      "datetime_beginning_utc": "2025-02-09T18:00:00",
+      "fuel_type": "Solar",
+      "mw": 5407.0
+    },
+    {
+      "datetime_beginning_utc": "2025-02-09T18:00:00",
+      "fuel_type": "Storage",
+      "mw": 0.0
+    },
+    {
+      "datetime_beginning_utc": "2025-02-09T18:00:00",
+      "fuel_type": "Wind",
+      "mw": 1052.0
+    },
+    {
+      "datetime_beginning_utc": "2025-02-09T19:00:00",
+      "fuel_type": "Coal",
+      "mw": 16010.0
+    },
+    {
+      "datetime_beginning_utc": "2025-02-09T19:00:00",
+      "fuel_type": "Gas",
+      "mw": 42027.0
+    },
+    {
+      "datetime_beginning_utc": "2025-02-09T19:00:00",
+      "fuel_type": "Hydro",
+      "mw": 457.0
+    },
+    {
+      "datetime_beginning_utc": "2025-02-09T19:00:00",
+      "fuel_type": "Multiple Fuels",
+      "mw": 53.0
+    },
+    {
+      "datetime_beginning_utc": "2025-02-09T19:00:00",
+      "fuel_type": "Nuclear",
+      "mw": 33640.0
+    },
+    {
+      "datetime_beginning_utc": "2025-02-09T19:00:00",
+      "fuel_type": "Oil",
+      "mw": 205.0
+    },
+    {
+      "datetime_beginning_utc": "2025-02-09T19:00:00",
+      "fuel_type": "Other Renewables",
+      "mw": 671.0
+    },
+    {
+      "datetime_beginning_utc": "2025-02-09T19:00:00",
+      "fuel_type": "Solar",
+      "mw": 5231.0
+    },
+    {
+      "datetime_beginning_utc": "2025-02-09T19:00:00",
+      "fuel_type": "Storage",
+      "mw": 0.0
+    },
+    {
+      "datetime_beginning_utc": "2025-02-09T19:00:00",
+      "fuel_type": "Wind",
+      "mw": 1187.0
+    },
+    {
+      "datetime_beginning_utc": "2025-02-09T20:00:00",
+      "fuel_type": "Coal",
+      "mw": 15907.0
+    },
+    {
+      "datetime_beginning_utc": "2025-02-09T20:00:00",
+      "fuel_type": "Gas",
+      "mw": 41535.0
+    },
+    {
+      "datetime_beginning_utc": "2025-02-09T20:00:00",
+      "fuel_type": "Hydro",
+      "mw": 522.0
+    },
+    {
+      "datetime_beginning_utc": "2025-02-09T20:00:00",
+      "fuel_type": "Multiple Fuels",
+      "mw": 309.0
+    },
+    {
+      "datetime_beginning_utc": "2025-02-09T20:00:00",
+      "fuel_type": "Nuclear",
+      "mw": 33629.0
+    },
+    {
+      "datetime_beginning_utc": "2025-02-09T20:00:00",
+      "fuel_type": "Oil",
+      "mw": 205.0
+    },
+    {
+      "datetime_beginning_utc": "2025-02-09T20:00:00",
+      "fuel_type": "Other Renewables",
+      "mw": 658.0
+    },
+    {
+      "datetime_beginning_utc": "2025-02-09T20:00:00",
+      "fuel_type": "Solar",
+      "mw": 4629.0
+    },
+    {
+      "datetime_beginning_utc": "2025-02-09T20:00:00",
+      "fuel_type": "Storage",
+      "mw": 0.0
+    },
+    {
+      "datetime_beginning_utc": "2025-02-09T20:00:00",
+      "fuel_type": "Wind",
+      "mw": 1221.0
+    },
+    {
+      "datetime_beginning_utc": "2025-02-09T21:00:00",
+      "fuel_type": "Coal",
+      "mw": 15772.0
+    },
+    {
+      "datetime_beginning_utc": "2025-02-09T21:00:00",
+      "fuel_type": "Gas",
+      "mw": 43252.0
+    },
+    {
+      "datetime_beginning_utc": "2025-02-09T21:00:00",
+      "fuel_type": "Hydro",
+      "mw": 1421.0
+    },
+    {
+      "datetime_beginning_utc": "2025-02-09T21:00:00",
+      "fuel_type": "Multiple Fuels",
+      "mw": 431.0
+    },
+    {
+      "datetime_beginning_utc": "2025-02-09T21:00:00",
+      "fuel_type": "Nuclear",
+      "mw": 33625.0
+    },
+    {
+      "datetime_beginning_utc": "2025-02-09T21:00:00",
+      "fuel_type": "Oil",
+      "mw": 401.0
+    },
+    {
+      "datetime_beginning_utc": "2025-02-09T21:00:00",
+      "fuel_type": "Other Renewables",
+      "mw": 651.0
+    },
+    {
+      "datetime_beginning_utc": "2025-02-09T21:00:00",
+      "fuel_type": "Solar",
+      "mw": 2719.0
+    },
+    {
+      "datetime_beginning_utc": "2025-02-09T21:00:00",
+      "fuel_type": "Storage",
+      "mw": 0.0
+    },
+    {
+      "datetime_beginning_utc": "2025-02-09T21:00:00",
+      "fuel_type": "Wind",
+      "mw": 1341.0
+    }
+  ],
+  "searchSpecification": {
+    "rowCount": 500,
+    "order": "Asc",
+    "startRow": 1,
+    "isActiveMetadata": true,
+    "fields": [
+      "datetime_beginning_utc",
+      "fuel_type",
+      "mw"
+    ],
+    "filters": [
+      {
+        "datetime_beginning_utc": "2025-02-09T00:00:00.0000000"
+      }
+    ]
+  },
+  "totalRows": 220
+}

--- a/parsers/test/mocks/US_PJM/settings.json
+++ b/parsers/test/mocks/US_PJM/settings.json
@@ -1,0 +1,11 @@
+{
+  "baseUrl": "https://api.pjm.com/api/v1",
+  "baseAdminUrl": "http://localhost:44346/admin",
+  "baseSyndicationUrl": "https://api.pjm.com/syndication/v1",
+  "subscriptionKey": "aca459ab4b064b9ca31ca87ceaa23254",
+  "registerUrl": "https://apiportal.pjm.com/",
+  "connextUrl": "https://pjmconnext.com",
+  "feedbackUri": "https://www.pjm.com/AjaxService/FeedbackService.asmx/PostFeedback",
+  "feedbackKey": "SV_eJuz6ckkcfxzwJ7",
+  "tool": "Data Miner 2"
+}

--- a/parsers/test/test_US_PJM.py
+++ b/parsers/test/test_US_PJM.py
@@ -1,0 +1,33 @@
+import re
+from json import loads
+from pathlib import Path
+
+from requests_mock import GET
+
+from electricitymap.contrib.lib.types import ZoneKey
+from parsers.US_PJM import fetch_production
+
+base_path_to_mock = Path("parsers/test/mocks/US_PJM")
+
+
+def test_production(adapter, session, snapshot):
+    settings = Path(base_path_to_mock, "settings.json")
+    adapter.register_uri(
+        GET,
+        "https://dataminer2.pjm.com/config/settings.json",
+        json=loads(settings.read_text()),
+    )
+
+    data = Path(base_path_to_mock, "gen_by_fuel.json")
+    adapter.register_uri(
+        GET,
+        re.compile(
+            r"https://us-ca-proxy-jfnx5klx2a-uw\.a\.run\.app/api/v1/gen_by_fuel.*"
+        ),
+        json=loads(data.read_text()),
+    )
+
+    assert snapshot == fetch_production(
+        zone_key=ZoneKey("US-MIDA-PJM"),
+        session=session,
+    )


### PR DESCRIPTION
## Description
This pull request includes several changes to the `US_PJM` parser and its associated test files. The most notable changes involve importing new modules, refactoring the `fetch_production` function, and adding new test configurations and cases.

### Parser Improvements and Refactoring:

* [`parsers/US_PJM.py`](diffhunk://#diff-40a3ce6e7bcbd2976197b77c0d82bf8cfd6335230a68ae48e37ca0ad6321189bR5-L10): Added imports for `groupby` from `itertools` and `itemgetter` from `operator`, and removed the unused `pandas` import.
* [`parsers/US_PJM.py`](diffhunk://#diff-40a3ce6e7bcbd2976197b77c0d82bf8cfd6335230a68ae48e37ca0ad6321189bL167-L200): Refactored the `fetch_production` function to replace the use of `pandas` with `groupby` and `itemgetter`, improving performance and readability.

### Test Enhancements:

* [`parsers/test/mocks/US_PJM/settings.json`](diffhunk://#diff-7fdae9df7c5cb1964632af835c56932f725ac5c505b4b408a978bf22aab66c82R1-R11): Added a new settings file to mock API responses for tests.
* [`parsers/test/test_US_PJM.py`](diffhunk://#diff-cbf2fc2dc4dabee2d38456dbf399123e3174679c834c2c75d1552e614b6d04c6R1-R33): Added a new test case to verify the `fetch_production` function using the new settings and mock data.

### Contributor Update:

* [`config/zones/US-MIDA-PJM.yaml`](diffhunk://#diff-ff3c05f30e2d63ff143908a3ae3d3388a4d7a4108566a2be7929c5f67b045ea8R181): Added `VIKTORVAV99` to the list of contributors.


### Double check

- [x] I have tested my parser changes locally with `poetry run test_parser "zone_key"`
- [x] I have run `pnpx prettier@2 --write .` and `poetry run format` in the top level directory to format my changes.
