### PR TITLE
Fix Danish name for Moldova

### DIFF
--- a/web/src/locales/da.json
+++ b/web/src/locales/da.json
@@ -1319,7 +1319,7 @@
       "zoneName": "Monaco"
     },
     "MD": {
-      "zoneName": "Moldavien"
+      "zoneName": "Moldova"
     },
     "ME": {
       "zoneName": "Montenegro"


### PR DESCRIPTION
## Issue

<!-- If you want to close an issue automatically when your PR is merged, write "Closes X" where X is the issue number. For example: Closes #000 -->

## Description

<!-- Explains the goal of this PR -->
The modern-day Republic of Moldova is called "Moldova" in Danish; "Moldavien" is the historical region of Moldavia.

Wikipedia: [Moldova](https://da.wikipedia.org/wiki/Moldova)/[Moldavien](https://da.wikipedia.org/wiki/Moldavien)
Lex: [Moldova](https://lex.dk/Moldova)/[Moldavien](https://lex.dk/Moldavien)
The [Danish Ministry of Foreign Affairs](https://um.dk/) also uses "Moldova".

### Preview

<!-- Please add screenshots and/or gif that shows visual changes (if applicable) -->

### Double check

- [ ] I have tested my parser changes locally with `poetry run test_parser "zone_key"`
- [ ] I have run `pnpx prettier@2 --write .` and `poetry run format` in the top level directory to format my changes.
