### PR TITLE
Fix fuerteventura lanzarote exchange direction

### DIFF
--- a/parsers/ES.py
+++ b/parsers/ES.py
@@ -201,7 +201,7 @@ EXCHANGE_MAPPING = {
     ZoneKey("ES-CN-FV->ES-CN-LZ"): {
         "zone_ref": ZoneKey("ES-CN-LZ"),
         "codes": ["efl"],
-        "coef": -1,
+        "coef": 1,
     },
 }
 


### PR DESCRIPTION
## Issue

## Description

With the recent changes, the electricity production of Fuerteventura and Lanzarote has been added. These two islands exchange electricity. The direction of the electricity seems wrong (my fault). This patch changes the direction

### Preview

https://demanda.ree.es/visiona/canarias/fuerteveau/acumulada/2025-2-13
![image](https://github.com/user-attachments/assets/0dcd7c9f-73fd-4697-9558-b55d2691c3c2)
![image](https://github.com/user-attachments/assets/04b23016-6e37-44e1-baec-5368d1981d0c)

```
 {'datetime': datetime.datetime(2025, 2, 13, 19, 0, tzinfo=zoneinfo.ZoneInfo(key='Atlantic/Canary')),
  'netFlow': -14.8,
  'sortedZoneKeys': 'ES-CN-FV->ES-CN-LZ',
  'source': 'demanda.ree.es',
  'sourceType': <EventSourceType.measured: 'measured'>},
```

### Double check

- [X] I have tested my parser changes locally with `poetry run test_parser ES-CN-FV->ES-CN-LZ exchange"`
- [X] I have run  `poetry run format` in the top level directory to format my changes.
