### PR TITLE
fix(web): remove pill from estimation card

### DIFF
--- a/web/src/features/panels/zone/EstimationCard.cy.tsx
+++ b/web/src/features/panels/zone/EstimationCard.cy.tsx
@@ -61,7 +61,6 @@ describe('EstimationCard with known estimation method', () => {
 
   it('Estimation card contains expected information', () => {
     cy.get('[data-testid=title]').contains('Data is always estimated');
-    cy.get('[data-testid=badge]').contains('Not realtime');
     cy.get('[data-testid="collapse-button"]').click();
     cy.get('[data-testid="body-text"]').contains(
       'The data for this zone is not published in realtime and only provides the total production. Both hourly production and production sources are estimated based on historical data for each production source.'
@@ -91,7 +90,6 @@ describe('EstimationCard', () => {
       </I18nextProvider>
     );
     cy.get('[data-testid=title]').contains('Data is estimated');
-    cy.get('[data-testid=badge]').contains('Imprecise');
     cy.get('[data-testid="collapse-button"]').click();
     cy.get('[data-testid="body-text"]').contains(
       'The published data for this zone is unavailable or incomplete. The data shown on the map is estimated using our best effort, but might differ from the actual values.'
@@ -127,7 +125,6 @@ describe('OutageCard', () => {
 
   it('Outage message contains expected information', () => {
     cy.get('[data-testid=title]').contains('Ongoing issues');
-    cy.get('[data-testid=badge]').contains('Unavailable');
   });
 
   it('For outage start as expanded and toggles collapse when collapse button is clicked', () => {
@@ -153,7 +150,6 @@ describe('AggregatedCard', () => {
       </I18nextProvider>
     );
     cy.get('[data-testid=title]').contains('Data is aggregated');
-    cy.get('[data-testid=badge]').contains('50% estimated');
     cy.get('[data-testid="collapse-button"]').click();
     cy.get('[data-testid="body-text"]').contains(
       'The data consists of an aggregation of hourly values. 50% of the production values are estimated.'
@@ -173,7 +169,6 @@ describe('AggregatedCard', () => {
       </I18nextProvider>
     );
     cy.get('[data-testid=title]').contains('Data is aggregated');
-    cy.get('[data-testid=badge]').should('not.exist');
     cy.get('[data-testid="collapse-button"]').click();
     cy.get('[data-testid="body-text"]').contains(
       'The data consists of an aggregation of hourly values.'

--- a/web/src/features/panels/zone/EstimationCard.tsx
+++ b/web/src/features/panels/zone/EstimationCard.tsx
@@ -1,15 +1,9 @@
 import Accordion from 'components/Accordion';
 import FeedbackCard, { SurveyResponseProps } from 'components/app-survey/FeedbackCard';
-import Badge, { PillType } from 'components/Badge';
 import { useFeatureFlag } from 'features/feature-flags/api';
 import { useGetEstimationTranslation } from 'hooks/getEstimationTranslation';
 import { useAtom, useAtomValue } from 'jotai';
-import {
-  ChartNoAxesColumn,
-  CircleDashed,
-  TrendingUpDown,
-  TriangleAlert,
-} from 'lucide-react';
+import { ChartNoAxesColumn, CircleDashed, TrendingUpDown } from 'lucide-react';
 import React, { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { FaGithub } from 'react-icons/fa6';
@@ -112,9 +106,7 @@ function BaseCard({
   estimatedPercentage,
   zoneMessage,
   icon,
-  iconPill,
   showMethodologyLink,
-  pillType,
   textColorTitle,
   cardType,
 }: {
@@ -122,9 +114,7 @@ function BaseCard({
   estimatedPercentage?: number;
   zoneMessage?: ZoneMessage;
   icon: React.ReactElement;
-  iconPill?: React.ReactElement;
   showMethodologyLink: boolean;
-  pillType?: PillType;
   textColorTitle: string;
   cardType: string;
 }) {
@@ -143,18 +133,11 @@ function BaseCard({
   const { t } = useTranslation();
 
   const title = useGetEstimationTranslation('title', estimationMethod);
-  const pillText = useGetEstimationTranslation(
-    'pill',
-    estimationMethod,
-    estimatedPercentage
-  );
+
   const bodyText = useGetEstimationTranslation(
     'body',
     estimationMethod,
     estimatedPercentage
-  );
-  const showBadge = Boolean(
-    estimationMethod == 'aggregated' ? estimatedPercentage : pillType
   );
 
   return (
@@ -167,9 +150,6 @@ function BaseCard({
     >
       <Accordion
         onClick={() => trackToggle()}
-        badge={
-          showBadge && <Badge type={pillType} icon={iconPill} pillText={pillText}></Badge>
-        }
         className={textColorTitle}
         icon={icon}
         title={title}
@@ -225,9 +205,7 @@ function OutageCard({
       estimationMethod={EstimationMethods.OUTAGE}
       zoneMessage={zoneMessageText}
       icon={<TrendingUpDown size={16} />}
-      iconPill={<TriangleAlert size={16} />}
       showMethodologyLink={false}
-      pillType="warning"
       textColorTitle="text-warning dark:text-warning-dark"
       cardType="outage-card"
     />
@@ -241,9 +219,7 @@ function AggregatedCard({ estimatedPercentage }: { estimatedPercentage?: number 
       estimatedPercentage={estimatedPercentage}
       zoneMessage={undefined}
       icon={<ChartNoAxesColumn size={16} />}
-      iconPill={undefined}
       showMethodologyLink={false}
-      pillType={'warning'}
       textColorTitle="text-black dark:text-white"
       cardType="aggregated-card"
     />
@@ -260,9 +236,7 @@ function EstimatedCard({
       estimationMethod={estimationMethod}
       zoneMessage={undefined}
       icon={<TrendingUpDown size={16} />}
-      iconPill={undefined}
       showMethodologyLink={true}
-      pillType="default"
       textColorTitle="text-warning dark:text-warning-dark"
       cardType="estimated-card"
     />
@@ -275,9 +249,7 @@ function EstimatedTSACard() {
       estimationMethod={EstimationMethods.TSA}
       zoneMessage={undefined}
       icon={<CircleDashed size={16} />}
-      iconPill={undefined}
       showMethodologyLink={true}
-      pillType={undefined}
       textColorTitle="text-warning dark:text-warning-dark"
       cardType="estimated-card"
     />


### PR DESCRIPTION
## Issue

<!-- If you want to close an issue automatically when your PR is merged, write "Closes X" where X is the issue number. For example: Closes #000 -->
[GMM-526](https://linear.app/electricitymaps/issue/GMM-526/remove-pill-inside-estimated-card)

## Description

<!-- Explains the goal of this PR -->
This PR remove the pill from the estimation, aggregation and outage card.

### Preview

<!-- Please add screenshots and/or gif that shows visual changes (if applicable) -->
Before:
<img width="444" alt="Screenshot 2025-02-19 at 17 05 34" src="https://github.com/user-attachments/assets/0ba9f3e0-f440-417a-99f8-193fd08accda" />

After:
<img width="439" alt="Screenshot 2025-02-19 at 17 05 44" src="https://github.com/user-attachments/assets/f2499111-4a7e-4036-8229-129eb4e2f40a" />

### Double check

- [ ] I have tested my parser changes locally with `poetry run test_parser "zone_key"`
- [x] I have run `pnpx prettier@2 --write .` and `poetry run format` in the top level directory to format my changes.
