### PR TITLE
fix(web): change map tooltip color for preliminary

### DIFF
--- a/web/src/features/map/MapTooltip.tsx
+++ b/web/src/features/map/MapTooltip.tsx
@@ -83,6 +83,7 @@ export const DataValidityBadge = memo(function DataValidityBadge({
         <EstimationBadge
           text={t('estimation-card.ESTIMATED_TIME_SLICER_AVERAGE.pill')}
           Icon={CircleDashed}
+          isPreliminary={true}
         />
       );
     }


### PR DESCRIPTION
## Issue

<!-- If you want to close an issue automatically when your PR is merged, write "Closes X" where X is the issue number. For example: Closes #000 -->
The map tooltip should also be grey for prelimiary
<img width="886" alt="image" src="https://github.com/user-attachments/assets/59b618de-4cd0-47db-94ab-76326d1eecbc" />

## Description

<!-- Explains the goal of this PR -->
This makes the tooltip grey for preliminary

### Preview

<!-- Please add screenshots and/or gif that shows visual changes (if applicable) -->

### Double check

- [ ] I have tested my parser changes locally with `poetry run test_parser "zone_key"`
- [ ] I have run `pnpx prettier@2 --write .` and `poetry run format` in the top level directory to format my changes.
