### PR TITLE
add name to hawaii zone

### DIFF
--- a/web/public/locales/en.json
+++ b/web/public/locales/en.json
@@ -1281,6 +1281,10 @@
       "countryName": "USA",
       "zoneName": "Southeast Alaska Power Agency"
     },
+    "US-HI": {
+      "countryName": "USA",
+      "zoneName": "Hawaii"
+    },
     "US-HI-HA": {
       "countryName": "USA",
       "zoneName": "Hawaii"

--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -1784,6 +1784,10 @@
       "countryName": "USA",
       "zoneName": "Southeast Alaska Power Agency"
     },
+    "US-HI": {
+      "countryName": "USA",
+      "zoneName": "Hawaii"
+    },
     "US-HI-HA": {
       "countryName": "USA",
       "zoneName": "Hawaii"


### PR DESCRIPTION
## Issue

<!-- If you want to close an issue automatically when your PR is merged, write "Closes X" where X is the issue number. For example: Closes #000 -->
[GMM-583](https://linear.app/electricitymaps/issue/GMM-583/hawai-is-displayed-as-us-hi-on-the-map-has-no-name-on-the-left-panel)

## Description

<!-- Explains the goal of this PR -->
This PR adds Hawaii as a name for US-HI.

### Preview

<!-- Please add screenshots and/or gif that shows visual changes (if applicable) -->
<img width="913" alt="image" src="https://github.com/user-attachments/assets/32781f39-30e5-4cfd-a8d0-684484ec3b63" />


### Double check

- [ ] I have tested my parser changes locally with `poetry run test_parser "zone_key"`
- [ ] I have run `pnpx prettier@2 --write .` and `poetry run format` in the top level directory to format my changes.
