### PR TITLE
feat(metrics/parser-data): Increase production parser delay for AU-NT, AU-WA and ZA

### DIFF
--- a/config/zones/AU-NT.yaml
+++ b/config/zones/AU-NT.yaml
@@ -14,7 +14,7 @@ country: AU
 delays:
   consumption: 30
   price: 30
-  production: 55
+  production: 58
 disclaimer: The Northern Territory power grid is not connected to the (Australian)
   National Electricity Market or Western Australia's grid.
 emissionFactors:

--- a/config/zones/AU-WA.yaml
+++ b/config/zones/AU-WA.yaml
@@ -47,7 +47,7 @@ contributors:
   - MariusKroon
 country: AU
 delays:
-  production: 28
+  production: 58
 disclaimer: Western Australia's power grid is not connected to the (Australian) National
   Electricity Market or the Northern Territory grid.
 emissionFactors:

--- a/config/zones/ZA.yaml
+++ b/config/zones/ZA.yaml
@@ -58,7 +58,7 @@ contributors:
   - IV1T3
 country: ZA
 delays:
-  production: 74
+  production: 96 # 4 days - as of 11/03/2025, on 10/03/2025, delay was above 4 days for the first time, so do not set it higher
 emissionFactors:
   direct:
     battery discharge:


### PR DESCRIPTION
## Description
We have frequent alert on those zones because the data source is reporting data with some delay.

We want to avoid noisy alerts of those parsers when it is just the datasource that is delayed and we cannot take action on those alerts. To avoid noisy alerts, we increase the delay threshold with which we trigger alerts for those zones. 

### Double check

- [x] I have tested my parser changes locally with `poetry run test_parser "zone_key"`
- [x] I have run `pnpx prettier@2 --write .` and `poetry run format` in the top level directory to format my changes.
