### PR TITLE
Increase delay for CO and MX

### DIFF
--- a/config/zones/CO.yaml
+++ b/config/zones/CO.yaml
@@ -113,7 +113,7 @@ contributors:
   - consideRatio
 country: CO
 delays:
-  production: 48
+  production: 84 # As of 2025-03-17, Colombia's recent maximum delay is 3.5 days
 emissionFactors:
   lifecycle:
     battery discharge:

--- a/config/zones/MX.yaml
+++ b/config/zones/MX.yaml
@@ -119,6 +119,8 @@ contributors:
   - tuxity
   - consideRatio
 country: MX
+delays:
+  production: 1080 # = 45 * 24 Mexico is known for having a maximum delay of 45 days
 emissionFactors:
   direct:
     unknown:


### PR DESCRIPTION
## Issue
MX and CO report data with delay (resp. unto 1.5 month and 3.5 days). 
Specify those delays in the configuration. 
