### PR TITLE
correct name zone in US_SPP.py

### DIFF
--- a/parsers/US_SPP.py
+++ b/parsers/US_SPP.py
@@ -422,16 +422,20 @@ def fetch_exchange(
 
 if __name__ == "__main__":
     print("fetch_production() -> ")
-    print(fetch_production(zone_key=ZoneKey("US-SW-AZPS")))
+    print(fetch_production(zone_key=ZoneKey("US-CENT-SWPP")))
+
     print("fetch_exchange() -> ")
     print(fetch_exchange("US-CENT-SWPP", "US-MIDW-MISO"))
+
     print("fetch_load_forecast() -> ")
     print(
-        fetch_load_forecast(zone_key=ZoneKey("US-SW-AZPS"), target_datetime="20190125")
+        fetch_load_forecast(
+            zone_key=ZoneKey("US-CENT-SWPP"), target_datetime="20190125"
+        )
     )
     print("fetch_wind_solar_forecasts() -> ")
     print(
         fetch_wind_solar_forecasts(
-            zone_key=ZoneKey("US-SW-AZPS"), target_datetime="20221118"
+            zone_key=ZoneKey("US-CENT-SWPP"), target_datetime="20221118"
         )
     )


### PR DESCRIPTION
change zone in main method to US-CENT-SWPP in US_SPP.py

## Issue

<!-- If you want to close an issue automatically when your PR is merged, write "Closes X" where X is the issue number. For example: Closes #000 -->

## Description

<!-- Explains the goal of this PR -->

### Preview

<!-- Please add screenshots and/or gif that shows visual changes (if applicable) -->

### Double check

- [x] I have tested my parser changes locally with `poetry run test_parser "zone_key"`
- [x] I have run `pnpx prettier@2 --write .` and `poetry run format` in the top level directory to format my changes.
