### PR TITLE
feat(app): reduce spammy errors from blocked plausible

### DIFF
--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -44,6 +44,7 @@ if (isProduction) {
       scope.setTag('browser.locale', window.navigator.language); // Set the language tag for Sentry to correlate errors with the user's language
       return scope;
     },
+    ignoreErrors: [/plausible\.local\.js/],
   });
 }
 


### PR DESCRIPTION
## Issue
We're often exceeding our warning for error events in one hour on sentry

## Description
We believe the large number of errors from plausible is due to updated adblocking or similar causing the script to fail. 

This PR updates sentry to ignore errors that originate from the plausible script
