### PR TITLE
Dark Mode, Lighter Tides: A Sea of Subtle Shades 🌚 

### DIFF
--- a/web/src/features/app-sidebar/AppSidebar.tsx
+++ b/web/src/features/app-sidebar/AppSidebar.tsx
@@ -2,7 +2,7 @@ import { LogoIcon } from 'components/Logo';
 import {
   BookOpenIcon,
   CodeXmlIcon,
-  FileSpreadsheetIcon,
+  FileDownIcon,
   HelpCircleIcon,
   MapIcon,
 } from 'lucide-react';
@@ -33,7 +33,7 @@ const MENU_ITEMS = [
   {
     label: 'Datasets',
     to: `${PORTAL_URL}/datasets`,
-    icon: FileSpreadsheetIcon,
+    icon: FileDownIcon,
   },
   {
     label: 'API',

--- a/web/src/hooks/colors.ts
+++ b/web/src/hooks/colors.ts
@@ -28,7 +28,7 @@ export const colors: Colors = {
   },
   dark: {
     co2Scale: defaultCo2Scale,
-    oceanColor: '#0A0A0A',
+    oceanColor: '#262626',
     strokeWidth: 0.15,
     strokeColor: '#6D6D6D',
     stateBorderColor: '#d1d5db',


### PR DESCRIPTION
## Issue

Closes #7937

## Description

During the redesign, we did perhaps go a bit too dark on the ocean - so this PR now reverts it back to a nice dark grey instead. Thanks for the feedback from users on this :)

While at it, I also fixed the icon so we use the same one across platforms.
