### PR TITLE
chore(zone-configs): increase delay on AU zones

### DIFF
--- a/config/zones/AU-NSW.yaml
+++ b/config/zones/AU-NSW.yaml
@@ -70,7 +70,7 @@ contributors:
   - corradio
 country: AU
 delays:
-  production: 5
+  production: 96
 emissionFactors:
   direct:
     battery discharge:

--- a/config/zones/AU-NT.yaml
+++ b/config/zones/AU-NT.yaml
@@ -14,7 +14,7 @@ country: AU
 delays:
   consumption: 30
   price: 30
-  production: 58
+  production: 96
 disclaimer: The Northern Territory power grid is not connected to the (Australian)
   National Electricity Market or Western Australia's grid.
 emissionFactors:

--- a/config/zones/AU-QLD.yaml
+++ b/config/zones/AU-QLD.yaml
@@ -64,7 +64,7 @@ contributors:
   - corradio
 country: AU
 delays:
-  production: 5
+  production: 96
 emissionFactors:
   direct:
     battery discharge:

--- a/config/zones/AU-SA.yaml
+++ b/config/zones/AU-SA.yaml
@@ -58,7 +58,7 @@ contributors:
   - corradio
 country: AU
 delays:
-  production: 5
+  production: 96
 emissionFactors:
   direct:
     battery discharge:

--- a/config/zones/AU-TAS.yaml
+++ b/config/zones/AU-TAS.yaml
@@ -34,7 +34,7 @@ contributors:
   - corradio
 country: AU
 delays:
-  production: 5
+  production: 96
 emissionFactors:
   direct:
     battery discharge:

--- a/config/zones/AU-VIC.yaml
+++ b/config/zones/AU-VIC.yaml
@@ -58,7 +58,7 @@ contributors:
   - corradio
 country: AU
 delays:
-  production: 5
+  production: 96
 emissionFactors:
   direct:
     battery discharge:

--- a/config/zones/AU-WA.yaml
+++ b/config/zones/AU-WA.yaml
@@ -47,7 +47,7 @@ contributors:
   - MariusKroon
 country: AU
 delays:
-  production: 58
+  production: 96
 disclaimer: Western Australia's power grid is not connected to the (Australian) National
   Electricity Market or the Northern Territory grid.
 emissionFactors:


### PR DESCRIPTION
## Issue

<!-- If you want to close an issue automatically when your PR is merged, write "Closes X" where X is the issue number. For example: Closes #000 -->
AU zones are often delayed by several days, so I'm increasing delay so we do not get alerts for this all the time

## Description

<!-- Explains the goal of this PR -->
This PR sets the delay to 4 days (4*24=96 hours) for the AU-zones. 

### Preview

<!-- Please add screenshots and/or gif that shows visual changes (if applicable) -->

### Double check

- [ ] I have tested my parser changes locally with `poetry run test_parser "zone_key"`
- [ ] I have run `pnpx prettier@2 --write .` and `poetry run format` in the top level directory to format my changes.
