### PR TITLE
feat(app): remove exchange zone disclaimer

### DIFF
--- a/config/zones/US-CAL-BANC.yaml
+++ b/config/zones/US-CAL-BANC.yaml
@@ -80,8 +80,6 @@ delays:
   consumption: 30
   consumptionForecast: 30
   production: 48
-disclaimer: Data for real-time consumption and generation mix is estimated. Real-time
-  exchanges are not available.
 emissionFactors:
   direct:
     battery discharge:

--- a/config/zones/US-CAL-IID.yaml
+++ b/config/zones/US-CAL-IID.yaml
@@ -95,8 +95,6 @@ delays:
   consumption: 30
   consumptionForecast: 30
   production: 48
-disclaimer: Data for real-time consumption and generation mix is estimated. Real-time
-  exchanges are not available.
 emissionFactors:
   direct:
     battery discharge:

--- a/config/zones/US-CAL-LDWP.yaml
+++ b/config/zones/US-CAL-LDWP.yaml
@@ -122,8 +122,6 @@ delays:
   consumption: 30
   consumptionForecast: 30
   production: 48
-disclaimer: Data for real-time consumption and generation mix is estimated. Real-time
-  exchanges are not available.
 emissionFactors:
   direct:
     battery discharge:

--- a/config/zones/US-CAL-TIDC.yaml
+++ b/config/zones/US-CAL-TIDC.yaml
@@ -65,8 +65,6 @@ delays:
   consumption: 30
   consumptionForecast: 30
   production: 48
-disclaimer: Data for real-time consumption and generation mix is estimated. Real-time
-  exchanges are not available.
 emissionFactors:
   direct:
     battery discharge:

--- a/config/zones/US-CAR-CPLE.yaml
+++ b/config/zones/US-CAR-CPLE.yaml
@@ -176,8 +176,6 @@ delays:
   consumption: 30
   consumptionForecast: 30
   production: 48
-disclaimer: Data for real-time consumption and generation mix is estimated. Real-time
-  exchanges are not available.
 emissionFactors:
   direct:
     battery discharge:

--- a/config/zones/US-CAR-CPLW.yaml
+++ b/config/zones/US-CAR-CPLW.yaml
@@ -71,8 +71,6 @@ delays:
   consumption: 30
   consumptionForecast: 30
   production: 48
-disclaimer: Data for real-time consumption and generation mix is estimated. Real-time
-  exchanges are not available.
 emissionFactors:
   direct:
     battery discharge:

--- a/config/zones/US-CAR-DUK.yaml
+++ b/config/zones/US-CAR-DUK.yaml
@@ -185,8 +185,6 @@ delays:
   consumption: 30
   consumptionForecast: 30
   production: 48
-disclaimer: Data for real-time consumption and generation mix is estimated. Real-time
-  exchanges are not available.
 emissionFactors:
   direct:
     battery discharge:

--- a/config/zones/US-CAR-SC.yaml
+++ b/config/zones/US-CAR-SC.yaml
@@ -74,8 +74,7 @@ delays:
   consumption: 30
   consumptionForecast: 30
   production: 48
-disclaimer: Data for real-time consumption and generation mix is estimated. Real-time
-  exchanges are not available. This zone includes a third of the nuclear related electricity
+disclaimer: This zone includes a third of the nuclear related electricity
   production from the balancing authority South Carolina Electric & Gas Company. Read
   more on the zone definition wiki page.
 emissionFactors:

--- a/config/zones/US-CAR-SCEG.yaml
+++ b/config/zones/US-CAR-SCEG.yaml
@@ -110,8 +110,7 @@ delays:
   consumption: 30
   consumptionForecast: 30
   production: 48
-disclaimer: Data for real-time consumption and generation mix is estimated. Real-time
-  exchanges are not available. A third of the nuclear-related electricity production
+disclaimer: A third of the nuclear-related electricity production
   is attributed to the balancing authority South Carolina Public Service Authority
   (US-CAR-SC) due to an agreement between the two balancing authorities. Read more
   on the zone definition wiki page.

--- a/config/zones/US-CAR-YAD.yaml
+++ b/config/zones/US-CAR-YAD.yaml
@@ -60,8 +60,6 @@ contributors:
 country: US
 delays:
   production: 48
-disclaimer: Data for real-time consumption and generation mix is estimated. Real-time
-  exchanges are not available.
 emissionFactors:
   direct:
     battery discharge:

--- a/config/zones/US-CENT-SPA.yaml
+++ b/config/zones/US-CENT-SPA.yaml
@@ -71,8 +71,6 @@ delays:
   consumption: 30
   consumptionForecast: 30
   production: 48
-disclaimer: Data for real-time consumption and generation mix is estimated. Real-time
-  exchanges are not available.
 emissionFactors:
   direct:
     battery discharge:

--- a/config/zones/US-FLA-FMPP.yaml
+++ b/config/zones/US-FLA-FMPP.yaml
@@ -71,8 +71,6 @@ delays:
   consumption: 30
   consumptionForecast: 30
   production: 48
-disclaimer: Data for real-time consumption and generation mix is estimated. Real-time
-  exchanges are not available.
 emissionFactors:
   direct:
     battery discharge:

--- a/config/zones/US-FLA-FPC.yaml
+++ b/config/zones/US-FLA-FPC.yaml
@@ -131,8 +131,6 @@ delays:
   consumption: 30
   consumptionForecast: 30
   production: 48
-disclaimer: Data for real-time consumption and generation mix is estimated. Real-time
-  exchanges are not available.
 emissionFactors:
   direct:
     battery discharge:

--- a/config/zones/US-FLA-FPL.yaml
+++ b/config/zones/US-FLA-FPL.yaml
@@ -125,8 +125,6 @@ delays:
   consumption: 30
   consumptionForecast: 30
   production: 48
-disclaimer: Data for real-time consumption and generation mix is estimated. Real-time
-  exchanges are not available.
 emissionFactors:
   direct:
     battery discharge:

--- a/config/zones/US-FLA-GVL.yaml
+++ b/config/zones/US-FLA-GVL.yaml
@@ -68,8 +68,6 @@ delays:
   consumption: 30
   consumptionForecast: 30
   production: 48
-disclaimer: Data for real-time consumption and generation mix is estimated. Real-time
-  exchanges are not available.
 emissionFactors:
   direct:
     battery discharge:

--- a/config/zones/US-FLA-JEA.yaml
+++ b/config/zones/US-FLA-JEA.yaml
@@ -70,8 +70,6 @@ delays:
   consumption: 30
   consumptionForecast: 30
   production: 48
-disclaimer: Data for real-time consumption and generation mix is estimated. Real-time
-  exchanges are not available.
 emissionFactors:
   direct:
     battery discharge:

--- a/config/zones/US-FLA-SEC.yaml
+++ b/config/zones/US-FLA-SEC.yaml
@@ -71,8 +71,6 @@ delays:
   consumption: 30
   consumptionForecast: 30
   production: 48
-disclaimer: Data for real-time consumption and generation mix is estimated. Real-time
-  exchanges are not available.
 emissionFactors:
   direct:
     battery discharge:

--- a/config/zones/US-FLA-TAL.yaml
+++ b/config/zones/US-FLA-TAL.yaml
@@ -62,8 +62,6 @@ delays:
   consumption: 30
   consumptionForecast: 30
   production: 48
-disclaimer: Data for real-time consumption and generation mix is estimated. Real-time
-  exchanges are not available.
 emissionFactors:
   direct:
     battery discharge:

--- a/config/zones/US-FLA-TEC.yaml
+++ b/config/zones/US-FLA-TEC.yaml
@@ -111,8 +111,6 @@ delays:
   consumption: 30
   consumptionForecast: 30
   production: 48
-disclaimer: Data for real-time consumption and generation mix is estimated. Real-time
-  exchanges are not available.
 emissionFactors:
   direct:
     battery discharge:

--- a/config/zones/US-MIDW-AECI.yaml
+++ b/config/zones/US-MIDW-AECI.yaml
@@ -71,8 +71,6 @@ delays:
   consumption: 30
   consumptionForecast: 30
   production: 48
-disclaimer: Data for real-time consumption and generation mix is estimated. Real-time
-  exchanges are not available.
 emissionFactors:
   direct:
     battery discharge:

--- a/config/zones/US-MIDW-LGEE.yaml
+++ b/config/zones/US-MIDW-LGEE.yaml
@@ -74,8 +74,6 @@ delays:
   consumption: 30
   consumptionForecast: 30
   production: 48
-disclaimer: Data for real-time consumption and generation mix is estimated. Real-time
-  exchanges are not available.
 emissionFactors:
   direct:
     battery discharge:

--- a/config/zones/US-MIDW-MISO.yaml
+++ b/config/zones/US-MIDW-MISO.yaml
@@ -551,8 +551,6 @@ delays:
   consumption: 30
   consumptionForecast: 30
   production: 48
-disclaimer: Data for real-time consumption and generation mix is estimated. Real-time
-  exchanges are not available.
 emissionFactors:
   direct:
     battery discharge:

--- a/config/zones/US-NW-AVA.yaml
+++ b/config/zones/US-NW-AVA.yaml
@@ -77,8 +77,6 @@ delays:
   consumption: 30
   consumptionForecast: 30
   production: 48
-disclaimer: Data for real-time consumption and generation mix is estimated. Real-time
-  exchanges are not available.
 emissionFactors:
   direct:
     battery discharge:

--- a/config/zones/US-NW-BPAT.yaml
+++ b/config/zones/US-NW-BPAT.yaml
@@ -101,8 +101,7 @@ delays:
   consumption: 30
   consumptionForecast: 30
   production: 48
-disclaimer: Data for real-time consumption and generation mix is estimated. Real-time
-  exchanges are not available. This zone includes all wind related electricity production
+disclaimer: This zone includes all wind related electricity production
   from the generation-only balancing authority Avangrid Renewables, LLC. Read more
   on the zone definition wiki page.
 emissionFactors:

--- a/config/zones/US-NW-CHPD.yaml
+++ b/config/zones/US-NW-CHPD.yaml
@@ -68,8 +68,6 @@ delays:
   consumption: 30
   consumptionForecast: 30
   production: 48
-disclaimer: Data for real-time consumption and generation mix is estimated. Real-time
-  exchanges are not available.
 emissionFactors:
   direct:
     battery discharge:

--- a/config/zones/US-NW-DOPD.yaml
+++ b/config/zones/US-NW-DOPD.yaml
@@ -62,8 +62,6 @@ delays:
   consumption: 30
   consumptionForecast: 30
   production: 48
-disclaimer: Data for real-time consumption and generation mix is estimated. Real-time
-  exchanges are not available.
 emissionFactors:
   direct:
     battery discharge:

--- a/config/zones/US-NW-GCPD.yaml
+++ b/config/zones/US-NW-GCPD.yaml
@@ -62,8 +62,6 @@ delays:
   consumption: 30
   consumptionForecast: 30
   production: 48
-disclaimer: Data for real-time consumption and generation mix is estimated. Real-time
-  exchanges are not available.
 emissionFactors:
   direct:
     battery discharge:

--- a/config/zones/US-NW-GRID.yaml
+++ b/config/zones/US-NW-GRID.yaml
@@ -59,8 +59,6 @@ contributors:
 country: US
 delays:
   production: 48
-disclaimer: Data for real-time consumption and generation mix is estimated. Real-time
-  exchanges are not available.
 emissionFactors:
   direct:
     battery discharge:

--- a/config/zones/US-NW-IPCO.yaml
+++ b/config/zones/US-NW-IPCO.yaml
@@ -107,8 +107,6 @@ delays:
   consumption: 30
   consumptionForecast: 30
   production: 48
-disclaimer: Data for real-time consumption and generation mix is estimated. Real-time
-  exchanges are not available.
 emissionFactors:
   direct:
     battery discharge:

--- a/config/zones/US-NW-NEVP.yaml
+++ b/config/zones/US-NW-NEVP.yaml
@@ -167,8 +167,6 @@ delays:
   consumption: 30
   consumptionForecast: 30
   production: 48
-disclaimer: Data for real-time consumption and generation mix is estimated. Real-time
-  exchanges are not available.
 emissionFactors:
   direct:
     battery discharge:

--- a/config/zones/US-NW-NWMT.yaml
+++ b/config/zones/US-NW-NWMT.yaml
@@ -98,8 +98,7 @@ delays:
   consumption: 30
   consumptionForecast: 30
   production: 48
-disclaimer: Data for real-time consumption and generation mix is estimated. Real-time
-  exchanges are not available. This zone includes all electricity production from
+disclaimer: This zone includes all electricity production from
   the generation-only balancing authorities NaturEner Power Watch, LLC and NaturEner
   Wind Watch, LLC. Read more on the wiki page.
 emissionFactors:

--- a/config/zones/US-NW-PACE.yaml
+++ b/config/zones/US-NW-PACE.yaml
@@ -185,8 +185,7 @@ delays:
   consumption: 30
   consumptionForecast: 30
   production: 48
-disclaimer: Data for real-time consumption and generation mix is estimated. Real-time
-  exchanges are not available. This zone includes all gas related electricity production
+disclaimer: This zone includes all gas related electricity production
   from the generation-only balancing authority Avangrid Renewables, LLC. Read more
   on the zone definition wiki page.
 emissionFactors:

--- a/config/zones/US-NW-PACW.yaml
+++ b/config/zones/US-NW-PACW.yaml
@@ -101,8 +101,6 @@ delays:
   consumption: 30
   consumptionForecast: 30
   production: 48
-disclaimer: Data for real-time consumption and generation mix is estimated. Real-time
-  exchanges are not available.
 emissionFactors:
   direct:
     battery discharge:

--- a/config/zones/US-NW-PGE.yaml
+++ b/config/zones/US-NW-PGE.yaml
@@ -104,8 +104,6 @@ delays:
   consumption: 30
   consumptionForecast: 30
   production: 48
-disclaimer: Data for real-time consumption and generation mix is estimated. Real-time
-  exchanges are not available.
 emissionFactors:
   direct:
     battery discharge:

--- a/config/zones/US-NW-PSCO.yaml
+++ b/config/zones/US-NW-PSCO.yaml
@@ -164,8 +164,6 @@ delays:
   consumption: 30
   consumptionForecast: 30
   production: 48
-disclaimer: Data for real-time consumption and generation mix is estimated. Real-time
-  exchanges are not available.
 emissionFactors:
   direct:
     battery discharge:

--- a/config/zones/US-NW-PSEI.yaml
+++ b/config/zones/US-NW-PSEI.yaml
@@ -78,8 +78,6 @@ delays:
   consumption: 30
   consumptionForecast: 30
   production: 48
-disclaimer: Data for real-time consumption and generation mix is estimated. Real-time
-  exchanges are not available.
 emissionFactors:
   direct:
     battery discharge:

--- a/config/zones/US-NW-SCL.yaml
+++ b/config/zones/US-NW-SCL.yaml
@@ -71,8 +71,6 @@ delays:
   consumption: 30
   consumptionForecast: 30
   production: 48
-disclaimer: Data for real-time consumption and generation mix is estimated. Real-time
-  exchanges are not available.
 emissionFactors:
   direct:
     battery discharge:

--- a/config/zones/US-NW-TPWR.yaml
+++ b/config/zones/US-NW-TPWR.yaml
@@ -65,8 +65,6 @@ delays:
   consumption: 30
   consumptionForecast: 30
   production: 48
-disclaimer: Data for real-time consumption and generation mix is estimated. Real-time
-  exchanges are not available.
 emissionFactors:
   direct:
     battery discharge:

--- a/config/zones/US-NW-WACM.yaml
+++ b/config/zones/US-NW-WACM.yaml
@@ -173,8 +173,6 @@ delays:
   consumption: 30
   consumptionForecast: 30
   production: 48
-disclaimer: Data for real-time consumption and generation mix is estimated. Real-time
-  exchanges are not available.
 emissionFactors:
   direct:
     battery discharge:

--- a/config/zones/US-NW-WAUW.yaml
+++ b/config/zones/US-NW-WAUW.yaml
@@ -68,8 +68,6 @@ delays:
   consumption: 30
   consumptionForecast: 30
   production: 48
-disclaimer: Data for real-time consumption and generation mix is estimated. Real-time
-  exchanges are not available.
 emissionFactors:
   direct:
     battery discharge:

--- a/config/zones/US-SE-SEPA.yaml
+++ b/config/zones/US-SE-SEPA.yaml
@@ -66,8 +66,6 @@ contributors:
 country: US
 delays:
   production: 48
-disclaimer: Data for real-time consumption and generation mix is estimated. Real-time
-  exchanges are not available.
 emissionFactors:
   direct:
     battery discharge:

--- a/config/zones/US-SE-SOCO.yaml
+++ b/config/zones/US-SE-SOCO.yaml
@@ -231,8 +231,6 @@ delays:
   consumption: 30
   consumptionForecast: 30
   production: 48
-disclaimer: Data for real-time consumption and generation mix is estimated. Real-time
-  exchanges are not available.
 emissionFactors:
   direct:
     battery discharge:

--- a/config/zones/US-SW-AZPS.yaml
+++ b/config/zones/US-SW-AZPS.yaml
@@ -107,8 +107,6 @@ delays:
   consumption: 30
   consumptionForecast: 30
   production: 48
-disclaimer: Data for real-time consumption and generation mix is estimated. Real-time
-  exchanges are not available.
 emissionFactors:
   direct:
     battery discharge:

--- a/config/zones/US-SW-EPE.yaml
+++ b/config/zones/US-SW-EPE.yaml
@@ -80,8 +80,6 @@ delays:
   consumption: 30
   consumptionForecast: 30
   production: 48
-disclaimer: Data for real-time consumption and generation mix is estimated. Real-time
-  exchanges are not available.
 emissionFactors:
   direct:
     battery discharge:

--- a/config/zones/US-SW-PNM.yaml
+++ b/config/zones/US-SW-PNM.yaml
@@ -153,8 +153,6 @@ delays:
   consumption: 30
   consumptionForecast: 30
   production: 48
-disclaimer: Data for real-time consumption and generation mix is estimated. Real-time
-  exchanges are not available.
 emissionFactors:
   direct:
     battery discharge:

--- a/config/zones/US-SW-SRP.yaml
+++ b/config/zones/US-SW-SRP.yaml
@@ -119,8 +119,7 @@ delays:
   consumption: 30
   consumptionForecast: 30
   production: 48
-disclaimer: Data for real-time consumption and generation mix is estimated. Real-time
-  exchanges are not available. This zone includes all electricity production from
+disclaimer: This zone includes all electricity production from
   the generation-only balancing authorities Arlington Valley, LLC - AVBA and New Harquahala
   Generating Company, LLC - HGBA. Read more on the wiki page.
 emissionFactors:

--- a/config/zones/US-SW-TEPC.yaml
+++ b/config/zones/US-SW-TEPC.yaml
@@ -89,8 +89,6 @@ delays:
   consumption: 30
   consumptionForecast: 30
   production: 48
-disclaimer: Data for real-time consumption and generation mix is estimated. Real-time
-  exchanges are not available.
 emissionFactors:
   direct:
     battery discharge:

--- a/config/zones/US-SW-WALC.yaml
+++ b/config/zones/US-SW-WALC.yaml
@@ -86,8 +86,7 @@ delays:
   consumption: 30
   consumptionForecast: 30
   production: 48
-disclaimer: Data for real-time consumption and generation mix is estimated. Real-time
-  exchanges are not available. This zone includes all electricity production from
+disclaimer: This zone includes all electricity production from
   the generation-only balancing authority Griffith Energy, LLC. Read more on the zone
   definition wiki page.
 emissionFactors:

--- a/config/zones/US-TEN-TVA.yaml
+++ b/config/zones/US-TEN-TVA.yaml
@@ -140,8 +140,6 @@ delays:
   consumption: 30
   consumptionForecast: 30
   production: 48
-disclaimer: Data for real-time consumption and generation mix is estimated. Real-time
-  exchanges are not available.
 emissionFactors:
   direct:
     battery discharge:


### PR DESCRIPTION
## Issue
Mentioned in #7938 

## Description
This PR removes the disclaimer about estimations and lack of real time exchanges.

Example:
<img width="329" alt="image" src="https://github.com/user-attachments/assets/bb120aaf-f4fe-41f1-b899-0109f7c7965e" />
