### PR TITLE
Use generic type to avoid code duplication

### DIFF
--- a/electricitymap/contrib/lib/models/event_lists.py
+++ b/electricitymap/contrib/lib/models/event_lists.py
@@ -26,7 +26,6 @@ CAPACITY_STRICT_THRESHOLD = 0
 CAPACITY_LOOSE_THRESHOLD = 0.02
 
 EventType = TypeVar("EventType", bound="Event")
-EventListType = TypeVar("EventListType", bound="EventList")
 
 
 class EventList(ABC, Generic[EventType]):

--- a/electricitymap/contrib/lib/tests/test_event_lists.py
+++ b/electricitymap/contrib/lib/tests/test_event_lists.py
@@ -50,17 +50,18 @@ def test_append_to_list_logs_error():
 
 
 def test_merge_exchanges():
+    dt = datetime(2023, 1, 1, tzinfo=timezone.utc)
     exchange_list_1 = ExchangeList(logging.Logger("test"))
     exchange_list_1.append(
         zoneKey=ZoneKey("AT->DE"),
-        datetime=datetime(2023, 1, 1, tzinfo=timezone.utc),
+        datetime=dt,
         netFlow=1,
         source="trust.me",
     )
     exchange_list_2 = ExchangeList(logging.Logger("test"))
     exchange_list_2.append(
         zoneKey=ZoneKey("AT->DE"),
-        datetime=datetime(2023, 1, 1, tzinfo=timezone.utc),
+        datetime=dt,
         netFlow=2,
         source="trust.me",
     )
@@ -68,8 +69,8 @@ def test_merge_exchanges():
         [exchange_list_1, exchange_list_2], logging.Logger("test")
     )
     assert len(exchanges) == 1
-    assert exchanges.events[0].datetime == datetime(2023, 1, 1, tzinfo=timezone.utc)
-    assert exchanges.events[0].netFlow == 3
+    assert exchanges[dt].datetime == datetime(2023, 1, 1, tzinfo=timezone.utc)
+    assert exchanges[dt].netFlow == 3
 
 
 def test_merge_exchanges_with_none():


### PR DESCRIPTION
## Issue

We are duplicating code when we don't have to.

## Description

Code cleanup by using generic types.

### Double check

- [x] I have tested my parser changes locally with `poetry run test_parser "zone_key"`
- [x] I have run `pnpx prettier@2 --write .` and `poetry run format` in the top level directory to format my changes.
