### PR TITLE
update GB Capacity parser

### DIFF
--- a/config/zones/GB.yaml
+++ b/config/zones/GB.yaml
@@ -6,65 +6,113 @@ bounding_box:
     - 61.0795442346
 capacity:
   biomass:
-    - datetime: '2023-12-01'
-      source: bmreports.com
-      value: 4438
-    - datetime: '2022-12-01'
+    - datetime: '2022-01-01'
       source: bmreports.com
       value: 4572
+    - datetime: '2023-01-01'
+      source: bmreports.com
+      value: 4438
+    - datetime: '2024-01-01'
+      source: bmreports.com
+      value: 3535
+    - datetime: '2025-01-01'
+      source: bmreports.com
+      value: 4332
   coal:
-    - datetime: '2022-12-01'
+    - datetime: '2022-01-01'
       source: bmreports.com
       value: 1491
-  gas:
-    - datetime: '2023-12-01'
+    - datetime: '2024-01-01'
       source: bmreports.com
-      value: 37047
-    - datetime: '2022-12-01'
+      value: 1988
+    - datetime: '2025-01-01'
+      source: bmreports.com
+      value: 0
+  gas:
+    - datetime: '2022-01-01'
       source: bmreports.com
       value: 38985
-  hydro:
-    - datetime: '2023-12-01'
+    - datetime: '2023-01-01'
       source: bmreports.com
-      value: 2063
-    - datetime: '2022-12-01'
+      value: 37047
+    - datetime: '2024-01-01'
+      source: bmreports.com
+      value: 32631
+    - datetime: '2025-01-01'
+      source: bmreports.com
+      value: 40470
+  hydro:
+    - datetime: '2022-01-01'
       source: bmreports.com
       value: 4190
-  hydro storage:
-    - datetime: '2023-12-01'
+    - datetime: '2023-01-01'
       source: bmreports.com
-      value: 5603
-    - datetime: '2022-12-01'
+      value: 2063
+    - datetime: '2024-01-01'
+      source: bmreports.com
+      value: 1386
+    - datetime: '2025-01-01'
+      source: bmreports.com
+      value: 1687
+  hydro storage:
+    - datetime: '2022-01-01'
       source: bmreports.com
       value: 1928
+    - datetime: '2023-01-01'
+      source: bmreports.com
+      value: 5603
+    - datetime: '2024-01-01'
+      source: bmreports.com
+      value: 5891
+    - datetime: '2025-01-01'
+      source: bmreports.com
+      value: 11080
   nuclear:
-    - datetime: '2023-12-01'
+    - datetime: '2022-01-01'
+      source: IRENA.org
+      value: 7833
+    - datetime: '2023-01-01'
+      source: IRENA.org
+      value: 5883
+    - datetime: '2024-01-01'
       source: bmreports.com
-      value: 4950
-    - datetime: '2022-12-01'
-      source: bmreports.com
-      value: 9256
+      value: 6075
   solar:
-    - datetime: '2023-12-01'
-      source: bmreports.com
-      value: 14518
-    - datetime: '2022-12-01'
+    - datetime: '2022-01-01'
       source: bmreports.com
       value: 13324
-  unknown:
-    - datetime: '2023-12-01'
+    - datetime: '2023-01-01'
       source: bmreports.com
-      value: 4775
-    - datetime: '2022-12-01'
+      value: 14518
+    - datetime: '2024-01-01'
+      source: bmreports.com
+      value: 15896
+  unknown:
+    - datetime: '2022-01-01'
       source: bmreports.com
       value: 4906
-  wind:
-    - datetime: '2023-12-01'
+    - datetime: '2023-01-01'
       source: bmreports.com
-      value: 26945
-    - datetime: '2022-12-01'
+      value: 4775
+    - datetime: '2024-01-01'
+      source: bmreports.com
+      value: 745
+    - datetime: '2025-01-01'
+      source: bmreports.com
+      value: 6238
+  wind:
+    - datetime: '2022-01-01'
       source: bmreports.com
       value: 27330
+    - datetime: '2023-01-01'
+      source: bmreports.com
+      value: 26945
+    - datetime: '2024-01-01'
+      source: bmreports.com
+      value: 28535
+    - datetime: '2025-01-01'
+      source: bmreports.com
+      value: 32844
 contributors:
   - corradio
   - lorrieq

--- a/electricitymap/contrib/capacity_parsers/GB.py
+++ b/electricitymap/contrib/capacity_parsers/GB.py
@@ -1,64 +1,74 @@
-import pandas as pd
-import numpy as np
 from datetime import datetime, timedelta
 from logging import getLogger
 from typing import Any
 
+import numpy as np
+import pandas as pd
 from requests import Session
 
 from electricitymap.contrib.config import ZoneKey
 
 logger = getLogger(__name__)
 MODE_MAPPING = {
-    'Wind Onshore': "wind",
-    'Wind Offshore': "wind",
-    'Solar': "solar",
-    'Other renewable': "unknown",
-    'Other': "unknown",
-    'Nuclear': "nuclear",
-    'Hydro Run-of-river and poundage': "hydro",
-    'Fossil Hard coal': "coal",
-    'Fossil Gas': "gas",
-    'Biomass': "biomass",
-    'Hydro Pumped Storage': "hydro storage",
+    "Wind Onshore": "wind",
+    "Wind Offshore": "wind",
+    "Solar": "solar",
+    "Other renewable": "unknown",
+    "Other": "unknown",
+    "Nuclear": "nuclear",
+    "Hydro Run-of-river and poundage": "hydro",
+    "Fossil Hard coal": "coal",
+    "Fossil Gas": "gas",
+    "Biomass": "biomass",
+    "Hydro Pumped Storage": "hydro storage",
 }
 
 SOURCE = "bmreports.com"
-BMREPORTS_base_url = 'https://data.elexon.co.uk/bmrs/api/v1/datasets/IGCA'
+BMREPORTS_base_url = "https://data.elexon.co.uk/bmrs/api/v1/datasets/IGCA"
+
 
 def fetch_production_capacity(
     zone_key: ZoneKey, target_datetime: datetime, session: Session
 ) -> dict[str, Any] | None:
     start_date = (target_datetime - timedelta(days=366)).strftime("%Y-%m-%dT%H:%M:%SZ")
     end_date = target_datetime.strftime("%Y-%m-%dT%H:%M:%SZ")
-    
+
     url = f"{BMREPORTS_base_url}?publishDateTimeFrom={start_date}&publishDateTimeTo={end_date}&format=json"
-    
+
     r = session.get(url)
     if r.status_code != 200:
         raise ValueError(
             f"GB: No capacity data available for year {target_datetime.year}. {r.status_code} :{r.text}"
         )
     else:
-        if r.json()['data'] == []:
+        if r.json()["data"] == []:
             raise ValueError(
-            f"GB: No capacity data available for year {target_datetime.year}. {r.status_code} :{r.text}"
+                f"GB: No capacity data available for year {target_datetime.year}. {r.status_code} :{r.text}"
+            )
+        df = pd.DataFrame(r.json()["data"])
+        df["datetime"] = pd.to_datetime(df["year"].astype(str) + "-01-01").dt.strftime(
+            "%Y-%m-%d"
         )
-        df = pd.DataFrame(r.json()['data'])
-        df['datetime'] = pd.to_datetime(df['year'].astype(str) + '-01-01').dt.strftime("%Y-%m-%d")
-        df['mode'] = df['psrType'].str.strip().map(MODE_MAPPING)
-        df['source'] = SOURCE
-        df['value'] = pd.to_numeric(np.round(df['quantity'], 0), downcast='integer')
-        df_result = df[['datetime', 'value','mode','source']].groupby(['datetime', 'mode','source']).sum(numeric_only=True).reset_index()
+        df["mode"] = df["psrType"].str.strip().map(MODE_MAPPING)
+        df["source"] = SOURCE
+        df["value"] = pd.to_numeric(np.round(df["quantity"], 0), downcast="integer")
+        df_result = (
+            df[["datetime", "value", "mode", "source"]]
+            .groupby(["datetime", "mode", "source"])
+            .sum(numeric_only=True)
+            .reset_index()
+        )
         result = {}
         for _, row in df_result.iterrows():
-            result[row['mode']] = {
-                'datetime': row['datetime'],
-                'value': row['value'],
-                'source': row['source']
+            result[row["mode"]] = {
+                "datetime": row["datetime"],
+                "value": row["value"],
+                "source": row["source"],
             }
-        logger.info(f"Fetched capacity for {zone_key} on {target_datetime.date()}: \n{df}")
-        
+        logger.info(
+            f"Fetched capacity for {zone_key} on {target_datetime.date()}: \n{df}"
+        )
+
         return result
 
 

--- a/electricitymap/contrib/capacity_parsers/GB.py
+++ b/electricitymap/contrib/capacity_parsers/GB.py
@@ -1,61 +1,66 @@
-from datetime import datetime
+import pandas as pd
+import numpy as np
+from datetime import datetime, timedelta
 from logging import getLogger
 from typing import Any
 
-from bs4 import BeautifulSoup
-from requests import Response, Session
+from requests import Session
 
 from electricitymap.contrib.config import ZoneKey
 
 logger = getLogger(__name__)
 MODE_MAPPING = {
-    '"Wind Onshore"': "wind",
-    '"Wind Offshore"': "wind",
-    '"Solar"': "solar",
-    '"Other renewable"': "unknown",
-    '"Other"': "unknown",
-    '"Nuclear"': "nuclear",
-    '"Hydro Run-of-river and poundage"': "hydro",
-    '"Fossil Hard coal"': "coal",
-    '"Fossil Gas"': "gas",
-    '"Biomass"': "biomass",
-    '"Hydro Pumped Storage"': "hydro storage",
+    'Wind Onshore': "wind",
+    'Wind Offshore': "wind",
+    'Solar': "solar",
+    'Other renewable': "unknown",
+    'Other': "unknown",
+    'Nuclear': "nuclear",
+    'Hydro Run-of-river and poundage': "hydro",
+    'Fossil Hard coal': "coal",
+    'Fossil Gas': "gas",
+    'Biomass': "biomass",
+    'Hydro Pumped Storage': "hydro storage",
 }
 
 SOURCE = "bmreports.com"
-BMREPORTS_URL = "https://www.bmreports.com/bmrs/?q=ajax/year/B1410/{year}/"
-
+BMREPORTS_base_url = 'https://data.elexon.co.uk/bmrs/api/v1/datasets/IGCA'
 
 def fetch_production_capacity(
     zone_key: ZoneKey, target_datetime: datetime, session: Session
 ) -> dict[str, Any] | None:
-    url = BMREPORTS_URL.format(year=target_datetime.year)
-    r: Response = session.get(url)
-
-    if not r.ok:
+    start_date = (target_datetime - timedelta(days=366)).strftime("%Y-%m-%dT%H:%M:%SZ")
+    end_date = target_datetime.strftime("%Y-%m-%dT%H:%M:%SZ")
+    
+    url = f"{BMREPORTS_base_url}?publishDateTimeFrom={start_date}&publishDateTimeTo={end_date}&format=json"
+    
+    r = session.get(url)
+    if r.status_code != 200:
         raise ValueError(
-            f"GB: No capacity data available for year {target_datetime.year}"
+            f"GB: No capacity data available for year {target_datetime.year}. {r.status_code} :{r.text}"
         )
     else:
-        soup = BeautifulSoup(r.text, "lxml")
-        items = soup.find_all("item")
-        capacity = {}
-        for item in items:
-            mode = item.find("powersystemresourcetype").string
-            mode = MODE_MAPPING[mode]
-            if mode in capacity:
-                capacity[mode]["value"] += int(item.find("quantity").string)
-            else:
-                capacity[mode] = {
-                    "datetime": target_datetime.strftime("%Y-%m-%d"),
-                    "value": int(item.find("quantity").string),
-                    "source": SOURCE,
-                }
-        logger.info(
-            f"Fetched capacity for {zone_key} on {target_datetime.date()}: \n{capacity}"
+        if r.json()['data'] == []:
+            raise ValueError(
+            f"GB: No capacity data available for year {target_datetime.year}. {r.status_code} :{r.text}"
         )
-        return capacity
+        df = pd.DataFrame(r.json()['data'])
+        df['datetime'] = pd.to_datetime(df['year'].astype(str) + '-01-01').dt.strftime("%Y-%m-%d")
+        df['mode'] = df['psrType'].str.strip().map(MODE_MAPPING)
+        df['source'] = SOURCE
+        df['value'] = pd.to_numeric(np.round(df['quantity'], 0), downcast='integer')
+        df_result = df[['datetime', 'value','mode','source']].groupby(['datetime', 'mode','source']).sum(numeric_only=True).reset_index()
+        result = {}
+        for _, row in df_result.iterrows():
+            result[row['mode']] = {
+                'datetime': row['datetime'],
+                'value': row['value'],
+                'source': row['source']
+            }
+        logger.info(f"Fetched capacity for {zone_key} on {target_datetime.date()}: \n{df}")
+        
+        return result
 
 
 if __name__ == "__main__":
-    print(fetch_production_capacity("GB", datetime(2022, 1, 1), Session()))
+    print(fetch_production_capacity("GB", datetime(2024, 1, 1), Session()))


### PR DESCRIPTION
## Issue

The capacity parser for GB  was not longer working. I'm now using the API instead of Beautiful soup scrapping. 
Now the capacity is fetching from the same source as the generation. 
## Description

Get GB capacity.
### Preview
To be mightful -> Solar capacity for 2025 was uncorrect (10GW) while other sources says around 17 GW (https://www.solarpowerportal.co.uk/uk-solar-capacity-grows-1gw-year-on-year/) 

### Double check

- [x] I have tested my parser changes locally with `poetry run test_parser "zone_key"`
- [x] I have run `pnpx prettier@2 --write .` and `poetry run format` in the top level directory to format my changes.
