### PR TITLE
fix(parser): change the sign for storage for EIA parser

### DIFF
--- a/parsers/EIA.py
+++ b/parsers/EIA.py
@@ -488,10 +488,10 @@ def create_production_storage(
 
     # have to have early returns because of downstream validation in ProductionBreakdownList
     if fuel_type == "hydro_storage":
-        storage_mix.add_value("hydro", production_value)
+        storage_mix.add_value("hydro", -production_value)
         return None, storage_mix
     elif fuel_type == "battery_storage":
-        storage_mix.add_value("battery", production_value)
+        storage_mix.add_value("battery", -production_value)
         return None, storage_mix
     else:
         production_mix.add_value(

--- a/parsers/test/test_EIA.py
+++ b/parsers/test/test_EIA.py
@@ -78,7 +78,7 @@ def test_fetch_production_mix(adapter, session):
                 "solar": 1,
                 "geothermal": 1,
             },
-            "storage": {"hydro": 1, "battery": 1},
+            "storage": {"hydro": -1, "battery": -1},
         },
         {
             "zoneKey": "US-NW-PGE",
@@ -94,7 +94,7 @@ def test_fetch_production_mix(adapter, session):
                 "solar": 2,
                 "geothermal": 2,
             },
-            "storage": {"hydro": 2, "battery": 2},
+            "storage": {"hydro": -2, "battery": -2},
         },
     ]
     _check_production_matches(data_list, expected)
@@ -646,7 +646,7 @@ def test_fetch_production_mix_discards_null(adapter, session):
                 "solar": 400,
                 "geothermal": 400,
             },
-            "storage": {"hydro": 400, "battery": 400},
+            "storage": {"hydro": -400, "battery": -400},
         },
     ]
     assert (
@@ -810,7 +810,7 @@ def test_fetch_returns_storage(adapter, session):
                 "solar": 1,
                 "geothermal": 1,
             },
-            "storage": {"battery": 1, "hydro": 1},
+            "storage": {"battery": -1, "hydro": -1},
         },
     ]
     _check_production_matches(data_list, expected)


### PR DESCRIPTION
## Issue

<!-- If you want to close an issue automatically when your PR is merged, write "Closes X" where X is the issue number. For example: Closes #000 -->
[GMM-609](https://linear.app/electricitymaps/issue/GMM-609/battery-storage-flipped-in-public-service-company-of-new-mexico)

## Description

<!-- Explains the goal of this PR -->
This PR changes the sign for the storage values, since these seemed to be flipped (see linear issue above).

### Double check

- [x] I have tested my parser changes locally with `poetry run test_parser "zone_key"`
- [x] I have run `pnpx prettier@2 --write .` and `poetry run format` in the top level directory to format my changes.
