### PR TITLE
Bigger timeslider dropdown & capitalize first letter

### DIFF
--- a/web/src/components/TimeRangeSelector.tsx
+++ b/web/src/components/TimeRangeSelector.tsx
@@ -32,14 +32,14 @@ function TimeRangeSelector({ timeRange, onToggleGroupClick }: TimeRangeSelectorP
   return (
     <DropdownMenu.Root onOpenChange={onToggleDropdown} open={isOpen} modal={false}>
       <DropdownMenu.Trigger>
-        <div className="flex w-28 flex-row items-center justify-between rounded-xl bg-white p-1 pl-2 text-sm font-semibold capitalize outline outline-1 outline-neutral-200 hover:bg-neutral-100 dark:bg-neutral-900 dark:outline-neutral-700 dark:hover:bg-neutral-800">
+        <div className="flex w-32 flex-row items-center justify-between rounded-xl bg-white p-1 pl-2 text-sm font-semibold capitalize outline outline-1 outline-neutral-200 hover:bg-neutral-100 dark:bg-neutral-900 dark:outline-neutral-700 dark:hover:bg-neutral-800">
           {selectedLabel}
           <ChevronsUpDown height="14px" />
         </div>
       </DropdownMenu.Trigger>
       <DropdownMenu.Content
         sideOffset={4}
-        className="border-1 border-1 z-50 w-28 rounded-xl border border-neutral-200 bg-white p-1  dark:border-neutral-700 dark:bg-neutral-900"
+        className="border-1 border-1 z-50 w-32 rounded-xl border border-neutral-200 bg-white p-1  dark:border-neutral-700 dark:bg-neutral-900"
       >
         {options.map(({ value, label, dataTestId }) => (
           <DropdownMenu.Item

--- a/web/src/components/TimeRangeSelector.tsx
+++ b/web/src/components/TimeRangeSelector.tsx
@@ -32,7 +32,7 @@ function TimeRangeSelector({ timeRange, onToggleGroupClick }: TimeRangeSelectorP
   return (
     <DropdownMenu.Root onOpenChange={onToggleDropdown} open={isOpen} modal={false}>
       <DropdownMenu.Trigger>
-        <div className="flex w-32 flex-row items-center justify-between rounded-xl bg-white p-1 pl-2 text-sm font-semibold capitalize outline outline-1 outline-neutral-200 hover:bg-neutral-100 dark:bg-neutral-900 dark:outline-neutral-700 dark:hover:bg-neutral-800">
+        <div className="flex w-32 flex-row items-center justify-between rounded-xl bg-white p-1 pl-2 text-sm font-semibold capitalize-first-letter outline outline-1 outline-neutral-200 hover:bg-neutral-100 dark:bg-neutral-900 dark:outline-neutral-700 dark:hover:bg-neutral-800">
           {selectedLabel}
           <ChevronsUpDown height="14px" />
         </div>
@@ -47,7 +47,7 @@ function TimeRangeSelector({ timeRange, onToggleGroupClick }: TimeRangeSelectorP
             data-testid={dataTestId}
             aria-label={label}
             onClick={() => onToggleGroupClick(value)}
-            className={`h-full grow basis-0 select-none rounded-xl p-2 text-xs font-semibold capitalize hover:bg-neutral-100 focus-visible:outline-none dark:hover:bg-neutral-800 `}
+            className={`h-full grow basis-0 select-none rounded-xl p-2 text-xs font-semibold capitalize-first-letter hover:bg-neutral-100 focus-visible:outline-none dark:hover:bg-neutral-800 `}
           >
             {label}
           </DropdownMenu.Item>

--- a/web/src/components/TimeRangeSelector.tsx
+++ b/web/src/components/TimeRangeSelector.tsx
@@ -32,14 +32,14 @@ function TimeRangeSelector({ timeRange, onToggleGroupClick }: TimeRangeSelectorP
   return (
     <DropdownMenu.Root onOpenChange={onToggleDropdown} open={isOpen} modal={false}>
       <DropdownMenu.Trigger>
-        <div className="flex w-32 flex-row items-center justify-between rounded-xl bg-white p-1 pl-2 text-sm font-semibold capitalize-first-letter outline outline-1 outline-neutral-200 hover:bg-neutral-100 dark:bg-neutral-900 dark:outline-neutral-700 dark:hover:bg-neutral-800">
+        <div className="flex w-33 flex-row items-center justify-between rounded-xl bg-white p-1 pl-2 text-sm font-semibold capitalize-first-letter outline outline-1 outline-neutral-200 hover:bg-neutral-100 dark:bg-neutral-900 dark:outline-neutral-700 dark:hover:bg-neutral-800">
           {selectedLabel}
           <ChevronsUpDown height="14px" />
         </div>
       </DropdownMenu.Trigger>
       <DropdownMenu.Content
         sideOffset={4}
-        className="border-1 border-1 z-50 w-32 rounded-xl border border-neutral-200 bg-white p-1  dark:border-neutral-700 dark:bg-neutral-900"
+        className="border-1 border-1 z-50 w-33 rounded-xl border border-neutral-200 bg-white p-1 dark:border-neutral-700 dark:bg-neutral-900"
       >
         {options.map(({ value, label, dataTestId }) => (
           <DropdownMenu.Item

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -52,6 +52,13 @@
     @apply font-inter;
   }
 }
+
+@utility capitalize-first-letter {
+  &::first-letter {
+    text-transform: uppercase;
+  }
+}
+
 *::-webkit-scrollbar {
   /*remove scrollbar track chrome*/
   background-color: transparent;


### PR DESCRIPTION
Increase time slider dropdown width to allow bigger text to fit in it.

Add a capitalize-first-letter class to avoid all words to be capitalized. (https://play.tailwindcss.com/J8Rp7HA2WF?file=css)