### PR TITLE
chore(capacity): Fix BD wind capacity

### DIFF
--- a/config/zones/BD.yaml
+++ b/config/zones/BD.yaml
@@ -95,11 +95,17 @@ capacity:
     - datetime: '2017-01-01'
       source: Ember, Yearly electricity data
       value: 0.0
+    - datetime: '2024-03-08'
+      source: TBS News
+      value: 60.0
+      _comment: https://www.tbsnews.net/bangladesh/energy/countrys-first-commercial-wind-power-plant-starts-production-810678
+
 contributors:
   - systemcatch
   - alixunderplatz
   - MuffinCompiler
   - consideRatio
+  - VIKTORVAV99
 country: BD
 delays:
   production: 10

--- a/electricitymap/contrib/capacity_parsers/EMBER.py
+++ b/electricitymap/contrib/capacity_parsers/EMBER.py
@@ -109,6 +109,10 @@ def _ember_production_mode_mapper(row: pd.Series) -> str | None:
 
 
 def format_ember_data(ember_df: pd.DataFrame) -> pd.DataFrame:
+    if ember_df.empty:
+        logger.warning("Empty Ember data received")
+        return ember_df
+    logger.info("Formatting Ember data")
     ember_df.query(
         'variable != "Clean" and variable != "Fossil" and variable != "Wind and solar"',
         inplace=True,


### PR DESCRIPTION
## Issue

Fixes: GMM-735

## Description

Updates the wind capacity for BD so it's not flagged in the outlier detection.

### Double check

- [x] I have tested my parser changes locally with `poetry run test_parser "zone_key"`
- [x] I have run `pnpx prettier@2 --write .` and `poetry run format` in the top level directory to format my changes.
