### PR TITLE
Fix button background on time controller

### DIFF
--- a/web/src/features/time/TimeController.tsx
+++ b/web/src/features/time/TimeController.tsx
@@ -133,7 +133,7 @@ export default function TimeController({
               size="sm"
               onClick={onToggle}
               foregroundClasses="px-2"
-              backgroundClasses="outline outline-1 outline-neutral-200 dark:outline-neutral-700"
+              backgroundClasses="outline outline-1 outline-neutral-200 bg-white dark:bg-neutral-900 dark:outline-neutral-700"
               shouldShrink
             >
               <FormattedTime


### PR DESCRIPTION
## Description
Fix button background on time controller

### Preview
before (button background doesn't stand out):
<img width="497" alt="Screenshot 2025-04-10 at 13 30 38" src="https://github.com/user-attachments/assets/b37cdf56-f81b-48e7-aa55-a6299e866fc5" />
after:
<img width="487" alt="Screenshot 2025-04-10 at 13 40 39" src="https://github.com/user-attachments/assets/7e3cd171-55e0-469a-a61e-6049508cd5c4" />
dark:
<img width="508" alt="Screenshot 2025-04-10 at 13 40 29" src="https://github.com/user-attachments/assets/a1979bdc-4125-4798-aa01-bf6b6be730d6" />

### Double check

- [ ] I have tested my parser changes locally with `poetry run test_parser "zone_key"`
- [ ] I have run `pnpx prettier@2 --write .` and `poetry run format` in the top level directory to format my changes.
