### PR TITLE
Specify signing certificate in fastfile build_app

### DIFF
--- a/mobileapp/README.md
+++ b/mobileapp/README.md
@@ -81,6 +81,7 @@ See [fastlane/README.md](./fastlane/README.md) for more information.
    - Add your own Apple ID
    - Open https://appleid.apple.com/account/manage and create an App-Specific Password to be used for the FASTLANE_APPLE_APPLICATION_SPECIFIC_PASSWORD environment variable
    - Ask internally for the team ids
+4. Run `fastlane match appstore` to create or install the certificate and provisioning profile
 
 ### Making a beta build
 

--- a/mobileapp/fastlane/Fastfile
+++ b/mobileapp/fastlane/Fastfile
@@ -10,7 +10,7 @@ android_dir = File.expand_path("../android")
 
 private_lane :build_web_app do
   ensure_env_vars(
-  env_vars: ['SENTRY_AUTH_TOKEN', 'VITE_PUBLIC_ELECTRICITYMAP_PUBLIC_TOKEN_V9']
+  env_vars: ['SENTRY_AUTH_TOKEN', 'VITE_PUBLIC_ELECTRICITYMAP_PUBLIC_TOKEN_V9', 'TEAM_ID']
 )
   # Build the web app if we have both environment variables set
   sh("pnpm", "run", "build-web")
@@ -64,7 +64,8 @@ platform :ios do
     build_web_app
     match(type: "appstore")
     build_app(
-      workspace: File.join(ios_dir, "App/App.xcworkspace")
+      workspace: File.join(ios_dir, "App/App.xcworkspace"),
+      export_options:{ installerSigningCertificate: "Apple Distribution: Electricity Maps ApS #{TEAM_ID}" }
     )
     upload_to_testflight
     reset_git_repo(


### PR DESCRIPTION
## Description

While running the updated mobile release process, I was getting the follow errors:
```
error: exportArchive: Provisioning profile "match AppStore [redacted]" doesn't include signing certificate
"Apple Distribution: [redacted]".

Error Domain=IDEProfileQualificationErrorDomain Code=5 "Provisioning profile "match AppStore [redacted]"
doesn't include signing certificate "Apple Distribution: [redacted]"." 
```
This PR adds options to explicitly export a specified certificate that matches the AppStore, as per this [GitHub issue](https://github.com/fastlane/fastlane/issues/21407). There's probably a better way to do this, but this works for now.

### Preview

<!-- Please add screenshots and/or gif that shows visual changes (if applicable) -->

### Double check

- [ ] I have tested my parser changes locally with `poetry run test_parser "zone_key"`
- [ ] I have run `pnpx prettier@2 --write .` and `poetry run format` in the top level directory to format my changes.
