### PR TITLE
refactor: simplify option checks in ToggleButton toggles

### DIFF
--- a/web/src/components/ToggleButton.tsx
+++ b/web/src/components/ToggleButton.tsx
@@ -61,12 +61,12 @@ function ToggleButton({
         type="single"
         aria-label="Toggle between modes"
         value={selectedOption}
+        onValueChange={onToggle}
       >
         {options.map(({ value, translationKey, dataTestId }, key) => (
           <ToggleGroupItem
             key={`group-item-${key}`}
             value={value}
-            onClick={() => onToggle(value)}
             data-testid={`toggle-button-${dataTestId ?? value}`}
             className={twMerge(
               'inline-flex h-7 w-full items-center whitespace-nowrap rounded-full bg-neutral-100/0 px-3 text-xs dark:border dark:border-neutral-400/0 dark:bg-transparent',

--- a/web/src/components/ToggleButton.tsx
+++ b/web/src/components/ToggleButton.tsx
@@ -24,7 +24,8 @@ export type ToggleButtonOptions<T extends string> = Array<{
 interface ToggleButtonProperties<T extends string> {
   options: ToggleButtonOptions<T>;
   selectedOption: T;
-  onToggle: (option: T) => void;
+  // radix gives back an empty string if a new value is not selected
+  onToggle: (option: T | "") => void;
   tooltipKey?: string;
   transparentBackground?: boolean;
 }

--- a/web/src/components/ToggleButton.tsx
+++ b/web/src/components/ToggleButton.tsx
@@ -16,26 +16,26 @@ import { twMerge } from 'tailwind-merge';
 
 import { GlassBackdrop } from './GlassContainer';
 
-export type ToggleButtonOptions = Array<{
-  value: string;
+export type ToggleButtonOptions<T extends string> = Array<{
+  value: T;
   translationKey: string;
   dataTestId?: string;
 }>;
-interface ToggleButtonProperties {
-  options: ToggleButtonOptions;
-  selectedOption: string;
-  onToggle: (option: string) => void;
+interface ToggleButtonProperties<T extends string> {
+  options: ToggleButtonOptions<T>;
+  selectedOption: T;
+  onToggle: (option: T) => void;
   tooltipKey?: string;
   transparentBackground?: boolean;
 }
 
-function ToggleButton({
+function ToggleButton<T extends string>({
   options,
   selectedOption,
   tooltipKey,
   onToggle,
   transparentBackground = true,
-}: ToggleButtonProperties): ReactElement {
+}: ToggleButtonProperties<T>): ReactElement {
   const { t } = useTranslation();
   const [isToolTipOpen, setIsToolTipOpen] = useState(false);
   const onToolTipClick = () => {
@@ -116,4 +116,6 @@ function ToggleButton({
   );
 }
 
-export default memo(ToggleButton);
+// react and typescript doesn't pass through generics so we need to cast
+// https://github.com/DefinitelyTyped/DefinitelyTyped/issues/37087#issuecomment-1765701020
+export default memo(ToggleButton) as typeof ToggleButton;

--- a/web/src/components/ToggleButton.tsx
+++ b/web/src/components/ToggleButton.tsx
@@ -25,7 +25,7 @@ interface ToggleButtonProperties<T extends string> {
   options: ToggleButtonOptions<T>;
   selectedOption: T;
   // radix gives back an empty string if a new value is not selected
-  onToggle: (option: T | "") => void;
+  onToggle: (option: T | '') => void;
   tooltipKey?: string;
   transparentBackground?: boolean;
 }

--- a/web/src/features/map-controls/ConsumptionProductionToggle.tsx
+++ b/web/src/features/map-controls/ConsumptionProductionToggle.tsx
@@ -32,9 +32,7 @@ function ConsumptionProductionToggle({
       trackEvent(TrackEvent.PRODUCTION_CONSUMPTION_CLICKED, {
         productionConsumption: option,
       });
-      setCurrentMode(
-        currentMode === Mode.PRODUCTION ? Mode.CONSUMPTION : Mode.PRODUCTION
-      );
+      setCurrentMode(option as Mode);
     },
     [currentMode, setCurrentMode]
   );

--- a/web/src/features/map-controls/ConsumptionProductionToggle.tsx
+++ b/web/src/features/map-controls/ConsumptionProductionToggle.tsx
@@ -25,8 +25,8 @@ function ConsumptionProductionToggle({
 }): ReactElement {
   const [currentMode, setCurrentMode] = useAtom(productionConsumptionAtom);
   const onSetCurrentMode = useCallback(
-    (option: Mode | "") => {
-      if (option === "") {
+    (option: Mode | '') => {
+      if (option === '') {
         return;
       }
       trackEvent(TrackEvent.PRODUCTION_CONSUMPTION_CLICKED, {
@@ -34,7 +34,7 @@ function ConsumptionProductionToggle({
       });
       setCurrentMode(option);
     },
-    [currentMode, setCurrentMode]
+    [setCurrentMode]
   );
 
   return (

--- a/web/src/features/map-controls/ConsumptionProductionToggle.tsx
+++ b/web/src/features/map-controls/ConsumptionProductionToggle.tsx
@@ -25,14 +25,14 @@ function ConsumptionProductionToggle({
 }): ReactElement {
   const [currentMode, setCurrentMode] = useAtom(productionConsumptionAtom);
   const onSetCurrentMode = useCallback(
-    (option: string) => {
+    (option: Mode) => {
       if (option === currentMode) {
         return;
       }
       trackEvent(TrackEvent.PRODUCTION_CONSUMPTION_CLICKED, {
         productionConsumption: option,
       });
-      setCurrentMode(option as Mode);
+      setCurrentMode(option);
     },
     [currentMode, setCurrentMode]
   );

--- a/web/src/features/map-controls/ConsumptionProductionToggle.tsx
+++ b/web/src/features/map-controls/ConsumptionProductionToggle.tsx
@@ -25,8 +25,8 @@ function ConsumptionProductionToggle({
 }): ReactElement {
   const [currentMode, setCurrentMode] = useAtom(productionConsumptionAtom);
   const onSetCurrentMode = useCallback(
-    (option: Mode) => {
-      if (option === currentMode) {
+    (option: Mode | "") => {
+      if (option === "") {
         return;
       }
       trackEvent(TrackEvent.PRODUCTION_CONSUMPTION_CLICKED, {

--- a/web/src/features/map-controls/SpatialAggregatesToggle.tsx
+++ b/web/src/features/map-controls/SpatialAggregatesToggle.tsx
@@ -27,17 +27,12 @@ function SpatialAggregatesToggle({
   const onSetCurrentMode = useCallback(
     (option: string) => {
       if (
-        (option === SpatialAggregate.ZONE && currentMode === SpatialAggregate.ZONE) ||
-        (option === SpatialAggregate.COUNTRY && currentMode === SpatialAggregate.COUNTRY)
+        (option === currentMode)
       ) {
         return;
       }
       trackEvent(TrackEvent.SPATIAL_AGGREGATE_CLICKED, { spatialAggregate: option });
-      setCurrentMode(
-        currentMode === SpatialAggregate.COUNTRY
-          ? SpatialAggregate.ZONE
-          : SpatialAggregate.COUNTRY
-      );
+      setCurrentMode(option as SpatialAggregate);
     },
     [currentMode, setCurrentMode]
   );
@@ -45,9 +40,7 @@ function SpatialAggregatesToggle({
   return (
     <ToggleButton
       options={options}
-      selectedOption={
-        currentMode === SpatialAggregate.ZONE ? options[1].value : options[0].value
-      }
+      selectedOption={currentMode}
       onToggle={onSetCurrentMode}
       transparentBackground={transparentBackground}
     />

--- a/web/src/features/map-controls/SpatialAggregatesToggle.tsx
+++ b/web/src/features/map-controls/SpatialAggregatesToggle.tsx
@@ -25,8 +25,8 @@ function SpatialAggregatesToggle({
 }): ReactElement {
   const [currentMode, setCurrentMode] = useAtom(spatialAggregateAtom);
   const onSetCurrentMode = useCallback(
-    (option: SpatialAggregate) => {
-      if (option === currentMode) {
+    (option: SpatialAggregate | "") => {
+      if (option === "") {
         return;
       }
       trackEvent(TrackEvent.SPATIAL_AGGREGATE_CLICKED, { spatialAggregate: option });

--- a/web/src/features/map-controls/SpatialAggregatesToggle.tsx
+++ b/web/src/features/map-controls/SpatialAggregatesToggle.tsx
@@ -25,14 +25,12 @@ function SpatialAggregatesToggle({
 }): ReactElement {
   const [currentMode, setCurrentMode] = useAtom(spatialAggregateAtom);
   const onSetCurrentMode = useCallback(
-    (option: string) => {
-      if (
-        (option === currentMode)
-      ) {
+    (option: SpatialAggregate) => {
+      if (option === currentMode) {
         return;
       }
       trackEvent(TrackEvent.SPATIAL_AGGREGATE_CLICKED, { spatialAggregate: option });
-      setCurrentMode(option as SpatialAggregate);
+      setCurrentMode(option);
     },
     [currentMode, setCurrentMode]
   );

--- a/web/src/features/map-controls/SpatialAggregatesToggle.tsx
+++ b/web/src/features/map-controls/SpatialAggregatesToggle.tsx
@@ -25,14 +25,14 @@ function SpatialAggregatesToggle({
 }): ReactElement {
   const [currentMode, setCurrentMode] = useAtom(spatialAggregateAtom);
   const onSetCurrentMode = useCallback(
-    (option: SpatialAggregate | "") => {
-      if (option === "") {
+    (option: SpatialAggregate | '') => {
+      if (option === '') {
         return;
       }
       trackEvent(TrackEvent.SPATIAL_AGGREGATE_CLICKED, { spatialAggregate: option });
       setCurrentMode(option);
     },
-    [currentMode, setCurrentMode]
+    [setCurrentMode]
   );
 
   return (

--- a/web/src/features/panels/zone/DisplayByEmissionToggle.tsx
+++ b/web/src/features/panels/zone/DisplayByEmissionToggle.tsx
@@ -5,7 +5,7 @@ import trackEvent from 'utils/analytics';
 import { LeftPanelToggleOptions, TrackEvent } from 'utils/constants';
 import { displayByEmissionsAtom } from 'utils/state/atoms';
 
-const options: ToggleButtonOptions = [
+const options: ToggleButtonOptions<LeftPanelToggleOptions> = [
   {
     value: LeftPanelToggleOptions.ELECTRICITY,
     translationKey: 'country-panel.electricityconsumption',
@@ -22,8 +22,8 @@ function EmissionToggle(): ReactElement {
   // TODO: perhaps togglebutton should accept boolean values
 
   const onSetCurrentMode = useCallback(
-    (option: LeftPanelToggleOptions | "") => {
-      if (option === "") {
+    (option: LeftPanelToggleOptions | '') => {
+      if (option === '') {
         return;
       }
       trackEvent(

--- a/web/src/features/panels/zone/DisplayByEmissionToggle.tsx
+++ b/web/src/features/panels/zone/DisplayByEmissionToggle.tsx
@@ -22,7 +22,10 @@ function EmissionToggle(): ReactElement {
   // TODO: perhaps togglebutton should accept boolean values
 
   const onSetCurrentMode = useCallback(
-    (option: string) => {
+    (option: LeftPanelToggleOptions | "") => {
+      if (option === "") {
+        return;
+      }
       trackEvent(
         displayByEmissions
           ? TrackEvent.PANEL_PRODUCTION_BUTTON_CLICKED


### PR DESCRIPTION
## Issue

Relates to https://github.com/electricitymaps/electricitymaps-contrib/issues/8035

## Description

Goal here is to address the zone/country _and_ electricity flows in settings not being saved on refresh. To accomplish this, I initially intended to use `atomWithStorage` and let it be. However, I noticed that the `onToggle` function wasn't being triggered correctly when the value is changed on the toggle buttons (this may have been my error, but I was having a hard time running the app locally so it's difficult to tell for sure). To make the minor change I had to change the usages of this function which include the zone/country and the emission/electricity buttons

Edit:

Removed the `atomWithStorage` change but kept the rest

### Preview

Sorry it's lagging out my PC, I can try on another machine later. Should be easy enough to validate

1. change the value from the default in your settings
2. refresh the page

Expect

1. the value is what you set it to
2. this is accomplished by saving the value in localstorage

### Double check

- [ ] I have tested my parser changes locally with `poetry run test_parser "zone_key"` -> not applicable
- [x] I have run `pnpx prettier@2 --write .` and `poetry run format` in the top level directory to format my changes. -> NO -> need to do this, eslint was lagging out my PC as well :'(
