### PR TITLE
no op service worker

### DIFF
--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -1,3 +1,5 @@
+/// <reference types="vite-plugin-pwa/client" />
+
 // Init CSS
 import 'maplibre-gl/dist/maplibre-gl.css';
 import 'react-spring-bottom-sheet/dist/style.css';
@@ -31,6 +33,7 @@ import { createConsoleGreeting } from 'utils/createConsoleGreeting';
 import enableErrorsInOverlay from 'utils/errorOverlay';
 import { getSentryUuid } from 'utils/getSentryUuid';
 import { refetchDataOnHourChange } from 'utils/refetching';
+import { registerSW } from 'virtual:pwa-register';
 
 const isProduction = import.meta.env.PROD;
 if (isProduction) {
@@ -274,6 +277,25 @@ const router = createBrowserRouter([
     ],
   },
 ]);
+
+// Service Worker update handling
+const updateSW = registerSW({
+  onNeedRefresh() {
+    console.log('PWA: New content available, refreshing...');
+    updateSW(true); // Attempt to skip waiting
+  },
+  onOfflineReady() {
+    console.log('PWA: App ready to work offline.');
+  },
+});
+
+// ADDED: Listen for controller change to reload page when new SW activates
+if ('serviceWorker' in navigator) {
+  navigator.serviceWorker.addEventListener('controllerchange', () => {
+    console.log('PWA: Controller changed, reloading page...');
+    window.location.reload();
+  });
+}
 
 const container = document.querySelector('#root');
 if (container) {

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -202,31 +202,10 @@ export default defineConfig(({ mode }) => ({
             workbox: {
               skipWaiting: true,
               clientsClaim: true,
-              maximumFileSizeToCacheInBytes: 3_500_000,
-              runtimeCaching: [
-                {
-                  urlPattern: ({ url }) => url.pathname.startsWith('/images/'),
-                  handler: 'CacheFirst',
-                  options: {
-                    cacheName: 'images',
-                    cacheableResponse: {
-                      statuses: [200],
-                    },
-                  },
-                },
-                {
-                  urlPattern: ({ url }) => url.pathname.startsWith('/icons/'),
-                  handler: 'CacheFirst',
-                  options: {
-                    cacheName: 'icons',
-                    cacheableResponse: {
-                      statuses: [200],
-                    },
-                  },
-                },
-              ],
+              globPatterns: [],
+              runtimeCaching: [],
+              navigateFallback: null,
             },
-            includeAssets: ['robots.txt', 'fonts/**/*.{woff2, pbf}'],
             manifest: PWAManifest,
           }),
           // Used to upload sourcemaps to Sentry


### PR DESCRIPTION
## Issue
Users don't receive the latest version of the app

## Description
This is an intermediate step to clean up old service worker configurations that might be stored in users' browsers.

This change should purge outdated configurations and reset them to default settings. We can then determine whether to achieve our desired outcome with a properly configured service worker or remove it entirely, allowing Cloudflare to handle all caching.

Without the requirement for offline functionality, combined with Cloudflare's built-in cache invalidation and the laborious workflow of making and validating service worker changes, I'm leaning toward eliminating the service worker completely.