### PR TITLE
chore: use v0.8 earthfiles

### DIFF
--- a/.github/workflows/earthly-contrib.yml
+++ b/.github/workflows/earthly-contrib.yml
@@ -16,7 +16,7 @@ jobs:
     steps:
       - uses: earthly/actions-setup@v1
         with:
-          version: v0.7.21
+          version: v0.8.15
       - uses: actions/checkout@v4
       - name: Put back the git branch into git (Earthly uses it for tagging)
         run: |

--- a/Earthfile
+++ b/Earthfile
@@ -1,4 +1,4 @@
-VERSION 0.7
+VERSION 0.8
 FROM python:3.10
 WORKDIR /contrib
 

--- a/config/Earthfile
+++ b/config/Earthfile
@@ -1,4 +1,4 @@
-VERSION 0.7
+VERSION 0.8
 FROM alpine:latest
 WORKDIR /contrib/config
 

--- a/web/Earthfile
+++ b/web/Earthfile
@@ -1,4 +1,4 @@
-VERSION --use-visited-upfront-hash-collection 0.7
+VERSION 0.8
 FROM node:20
 WORKDIR /contrib/web
 


### PR DESCRIPTION

## Description
This pull request updates the Earthly version across multiple files to ensure consistency and compatibility with the latest features. The most important changes involve updating the Earthly version in workflows and `Earthfile` configurations.

### Updates to Earthly version:

* [`.github/workflows/earthly-contrib.yml`](diffhunk://#diff-2acc0822a35539979857c0c0720d2e568b4e01f51891af51765308a080983f40L19-R19): Updated the Earthly version used in the GitHub Actions workflow from `v0.7.21` to `v0.8.15`.
* [`Earthfile`](diffhunk://#diff-2705f6016a64189abd14041e2f3e8dbb829553295d9088e4eb42eccb5e61bf47L1-R1): Updated the Earthly version directive from `0.7` to `0.8`.
* [`config/Earthfile`](diffhunk://#diff-a26d9ffa23f113835f05bb2ad94e7b5f9f2e4321755b996a22662687016ad7dfL1-R1): Updated the Earthly version directive from `0.7` to `0.8`.
* [`web/Earthfile`](diffhunk://#diff-2b3cbbebe9967712bc89a86f86d0965ab088b100597a85ddff3e8c02812a797fL1-R1): Updated the Earthly version directive from `--use-visited-upfront-hash-collection 0.7` to `0.8`.
