### PR TITLE
Add load chart

### DIFF
--- a/web/src/features/charts/LoadChart.tsx
+++ b/web/src/features/charts/LoadChart.tsx
@@ -1,0 +1,70 @@
+import { useTranslation } from 'react-i18next';
+import { Charts, TimeRange } from 'utils/constants';
+
+import { ChartSubtitle, ChartTitle } from './ChartTitle';
+import AreaGraph from './elements/AreaGraph';
+import { noop } from './graphUtils';
+import { useLoadChartData } from './hooks/useLoadChartData';
+import { NotEnoughDataMessage } from './NotEnoughDataMessage';
+import { RoundedCard } from './RoundedCard';
+import LoadChartTooltip from './tooltips/LoadChartTooltip';
+
+interface PriceChartProps {
+  datetimes: Date[];
+  timeRange: TimeRange;
+}
+
+function LoadChart({ datetimes, timeRange }: PriceChartProps) {
+  const { data, isLoading, isError } = useLoadChartData();
+  const { t } = useTranslation();
+
+  if (isLoading || isError || !data) {
+    return null;
+  }
+  const { chartData } = data;
+  const { layerFill, layerKeys, layerStroke, valueAxisLabel, markerFill } = data;
+
+  if (!Number.isFinite(chartData[0]?.layerData?.load)) {
+    return null;
+  }
+
+  const hasEnoughDataToDisplay = datetimes?.length > 2;
+
+  if (!hasEnoughDataToDisplay) {
+    return (
+      <NotEnoughDataMessage
+        id={Charts.LOAD_CHART}
+        title="country-history.electricityload"
+      />
+    );
+  }
+
+  return (
+    <RoundedCard>
+      <ChartTitle
+        titleText={t(`country-history.electricityLoad.${timeRange}`)}
+        unit={valueAxisLabel}
+        id={Charts.LOAD_CHART}
+        subtitle={<ChartSubtitle datetimes={datetimes} timeRange={timeRange} />}
+      />
+      <div className="relative">
+        <AreaGraph
+          testId="history-load-graph"
+          data={chartData}
+          layerKeys={layerKeys}
+          layerStroke={layerStroke}
+          layerFill={layerFill}
+          markerFill={markerFill}
+          markerUpdateHandler={noop}
+          markerHideHandler={noop}
+          height="6em"
+          datetimes={datetimes}
+          selectedTimeRange={timeRange}
+          tooltip={LoadChartTooltip}
+        />
+      </div>
+    </RoundedCard>
+  );
+}
+
+export default LoadChart;

--- a/web/src/features/charts/NetExchangeChart.tsx
+++ b/web/src/features/charts/NetExchangeChart.tsx
@@ -61,7 +61,7 @@ function NetExchangeChart({ datetimes, timeRange }: NetExchangeChartProps) {
           markerFill={markerFill}
           markerUpdateHandler={noop}
           markerHideHandler={noop}
-          height="10em"
+          height="6em"
           datetimes={datetimes}
           selectedTimeRange={timeRange}
           tooltip={NetExchangeChartTooltip}

--- a/web/src/features/charts/hooks/useLoadChartData.ts
+++ b/web/src/features/charts/hooks/useLoadChartData.ts
@@ -1,0 +1,70 @@
+import useGetZone from 'api/getZone';
+import { max as d3Max, min as d3Min } from 'd3-array';
+import { scaleLinear } from 'd3-scale';
+import { useAtomValue } from 'jotai';
+import { TimeRange } from 'utils/constants';
+import { scalePower } from 'utils/formatting';
+import { round } from 'utils/helpers';
+import { timeRangeAtom } from 'utils/state/atoms';
+
+import { AreaGraphElement } from '../types';
+
+export function getFills(data: AreaGraphElement[]) {
+  const values = Object.values(data).map((d) => d.layerData.load);
+  const maxValue = d3Max<number>(values) ?? 0;
+  const minValue = d3Min<number>(values) ?? 0;
+
+  const colorScale = scaleLinear<string>()
+    .domain([minValue, 0, maxValue])
+    .range(['gray', 'lightgray', '#616161']);
+
+  const layerFill = (key: string) => (d: { data: AreaGraphElement }) =>
+    colorScale(d.data.layerData[key]);
+
+  const markerFill = (key: string) => (d: { data: AreaGraphElement }) =>
+    colorScale(d.data.layerData[key]);
+
+  return { layerFill, markerFill };
+}
+
+export function useLoadChartData() {
+  const { data: zoneData, isLoading, isError } = useGetZone();
+  const timeRange = useAtomValue(timeRangeAtom);
+
+  if (isLoading || isError || !zoneData) {
+    return { isLoading, isError };
+  }
+
+  const chartData = Object.entries(zoneData.zoneStates).map(
+    ([datetimeString, zoneDetail]) => ({
+      datetime: new Date(datetimeString),
+      layerData: {
+        load: round(zoneDetail.totalConsumption),
+      },
+      meta: zoneDetail,
+    })
+  );
+
+  const isHourly = timeRange === TimeRange.H72;
+  const maxTotalValue = d3Max(chartData, (d) => d.layerData.load);
+  const { unit, formattingFactor } = scalePower(maxTotalValue, isHourly);
+  const valueAxisLabel = unit;
+  for (const d of chartData) {
+    d.layerData.load /= formattingFactor;
+  }
+
+  const { layerFill, markerFill } = getFills(chartData);
+
+  const layerKeys = ['load'];
+
+  const result = {
+    chartData,
+    layerKeys,
+    layerFill,
+    markerFill,
+    valueAxisLabel,
+    layerStroke: undefined,
+  };
+
+  return { data: result, isLoading, isError };
+}

--- a/web/src/features/charts/tooltips/LoadChartTooltip.tsx
+++ b/web/src/features/charts/tooltips/LoadChartTooltip.tsx
@@ -1,0 +1,44 @@
+import { useAtomValue } from 'jotai';
+import { useTranslation } from 'react-i18next';
+import { formatCo2, scalePower } from 'utils/formatting';
+import { getNetExchange, round } from 'utils/helpers';
+import { displayByEmissionsAtom, isHourlyAtom, timeRangeAtom } from 'utils/state/atoms';
+
+import { InnerAreaGraphTooltipProps } from '../types';
+import AreaGraphToolTipHeader from './AreaGraphTooltipHeader';
+
+export default function LoadChartTooltip({ zoneDetail }: InnerAreaGraphTooltipProps) {
+  const timeRange = useAtomValue(timeRangeAtom);
+  const displayByEmissions = useAtomValue(displayByEmissionsAtom);
+  const isHourly = useAtomValue(isHourlyAtom);
+  const { t } = useTranslation();
+
+  if (!zoneDetail) {
+    return null;
+  }
+
+  const { stateDatetime } = zoneDetail;
+
+  const netExchange = getNetExchange(zoneDetail, displayByEmissions);
+  const { formattingFactor, unit: powerUnit } = scalePower(netExchange, isHourly);
+
+  const unit = displayByEmissions ? t('ofCO2eq') : powerUnit;
+  const value = displayByEmissions
+    ? formatCo2({ value: Math.abs(netExchange) })
+    : Math.abs(round(netExchange / formattingFactor));
+
+  return (
+    <div className="w-full rounded-md bg-white p-3 shadow-xl dark:border dark:border-neutral-700 dark:bg-neutral-800 sm:w-[350px]">
+      <AreaGraphToolTipHeader
+        datetime={new Date(stateDatetime)}
+        timeRange={timeRange}
+        squareColor="#7f7f7f"
+        title={t('tooltips.netExchange')}
+      />
+      <p className="flex justify-center text-base">
+        {netExchange >= 0 ? t('tooltips.importing') : t('tooltips.exporting')}{' '}
+        <b className="mx-1">{Number.isFinite(value) ? value : '?'}</b> {unit}
+      </p>
+    </div>
+  );
+}

--- a/web/src/features/panels/zone/AreaGraphContainer.tsx
+++ b/web/src/features/panels/zone/AreaGraphContainer.tsx
@@ -1,5 +1,6 @@
 import CarbonChart from 'features/charts/CarbonChart';
 import EmissionChart from 'features/charts/EmissionChart';
+import LoadChart from 'features/charts/LoadChart';
 import NetExchangeChart from 'features/charts/NetExchangeChart';
 import OriginChart from 'features/charts/OriginChart';
 import PriceChart from 'features/charts/PriceChart';
@@ -28,6 +29,7 @@ export default function AreaGraphContainer({
       />
       <NetExchangeChart datetimes={datetimes} timeRange={timeRange} />
       <PriceChart datetimes={datetimes} timeRange={timeRange} />
+      <LoadChart datetimes={datetimes} timeRange={timeRange} />
     </div>
   );
 }

--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -312,6 +312,13 @@
       "all_months": "Monthly electricity flow",
       "all_years": "Yearly electricity flow"
     },
+    "electricityLoad": {
+      "72h": "Hourly electricity load",
+      "3mo": "Daily electricity load",
+      "12mo": "Monthly electricity load",
+      "all_months": "Monthly electricity load",
+      "all_years": "Yearly electricity load"
+    },
     "not-enough-data": "Not enough data available to display chart",
     "exchange-delay": "Flow data may be delayed by up to 48h."
   },

--- a/web/src/utils/constants.ts
+++ b/web/src/utils/constants.ts
@@ -56,6 +56,7 @@ export enum Charts {
   CARBON_CHART = 'carbon_chart',
   EMISSION_CHART = 'emission_chart',
   NET_EXCHANGE_CHART = 'net_exchange_chart',
+  LOAD_CHART = 'load_chart',
 }
 
 export enum TrackEvent {


### PR DESCRIPTION
## Issue

Inspired by https://github.com/electricitymaps/electricitymaps-contrib/pull/8084

## Description

* Added the load graph (copy/pasted the netexchange graph and worked from there)
* Resized all scalar (i.e. unidimensional) graphs to `6em`

### Preview

<img width="883" alt="image" src="https://github.com/user-attachments/assets/8a5b39e4-6605-4d29-8c3e-45ee2c8d7e59" />


### Double check

- [x] I have tested my parser changes locally with `poetry run test_parser "zone_key"`
- [x] I have run `pnpx prettier@2 --write .` and `poetry run format` in the top level directory to format my changes.
