### PR TITLE
fix: set PT lower bound to 0

### DIFF
--- a/parsers/ENTSOE.py
+++ b/parsers/ENTSOE.py
@@ -419,7 +419,7 @@ VALIDATIONS: dict[str, dict[str, Any]] = {
         "expected_range": (5000, 35000),
     },
     "PT": {
-        "expected_range": (600, 20000),
+        "expected_range": (0, 20000),
     },
     "RO": {
         "expected_range": (2000, 25000),


### PR DESCRIPTION
## Issue
We still have some estimated datapoints for PT.

## Description
This pull request includes a small change to the `parsers/ENTSOE.py` file. The change updates the `expected_range` for "PT" to allow a lower bound of 0 instead of 600.
