### PR TITLE
bug(app): fix presentation error on missing price + currency

### DIFF
--- a/web/src/features/charts/tooltips/PriceChartTooltip.tsx
+++ b/web/src/features/charts/tooltips/PriceChartTooltip.tsx
@@ -19,8 +19,9 @@ export default function PriceChartTooltip({ zoneDetail }: InnerAreaGraphTooltipP
     priceObject?.value,
     priceObject?.currency
   );
-  const currencySymbol = getSymbolFromCurrency(currency) ?? '?';
   const price = Number.isFinite(value) ? value : '?';
+  const currencySymbol = getSymbolFromCurrency(currency) ?? '?';
+  const currencySymbolToDisplay = price === '?' ? '' : currencySymbol;
 
   return (
     <div className="w-full rounded-md bg-white p-3 shadow-xl dark:border dark:border-neutral-700 dark:bg-neutral-800 sm:w-64">
@@ -32,7 +33,7 @@ export default function PriceChartTooltip({ zoneDetail }: InnerAreaGraphTooltipP
       />
       <p className="flex justify-center text-base">
         <b className="mr-1">{price}</b>
-        {currencySymbol} / {unit}
+        {currencySymbolToDisplay} / {unit}
       </p>
     </div>
   );


### PR DESCRIPTION
When price and currency are missing, the tooltip displays ? ? / MWh. Instead, we should display ? / MWh in this scenario.

## Issue

<!-- If you want to close an issue automatically when your PR is merged, write "Closes X" where X is the issue number. For example: Closes #000 -->

## Description

<!-- Explains the goal of this PR -->

### Preview

<!-- Please add screenshots and/or gif that shows visual changes (if applicable) -->

### Double check

- [ ] I have tested my parser changes locally with `poetry run test_parser "zone_key"`
- [ ] I have run `pnpx prettier@2 --write .` and `poetry run format` in the top level directory to format my changes.
