### PR TITLE
Update en.json with net flows

### DIFF
--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -306,11 +306,11 @@
       "all_years": "Yearly electricity prices"
     },
     "netExchange": {
-      "72h": "Hourly electricity flow",
-      "3mo": "Daily electricity flow",
-      "12mo": "Monthly electricity flow",
-      "all_months": "Monthly electricity flow",
-      "all_years": "Yearly electricity flow"
+      "72h": "Hourly electricity net flow",
+      "3mo": "Daily electricity net flow",
+      "12mo": "Monthly electricity net flow",
+      "all_months": "Monthly electricity net flow",
+      "all_years": "Yearly electricity net flow"
     },
     "electricityLoad": {
       "72h": "Hourly electricity load",


### PR DESCRIPTION
## Issue

The title of the graph does not contain "net".

<img width="439" alt="image" src="https://github.com/user-attachments/assets/fabe7f32-dad4-4d0f-aa19-eafa09cc32fb" />

## Description

This PR adds it!

### Preview

<!-- Please add screenshots and/or gif that shows visual changes (if applicable) -->

### Double check

- [ ] I have tested my parser changes locally with `poetry run test_parser "zone_key"`
- [ ] I have run `pnpx prettier@2 --write .` and `poetry run format` in the top level directory to format my changes.
