### PR TITLE
Grid alerts card left panel

### DIFF
--- a/web/src/features/charts/ChartTitle.tsx
+++ b/web/src/features/charts/ChartTitle.tsx
@@ -14,6 +14,7 @@ type Props = {
   isEstimated?: boolean;
   id: Charts;
   subtitle?: React.ReactElement;
+  isMoreOptionsVisible?: boolean;
 };
 
 export function ChartTitle({
@@ -24,6 +25,7 @@ export function ChartTitle({
   isEstimated,
   id,
   subtitle,
+  isMoreOptionsVisible,
 }: Props) {
   const showMoreOptions = useFeatureFlag('more-options-dropdown');
   const url = useGetCurrentUrl();
@@ -37,16 +39,17 @@ export function ChartTitle({
           {titleText}
         </h2>
         {badge}
-        {showMoreOptions && (
-          <MoreOptionsDropdown
-            title={t(`more-options-dropdown.chart-title`)}
-            isEstimated={isEstimated}
-            id={id}
-            shareUrl={shareUrl}
-          >
-            <Ellipsis />
-          </MoreOptionsDropdown>
-        )}
+        {(isMoreOptionsVisible == null ? true : isMoreOptionsVisible) &&
+          showMoreOptions && (
+            <MoreOptionsDropdown
+              title={t(`more-options-dropdown.chart-title`)}
+              isEstimated={isEstimated}
+              id={id}
+              shareUrl={shareUrl}
+            >
+              <Ellipsis />
+            </MoreOptionsDropdown>
+          )}
       </div>
       <div className="flex flex-row items-center justify-between">
         {subtitle}

--- a/web/src/features/panels/zone/GridAlertsCard.tsx
+++ b/web/src/features/panels/zone/GridAlertsCard.tsx
@@ -1,0 +1,52 @@
+import { ChartSubtitle, ChartTitle } from 'features/charts/ChartTitle';
+import { RoundedCard } from 'features/charts/RoundedCard';
+import { Charts, TimeRange } from 'utils/constants';
+
+export default function GridAlertsCard({
+  datetimes,
+  timeRange,
+}: {
+  datetimes: Date[];
+  timeRange: TimeRange;
+  displayByEmissions: boolean;
+}) {
+  return (
+    <RoundedCard>
+      <ChartTitle
+        titleText="Reported grid alerts"
+        id={Charts.ELECTRICITY_GRID_ALERT}
+        subtitle={<ChartSubtitle datetimes={datetimes} timeRange={timeRange} />}
+        isMoreOptionsVisible={false}
+      />
+      <div className="flex flex-col items-center gap-2 rounded-lg bg-gray-100 p-4">
+        <div className="relative h-[76px] w-[76px] overflow-hidden">
+          <div className="absolute left-[43.5px] top-[1px] h-[54px] w-[25px] rounded border border-[#CCC] bg-[#FAFAFA]" />
+          <div className="absolute left-[25.5px] top-[21px] h-[44px] w-[25px] rounded border border-[#CCC] bg-[#FAFAFA]" />
+          <div className="absolute left-[7.5px] top-[43px] h-[32px] w-[25px] rounded border border-[#CCC] bg-[#FAFAFA]" />
+          <div className="absolute left-[8.5px] top-[44.5px] h-[13px] w-[23px] rounded-sm bg-[#EAEAEA]" />
+          <div className="absolute left-[44.5px] top-[2.5px] h-[13px] w-[23px] rounded-sm bg-[#EAEAEA]" />
+          <div className="absolute left-[26.5px] top-[22.5px] h-[13px] w-[23px] rounded-sm bg-[#EAEAEA]" />
+        </div>
+        <p className="text-center text-xs">
+          We&apos;re missing data. Help us{' '}
+          <a
+            href="https://github.com/electricitymaps/electricitymaps-contrib/issues/8121"
+            target="_blank"
+            className="font-semibold text-emerald-800 underline underline-offset-2 dark:text-emerald-500" rel="noopener"
+          >
+            shape the feature
+          </a>{' '}
+          or tell us about your{' '}
+          <a
+            href="https://docs.google.com/forms/d/e/1FAIpQLSdVgjBHiune743TVvPyR1ydE4oY8znbO5jZHNyTbsT_dXCsvg/formResponse"
+            target="_blank"
+            className="font-semibold text-emerald-800 underline underline-offset-2 dark:text-emerald-500" rel="noopener"
+          >
+            ideas and experience
+          </a>
+          .
+        </p>
+      </div>
+    </RoundedCard>
+  );
+}

--- a/web/src/features/panels/zone/GridAlertsCard.tsx
+++ b/web/src/features/panels/zone/GridAlertsCard.tsx
@@ -32,7 +32,8 @@ export default function GridAlertsCard({
           <a
             href="https://github.com/electricitymaps/electricitymaps-contrib/issues/8121"
             target="_blank"
-            className="font-semibold text-emerald-800 underline underline-offset-2 dark:text-emerald-500" rel="noopener"
+            className="font-semibold text-emerald-800 underline underline-offset-2 dark:text-emerald-500"
+            rel="noopener"
           >
             shape the feature
           </a>{' '}
@@ -40,7 +41,8 @@ export default function GridAlertsCard({
           <a
             href="https://docs.google.com/forms/d/e/1FAIpQLSdVgjBHiune743TVvPyR1ydE4oY8znbO5jZHNyTbsT_dXCsvg/formResponse"
             target="_blank"
-            className="font-semibold text-emerald-800 underline underline-offset-2 dark:text-emerald-500" rel="noopener"
+            className="font-semibold text-emerald-800 underline underline-offset-2 dark:text-emerald-500"
+            rel="noopener"
           >
             ideas and experience
           </a>

--- a/web/src/features/panels/zone/ZoneDetails.tsx
+++ b/web/src/features/panels/zone/ZoneDetails.tsx
@@ -24,6 +24,7 @@ import AreaGraphContainer from './AreaGraphContainer';
 import Attribution from './Attribution';
 import DisplayByEmissionToggle from './DisplayByEmissionToggle';
 import EstimationCard from './EstimationCard';
+import GridAlertsCard from './GridAlertsCard';
 import MethodologyCard from './MethodologyCard';
 import NoInformationMessage from './NoInformationMessage';
 import { getHasSubZones, getZoneDataStatus, ZoneDataStatus } from './util';
@@ -103,6 +104,11 @@ export default function ZoneDetails(): JSX.Element {
             />
           )}
 
+          <GridAlertsCard
+            datetimes={datetimes}
+            timeRange={timeRange}
+            displayByEmissions={displayByEmissions}
+          />
           <MethodologyCard />
           <HorizontalDivider />
           <div className="flex items-center justify-between gap-2">

--- a/web/src/utils/constants.ts
+++ b/web/src/utils/constants.ts
@@ -55,6 +55,7 @@ export enum Charts {
   EMISSION_CHART = 'emission_chart',
   ELECTRTICITY_FLOW_CHART = 'electricity_flow_chart',
   ELECTRICITY_LOAD_CHART = 'electricity_load_chart',
+  ELECTRICITY_GRID_ALERT = 'electricity_grid_alert_chart',
   ELECTRICITY_MIX_CHART = 'electricity_mix_chart',
   ELECTRICITY_MIX_OVERVIEW_CHART = 'electricity_mix_overview_chart',
   ELECTRICITY_PRICE_CHART = 'electricity_price_chart',


### PR DESCRIPTION
## Description

This PR is to merge the creation of the Grid alerts card in the left panel for all zones.
In this initial state of the card, there is a call for contributors that links to the [Github issue](https://github.com/electricitymaps/electricitymaps-contrib/issues/8121) and to the grid alerts [survey](https://docs.google.com/forms/d/e/1FAIpQLSdVgjBHiune743TVvPyR1ydE4oY8znbO5jZHNyTbsT_dXCsvg/viewform).

### Preview

<img width="433" alt="Screenshot 2025-05-14 at 16 32 54" src="https://github.com/user-attachments/assets/fe7d1955-8e90-4add-9a91-f27f0e094b78" />


### Double check

- [x] I have run `pnpx prettier@2 --write .` and `poetry run format` in the top level directory to format my changes.
