### PR TITLE
fix(parsers): fix return type for some parsers

### DIFF
--- a/parsers/CA_AB.py
+++ b/parsers/CA_AB.py
@@ -121,40 +121,42 @@ def fetch_production(
         }
         for row in csv.reader(response.text.split("\r\n\r\n")[3].splitlines())
     }
-    return [validation.validate(
-        {
-            "capacity": {
-                "gas": generation["COGENERATION"]["MC"]
-                + generation["COMBINED CYCLE"]["MC"]
-                + generation["GAS FIRED STEAM"]["MC"]
-                + generation["SIMPLE CYCLE"]["MC"],
-                "wind": generation["WIND"]["MC"],
-                "solar": generation["SOLAR"]["MC"],
-                "hydro": generation["HYDRO"]["MC"],
-                "biomass": generation["OTHER"]["MC"],
-                "battery storage": generation["ENERGY STORAGE"]["MC"],
+    return [
+        validation.validate(
+            {
+                "capacity": {
+                    "gas": generation["COGENERATION"]["MC"]
+                    + generation["COMBINED CYCLE"]["MC"]
+                    + generation["GAS FIRED STEAM"]["MC"]
+                    + generation["SIMPLE CYCLE"]["MC"],
+                    "wind": generation["WIND"]["MC"],
+                    "solar": generation["SOLAR"]["MC"],
+                    "hydro": generation["HYDRO"]["MC"],
+                    "biomass": generation["OTHER"]["MC"],
+                    "battery storage": generation["ENERGY STORAGE"]["MC"],
+                },
+                "datetime": get_csd_report_timestamp(response.text),
+                "production": {
+                    "gas": generation["COGENERATION"]["TNG"]
+                    + generation["COMBINED CYCLE"]["TNG"]
+                    + generation["GAS FIRED STEAM"]["TNG"]
+                    + generation["SIMPLE CYCLE"]["TNG"],
+                    "wind": generation["WIND"]["TNG"],
+                    "solar": generation["SOLAR"]["TNG"],
+                    "hydro": generation["HYDRO"]["TNG"],
+                    "biomass": generation["OTHER"]["TNG"],
+                },
+                "source": URL.netloc,
+                "storage": {
+                    "battery": generation["ENERGY STORAGE"]["TNG"],
+                },
+                "zoneKey": zone_key,
             },
-            "datetime": get_csd_report_timestamp(response.text),
-            "production": {
-                "gas": generation["COGENERATION"]["TNG"]
-                + generation["COMBINED CYCLE"]["TNG"]
-                + generation["GAS FIRED STEAM"]["TNG"]
-                + generation["SIMPLE CYCLE"]["TNG"],
-                "wind": generation["WIND"]["TNG"],
-                "solar": generation["SOLAR"]["TNG"],
-                "hydro": generation["HYDRO"]["TNG"],
-                "biomass": generation["OTHER"]["TNG"],
-            },
-            "source": URL.netloc,
-            "storage": {
-                "battery": generation["ENERGY STORAGE"]["TNG"],
-            },
-            "zoneKey": zone_key,
-        },
-        logger,
-        floor=MINIMUM_PRODUCTION_THRESHOLD,
-        remove_negative=True,
-    )]
+            logger,
+            floor=MINIMUM_PRODUCTION_THRESHOLD,
+            remove_negative=True,
+        )
+    ]
 
 
 def get_csd_report_timestamp(report):

--- a/parsers/CA_AB.py
+++ b/parsers/CA_AB.py
@@ -121,7 +121,7 @@ def fetch_production(
         }
         for row in csv.reader(response.text.split("\r\n\r\n")[3].splitlines())
     }
-    return validation.validate(
+    return [validation.validate(
         {
             "capacity": {
                 "gas": generation["COGENERATION"]["MC"]
@@ -154,7 +154,7 @@ def fetch_production(
         logger,
         floor=MINIMUM_PRODUCTION_THRESHOLD,
         remove_negative=True,
-    )
+    )]
 
 
 def get_csd_report_timestamp(report):

--- a/parsers/GB_ORK.py
+++ b/parsers/GB_ORK.py
@@ -105,7 +105,7 @@ def fetch_production(
         "source": "ssen.co.uk",
     }
 
-    return data
+    return [data]
 
 
 def fetch_exchange(
@@ -132,7 +132,7 @@ def fetch_exchange(
         "source": "ssen.co.uk",
     }
 
-    return data
+    return [data]
 
 
 if __name__ == "__main__":

--- a/parsers/JP_KN.py
+++ b/parsers/JP_KN.py
@@ -51,7 +51,7 @@ def fetch_production(
 
     latest["production"]["nuclear"] = nuclear_mw
     latest["production"]["unknown"] = latest["production"]["unknown"] - nuclear_mw
-    return latest
+    return [latest]
 
 
 URL = (

--- a/parsers/JP_KY.py
+++ b/parsers/JP_KY.py
@@ -115,7 +115,7 @@ def fetch_production(
         data["production"]["nuclear"] = nuclear
         data["production"]["unknown"] = unknown
 
-        return data
+        return [data]
     else:
         return []
 

--- a/parsers/JP_SK.py
+++ b/parsers/JP_SK.py
@@ -56,7 +56,7 @@ def fetch_production(
         latest_data_point_JP_SK["datetime"] - datetime_nuclear
     ).total_seconds() / 3600 <= 1:
         latest_data_point_JP_SK["production"]["nuclear"] = nuclear_power_MW
-    return latest_data_point_JP_SK
+    return [latest_data_point_JP_SK]
 
 
 NUCLEAR_REPORT_URL = "https://www.yonden.co.jp/energy/atom/ikata/ikt722.html"

--- a/parsers/KW.py
+++ b/parsers/KW.py
@@ -74,7 +74,7 @@ def fetch_consumption(
         "source": "mew.gov.kw",
     }
 
-    return datapoint
+    return [datapoint]
 
 
 if __name__ == "__main__":

--- a/parsers/NZ.py
+++ b/parsers/NZ.py
@@ -65,13 +65,15 @@ def fetch_price(
         tzinfo=timezone.utc
     )
 
-    return [{
-        "datetime": date_time,
-        "price": avg_price,
-        "currency": "NZD",
-        "source": "api.em6.co.nz",
-        "zoneKey": zone_key,
-    }]
+    return [
+        {
+            "datetime": date_time,
+            "price": avg_price,
+            "currency": "NZD",
+            "source": "api.em6.co.nz",
+            "zoneKey": zone_key,
+        }
+    ]
 
 
 def fetch_production(

--- a/parsers/NZ.py
+++ b/parsers/NZ.py
@@ -65,13 +65,13 @@ def fetch_price(
         tzinfo=timezone.utc
     )
 
-    return {
+    return [{
         "datetime": date_time,
         "price": avg_price,
         "currency": "NZD",
         "source": "api.em6.co.nz",
         "zoneKey": zone_key,
-    }
+    }]
 
 
 def fetch_production(

--- a/parsers/ajenti.py
+++ b/parsers/ajenti.py
@@ -161,7 +161,7 @@ def fetch_production(
     technologies_parsed = parse_payload(logger, payload)
     storage_techs = sum_storage_techs(technologies_parsed)
 
-    return {
+    return [{
         "zoneKey": zone_key,
         "datetime": datetime.now(tz=ZoneInfo(tz)),
         "production": {
@@ -185,7 +185,7 @@ def fetch_production(
             * -1  # Somewhat counterintuitively,to ElectricityMap positive means charging and negative means discharging
         },
         "source": source,
-    }
+    }]
 
 
 if __name__ == "__main__":

--- a/parsers/ajenti.py
+++ b/parsers/ajenti.py
@@ -161,31 +161,34 @@ def fetch_production(
     technologies_parsed = parse_payload(logger, payload)
     storage_techs = sum_storage_techs(technologies_parsed)
 
-    return [{
-        "zoneKey": zone_key,
-        "datetime": datetime.now(tz=ZoneInfo(tz)),
-        "production": {
-            "biomass": technologies_parsed["biomass"],
-            "coal": technologies_parsed["coal"],
-            "gas": technologies_parsed["gas"],
-            "hydro": technologies_parsed["hydro"],
-            "nuclear": technologies_parsed["nuclear"],
-            "oil": technologies_parsed["oil"],
-            "solar": technologies_parsed["solar"],
-            "wind": 0
-            if technologies_parsed["wind"] < 0 and technologies_parsed["wind"] > -0.1
-            else technologies_parsed[
-                "wind"
-            ],  # If wind between 0 and -0.1 set to 0 to ignore self-consumption
-            "geothermal": technologies_parsed["geothermal"],
-            "unknown": technologies_parsed["unknown"],
-        },
-        "storage": {
-            "battery": storage_techs
-            * -1  # Somewhat counterintuitively,to ElectricityMap positive means charging and negative means discharging
-        },
-        "source": source,
-    }]
+    return [
+        {
+            "zoneKey": zone_key,
+            "datetime": datetime.now(tz=ZoneInfo(tz)),
+            "production": {
+                "biomass": technologies_parsed["biomass"],
+                "coal": technologies_parsed["coal"],
+                "gas": technologies_parsed["gas"],
+                "hydro": technologies_parsed["hydro"],
+                "nuclear": technologies_parsed["nuclear"],
+                "oil": technologies_parsed["oil"],
+                "solar": technologies_parsed["solar"],
+                "wind": 0
+                if technologies_parsed["wind"] < 0
+                and technologies_parsed["wind"] > -0.1
+                else technologies_parsed[
+                    "wind"
+                ],  # If wind between 0 and -0.1 set to 0 to ignore self-consumption
+                "geothermal": technologies_parsed["geothermal"],
+                "unknown": technologies_parsed["unknown"],
+            },
+            "storage": {
+                "battery": storage_techs
+                * -1  # Somewhat counterintuitively,to ElectricityMap positive means charging and negative means discharging
+            },
+            "source": source,
+        }
+    ]
 
 
 if __name__ == "__main__":

--- a/parsers/test/__snapshots__/test_JP_KY.ambr
+++ b/parsers/test/__snapshots__/test_JP_KY.ambr
@@ -1,22 +1,24 @@
 # serializer version: 1
 # name: test_snapshot_fetch_production
-  dict({
-    'datetime': datetime.datetime(2025, 4, 25, 16, 40, tzinfo=zoneinfo.ZoneInfo(key='Asia/Tokyo')),
-    'production': dict({
-      'biomass': 0,
-      'coal': 0,
-      'gas': 0,
-      'geothermal': None,
-      'hydro': None,
-      'nuclear': 3119.0,
-      'oil': 0,
-      'solar': 2100.0,
-      'unknown': 3861.0,
-      'wind': None,
+  list([
+    dict({
+      'datetime': datetime.datetime(2025, 4, 25, 16, 40, tzinfo=zoneinfo.ZoneInfo(key='Asia/Tokyo')),
+      'production': dict({
+        'biomass': 0,
+        'coal': 0,
+        'gas': 0,
+        'geothermal': None,
+        'hydro': None,
+        'nuclear': 3119.0,
+        'oil': 0,
+        'solar': 2100.0,
+        'unknown': 3861.0,
+        'wind': None,
+      }),
+      'source': 'www.kyuden.co.jp',
+      'storage': dict({
+      }),
+      'zoneKey': 'JP-KY',
     }),
-    'source': 'www.kyuden.co.jp',
-    'storage': dict({
-    }),
-    'zoneKey': 'JP-KY',
-  })
+  ])
 # ---

--- a/parsers/test/__snapshots__/test_NZ.ambr
+++ b/parsers/test/__snapshots__/test_NZ.ambr
@@ -1,20 +1,24 @@
 # serializer version: 1
 # name: test_snapshot_price_data
   list([
-    dict({
-      'currency': 'NZD',
-      'datetime': datetime.datetime(2024, 4, 24, 18, 30, tzinfo=datetime.timezone.utc),
-      'price': 79.8623076923077,
-      'source': 'api.em6.co.nz',
-      'zoneKey': 'NZ',
-    }),
-    dict({
-      'currency': 'NZD',
-      'datetime': datetime.datetime(2024, 4, 24, 18, 30, tzinfo=datetime.timezone.utc),
-      'price': 79.8623076923077,
-      'source': 'api.em6.co.nz',
-      'zoneKey': 'NZ',
-    }),
+    list([
+      dict({
+        'currency': 'NZD',
+        'datetime': datetime.datetime(2024, 4, 24, 18, 30, tzinfo=datetime.timezone.utc),
+        'price': 79.8623076923077,
+        'source': 'api.em6.co.nz',
+        'zoneKey': 'NZ',
+      }),
+    ]),
+    list([
+      dict({
+        'currency': 'NZD',
+        'datetime': datetime.datetime(2024, 4, 24, 18, 30, tzinfo=datetime.timezone.utc),
+        'price': 79.8623076923077,
+        'source': 'api.em6.co.nz',
+        'zoneKey': 'NZ',
+      }),
+    ]),
   ])
 # ---
 # name: test_snapshot_production_data

--- a/parsers/test/test_AU_TAS_FI.py
+++ b/parsers/test/test_AU_TAS_FI.py
@@ -12,7 +12,7 @@ def test_parsing_payload():
         fake_data = json.load(f)
     with patch("parsers.ajenti.SignalR.get_value") as f:
         f.return_value = fake_data
-        data = ajenti.fetch_production()
+        data = ajenti.fetch_production()[0]
 
     assert data["production"] is not None
     assert data["production"]["wind"] == 0.595

--- a/parsers/test/test_AU_TAS_KI.py
+++ b/parsers/test/test_AU_TAS_KI.py
@@ -12,7 +12,7 @@ def test_parsing_payload():
         fake_data = json.load(f)
     with patch("parsers.ajenti.SignalR.get_value") as f:
         f.return_value = fake_data
-        data = ajenti.fetch_production()
+        data = ajenti.fetch_production()[0]
 
     assert data["production"] is not None
     assert data["production"]["wind"] == 1.024

--- a/parsers/test/test_AU_WA_RI.py
+++ b/parsers/test/test_AU_WA_RI.py
@@ -12,7 +12,7 @@ def test_parsing_payload():
         fake_data = json.load(f)
     with patch("parsers.ajenti.SignalR.get_value") as f:
         f.return_value = fake_data
-        data = ajenti.fetch_production()
+        data = ajenti.fetch_production()[0]
 
     assert data["production"] is not None
     assert data["production"]["wind"] == 0.148

--- a/parsers/test/test_JP_KY.py
+++ b/parsers/test/test_JP_KY.py
@@ -140,7 +140,7 @@ def test_fetch_production_success_without_solar(
             return_value=mock_exchange_data_night,
         ),
     ):
-        result = JP_KY.fetch_production()
+        result = JP_KY.fetch_production()[0]
 
         nuclear = 3119  # (119.7 + 96.1 + 96.1) * 10
         unknown = 5091  # 8010 - (-200) - 0 - nuclear
@@ -172,7 +172,7 @@ def test_fetch_production_success_with_solar(
             return_value=mock_exchange_data_day,
         ),
     ):
-        result = JP_KY.fetch_production()
+        result = JP_KY.fetch_production()[0]
 
         nuclear = 3119  # (119.7 + 96.1 + 96.1) * 10
         unknown = 3861  #  8680 - (-400) - 2100 - nuclear


### PR DESCRIPTION
We enforced type checking of the returned value from the parsers. 
We expects the parsers to return a list. 

The following were returning a dict and thus were failing. 
The list of affected parsers is :
- production: JP-KN, JP-SK, JP-KY, GB-ORK, CA-AB, AU-WA-RI, AU-TAS-FI, AU-TAS-KI
- consumption: KW
- price: NZ
- exchange: GB->GB-ORK

### Double check

- [x] I have tested my parser changes locally with `poetry run test_parser "zone_key"`
- [ ] I have run `pnpx prettier@2 --write .` and `poetry run format` in the top level directory to format my changes.
