### PR TITLE
chore(config): Switch ruff target python version to 3.11

### DIFF
--- a/electricitymap/contrib/lib/models/events.py
+++ b/electricitymap/contrib/lib/models/events.py
@@ -3,7 +3,7 @@ import datetime as dt
 import math
 from abc import ABC, abstractmethod
 from collections.abc import Set
-from datetime import datetime, timedelta, timezone
+from datetime import datetime, timedelta
 from enum import Enum
 from logging import Logger
 from typing import Any
@@ -20,7 +20,7 @@ from electricitymap.contrib.lib.models.constants import VALID_CURRENCIES
 from electricitymap.contrib.lib.types import ZoneKey
 from parsers.lib.config import ProductionModes, StorageModes
 
-LOWER_DATETIME_BOUND = datetime(2000, 1, 1, tzinfo=timezone.utc)
+LOWER_DATETIME_BOUND = datetime(2000, 1, 1, tzinfo=dt.UTC)
 
 
 def _is_naive(t: dt.datetime) -> bool:
@@ -322,8 +322,8 @@ class Event(BaseModel, ABC):
             raise ValueError(f"Date is before 2000, this is not plausible: {v}")
         if values.get(
             "sourceType", EventSourceType.measured
-        ) != EventSourceType.forecasted and v.astimezone(timezone.utc) > datetime.now(
-            timezone.utc
+        ) != EventSourceType.forecasted and v.astimezone(dt.UTC) > datetime.now(
+            dt.UTC
         ) + timedelta(days=1):
             raise ValueError(
                 f"Date is in the future and this is not a forecasted point: {v}"

--- a/electricitymap/contrib/lib/tests/test_event_lists.py
+++ b/electricitymap/contrib/lib/tests/test_event_lists.py
@@ -1,5 +1,5 @@
 import logging
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from unittest.mock import patch
 
 import numpy as np
@@ -25,13 +25,13 @@ def test_exchange_list():
     exchange_list = ExchangeList(logging.Logger("test"))
     exchange_list.append(
         zoneKey=ZoneKey("AT->DE"),
-        datetime=datetime(2023, 1, 1, tzinfo=timezone.utc),
+        datetime=datetime(2023, 1, 1, tzinfo=UTC),
         netFlow=1,
         source="trust.me",
     )
     exchange_list.append(
         zoneKey=ZoneKey("AT->DE"),
-        datetime=datetime(2023, 1, 2, tzinfo=timezone.utc),
+        datetime=datetime(2023, 1, 2, tzinfo=UTC),
         netFlow=1,
         source="trust.me",
     )
@@ -43,7 +43,7 @@ def test_append_to_list_logs_error():
     with patch.object(exchange_list.logger, "error") as mock_error:
         exchange_list.append(
             zoneKey=ZoneKey("AT"),
-            datetime=datetime(2023, 1, 1, tzinfo=timezone.utc),
+            datetime=datetime(2023, 1, 1, tzinfo=UTC),
             netFlow=1,
             source="trust.me",
         )
@@ -51,7 +51,7 @@ def test_append_to_list_logs_error():
 
 
 def test_merge_exchanges():
-    dt = datetime(2023, 1, 1, tzinfo=timezone.utc)
+    dt = datetime(2023, 1, 1, tzinfo=UTC)
     exchange_list_1 = ExchangeList(logging.Logger("test"))
     exchange_list_1.append(
         zoneKey=ZoneKey("AT->DE"),
@@ -70,7 +70,7 @@ def test_merge_exchanges():
         [exchange_list_1, exchange_list_2], logging.Logger("test")
     )
     assert len(exchanges) == 1
-    assert exchanges[dt].datetime == datetime(2023, 1, 1, tzinfo=timezone.utc)
+    assert exchanges[dt].datetime == datetime(2023, 1, 1, tzinfo=UTC)
     assert exchanges[dt].netFlow == 3
 
 
@@ -78,14 +78,14 @@ def test_merge_exchanges_with_none():
     exchange_list_1 = ExchangeList(logging.Logger("test"))
     exchange_list_1.append(
         zoneKey=ZoneKey("AT->DE"),
-        datetime=datetime(2023, 1, 1, tzinfo=timezone.utc),
+        datetime=datetime(2023, 1, 1, tzinfo=UTC),
         netFlow=1,
         source="trust.me",
     )
     exchange_list_2 = ExchangeList(logging.Logger("test"))
     exchange_list_2.append(
         zoneKey=ZoneKey("AT->DE"),
-        datetime=datetime(2023, 1, 1, tzinfo=timezone.utc),
+        datetime=datetime(2023, 1, 1, tzinfo=UTC),
         netFlow=np.nan,
         source="trust.me",
     )
@@ -93,7 +93,7 @@ def test_merge_exchanges_with_none():
         [exchange_list_1, exchange_list_2], logging.Logger("test")
     )
     assert len(exchanges) == 1
-    assert exchanges.events[0].datetime == datetime(2023, 1, 1, tzinfo=timezone.utc)
+    assert exchanges.events[0].datetime == datetime(2023, 1, 1, tzinfo=UTC)
     assert exchanges.events[0].netFlow == 1
 
 
@@ -101,14 +101,14 @@ def test_merge_exchanges_with_negatives():
     exchange_list_1 = ExchangeList(logging.Logger("test"))
     exchange_list_1.append(
         zoneKey=ZoneKey("AT->DE"),
-        datetime=datetime(2023, 1, 1, tzinfo=timezone.utc),
+        datetime=datetime(2023, 1, 1, tzinfo=UTC),
         netFlow=1,
         source="trust.me",
     )
     exchange_list_2 = ExchangeList(logging.Logger("test"))
     exchange_list_2.append(
         zoneKey=ZoneKey("AT->DE"),
-        datetime=datetime(2023, 1, 1, tzinfo=timezone.utc),
+        datetime=datetime(2023, 1, 1, tzinfo=UTC),
         netFlow=-11,
         source="trust.me",
     )
@@ -116,7 +116,7 @@ def test_merge_exchanges_with_negatives():
         [exchange_list_1, exchange_list_2], logging.Logger("test")
     )
     assert len(exchanges) == 1
-    assert exchanges.events[0].datetime == datetime(2023, 1, 1, tzinfo=timezone.utc)
+    assert exchanges.events[0].datetime == datetime(2023, 1, 1, tzinfo=UTC)
     assert exchanges.events[0].netFlow == -10
 
 
@@ -124,20 +124,20 @@ def test_update_exchange_list():
     exchange_list1 = ExchangeList(logging.Logger("test"))
     exchange_list1.append(
         zoneKey=ZoneKey("AT->DE"),
-        datetime=datetime(2023, 1, 1, tzinfo=timezone.utc),
+        datetime=datetime(2023, 1, 1, tzinfo=UTC),
         netFlow=1,
         source="trust.me",
     )
     exchange_list1.append(
         zoneKey=ZoneKey("AT->DE"),
-        datetime=datetime(2023, 1, 2, tzinfo=timezone.utc),
+        datetime=datetime(2023, 1, 2, tzinfo=UTC),
         netFlow=1,
         source="trust.me",
     )
     exchange_list2 = ExchangeList(logging.Logger("test"))
     exchange_list2.append(
         zoneKey=ZoneKey("AT->DE"),
-        datetime=datetime(2023, 1, 1, tzinfo=timezone.utc),
+        datetime=datetime(2023, 1, 1, tzinfo=UTC),
         netFlow=2,
         source="trust.me",
     )
@@ -145,10 +145,10 @@ def test_update_exchange_list():
         exchange_list1, exchange_list2, logging.Logger("test")
     )
     assert len(updated_list.events) == 2
-    assert updated_list.events[0].datetime == datetime(2023, 1, 1, tzinfo=timezone.utc)
+    assert updated_list.events[0].datetime == datetime(2023, 1, 1, tzinfo=UTC)
     assert updated_list.events[0].netFlow == 2
     assert updated_list.events[0].source == "trust.me"
-    assert updated_list.events[1].datetime == datetime(2023, 1, 2, tzinfo=timezone.utc)
+    assert updated_list.events[1].datetime == datetime(2023, 1, 2, tzinfo=UTC)
     assert updated_list.events[1].netFlow == 1
     assert updated_list.events[1].source == "trust.me"
 
@@ -157,14 +157,14 @@ def test_update_exchange_list_with_different_zoneKey():
     exchange_list1 = ExchangeList(logging.Logger("test"))
     exchange_list1.append(
         zoneKey=ZoneKey("AT->DE"),
-        datetime=datetime(2023, 1, 1, tzinfo=timezone.utc),
+        datetime=datetime(2023, 1, 1, tzinfo=UTC),
         netFlow=1,
         source="trust.me",
     )
     exchange_list2 = ExchangeList(logging.Logger("test"))
     exchange_list2.append(
         zoneKey=ZoneKey("DE->DK-DK1"),
-        datetime=datetime(2023, 1, 1, tzinfo=timezone.utc),
+        datetime=datetime(2023, 1, 1, tzinfo=UTC),
         netFlow=2,
         source="trust.me",
     )
@@ -178,20 +178,20 @@ def test_update_exchange_list_with_longer_new_list():
     exchange_list1 = ExchangeList(logging.Logger("test"))
     exchange_list1.append(
         zoneKey=ZoneKey("AT->DE"),
-        datetime=datetime(2023, 1, 1, tzinfo=timezone.utc),
+        datetime=datetime(2023, 1, 1, tzinfo=UTC),
         netFlow=1,
         source="trust.me",
     )
     exchange_list2 = ExchangeList(logging.Logger("test"))
     exchange_list2.append(
         zoneKey=ZoneKey("AT->DE"),
-        datetime=datetime(2023, 1, 1, tzinfo=timezone.utc),
+        datetime=datetime(2023, 1, 1, tzinfo=UTC),
         netFlow=2,
         source="trust.me",
     )
     exchange_list2.append(
         zoneKey=ZoneKey("AT->DE"),
-        datetime=datetime(2023, 1, 2, tzinfo=timezone.utc),
+        datetime=datetime(2023, 1, 2, tzinfo=UTC),
         netFlow=3,
         source="trust.me",
     )
@@ -199,10 +199,10 @@ def test_update_exchange_list_with_longer_new_list():
         exchange_list1, exchange_list2, logging.Logger("test")
     )
     assert len(updated_list.events) == 2
-    assert updated_list.events[0].datetime == datetime(2023, 1, 1, tzinfo=timezone.utc)
+    assert updated_list.events[0].datetime == datetime(2023, 1, 1, tzinfo=UTC)
     assert updated_list.events[0].netFlow == 2
     assert updated_list.events[0].source == "trust.me"
-    assert updated_list.events[1].datetime == datetime(2023, 1, 2, tzinfo=timezone.utc)
+    assert updated_list.events[1].datetime == datetime(2023, 1, 2, tzinfo=UTC)
     assert updated_list.events[1].netFlow == 3
     assert updated_list.events[1].source == "trust.me"
 
@@ -211,13 +211,13 @@ def test_consumption_list():
     consumption_list = TotalConsumptionList(logging.Logger("test"))
     consumption_list.append(
         zoneKey=ZoneKey("AT"),
-        datetime=datetime(2023, 1, 1, tzinfo=timezone.utc),
+        datetime=datetime(2023, 1, 1, tzinfo=UTC),
         consumption=1,
         source="trust.me",
     )
     consumption_list.append(
         zoneKey=ZoneKey("AT"),
-        datetime=datetime(2023, 1, 2, tzinfo=timezone.utc),
+        datetime=datetime(2023, 1, 2, tzinfo=UTC),
         consumption=1,
         source="trust.me",
     )
@@ -229,7 +229,7 @@ def test_append_to_consumption_list_logs_error():
     with patch.object(consumption_list.logger, "error") as mock_error:
         consumption_list.append(
             zoneKey=ZoneKey("AT"),
-            datetime=datetime(2023, 1, 1, tzinfo=timezone.utc),
+            datetime=datetime(2023, 1, 1, tzinfo=UTC),
             consumption=-1,
             source="trust.me",
         )
@@ -240,7 +240,7 @@ def test_price_list():
     price_list = PriceList(logging.Logger("test"))
     price_list.append(
         zoneKey=ZoneKey("AT"),
-        datetime=datetime(2023, 1, 1, tzinfo=timezone.utc),
+        datetime=datetime(2023, 1, 1, tzinfo=UTC),
         price=1,
         source="trust.me",
         currency="EUR",
@@ -253,7 +253,7 @@ def test_append_to_price_list_logs_error():
     with patch.object(price_list.logger, "error") as mock_error:
         price_list.append(
             zoneKey=ZoneKey("AT"),
-            datetime=datetime(2023, 1, 1, tzinfo=timezone.utc),
+            datetime=datetime(2023, 1, 1, tzinfo=UTC),
             price=1,
             source="trust.me",
             currency="EURO",
@@ -265,7 +265,7 @@ def test_locational_marginal_price_list():
     lmp_list = LocationalMarginalPriceList(logging.Logger("test"))
     lmp_list.append(
         zoneKey=ZoneKey("US-CENT-SWPP"),
-        datetime=datetime(2025, 3, 1, tzinfo=timezone.utc),
+        datetime=datetime(2025, 3, 1, tzinfo=UTC),
         price=1,
         source="trust.me",
         currency="USD",
@@ -279,7 +279,7 @@ def test_append_to_locational_marginal_price_list_logs_error():
     with patch.object(lmp_list.logger, "error") as mock_error:
         lmp_list.append(
             zoneKey=ZoneKey("US-CENT-SWPP"),
-            datetime=datetime(2025, 3, 1, tzinfo=timezone.utc),
+            datetime=datetime(2025, 3, 1, tzinfo=UTC),
             price=1,
             source="trust.me",
             currency="EUR",
@@ -292,7 +292,7 @@ def test_production_list():
     production_list = ProductionBreakdownList(logging.Logger("test"))
     production_list.append(
         zoneKey=ZoneKey("AT"),
-        datetime=datetime(2023, 1, 1, tzinfo=timezone.utc),
+        datetime=datetime(2023, 1, 1, tzinfo=UTC),
         production=ProductionMix(wind=10),
         source="trust.me",
     )
@@ -312,7 +312,7 @@ def test_production_list_logs_error():
     with patch.object(production_list.logger, "debug") as mock_logger:
         production_list.append(
             zoneKey=ZoneKey("AT"),
-            datetime=datetime(2023, 1, 1, tzinfo=timezone.utc),
+            datetime=datetime(2023, 1, 1, tzinfo=UTC),
             production=ProductionMix(wind=-10),
             source="trust.me",
         )
@@ -323,51 +323,51 @@ def test_merge_production_list_production_mix_only():
     production_list_1 = ProductionBreakdownList(logging.Logger("test"))
     production_list_1.append(
         zoneKey=ZoneKey("AT"),
-        datetime=datetime(2023, 1, 1, tzinfo=timezone.utc),
+        datetime=datetime(2023, 1, 1, tzinfo=UTC),
         production=ProductionMix(wind=10),
         source="trust.me",
     )
     production_list_1.append(
         zoneKey=ZoneKey("AT"),
-        datetime=datetime(2023, 1, 2, tzinfo=timezone.utc),
+        datetime=datetime(2023, 1, 2, tzinfo=UTC),
         production=ProductionMix(wind=11, coal=1),
         source="trust.me",
     )
     production_list_1.append(
         zoneKey=ZoneKey("AT"),
-        datetime=datetime(2023, 1, 3, tzinfo=timezone.utc),
+        datetime=datetime(2023, 1, 3, tzinfo=UTC),
         production=ProductionMix(wind=12, coal=2),
         source="trust.me",
     )
     production_list_2 = ProductionBreakdownList(logging.Logger("test"))
     production_list_2.append(
         zoneKey=ZoneKey("AT"),
-        datetime=datetime(2023, 1, 1, tzinfo=timezone.utc),
+        datetime=datetime(2023, 1, 1, tzinfo=UTC),
         production=ProductionMix(wind=20),
         source="trust2.me",
     )
     production_list_2.append(
         zoneKey=ZoneKey("AT"),
-        datetime=datetime(2023, 1, 2, tzinfo=timezone.utc),
+        datetime=datetime(2023, 1, 2, tzinfo=UTC),
         production=ProductionMix(wind=21, coal=1),
         source="trust2.me",
     )
     production_list_2.append(
         zoneKey=ZoneKey("AT"),
-        datetime=datetime(2023, 1, 3, tzinfo=timezone.utc),
+        datetime=datetime(2023, 1, 3, tzinfo=UTC),
         production=ProductionMix(wind=22, coal=2),
         source="trust2.me",
     )
     production_list_3 = ProductionBreakdownList(logging.Logger("test"))
     production_list_3.append(
         zoneKey=ZoneKey("AT"),
-        datetime=datetime(2023, 1, 1, tzinfo=timezone.utc),
+        datetime=datetime(2023, 1, 1, tzinfo=UTC),
         production=ProductionMix(wind=30),
         source="trust3.me",
     )
     production_list_3.append(
         zoneKey=ZoneKey("AT"),
-        datetime=datetime(2023, 1, 2, tzinfo=timezone.utc),
+        datetime=datetime(2023, 1, 2, tzinfo=UTC),
         production=ProductionMix(wind=31, coal=1),
         source="trust3.me",
     )
@@ -376,7 +376,7 @@ def test_merge_production_list_production_mix_only():
         logging.Logger("test"),
     )
     assert len(merged.events) == 3
-    assert merged.events[0].datetime == datetime(2023, 1, 1, tzinfo=timezone.utc)
+    assert merged.events[0].datetime == datetime(2023, 1, 1, tzinfo=UTC)
     assert merged.events[0].production is not None
     assert merged.events[0].production.wind == 60
     assert merged.events[0].production.coal is None
@@ -385,12 +385,12 @@ def test_merge_production_list_production_mix_only():
     assert merged.events[0].storage is None
     assert merged.events[0].sourceType == EventSourceType.measured
 
-    assert merged.events[1].datetime == datetime(2023, 1, 2, tzinfo=timezone.utc)
+    assert merged.events[1].datetime == datetime(2023, 1, 2, tzinfo=UTC)
     assert merged.events[1].production is not None
     assert merged.events[1].production.wind == 63
     assert merged.events[1].production.coal == 3
 
-    assert merged.events[2].datetime == datetime(2023, 1, 3, tzinfo=timezone.utc)
+    assert merged.events[2].datetime == datetime(2023, 1, 3, tzinfo=UTC)
     assert merged.events[2].production is not None
     assert merged.events[2].production.wind == 34
     assert merged.events[2].production.coal == 4
@@ -400,41 +400,41 @@ def test_merge_production_list():
     production_list_1 = ProductionBreakdownList(logging.Logger("test"))
     production_list_1.append(
         zoneKey=ZoneKey("AT"),
-        datetime=datetime(2023, 1, 1, tzinfo=timezone.utc),
+        datetime=datetime(2023, 1, 1, tzinfo=UTC),
         production=ProductionMix(wind=10),
         storage=StorageMix(hydro=1),
         source="trust.me",
     )
     production_list_1.append(
         zoneKey=ZoneKey("AT"),
-        datetime=datetime(2023, 1, 2, tzinfo=timezone.utc),
+        datetime=datetime(2023, 1, 2, tzinfo=UTC),
         production=ProductionMix(wind=11, coal=1),
         storage=StorageMix(hydro=1, battery=1),
         source="trust.me",
     )
     production_list_1.append(
         zoneKey=ZoneKey("AT"),
-        datetime=datetime(2023, 1, 3, tzinfo=timezone.utc),
+        datetime=datetime(2023, 1, 3, tzinfo=UTC),
         production=ProductionMix(wind=12, coal=2),
         source="trust.me",
     )
     production_list_2 = ProductionBreakdownList(logging.Logger("test"))
     production_list_2.append(
         zoneKey=ZoneKey("AT"),
-        datetime=datetime(2023, 1, 1, tzinfo=timezone.utc),
+        datetime=datetime(2023, 1, 1, tzinfo=UTC),
         production=ProductionMix(wind=20),
         storage=StorageMix(hydro=1, battery=1),
         source="trust.me",
     )
     production_list_2.append(
         zoneKey=ZoneKey("AT"),
-        datetime=datetime(2023, 1, 2, tzinfo=timezone.utc),
+        datetime=datetime(2023, 1, 2, tzinfo=UTC),
         production=ProductionMix(wind=21, coal=1),
         source="trust.me",
     )
     production_list_2.append(
         zoneKey=ZoneKey("AT"),
-        datetime=datetime(2023, 1, 3, tzinfo=timezone.utc),
+        datetime=datetime(2023, 1, 3, tzinfo=UTC),
         production=ProductionMix(wind=22, coal=2),
         storage=StorageMix(hydro=1, battery=1),
         source="trust.me",
@@ -442,13 +442,13 @@ def test_merge_production_list():
     production_list_3 = ProductionBreakdownList(logging.Logger("test"))
     production_list_3.append(
         zoneKey=ZoneKey("AT"),
-        datetime=datetime(2023, 1, 1, tzinfo=timezone.utc),
+        datetime=datetime(2023, 1, 1, tzinfo=UTC),
         production=ProductionMix(wind=30),
         source="trust.me",
     )
     production_list_3.append(
         zoneKey=ZoneKey("AT"),
-        datetime=datetime(2023, 1, 2, tzinfo=timezone.utc),
+        datetime=datetime(2023, 1, 2, tzinfo=UTC),
         production=ProductionMix(wind=31, coal=1),
         source="trust.me",
     )
@@ -457,7 +457,7 @@ def test_merge_production_list():
         logging.Logger("test"),
     )
     assert len(merged.events) == 3
-    assert merged.events[0].datetime == datetime(2023, 1, 1, tzinfo=timezone.utc)
+    assert merged.events[0].datetime == datetime(2023, 1, 1, tzinfo=UTC)
     assert merged.events[0].storage.hydro == 2
 
 
@@ -465,7 +465,7 @@ def test_merge_production_list_doesnt_yield_extra_modes():
     production_list_1 = ProductionBreakdownList(logging.Logger("test"))
     production_list_1.append(
         zoneKey=ZoneKey("AT"),
-        datetime=datetime(2023, 1, 1, tzinfo=timezone.utc),
+        datetime=datetime(2023, 1, 1, tzinfo=UTC),
         production=ProductionMix(wind=10, coal=None),
         storage=StorageMix(hydro=1),
         source="trust.me",
@@ -475,7 +475,7 @@ def test_merge_production_list_doesnt_yield_extra_modes():
     production_mix.add_value("hydro", None)
     production_list_2.append(
         zoneKey=ZoneKey("AT"),
-        datetime=datetime(2023, 1, 1, tzinfo=timezone.utc),
+        datetime=datetime(2023, 1, 1, tzinfo=UTC),
         production=production_mix,
         storage=StorageMix(hydro=1),
         source="trust.me",
@@ -484,7 +484,7 @@ def test_merge_production_list_doesnt_yield_extra_modes():
         [production_list_1, production_list_2], logging.Logger("test")
     )
     assert len(merged.events) == 1
-    assert merged.events[0].datetime == datetime(2023, 1, 1, tzinfo=timezone.utc)
+    assert merged.events[0].datetime == datetime(2023, 1, 1, tzinfo=UTC)
     assert merged.events[0].production.hydro is None
     assert merged.events[0].storage.battery is None
     merged_dict = merged.events[0].to_dict()
@@ -496,7 +496,7 @@ def test_merge_production_list_predicted():
     production_list_1 = ProductionBreakdownList(logging.Logger("test"))
     production_list_1.append(
         zoneKey=ZoneKey("AT"),
-        datetime=datetime(2023, 1, 1, tzinfo=timezone.utc),
+        datetime=datetime(2023, 1, 1, tzinfo=UTC),
         production=ProductionMix(wind=10),
         storage=StorageMix(hydro=1),
         source="trust.me",
@@ -504,7 +504,7 @@ def test_merge_production_list_predicted():
     )
     production_list_1.append(
         zoneKey=ZoneKey("AT"),
-        datetime=datetime(2023, 1, 3, tzinfo=timezone.utc),
+        datetime=datetime(2023, 1, 3, tzinfo=UTC),
         production=ProductionMix(wind=12, coal=2),
         source="trust.me",
         sourceType=EventSourceType.forecasted,
@@ -512,7 +512,7 @@ def test_merge_production_list_predicted():
     production_list_2 = ProductionBreakdownList(logging.Logger("test"))
     production_list_2.append(
         zoneKey=ZoneKey("AT"),
-        datetime=datetime(2023, 1, 1, tzinfo=timezone.utc),
+        datetime=datetime(2023, 1, 1, tzinfo=UTC),
         production=ProductionMix(wind=20),
         storage=StorageMix(hydro=1, battery=1),
         source="trust.me",
@@ -520,7 +520,7 @@ def test_merge_production_list_predicted():
     )
     production_list_2.append(
         zoneKey=ZoneKey("AT"),
-        datetime=datetime(2023, 1, 3, tzinfo=timezone.utc),
+        datetime=datetime(2023, 1, 3, tzinfo=UTC),
         production=ProductionMix(wind=22, coal=2),
         storage=StorageMix(hydro=1, battery=1),
         source="trust.me",
@@ -531,7 +531,7 @@ def test_merge_production_list_predicted():
         logging.Logger("test"),
     )
     assert len(merged.events) == 2
-    assert merged.events[0].datetime == datetime(2023, 1, 1, tzinfo=timezone.utc)
+    assert merged.events[0].datetime == datetime(2023, 1, 1, tzinfo=UTC)
     assert merged.events[0].storage is not None
     assert merged.events[0].storage.hydro == 2
     assert merged.events[0].sourceType == EventSourceType.forecasted
@@ -541,14 +541,14 @@ def test_merge_production_retains_corrected_negatives():
     production_list_1 = ProductionBreakdownList(logging.Logger("test"))
     production_list_1.append(
         zoneKey=ZoneKey("AT"),
-        datetime=datetime(2023, 1, 1, tzinfo=timezone.utc),
+        datetime=datetime(2023, 1, 1, tzinfo=UTC),
         production=ProductionMix(wind=-10, coal=10),
         storage=StorageMix(hydro=1),
         source="trust.me",
     )
     production_list_1.append(
         zoneKey=ZoneKey("AT"),
-        datetime=datetime(2023, 1, 3, tzinfo=timezone.utc),
+        datetime=datetime(2023, 1, 3, tzinfo=UTC),
         production=ProductionMix(wind=-12, coal=12),
         storage=StorageMix(hydro=1, battery=1),
         source="trust.me",
@@ -556,14 +556,14 @@ def test_merge_production_retains_corrected_negatives():
     production_list_2 = ProductionBreakdownList(logging.Logger("test"))
     production_list_2.append(
         zoneKey=ZoneKey("AT"),
-        datetime=datetime(2023, 1, 1, tzinfo=timezone.utc),
+        datetime=datetime(2023, 1, 1, tzinfo=UTC),
         production=ProductionMix(hydro=20, coal=20),
         storage=StorageMix(hydro=1, battery=1),
         source="trust.me",
     )
     production_list_2.append(
         zoneKey=ZoneKey("AT"),
-        datetime=datetime(2023, 1, 3, tzinfo=timezone.utc),
+        datetime=datetime(2023, 1, 3, tzinfo=UTC),
         production=ProductionMix(hydro=22, coal=22),
         storage=StorageMix(hydro=1, battery=1),
         source="trust.me",
@@ -573,14 +573,14 @@ def test_merge_production_retains_corrected_negatives():
         logging.Logger("test"),
     )
     assert len(merged.events) == 2
-    assert merged.events[0].datetime == datetime(2023, 1, 1, tzinfo=timezone.utc)
+    assert merged.events[0].datetime == datetime(2023, 1, 1, tzinfo=UTC)
     assert merged.events[0].production is not None
     assert merged.events[0].production.wind is None
     assert merged.events[0].production.coal == 30
     assert merged.events[0].storage.hydro == 2
     assert merged.events[0].production._corrected_negative_values == {"wind"}
 
-    assert merged.events[1].datetime == datetime(2023, 1, 3, tzinfo=timezone.utc)
+    assert merged.events[1].datetime == datetime(2023, 1, 3, tzinfo=UTC)
     assert merged.events[1].production is not None
     assert merged.events[1].production.wind is None
     assert merged.events[1].production.coal == 34
@@ -595,7 +595,7 @@ def test_merge_production_retains_corrected_negatives_with_0_and_none():
     production_mix_1.add_value("biomass", -10, correct_negative_with_zero=True)
     production_list_1.append(
         zoneKey=ZoneKey("AT"),
-        datetime=datetime(2023, 1, 1, tzinfo=timezone.utc),
+        datetime=datetime(2023, 1, 1, tzinfo=UTC),
         production=production_mix_1,
         storage=StorageMix(hydro=1),
         source="trust.me",
@@ -605,7 +605,7 @@ def test_merge_production_retains_corrected_negatives_with_0_and_none():
     production_mix_2.add_value("solar", 20, correct_negative_with_zero=True)
     production_list_2.append(
         zoneKey=ZoneKey("AT"),
-        datetime=datetime(2023, 1, 1, tzinfo=timezone.utc),
+        datetime=datetime(2023, 1, 1, tzinfo=UTC),
         production=production_mix_2,
         storage=StorageMix(hydro=1, battery=1),
         source="trust.me",
@@ -615,7 +615,7 @@ def test_merge_production_retains_corrected_negatives_with_0_and_none():
         logging.Logger("test"),
     )
     assert len(merged.events) == 1
-    assert merged.events[0].datetime == datetime(2023, 1, 1, tzinfo=timezone.utc)
+    assert merged.events[0].datetime == datetime(2023, 1, 1, tzinfo=UTC)
     assert merged.events[0].production is not None
     assert merged.events[0].production.wind is None
     assert merged.events[0].production.solar == 20
@@ -632,20 +632,20 @@ def test_update_production_list_with_production():
     production_list1 = ProductionBreakdownList(logging.Logger("test"))
     production_list1.append(
         zoneKey=ZoneKey("AT"),
-        datetime=datetime(2023, 1, 1, tzinfo=timezone.utc),
+        datetime=datetime(2023, 1, 1, tzinfo=UTC),
         production=ProductionMix(wind=10, coal=10),
         source="trust.me",
     )
     production_list1.append(
         zoneKey=ZoneKey("AT"),
-        datetime=datetime(2023, 1, 2, tzinfo=timezone.utc),
+        datetime=datetime(2023, 1, 2, tzinfo=UTC),
         production=ProductionMix(wind=11, coal=11),
         source="trust.me",
     )
     production_list2 = ProductionBreakdownList(logging.Logger("test"))
     production_list2.append(
         zoneKey=ZoneKey("AT"),
-        datetime=datetime(2023, 1, 1, tzinfo=timezone.utc),
+        datetime=datetime(2023, 1, 1, tzinfo=UTC),
         production=ProductionMix(wind=20, coal=20),
         source="trust.me",
     )
@@ -653,11 +653,11 @@ def test_update_production_list_with_production():
         production_list1, production_list2, logging.Logger("test")
     )
     assert len(updated_list.events) == 2
-    assert updated_list.events[0].datetime == datetime(2023, 1, 1, tzinfo=timezone.utc)
+    assert updated_list.events[0].datetime == datetime(2023, 1, 1, tzinfo=UTC)
     assert updated_list.events[0].production.wind == 20
     assert updated_list.events[0].production.coal == 20
     assert updated_list.events[0].source == "trust.me"
-    assert updated_list.events[1].datetime == datetime(2023, 1, 2, tzinfo=timezone.utc)
+    assert updated_list.events[1].datetime == datetime(2023, 1, 2, tzinfo=UTC)
     assert updated_list.events[1].production.wind == 11
     assert updated_list.events[1].production.coal == 11
     assert updated_list.events[1].source == "trust.me"
@@ -667,20 +667,20 @@ def test_update_production_list_with_new_list_being_longer():
     production_list1 = ProductionBreakdownList(logging.Logger("test"))
     production_list1.append(
         zoneKey=ZoneKey("AT"),
-        datetime=datetime(2023, 1, 1, tzinfo=timezone.utc),
+        datetime=datetime(2023, 1, 1, tzinfo=UTC),
         production=ProductionMix(wind=10, coal=10),
         source="trust.me",
     )
     production_list2 = ProductionBreakdownList(logging.Logger("test"))
     production_list2.append(
         zoneKey=ZoneKey("AT"),
-        datetime=datetime(2023, 1, 1, tzinfo=timezone.utc),
+        datetime=datetime(2023, 1, 1, tzinfo=UTC),
         production=ProductionMix(wind=20, coal=20),
         source="trust.me",
     )
     production_list2.append(
         zoneKey=ZoneKey("AT"),
-        datetime=datetime(2023, 1, 2, tzinfo=timezone.utc),
+        datetime=datetime(2023, 1, 2, tzinfo=UTC),
         production=ProductionMix(wind=21, coal=21),
         source="trust.me",
     )
@@ -688,12 +688,12 @@ def test_update_production_list_with_new_list_being_longer():
         production_list1, production_list2, logging.Logger("test")
     )
     assert len(updated_list.events) == 2
-    assert updated_list.events[0].datetime == datetime(2023, 1, 1, tzinfo=timezone.utc)
+    assert updated_list.events[0].datetime == datetime(2023, 1, 1, tzinfo=UTC)
     assert updated_list.events[0].production is not None
     assert updated_list.events[0].production.wind == 20
     assert updated_list.events[0].production.coal == 20
     assert updated_list.events[0].source == "trust.me"
-    assert updated_list.events[1].datetime == datetime(2023, 1, 2, tzinfo=timezone.utc)
+    assert updated_list.events[1].datetime == datetime(2023, 1, 2, tzinfo=UTC)
     assert updated_list.events[1].production is not None
     assert updated_list.events[1].production.wind == 21
     assert updated_list.events[1].production.coal == 21
@@ -704,20 +704,20 @@ def test_update_storage_list_with_new_list_being_longer():
     production_list1 = ProductionBreakdownList(logging.Logger("test"))
     production_list1.append(
         zoneKey=ZoneKey("AT"),
-        datetime=datetime(2023, 1, 1, tzinfo=timezone.utc),
+        datetime=datetime(2023, 1, 1, tzinfo=UTC),
         storage=StorageMix(hydro=1),
         source="trust.me",
     )
     production_list2 = ProductionBreakdownList(logging.Logger("test"))
     production_list2.append(
         zoneKey=ZoneKey("AT"),
-        datetime=datetime(2023, 1, 1, tzinfo=timezone.utc),
+        datetime=datetime(2023, 1, 1, tzinfo=UTC),
         storage=StorageMix(hydro=2),
         source="trust.me",
     )
     production_list2.append(
         zoneKey=ZoneKey("AT"),
-        datetime=datetime(2023, 1, 2, tzinfo=timezone.utc),
+        datetime=datetime(2023, 1, 2, tzinfo=UTC),
         storage=StorageMix(hydro=3),
         source="trust.me",
     )
@@ -725,11 +725,11 @@ def test_update_storage_list_with_new_list_being_longer():
         production_list1, production_list2, logging.Logger("test")
     )
     assert len(updated_list.events) == 2
-    assert updated_list.events[0].datetime == datetime(2023, 1, 1, tzinfo=timezone.utc)
+    assert updated_list.events[0].datetime == datetime(2023, 1, 1, tzinfo=UTC)
     assert updated_list.events[0].storage is not None
     assert updated_list.events[0].storage.hydro == 2
     assert updated_list.events[0].source == "trust.me"
-    assert updated_list.events[1].datetime == datetime(2023, 1, 2, tzinfo=timezone.utc)
+    assert updated_list.events[1].datetime == datetime(2023, 1, 2, tzinfo=UTC)
     assert updated_list.events[1].storage is not None
     assert updated_list.events[1].storage.hydro == 3
     assert updated_list.events[1].source == "trust.me"
@@ -739,20 +739,20 @@ def test_update_production_list_with_storage():
     production_list1 = ProductionBreakdownList(logging.Logger("test"))
     production_list1.append(
         zoneKey=ZoneKey("AT"),
-        datetime=datetime(2023, 1, 1, tzinfo=timezone.utc),
+        datetime=datetime(2023, 1, 1, tzinfo=UTC),
         storage=StorageMix(hydro=1),
         source="trust.me",
     )
     production_list1.append(
         zoneKey=ZoneKey("AT"),
-        datetime=datetime(2023, 1, 2, tzinfo=timezone.utc),
+        datetime=datetime(2023, 1, 2, tzinfo=UTC),
         storage=StorageMix(hydro=2),
         source="trust.me",
     )
     production_list2 = ProductionBreakdownList(logging.Logger("test"))
     production_list2.append(
         zoneKey=ZoneKey("AT"),
-        datetime=datetime(2023, 1, 1, tzinfo=timezone.utc),
+        datetime=datetime(2023, 1, 1, tzinfo=UTC),
         storage=StorageMix(hydro=2),
         source="trust.me",
     )
@@ -760,11 +760,11 @@ def test_update_production_list_with_storage():
         production_list1, production_list2, logging.Logger("test")
     )
     assert len(updated_list.events) == 2
-    assert updated_list.events[0].datetime == datetime(2023, 1, 1, tzinfo=timezone.utc)
+    assert updated_list.events[0].datetime == datetime(2023, 1, 1, tzinfo=UTC)
     assert updated_list.events[0].storage is not None
     assert updated_list.events[0].storage.hydro == 2
     assert updated_list.events[0].source == "trust.me"
-    assert updated_list.events[1].datetime == datetime(2023, 1, 2, tzinfo=timezone.utc)
+    assert updated_list.events[1].datetime == datetime(2023, 1, 2, tzinfo=UTC)
     assert updated_list.events[1].storage is not None
     assert updated_list.events[1].storage.hydro == 2
     assert updated_list.events[1].source == "trust.me"
@@ -774,14 +774,14 @@ def test_update_production_list_with_none_in_production():
     production_list1 = ProductionBreakdownList(logging.Logger("test"))
     production_list1.append(
         zoneKey=ZoneKey("AT"),
-        datetime=datetime(2023, 1, 1, tzinfo=timezone.utc),
+        datetime=datetime(2023, 1, 1, tzinfo=UTC),
         production=ProductionMix(wind=10, coal=10),
         source="trust.me",
     )
     production_list2 = ProductionBreakdownList(logging.Logger("test"))
     production_list2.append(
         zoneKey=ZoneKey("AT"),
-        datetime=datetime(2023, 1, 1, tzinfo=timezone.utc),
+        datetime=datetime(2023, 1, 1, tzinfo=UTC),
         production=ProductionMix(wind=None, coal=20),
         source="trust.me",
     )
@@ -789,7 +789,7 @@ def test_update_production_list_with_none_in_production():
         production_list1, production_list2, logging.Logger("test")
     )
     assert len(updated_list.events) == 1
-    assert updated_list.events[0].datetime == datetime(2023, 1, 1, tzinfo=timezone.utc)
+    assert updated_list.events[0].datetime == datetime(2023, 1, 1, tzinfo=UTC)
     assert updated_list.events[0].production is not None
     assert updated_list.events[0].production.wind == 10
     assert updated_list.events[0].production.coal == 20
@@ -800,14 +800,14 @@ def test_update_production_list_with_none_in_storage():
     production_list1 = ProductionBreakdownList(logging.Logger("test"))
     production_list1.append(
         zoneKey=ZoneKey("AT"),
-        datetime=datetime(2023, 1, 1, tzinfo=timezone.utc),
+        datetime=datetime(2023, 1, 1, tzinfo=UTC),
         storage=StorageMix(hydro=1),
         source="trust.me",
     )
     production_list2 = ProductionBreakdownList(logging.Logger("test"))
     production_list2.append(
         zoneKey=ZoneKey("AT"),
-        datetime=datetime(2023, 1, 1, tzinfo=timezone.utc),
+        datetime=datetime(2023, 1, 1, tzinfo=UTC),
         storage=StorageMix(hydro=None),
         source="trust.me",
     )
@@ -815,7 +815,7 @@ def test_update_production_list_with_none_in_storage():
         production_list1, production_list2, logging.Logger("test")
     )
     assert len(updated_list.events) == 1
-    assert updated_list.events[0].datetime == datetime(2023, 1, 1, tzinfo=timezone.utc)
+    assert updated_list.events[0].datetime == datetime(2023, 1, 1, tzinfo=UTC)
     assert updated_list.events[0].storage.hydro == 1
     assert updated_list.events[0].source == "trust.me"
 
@@ -824,14 +824,14 @@ def test_update_production_with_different_zoneKey():
     production_list1 = ProductionBreakdownList(logging.Logger("test"))
     production_list1.append(
         zoneKey=ZoneKey("AT"),
-        datetime=datetime(2023, 1, 1, tzinfo=timezone.utc),
+        datetime=datetime(2023, 1, 1, tzinfo=UTC),
         production=ProductionMix(wind=10, coal=10),
         source="trust.me",
     )
     production_list2 = ProductionBreakdownList(logging.Logger("test"))
     production_list2.append(
         zoneKey=ZoneKey("DE"),
-        datetime=datetime(2023, 1, 1, tzinfo=timezone.utc),
+        datetime=datetime(2023, 1, 1, tzinfo=UTC),
         production=ProductionMix(wind=20, coal=20),
         source="trust.me",
     )
@@ -845,14 +845,14 @@ def test_update_production_with_different_source():
     production_list1 = ProductionBreakdownList(logging.Logger("test"))
     production_list1.append(
         zoneKey=ZoneKey("AT"),
-        datetime=datetime(2023, 1, 1, tzinfo=timezone.utc),
+        datetime=datetime(2023, 1, 1, tzinfo=UTC),
         production=ProductionMix(wind=10, coal=10),
         source="trust.me",
     )
     production_list2 = ProductionBreakdownList(logging.Logger("test"))
     production_list2.append(
         zoneKey=ZoneKey("AT"),
-        datetime=datetime(2023, 1, 1, tzinfo=timezone.utc),
+        datetime=datetime(2023, 1, 1, tzinfo=UTC),
         production=ProductionMix(wind=20, coal=20),
         source="trust.me.too",
     )
@@ -860,7 +860,7 @@ def test_update_production_with_different_source():
         production_list1, production_list2, logging.Logger("test")
     )
     assert len(updated_list.events) == 1
-    assert updated_list.events[0].datetime == datetime(2023, 1, 1, tzinfo=timezone.utc)
+    assert updated_list.events[0].datetime == datetime(2023, 1, 1, tzinfo=UTC)
     assert updated_list.events[0].production is not None
     assert updated_list.events[0].production.wind == 20
     assert updated_list.events[0].production.coal == 20
@@ -871,14 +871,14 @@ def test_update_production_with_different_sourceType():
     production_list1 = ProductionBreakdownList(logging.Logger("test"))
     production_list1.append(
         zoneKey=ZoneKey("AT"),
-        datetime=datetime(2023, 1, 1, tzinfo=timezone.utc),
+        datetime=datetime(2023, 1, 1, tzinfo=UTC),
         production=ProductionMix(wind=10, coal=10),
         source="trust.me",
     )
     production_list2 = ProductionBreakdownList(logging.Logger("test"))
     production_list2.append(
         zoneKey=ZoneKey("AT"),
-        datetime=datetime(2023, 1, 1, tzinfo=timezone.utc),
+        datetime=datetime(2023, 1, 1, tzinfo=UTC),
         production=ProductionMix(wind=20, coal=20),
         source="trust.me",
         sourceType=EventSourceType.forecasted,
@@ -894,7 +894,7 @@ def test_update_production_with_empty_list():
     production_list2 = ProductionBreakdownList(logging.Logger("test"))
     production_list2.append(
         zoneKey=ZoneKey("AT"),
-        datetime=datetime(2023, 1, 1, tzinfo=timezone.utc),
+        datetime=datetime(2023, 1, 1, tzinfo=UTC),
         production=ProductionMix(wind=20, coal=20),
         source="trust.me",
     )
@@ -902,7 +902,7 @@ def test_update_production_with_empty_list():
         production_list1, production_list2, logging.Logger("test")
     )
     assert len(updated_list.events) == 1
-    assert updated_list.events[0].datetime == datetime(2023, 1, 1, tzinfo=timezone.utc)
+    assert updated_list.events[0].datetime == datetime(2023, 1, 1, tzinfo=UTC)
     assert updated_list.events[0].production is not None
     assert updated_list.events[0].production.wind == 20
     assert updated_list.events[0].production.coal == 20
@@ -913,7 +913,7 @@ def test_update_production_with_empty_new_list():
     production_list1 = ProductionBreakdownList(logging.Logger("test"))
     production_list1.append(
         zoneKey=ZoneKey("AT"),
-        datetime=datetime(2023, 1, 1, tzinfo=timezone.utc),
+        datetime=datetime(2023, 1, 1, tzinfo=UTC),
         production=ProductionMix(wind=10, coal=10),
         source="trust.me",
     )
@@ -922,7 +922,7 @@ def test_update_production_with_empty_new_list():
         production_list1, production_list2, logging.Logger("test")
     )
     assert len(updated_list.events) == 1
-    assert updated_list.events[0].datetime == datetime(2023, 1, 1, tzinfo=timezone.utc)
+    assert updated_list.events[0].datetime == datetime(2023, 1, 1, tzinfo=UTC)
     assert updated_list.events[0].production is not None
     assert updated_list.events[0].production.wind == 10
     assert updated_list.events[0].production.coal == 10
@@ -934,7 +934,7 @@ def test_update_stroage_with_empty_list():
     production_list2 = ProductionBreakdownList(logging.Logger("test"))
     production_list2.append(
         zoneKey=ZoneKey("AT"),
-        datetime=datetime(2023, 1, 1, tzinfo=timezone.utc),
+        datetime=datetime(2023, 1, 1, tzinfo=UTC),
         storage=StorageMix(hydro=1),
         source="trust.me",
     )
@@ -942,7 +942,7 @@ def test_update_stroage_with_empty_list():
         production_list1, production_list2, logging.Logger("test")
     )
     assert len(updated_list.events) == 1
-    assert updated_list.events[0].datetime == datetime(2023, 1, 1, tzinfo=timezone.utc)
+    assert updated_list.events[0].datetime == datetime(2023, 1, 1, tzinfo=UTC)
     assert updated_list.events[0].storage is not None
     assert updated_list.events[0].storage.hydro == 1
     assert updated_list.events[0].source == "trust.me"
@@ -952,7 +952,7 @@ def test_update_stroage_with_empty_new_list():
     production_list1 = ProductionBreakdownList(logging.Logger("test"))
     production_list1.append(
         zoneKey=ZoneKey("AT"),
-        datetime=datetime(2023, 1, 1, tzinfo=timezone.utc),
+        datetime=datetime(2023, 1, 1, tzinfo=UTC),
         storage=StorageMix(hydro=1),
         source="trust.me",
     )
@@ -961,7 +961,7 @@ def test_update_stroage_with_empty_new_list():
         production_list1, production_list2, logging.Logger("test")
     )
     assert len(updated_list.events) == 1
-    assert updated_list.events[0].datetime == datetime(2023, 1, 1, tzinfo=timezone.utc)
+    assert updated_list.events[0].datetime == datetime(2023, 1, 1, tzinfo=UTC)
     assert updated_list.events[0].storage is not None
     assert updated_list.events[0].storage.hydro == 1
     assert updated_list.events[0].source == "trust.me"
@@ -971,7 +971,7 @@ def test_filter_expected_modes():
     production_list_1 = ProductionBreakdownList(logging.Logger("test"))
     production_list_1.append(
         zoneKey=ZoneKey("AT"),
-        datetime=datetime(2023, 1, 1, tzinfo=timezone.utc),
+        datetime=datetime(2023, 1, 1, tzinfo=UTC),
         production=ProductionMix(
             wind=10,
             coal=None,
@@ -987,7 +987,7 @@ def test_filter_expected_modes():
     )
     production_list_1.append(
         zoneKey=ZoneKey("AT"),
-        datetime=datetime(2023, 1, 3, tzinfo=timezone.utc),
+        datetime=datetime(2023, 1, 3, tzinfo=UTC),
         production=ProductionMix(
             wind=12, coal=12, solar=12, gas=12, unknown=12, hydro=12
         ),
@@ -996,7 +996,7 @@ def test_filter_expected_modes():
     )
     production_list_1.append(
         zoneKey=ZoneKey("AT"),
-        datetime=datetime(2023, 1, 4, tzinfo=timezone.utc),
+        datetime=datetime(2023, 1, 4, tzinfo=UTC),
         production=ProductionMix(
             wind=12, coal=12, solar=12, gas=12, unknown=12, hydro=12
         ),
@@ -1005,14 +1005,14 @@ def test_filter_expected_modes():
     )
     output = ProductionBreakdownList.filter_expected_modes(production_list_1)
     assert len(output.events) == 1
-    assert output.events[0].datetime == datetime(2023, 1, 1, tzinfo=timezone.utc)
+    assert output.events[0].datetime == datetime(2023, 1, 1, tzinfo=UTC)
 
 
 def test_filter_expected_modes_none():
     production_list_1 = ProductionBreakdownList(logging.Logger("test"))
     production_list_1.append(
         zoneKey=ZoneKey("AT"),
-        datetime=datetime(2023, 1, 1, tzinfo=timezone.utc),
+        datetime=datetime(2023, 1, 1, tzinfo=UTC),
         production=ProductionMix(
             wind=10,
             coal=None,
@@ -1034,7 +1034,7 @@ def test_filter_corrected_negatives():
     production_list_1 = ProductionBreakdownList(logging.Logger("test"))
     production_list_1.append(
         zoneKey=ZoneKey("AT"),
-        datetime=datetime(2023, 1, 1, tzinfo=timezone.utc),
+        datetime=datetime(2023, 1, 1, tzinfo=UTC),
         production=ProductionMix(
             wind=10,
             coal=None,
@@ -1057,7 +1057,7 @@ def test_not_strict_mode():
     production_list = ProductionBreakdownList(logging.Logger("test"))
     production_list.append(
         zoneKey=ZoneKey("AT"),
-        datetime=datetime(2023, 1, 1, tzinfo=timezone.utc),
+        datetime=datetime(2023, 1, 1, tzinfo=UTC),
         production=ProductionMix(
             wind=10,
             coal=None,
@@ -1078,7 +1078,7 @@ def test_filter_by_passed_modes():
     production_list = ProductionBreakdownList(logging.Logger("test"))
     production_list.append(
         zoneKey=ZoneKey("US-NW-PGE"),
-        datetime=datetime(2023, 1, 1, tzinfo=timezone.utc),
+        datetime=datetime(2023, 1, 1, tzinfo=UTC),
         production=ProductionMix(
             wind=10,
             coal=None,
@@ -1100,7 +1100,7 @@ def test_total_production_list():
     total_production = TotalProductionList(logging.Logger("test"))
     total_production.append(
         zoneKey=ZoneKey("AT"),
-        datetime=datetime(2023, 1, 1, tzinfo=timezone.utc),
+        datetime=datetime(2023, 1, 1, tzinfo=UTC),
         value=1,
         source="trust.me",
     )
@@ -1114,14 +1114,14 @@ def test_df_representation():
     production_mix_1.add_value("biomass", -10, correct_negative_with_zero=True)
     production_list_1.append(
         zoneKey=ZoneKey("AT"),
-        datetime=datetime(2023, 1, 1, tzinfo=timezone.utc),
+        datetime=datetime(2023, 1, 1, tzinfo=UTC),
         production=production_mix_1,
         storage=StorageMix(hydro=1),
         source="trust.me",
     )
     production_list_1.append(
         zoneKey=ZoneKey("AT"),
-        datetime=datetime(2023, 1, 2, tzinfo=timezone.utc),
+        datetime=datetime(2023, 1, 2, tzinfo=UTC),
         production=ProductionMix(wind=-12, coal=12),
         storage=StorageMix(hydro=1),
         source="trust.me",

--- a/electricitymap/contrib/lib/tests/test_events.py
+++ b/electricitymap/contrib/lib/tests/test_events.py
@@ -1,6 +1,6 @@
 import logging
 import math
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from unittest.mock import patch
 from zoneinfo import ZoneInfo
 
@@ -26,18 +26,18 @@ from electricitymap.contrib.lib.types import ZoneKey
 def test_create_exchange():
     exchange = Exchange(
         zoneKey=ZoneKey("AT->DE"),
-        datetime=datetime(2023, 1, 1, tzinfo=timezone.utc),
+        datetime=datetime(2023, 1, 1, tzinfo=UTC),
         netFlow=1,
         source="trust.me",
     )
     assert exchange.zoneKey == ZoneKey("AT->DE")
-    assert exchange.datetime == datetime(2023, 1, 1, tzinfo=timezone.utc)
+    assert exchange.datetime == datetime(2023, 1, 1, tzinfo=UTC)
     assert exchange.netFlow == 1
     assert exchange.source == "trust.me"
 
     exchange = Exchange(
         zoneKey=ZoneKey("AT->DE"),
-        datetime=datetime(2023, 1, 1, tzinfo=timezone.utc),
+        datetime=datetime(2023, 1, 1, tzinfo=UTC),
         netFlow=-1,
         source="trust.me",
     )
@@ -49,7 +49,7 @@ def test_raises_if_invalid_exchange():
     with pytest.raises(ValueError):
         Exchange(
             zoneKey=ZoneKey("AT->DE"),
-            datetime=datetime(2023, 1, 1, tzinfo=timezone.utc),
+            datetime=datetime(2023, 1, 1, tzinfo=UTC),
             netFlow=None,
             source="trust.me",
         )
@@ -58,7 +58,7 @@ def test_raises_if_invalid_exchange():
     with pytest.raises(ValueError):
         Exchange(
             zoneKey=ZoneKey("AT->DE"),
-            datetime=datetime(2023, 1, 1, tzinfo=timezone.utc),
+            datetime=datetime(2023, 1, 1, tzinfo=UTC),
             netFlow=math.nan,
             source="trust.me",
         )
@@ -67,7 +67,7 @@ def test_raises_if_invalid_exchange():
     with pytest.raises(ValueError):
         Exchange(
             zoneKey=ZoneKey("AT->DE"),
-            datetime=datetime(2023, 1, 1, tzinfo=timezone.utc),
+            datetime=datetime(2023, 1, 1, tzinfo=UTC),
             netFlow=np.nan,
             source="trust.me",
         )
@@ -85,7 +85,7 @@ def test_raises_if_invalid_exchange():
     with pytest.raises(ValueError):
         Exchange(
             zoneKey=ZoneKey("AT"),
-            datetime=datetime(2023, 1, 1, tzinfo=timezone.utc),
+            datetime=datetime(2023, 1, 1, tzinfo=UTC),
             netFlow=1,
             source="trust.me",
         )
@@ -93,7 +93,7 @@ def test_raises_if_invalid_exchange():
     with pytest.raises(ValueError):
         Exchange(
             zoneKey=ZoneKey("AT-DE"),
-            datetime=datetime(2023, 1, 1, tzinfo=timezone.utc),
+            datetime=datetime(2023, 1, 1, tzinfo=UTC),
             netFlow=1,
             source="trust.me",
         )
@@ -101,7 +101,7 @@ def test_raises_if_invalid_exchange():
     with pytest.raises(ValueError):
         Exchange(
             zoneKey=ZoneKey("UNKNOWN->UNKNOWN"),
-            datetime=datetime(2023, 1, 1, tzinfo=timezone.utc),
+            datetime=datetime(2023, 1, 1, tzinfo=UTC),
             netFlow=1,
             source="trust.me",
         )
@@ -109,7 +109,7 @@ def test_raises_if_invalid_exchange():
     with pytest.raises(ValueError):
         Exchange(
             zoneKey=ZoneKey("DE->AT"),
-            datetime=datetime(2023, 1, 1, tzinfo=timezone.utc),
+            datetime=datetime(2023, 1, 1, tzinfo=UTC),
             netFlow=1,
             source="trust.me",
         )
@@ -121,7 +121,7 @@ def test_exchange_static_create_logs_error():
         Exchange.create(
             logger=logger,
             zoneKey=ZoneKey("DER->FR"),
-            datetime=datetime(2023, 1, 1, tzinfo=timezone.utc),
+            datetime=datetime(2023, 1, 1, tzinfo=UTC),
             netFlow=-1,
             source="trust.me",
         )
@@ -131,13 +131,13 @@ def test_exchange_static_create_logs_error():
 def test_update_exchange():
     exchange = Exchange(
         zoneKey=ZoneKey("AT->DE"),
-        datetime=datetime(2023, 1, 1, tzinfo=timezone.utc),
+        datetime=datetime(2023, 1, 1, tzinfo=UTC),
         netFlow=1,
         source="trust.me",
     )
     new_exchange = Exchange(
         zoneKey=ZoneKey("AT->DE"),
-        datetime=datetime(2023, 1, 1, tzinfo=timezone.utc),
+        datetime=datetime(2023, 1, 1, tzinfo=UTC),
         netFlow=2,
         source="trust.me",
     )
@@ -145,19 +145,19 @@ def test_update_exchange():
     assert final_exchange is not None
     assert final_exchange.netFlow == 2
     assert final_exchange.zoneKey == ZoneKey("AT->DE")
-    assert final_exchange.datetime == datetime(2023, 1, 1, tzinfo=timezone.utc)
+    assert final_exchange.datetime == datetime(2023, 1, 1, tzinfo=UTC)
     assert final_exchange.source == "trust.me"
 
 
 def test_create_consumption():
     consumption = TotalConsumption(
         zoneKey=ZoneKey("DE"),
-        datetime=datetime(2023, 1, 1, tzinfo=timezone.utc),
+        datetime=datetime(2023, 1, 1, tzinfo=UTC),
         consumption=1,
         source="trust.me",
     )
     assert consumption.zoneKey == ZoneKey("DE")
-    assert consumption.datetime == datetime(2023, 1, 1, tzinfo=timezone.utc)
+    assert consumption.datetime == datetime(2023, 1, 1, tzinfo=UTC)
     assert consumption.consumption == 1
     assert consumption.source == "trust.me"
 
@@ -167,7 +167,7 @@ def test_raises_if_invalid_consumption():
     with pytest.raises(ValueError):
         TotalConsumption(
             zoneKey=ZoneKey("AT"),
-            datetime=datetime(2023, 1, 1, tzinfo=timezone.utc),
+            datetime=datetime(2023, 1, 1, tzinfo=UTC),
             consumption=None,
             source="trust.me",
         )
@@ -176,7 +176,7 @@ def test_raises_if_invalid_consumption():
     with pytest.raises(ValueError):
         TotalConsumption(
             zoneKey=ZoneKey("AT"),
-            datetime=datetime(2023, 1, 1, tzinfo=timezone.utc),
+            datetime=datetime(2023, 1, 1, tzinfo=UTC),
             consumption=math.nan,
             source="trust.me",
         )
@@ -185,7 +185,7 @@ def test_raises_if_invalid_consumption():
     with pytest.raises(ValueError):
         TotalConsumption(
             zoneKey=ZoneKey("AT"),
-            datetime=datetime(2023, 1, 1, tzinfo=timezone.utc),
+            datetime=datetime(2023, 1, 1, tzinfo=UTC),
             consumption=np.nan,
             source="trust.me",
         )
@@ -193,7 +193,7 @@ def test_raises_if_invalid_consumption():
     with pytest.raises(ValueError):
         TotalConsumption(
             zoneKey=ZoneKey("ATT"),
-            datetime=datetime(2023, 1, 1, tzinfo=timezone.utc),
+            datetime=datetime(2023, 1, 1, tzinfo=UTC),
             consumption=1,
             source="trust.me",
         )
@@ -207,7 +207,7 @@ def test_raises_if_invalid_consumption():
     with pytest.raises(ValueError):
         TotalConsumption(
             zoneKey=ZoneKey("AT"),
-            datetime=datetime(2023, 1, 1, tzinfo=timezone.utc),
+            datetime=datetime(2023, 1, 1, tzinfo=UTC),
             consumption=-1,
             source="trust.me",
         )
@@ -219,7 +219,7 @@ def test_static_create_logs_error():
         TotalConsumption.create(
             logger=logger,
             zoneKey=ZoneKey("DE"),
-            datetime=datetime(2023, 1, 1, tzinfo=timezone.utc),
+            datetime=datetime(2023, 1, 1, tzinfo=UTC),
             consumption=-1,
             source="trust.me",
         )
@@ -229,13 +229,13 @@ def test_static_create_logs_error():
 def test_create_price():
     price = Price(
         zoneKey=ZoneKey("DE"),
-        datetime=datetime(2023, 1, 1, tzinfo=timezone.utc),
+        datetime=datetime(2023, 1, 1, tzinfo=UTC),
         price=1,
         source="trust.me",
         currency="EUR",
     )
     assert price.zoneKey == ZoneKey("DE")
-    assert price.datetime == datetime(2023, 1, 1, tzinfo=timezone.utc)
+    assert price.datetime == datetime(2023, 1, 1, tzinfo=UTC)
     assert price.price == 1
     assert price.source == "trust.me"
     assert price.currency == "EUR"
@@ -246,7 +246,7 @@ def test_invalid_price_raises():
     with pytest.raises(ValueError):
         Price(
             zoneKey=ZoneKey("AT"),
-            datetime=datetime(2023, 1, 1, tzinfo=timezone.utc),
+            datetime=datetime(2023, 1, 1, tzinfo=UTC),
             price=None,
             source="trust.me",
             currency="EUR",
@@ -256,7 +256,7 @@ def test_invalid_price_raises():
     with pytest.raises(ValueError):
         Price(
             zoneKey=ZoneKey("AT"),
-            datetime=datetime(2023, 1, 1, tzinfo=timezone.utc),
+            datetime=datetime(2023, 1, 1, tzinfo=UTC),
             price=math.nan,
             source="trust.me",
             currency="EUR",
@@ -266,7 +266,7 @@ def test_invalid_price_raises():
     with pytest.raises(ValueError):
         Price(
             zoneKey=ZoneKey("AT"),
-            datetime=datetime(2023, 1, 1, tzinfo=timezone.utc),
+            datetime=datetime(2023, 1, 1, tzinfo=UTC),
             price=np.nan,
             source="trust.me",
             currency="EUR",
@@ -275,7 +275,7 @@ def test_invalid_price_raises():
     with pytest.raises(ValueError):
         Price(
             zoneKey=ZoneKey("ATT"),
-            datetime=datetime(2023, 1, 1, tzinfo=timezone.utc),
+            datetime=datetime(2023, 1, 1, tzinfo=UTC),
             price=1,
             source="trust.me",
             currency="EUR",
@@ -291,7 +291,7 @@ def test_invalid_price_raises():
     with pytest.raises(ValueError):
         Price(
             zoneKey=ZoneKey("AT"),
-            datetime=datetime(2023, 1, 1, tzinfo=timezone.utc),
+            datetime=datetime(2023, 1, 1, tzinfo=UTC),
             price=1,
             source="trust.me",
             currency="EURO",
@@ -302,7 +302,7 @@ def test_invalid_price_raises():
 def test_prices_can_be_in_future():
     Price(
         zoneKey=ZoneKey("DE"),
-        datetime=datetime(2023, 1, 2, tzinfo=timezone.utc),
+        datetime=datetime(2023, 1, 2, tzinfo=UTC),
         price=1,
         source="trust.me",
         currency="EUR",
@@ -312,14 +312,14 @@ def test_prices_can_be_in_future():
 def test_create_locational_marginal_price():
     lmp = LocationalMarginalPrice(
         zoneKey=ZoneKey("US-CENT-SWPP"),
-        datetime=datetime(2025, 3, 1, tzinfo=timezone.utc),
+        datetime=datetime(2025, 3, 1, tzinfo=UTC),
         price=1,
         source="trust.me",
         currency="USD",
         node="SPPNORTH_HUB",
     )
     assert lmp.zoneKey == ZoneKey("US-CENT-SWPP")
-    assert lmp.datetime == datetime(2025, 3, 1, tzinfo=timezone.utc)
+    assert lmp.datetime == datetime(2025, 3, 1, tzinfo=UTC)
     assert lmp.price == 1
     assert lmp.source == "trust.me"
     assert lmp.currency == "USD"
@@ -345,7 +345,7 @@ def test_invalid_locational_marginal_price_node_raises(node):
     with pytest.raises(ValueError):
         LocationalMarginalPrice(
             zoneKey=ZoneKey("US-CENT-SWPP"),
-            datetime=datetime(2025, 3, 1, tzinfo=timezone.utc),
+            datetime=datetime(2025, 3, 1, tzinfo=UTC),
             price=1,
             source="trust.me",
             currency="USD",
@@ -357,12 +357,12 @@ def test_create_production_breakdown():
     mix = ProductionMix(wind=10)
     breakdown = ProductionBreakdown(
         zoneKey=ZoneKey("DE"),
-        datetime=datetime(2023, 1, 1, tzinfo=timezone.utc),
+        datetime=datetime(2023, 1, 1, tzinfo=UTC),
         production=mix,
         source="trust.me",
     )
     assert breakdown.zoneKey == ZoneKey("DE")
-    assert breakdown.datetime == datetime(2023, 1, 1, tzinfo=timezone.utc)
+    assert breakdown.datetime == datetime(2023, 1, 1, tzinfo=UTC)
     assert breakdown.production is not None
     assert breakdown.production.wind == 10
     assert breakdown.source == "trust.me"
@@ -378,7 +378,7 @@ def test_create_production_breakdown_with_storage():
     )
     breakdown = ProductionBreakdown(
         zoneKey=ZoneKey("DE"),
-        datetime=datetime(2023, 1, 1, tzinfo=timezone.utc),
+        datetime=datetime(2023, 1, 1, tzinfo=UTC),
         production=mix,
         storage=storage,
         source="trust.me",
@@ -401,7 +401,7 @@ def test_invalid_breakdown_raises():
     with pytest.raises(ValueError):
         ProductionBreakdown(
             zoneKey=ZoneKey("ATT"),
-            datetime=datetime(2023, 1, 1, tzinfo=timezone.utc),
+            datetime=datetime(2023, 1, 1, tzinfo=UTC),
             production=mix,
             source="trust.me",
         )
@@ -415,7 +415,7 @@ def test_invalid_breakdown_raises():
     with pytest.raises(ValueError):
         ProductionBreakdown(
             zoneKey=ZoneKey("AT"),
-            datetime=datetime(2023, 1, 1, tzinfo=timezone.utc),
+            datetime=datetime(2023, 1, 1, tzinfo=UTC),
             production=ProductionMix(wind=None),
             storage=storage,
             source="trust.me",
@@ -432,7 +432,7 @@ def test_negative_production_gets_corrected():
         breakdown = ProductionBreakdown.create(
             logger=logger,
             zoneKey=ZoneKey("DE"),
-            datetime=datetime(2023, 1, 1, tzinfo=timezone.utc),
+            datetime=datetime(2023, 1, 1, tzinfo=UTC),
             production=mix,
             source="trust.me",
         )
@@ -458,7 +458,7 @@ def test_self_report_negative_value():
         breakdown = ProductionBreakdown.create(
             logger=logger,
             zoneKey=ZoneKey("DE"),
-            datetime=datetime(2023, 1, 1, tzinfo=timezone.utc),
+            datetime=datetime(2023, 1, 1, tzinfo=UTC),
             production=mix,
             source="trust.me",
         )
@@ -487,13 +487,13 @@ def test_forecasted_points():
     mix = ProductionMix(wind=10)
     breakdown = ProductionBreakdown(
         zoneKey=ZoneKey("DE"),
-        datetime=datetime(2023, 2, 1, tzinfo=timezone.utc),
+        datetime=datetime(2023, 2, 1, tzinfo=UTC),
         production=mix,
         source="trust.me",
         sourceType=EventSourceType.forecasted,
     )
     assert breakdown.zoneKey == ZoneKey("DE")
-    assert breakdown.datetime == datetime(2023, 2, 1, tzinfo=timezone.utc)
+    assert breakdown.datetime == datetime(2023, 2, 1, tzinfo=UTC)
     assert breakdown.production is not None
     assert breakdown.production.wind == 10
     assert breakdown.source == "trust.me"
@@ -506,7 +506,7 @@ def test_non_forecasted_points_in_future():
     with pytest.raises(ValueError):
         _breakdown = ProductionBreakdown(
             zoneKey=ZoneKey("DE"),
-            datetime=datetime(2023, 3, 1, tzinfo=timezone.utc),
+            datetime=datetime(2023, 3, 1, tzinfo=UTC),
             production=mix,
             source="trust.me",
         )
@@ -531,7 +531,7 @@ def test_static_create_logs_error_with_none():
         ProductionBreakdown.create(
             logger=logger,
             zoneKey=ZoneKey("DE"),
-            datetime=datetime(2023, 1, 1, tzinfo=timezone.utc),
+            datetime=datetime(2023, 1, 1, tzinfo=UTC),
             production=ProductionMix(wind=None),
             source="trust.me",
         )
@@ -544,7 +544,7 @@ def test_static_create_logs_with_nan():
         ProductionBreakdown.create(
             logger=logger,
             zoneKey=ZoneKey("DE"),
-            datetime=datetime(2023, 1, 1, tzinfo=timezone.utc),
+            datetime=datetime(2023, 1, 1, tzinfo=UTC),
             production=ProductionMix(wind=math.nan),
             source="trust.me",
         )
@@ -557,7 +557,7 @@ def test_static_create_logs_with_nan_using_numpy():
         ProductionBreakdown.create(
             logger=logger,
             zoneKey=ZoneKey("DE"),
-            datetime=datetime(2023, 1, 1, tzinfo=timezone.utc),
+            datetime=datetime(2023, 1, 1, tzinfo=UTC),
             production=ProductionMix(wind=np.nan),
             source="trust.me",
         )
@@ -567,7 +567,7 @@ def test_static_create_logs_with_nan_using_numpy():
 def test_set_breakdown_all_present():
     breakdown = ProductionBreakdown(
         zoneKey=ZoneKey("DE"),
-        datetime=datetime(2023, 1, 1, tzinfo=timezone.utc),
+        datetime=datetime(2023, 1, 1, tzinfo=UTC),
         production=ProductionMix(wind=10, solar=None),
         source="trust.me",
     )
@@ -582,7 +582,7 @@ def test_set_modes_all_present_add_mode():
     mix.add_value("solar", None)
     breakdown = ProductionBreakdown(
         zoneKey=ZoneKey("DE"),
-        datetime=datetime(2023, 1, 1, tzinfo=timezone.utc),
+        datetime=datetime(2023, 1, 1, tzinfo=UTC),
         production=mix,
         source="trust.me",
     )
@@ -595,12 +595,12 @@ def test_set_modes_all_present_add_mode():
 def test_create_generation():
     generation = TotalProduction(
         zoneKey=ZoneKey("DE"),
-        datetime=datetime(2023, 1, 1, tzinfo=timezone.utc),
+        datetime=datetime(2023, 1, 1, tzinfo=UTC),
         source="trust.me",
         value=1,
     )
     assert generation.zoneKey == ZoneKey("DE")
-    assert generation.datetime == datetime(2023, 1, 1, tzinfo=timezone.utc)
+    assert generation.datetime == datetime(2023, 1, 1, tzinfo=UTC)
     assert generation.source == "trust.me"
     assert generation.value == 1
 
@@ -611,7 +611,7 @@ def test_total_production_static_create_logs_error():
         TotalProduction.create(
             logger=logger,
             zoneKey=ZoneKey("DE"),
-            datetime=datetime(2023, 1, 1, tzinfo=timezone.utc),
+            datetime=datetime(2023, 1, 1, tzinfo=UTC),
             value=-1,
             source="trust.me",
         )
@@ -623,7 +623,7 @@ def test_raises_if_invalid_generation():
     with pytest.raises(ValueError):
         TotalProduction(
             zoneKey=ZoneKey("AT"),
-            datetime=datetime(2023, 1, 1, tzinfo=timezone.utc),
+            datetime=datetime(2023, 1, 1, tzinfo=UTC),
             value=None,
             source="trust.me",
         )
@@ -632,7 +632,7 @@ def test_raises_if_invalid_generation():
     with pytest.raises(ValueError):
         TotalProduction(
             zoneKey=ZoneKey("AT"),
-            datetime=datetime(2023, 1, 1, tzinfo=timezone.utc),
+            datetime=datetime(2023, 1, 1, tzinfo=UTC),
             value=math.nan,
             source="trust.me",
         )
@@ -641,7 +641,7 @@ def test_raises_if_invalid_generation():
     with pytest.raises(ValueError):
         TotalProduction(
             zoneKey=ZoneKey("AT"),
-            datetime=datetime(2023, 1, 1, tzinfo=timezone.utc),
+            datetime=datetime(2023, 1, 1, tzinfo=UTC),
             value=np.nan,
             source="trust.me",
         )
@@ -659,7 +659,7 @@ def test_raises_if_invalid_generation():
     with pytest.raises(ValueError):
         TotalProduction(
             zoneKey=ZoneKey("ATT"),
-            datetime=datetime(2023, 1, 1, tzinfo=timezone.utc),
+            datetime=datetime(2023, 1, 1, tzinfo=UTC),
             value=1,
             source="trust.me",
         )
@@ -668,7 +668,7 @@ def test_raises_if_invalid_generation():
     with pytest.raises(ValueError):
         TotalProduction(
             zoneKey=ZoneKey("AT"),
-            datetime=datetime(2023, 1, 1, tzinfo=timezone.utc),
+            datetime=datetime(2023, 1, 1, tzinfo=UTC),
             value=-1,
             source="trust.me",
         )

--- a/parsers/BG.py
+++ b/parsers/BG.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from logging import Logger, getLogger
 
 from requests import Session
@@ -39,7 +39,7 @@ def fetch_production(
             PARSER, "This parser is not yet able to parse historical data", zone_key
         )
 
-    time = datetime.now(timezone.utc)
+    time = datetime.now(UTC)
     response = session.get(SOURCE_API_URL)
     if not response.ok:
         raise ParserException(

--- a/parsers/CA_NB.py
+++ b/parsers/CA_NB.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from logging import Logger, getLogger
 from typing import Any
 
@@ -91,9 +91,7 @@ def fetch_production(
     production.append(
         zoneKey=zone_key,
         # Using the current utc time because the page returns the current time.
-        datetime=datetime.now(tz=timezone.utc).replace(
-            minute=0, second=0, microsecond=0
-        ),
+        datetime=datetime.now(tz=UTC).replace(minute=0, second=0, microsecond=0),
         source=SOURCE,
         production=ProductionMix(
             unknown=generated,
@@ -128,9 +126,7 @@ def fetch_exchange(
     exchanges = ExchangeList(logger)
     exchanges.append(
         zoneKey=sorted_zone_keys,
-        datetime=datetime.now(tz=timezone.utc).replace(
-            minute=0, second=0, microsecond=0
-        ),
+        datetime=datetime.now(tz=UTC).replace(minute=0, second=0, microsecond=0),
         source=SOURCE,
         netFlow=sum([flows[flow] for flow in EXCHANGE_TO_FLOWS[sorted_zone_keys]]),
     )

--- a/parsers/CA_NS.py
+++ b/parsers/CA_NS.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from logging import Logger, getLogger
 from typing import Any
 from zoneinfo import ZoneInfo
@@ -34,7 +34,7 @@ def _parse_timestamp(timestamp: str) -> datetime:
     "/Date(1493924400000)/" by extracting the Unix timestamp 1493924400. Note
     that the three trailing zeros are cut out as well).
     """
-    return datetime.fromtimestamp(int(timestamp[6:-5]), tz=timezone.utc)
+    return datetime.fromtimestamp(int(timestamp[6:-5]), tz=UTC)
 
 
 def fetch_production(

--- a/parsers/CH.py
+++ b/parsers/CH.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timedelta, timezone
+from datetime import UTC, datetime, timedelta
 from io import StringIO
 from logging import Logger, getLogger
 
@@ -46,9 +46,7 @@ def get_solar_capacity_at(target_datetime: datetime) -> float:
     )
 
     # mask all rows earlier than target date (use the earliest date in dataset if target date is even earlier)
-    dt = max(
-        target_datetime.astimezone(timezone.utc), historical_capacities.index.min()
-    )
+    dt = max(target_datetime.astimezone(UTC), historical_capacities.index.min())
     mask = historical_capacities.index <= dt
     return historical_capacities[mask].iloc[-1].loc["installed capacity in megawatts"]
 
@@ -104,9 +102,9 @@ def fetch_production(
     The total production is calculated as sum of the consumption, storage and net imports.
     """
     target_datetime = (
-        datetime.now(timezone.utc)
+        datetime.now(UTC)
         if target_datetime is None
-        else target_datetime.astimezone(timezone.utc)
+        else target_datetime.astimezone(UTC)
     )
 
     r = session or Session()

--- a/parsers/CR.py
+++ b/parsers/CR.py
@@ -1,5 +1,5 @@
 from collections import defaultdict
-from datetime import datetime, time, timedelta, timezone
+from datetime import UTC, datetime, time, timedelta
 from logging import Logger, getLogger
 from zoneinfo import ZoneInfo
 
@@ -66,7 +66,7 @@ def fetch_production(
     logger: Logger = getLogger(__name__),
 ) -> list[dict]:
     # if no target_datetime is specified, this defaults to now.
-    now = datetime.now(timezone.utc)
+    now = datetime.now(UTC)
     target_datetime = now if target_datetime is None else target_datetime
 
     # the backend production API works in terms of local times

--- a/parsers/DK.py
+++ b/parsers/DK.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timedelta, timezone
+from datetime import UTC, datetime, timedelta
 from itertools import groupby
 from logging import Logger, getLogger
 from operator import itemgetter
@@ -146,7 +146,7 @@ def fetch_exchange(
             all_exchange_data.append(
                 zoneKey=sorted_keys,
                 datetime=datetime.fromisoformat(datapoint["Minutes5UTC"]).replace(
-                    tzinfo=timezone.utc
+                    tzinfo=UTC
                 ),
                 netFlow=flow(sorted_keys, datapoint),
                 source=SOURCE,
@@ -168,7 +168,7 @@ def fetch_wind_solar_forecasts(
 
     forecast = ProductionBreakdownList(logger=logger)
     for date_time_str, group in grouped_data:
-        date_time = datetime.fromisoformat(date_time_str).replace(tzinfo=timezone.utc)
+        date_time = datetime.fromisoformat(date_time_str).replace(tzinfo=UTC)
         productionMix = ProductionMix()
         for datapoint in group:
             productionMix.add_value(

--- a/parsers/EIA.py
+++ b/parsers/EIA.py
@@ -9,7 +9,7 @@ Requires an API key, set in the EIA_KEY environment variable. Get one here:
 https://www.eia.gov/opendata/register.php
 """
 
-from datetime import datetime, timedelta, timezone
+from datetime import UTC, datetime, timedelta
 from logging import Logger, getLogger
 from typing import Any
 
@@ -548,12 +548,8 @@ def fetch_production_mix(
         # we set unknown to 0.0 and keep geothermal as is
         # see GMM-555 for details
         if zone_key == "US-CAL-IID" and production_mode == "unknown":
-            first_appearance = datetime(
-                year=2025, month=1, day=1, hour=8, tzinfo=timezone.utc
-            )
-            last_apperance = datetime(
-                year=2025, month=2, day=12, hour=7, tzinfo=timezone.utc
-            )
+            first_appearance = datetime(year=2025, month=1, day=1, hour=8, tzinfo=UTC)
+            last_apperance = datetime(year=2025, month=2, day=12, hour=7, tzinfo=UTC)
             for event in production_and_storage_values:
                 if (
                     event["datetime"] >= first_appearance
@@ -748,7 +744,7 @@ def _parse_hourly_interval(period: str):
     # or local-time.  We request UTC times using the 'frequency=hourly'
     # parameter, meaning that we can attach timezone.utc without performing
     # any timezone conversion.
-    interval_end = interval_end_naive.replace(tzinfo=timezone.utc)
+    interval_end = interval_end_naive.replace(tzinfo=UTC)
 
     # The timestamp given by EIA represents the end of the time interval.
     # ElectricityMap using another convention,

--- a/parsers/ELEXON.py
+++ b/parsers/ELEXON.py
@@ -11,7 +11,7 @@ https://bscdocs.elexon.co.uk/guidance-notes/bmrs-api-and-data-push-user-guide
 """
 
 import re
-from datetime import datetime, timedelta, timezone
+from datetime import UTC, datetime, timedelta
 from logging import Logger, getLogger
 from typing import Any
 
@@ -33,7 +33,7 @@ ELEXON_URLS = {
     "balancing": "/".join((ELEXON_API_ENDPOINT, "balancing/physical")),
 }
 ELEXON_START_DATE = datetime(
-    2019, 1, 1, tzinfo=timezone.utc
+    2019, 1, 1, tzinfo=UTC
 )  # ELEXON API only has data from 2019-01-01
 ELEXON_SOURCE = "elexon.co.uk"
 ESO_NATIONAL_GRID_ENDPOINT = (
@@ -135,7 +135,7 @@ def parse_datetime(
         )
     parsed_datetime = datetime.strptime(settlementDate, "%Y-%m-%d")
     parsed_datetime += timedelta(hours=(settlementPeriod - 1) / 2)
-    return parsed_datetime.replace(tzinfo=timezone.utc)
+    return parsed_datetime.replace(tzinfo=UTC)
 
 
 def query_IM_exchange(
@@ -257,7 +257,7 @@ def query_additional_eso_data(
     """Fetches embedded wind and solar and hydro storage data from the ESO API."""
     begin = (target_datetime - timedelta(days=2)).strftime("%Y-%m-%d")
     end = (target_datetime).strftime("%Y-%m-%d")
-    if target_datetime > (datetime.now(tz=timezone.utc) - timedelta(days=30)):
+    if target_datetime > (datetime.now(tz=UTC) - timedelta(days=30)):
         report_id = ESO_DEMAND_DATA_UPDATE_ID
     else:
         index = _create_eso_historical_demand_index(session)
@@ -416,10 +416,10 @@ def fetch_exchange(
 ):
     session = session or Session()
     if target_datetime is None:
-        target_datetime = datetime.now(tz=timezone.utc)
+        target_datetime = datetime.now(tz=UTC)
 
     if target_datetime.tzinfo is None:
-        target_datetime = target_datetime.replace(tzinfo=timezone.utc)
+        target_datetime = target_datetime.replace(tzinfo=UTC)
 
     exchangeKey = ZoneKey("->".join(sorted([zone_key1, zone_key2])))
     if target_datetime < ELEXON_START_DATE:
@@ -445,9 +445,9 @@ def fetch_production(
 ) -> list[dict]:
     session = session or Session()
     if target_datetime is None:
-        target_datetime = datetime.now(tz=timezone.utc)
+        target_datetime = datetime.now(tz=UTC)
     else:
-        target_datetime = target_datetime.astimezone(timezone.utc)
+        target_datetime = target_datetime.astimezone(UTC)
 
     if target_datetime < ELEXON_START_DATE:
         raise ParserException(

--- a/parsers/ENTSOE.py
+++ b/parsers/ENTSOE.py
@@ -17,7 +17,7 @@ https://documenter.getpostman.com/view/7009892/2s93JtP3F6
 
 import itertools
 import re
-from datetime import datetime, timedelta, timezone
+from datetime import UTC, datetime, timedelta
 from enum import Enum
 from functools import lru_cache
 from logging import Logger, getLogger
@@ -332,7 +332,7 @@ VALIDATIONS: dict[str, dict[str, Any]] = {
 
 def closest_in_time_key(x, target_datetime: datetime | None, datetime_key="datetime"):
     if target_datetime is None:
-        target_datetime = datetime.now(timezone.utc)
+        target_datetime = datetime.now(UTC)
     if isinstance(target_datetime, datetime):
         return np.abs((x[datetime_key] - target_datetime).seconds)
 
@@ -351,7 +351,7 @@ def query_ENTSOE(
     Returns a request object.
     """
     if target_datetime is None:
-        target_datetime = datetime.now(timezone.utc)
+        target_datetime = datetime.now(UTC)
 
     if not isinstance(target_datetime, datetime):
         raise ParserException(

--- a/parsers/ESKOM.py
+++ b/parsers/ESKOM.py
@@ -1,5 +1,5 @@
 import csv
-from datetime import datetime, timedelta, timezone
+from datetime import UTC, datetime, timedelta
 from logging import Logger, getLogger
 from pprint import PrettyPrinter
 from zoneinfo import ZoneInfo
@@ -53,7 +53,7 @@ PRODUCTION_IDS = [0, 6, 8, 9, 10, 11, 16, 17, 18, 19]
 
 def get_url() -> str:
     """Returns the formatted URL"""
-    date = datetime.now(timezone.utc)
+    date = datetime.now(UTC)
     return f"https://www.eskom.co.za/dataportal/wp-content/uploads/{date.strftime('%Y')}/{date.strftime('%m')}/Station_Build_Up.csv"
 
 

--- a/parsers/FO.py
+++ b/parsers/FO.py
@@ -1,4 +1,4 @@
-from datetime import datetime, time, timedelta, timezone
+from datetime import UTC, datetime, time, timedelta
 from itertools import groupby
 from logging import Logger, getLogger
 from operator import itemgetter
@@ -63,9 +63,7 @@ def _fetch_production_historical(
     """
 
     # API provides max one day of backlog
-    target_date_utc_to = datetime.combine(
-        target_datetime_utc, time(), tzinfo=timezone.utc
-    )
+    target_date_utc_to = datetime.combine(target_datetime_utc, time(), tzinfo=UTC)
     target_date_utc_from = target_date_utc_to - timedelta(days=1)
 
     # API takes local days as query parameters and returns data for the corresponding interval as UTC
@@ -94,7 +92,7 @@ def _fetch_production_historical(
         hourly_production_for_each_power_plant, key=itemgetter("date")
     )
     for hour, group in hourly_production_for_each_power_plant_by_hour:
-        dt = datetime.fromisoformat(hour).replace(tzinfo=timezone.utc)
+        dt = datetime.fromisoformat(hour).replace(tzinfo=UTC)
 
         # filter out entries outside of time window of interest (which happens if DST)
         end_of_day = target_date_utc_to + timedelta(days=1) - timedelta(microseconds=1)
@@ -179,7 +177,7 @@ def _fetch_production_live(
         # floor to hourly granularity to match historical API entries
         .replace(minute=0, second=0, microsecond=0, tzinfo=TIMEZONE)
         # cast to UTC just to keep consistent with historical API entries
-        .astimezone(timezone.utc)
+        .astimezone(UTC)
     )
 
     production_breakdown_list.append(
@@ -205,9 +203,9 @@ def fetch_production(
             f"This parser cannot retrieve data for zone {zone_key!r}",
         )
 
-    now = datetime.now(timezone.utc)
+    now = datetime.now(UTC)
     target_datetime = (
-        now if target_datetime is None else target_datetime.astimezone(timezone.utc)
+        now if target_datetime is None else target_datetime.astimezone(UTC)
     )
 
     session = session or Session()

--- a/parsers/GB.py
+++ b/parsers/GB.py
@@ -1,7 +1,7 @@
 """Parser that uses the RTE-FRANCE API"""
 
 import xml.etree.ElementTree as ET
-from datetime import datetime, timedelta, timezone
+from datetime import UTC, datetime, timedelta
 from logging import Logger, getLogger
 from zoneinfo import ZoneInfo
 
@@ -31,9 +31,9 @@ def fetch_price(
     return prices from day-ahead market data.
     """
 
-    now = datetime.now(timezone.utc)
+    now = datetime.now(UTC)
     target_datetime = (
-        now if target_datetime is None else target_datetime.astimezone(timezone.utc)
+        now if target_datetime is None else target_datetime.astimezone(UTC)
     )
     is_today = target_datetime.date() == now.date()
 
@@ -68,7 +68,7 @@ def fetch_price(
                 "Exception when parsing price API response: missing 'date' for daily market data.",
                 zone_key,
             )
-        day = datetime.strptime(date, "%Y-%m-%d").replace(tzinfo=timezone.utc)
+        day = datetime.strptime(date, "%Y-%m-%d").replace(tzinfo=UTC)
 
         for daily_zone_data in daily_market_data:
             zone_code = daily_zone_data.get("perimetre")
@@ -116,6 +116,6 @@ if __name__ == "__main__":
         print(f"fetch_price({zone_key}) ->")
         print(fetch_price(ZoneKey(zone_key)))
 
-    historical_datetime = datetime(2022, 7, 16, 12, tzinfo=timezone.utc)
+    historical_datetime = datetime(2022, 7, 16, 12, tzinfo=UTC)
     print(f"fetch_price(target_datetime={historical_datetime.isoformat()}) ->")
     print(fetch_price(target_datetime=historical_datetime))

--- a/parsers/GE.py
+++ b/parsers/GE.py
@@ -1,7 +1,7 @@
 """Fetch the status of the Georgian electricity grid."""
 
 import urllib.parse
-from datetime import datetime, time, timedelta, timezone
+from datetime import UTC, datetime, time, timedelta
 from logging import Logger, getLogger
 from zoneinfo import ZoneInfo
 
@@ -40,13 +40,13 @@ def fetch_production(
     session = session or Session()
 
     target_datetime = (
-        datetime.now(timezone.utc)
+        datetime.now(UTC)
         if target_datetime is None
-        else target_datetime.astimezone(timezone.utc)
+        else target_datetime.astimezone(UTC)
     )
 
     # Get the production mix for every hour on the (UTC) day of interest.
-    day = datetime.combine(target_datetime, time(), tzinfo=timezone.utc)
+    day = datetime.combine(target_datetime, time(), tzinfo=UTC)
     timestamp_from, timestamp_to = (
         day,
         day + timedelta(days=1) - timedelta(seconds=1),
@@ -105,7 +105,7 @@ def fetch_production(
 
             production_breakdown_list.append(
                 zoneKey=zone_key,
-                datetime=dt.astimezone(timezone.utc),
+                datetime=dt.astimezone(UTC),
                 source=SOURCE,
                 production=production_mix,
             )
@@ -135,7 +135,7 @@ def fetch_exchange(
             zone_key1, zone_key2, session, target_datetime, logger
         )
 
-    now = datetime.now(timezone.utc)
+    now = datetime.now(UTC)
     # The API uses the convention of positive net flow into GE.
     # TODO: remove `verify=False` ASAP.
     response = session.get(f"{URL_STRING}/map", verify=False)
@@ -184,7 +184,7 @@ if __name__ == "__main__":
     print(fetch_production())
 
     print("fetch_production(target_datetime=datetime.datetime(2020, 1, 1)) ->")
-    print(fetch_production(target_datetime=datetime(2020, 1, 1, tzinfo=timezone.utc)))
+    print(fetch_production(target_datetime=datetime(2020, 1, 1, tzinfo=UTC)))
 
     for neighbour in ["AM", "AZ", "RU-1", "TR"]:
         print(f"fetch_exchange('GE', {neighbour}) ->")

--- a/parsers/GT.py
+++ b/parsers/GT.py
@@ -2,7 +2,7 @@
 
 import collections
 import enum
-from datetime import datetime, time, timedelta, timezone
+from datetime import UTC, datetime, time, timedelta
 from logging import Logger, getLogger
 from zoneinfo import ZoneInfo
 
@@ -62,14 +62,14 @@ def _get_api_data(
 ) -> dict[datetime, dict]:
     """Get the one-hourly AMM API data for the desired UTC day + n days of backlog."""
 
-    now_utc = datetime.now(timezone.utc)
+    now_utc = datetime.now(UTC)
     hour_now_utc = now_utc.replace(minute=0, second=0, microsecond=0)
 
-    target_datetime_utc = target_datetime.astimezone(timezone.utc)
+    target_datetime_utc = target_datetime.astimezone(UTC)
 
     # The API expects local (TZ) timestamps and can only return one day of data
     # so might need to do multiple api calls if UTC day straddles multiple local days
-    target_day_utc = datetime.combine(target_datetime_utc, time(), tzinfo=timezone.utc)
+    target_day_utc = datetime.combine(target_datetime_utc, time(), tzinfo=UTC)
 
     target_day_utc_start = target_day_utc - timedelta(days=num_backlog_days)
     target_day_utc_end = target_day_utc + timedelta(days=1) - timedelta(microseconds=1)
@@ -113,7 +113,7 @@ def _get_api_data(
             # so each index represents the hour ahead and is in the range [0, 24),
             # e.g., hour 0 represents the period [00:00, 01:00).
             dt_local = local_day + timedelta(hours=int(row["hora"]) - 1)
-            dt_utc = dt_local.astimezone(timezone.utc)
+            dt_utc = dt_local.astimezone(UTC)
 
             # ignore data outside of range of interest
             if dt_utc < target_day_utc_start or dt_utc > target_day_utc_end:
@@ -140,9 +140,9 @@ def fetch_consumption(
 
     session = session or Session()
     target_datetime = (
-        datetime.now(timezone.utc)
+        datetime.now(UTC)
         if target_datetime is None
-        else target_datetime.astimezone(timezone.utc)
+        else target_datetime.astimezone(UTC)
     )
     api_data = _get_api_data(
         session,
@@ -177,9 +177,9 @@ def fetch_production(
 
     session = session or Session()
     target_datetime = (
-        datetime.now(timezone.utc)
+        datetime.now(UTC)
         if target_datetime is None
-        else target_datetime.astimezone(timezone.utc)
+        else target_datetime.astimezone(UTC)
     )
     api_data = _get_api_data(
         session,

--- a/parsers/IN.py
+++ b/parsers/IN.py
@@ -2,7 +2,7 @@
 
 """Parser for all of India"""
 
-from datetime import datetime, timedelta, timezone
+from datetime import UTC, datetime, timedelta
 from logging import Logger, getLogger
 from typing import Any
 from zoneinfo import ZoneInfo
@@ -452,7 +452,7 @@ def fetch_production(
     logger: Logger = getLogger(__name__),
 ) -> list[dict[str, Any]]:
     if target_datetime is None:
-        target_datetime = get_start_of_day(dt=datetime.now(timezone.utc))
+        target_datetime = get_start_of_day(dt=datetime.now(UTC))
     else:
         target_datetime = get_start_of_day(dt=target_datetime)
         if target_datetime < START_DATE_RENEWABLE_DATA:

--- a/parsers/MD.py
+++ b/parsers/MD.py
@@ -11,7 +11,7 @@
 # Annual reports from moldelectrica can be found at:
 # https://moldelectrica.md/ro/network/annual_report
 
-from datetime import datetime, time, timedelta, timezone
+from datetime import UTC, datetime, time, timedelta
 from logging import Logger, getLogger
 from operator import attrgetter
 from typing import NamedTuple
@@ -45,25 +45,25 @@ SOURCE = "moldelectrica.md"
 # Moldoelectrica electricity tariffs as defined by government-agency decisions.
 _MOLDOELECTRICA_NEW_POWER_PRICE_IN_MDL_PER_MW = {
     # https://www.legis.md/cautare/getResults?doc_id=78826&lang=ro
-    datetime(2000, 4, 1, tzinfo=timezone.utc): 18.8,
+    datetime(2000, 4, 1, tzinfo=UTC): 18.8,
     # https://www.legis.md/cautare/getResults?doc_id=103953&lang=ro
-    datetime(2001, 10, 1, tzinfo=timezone.utc): 28.0,
+    datetime(2001, 10, 1, tzinfo=UTC): 28.0,
     # https://www.legis.md/cautare/getResults?doc_id=40249&lang=ro
-    datetime(2002, 9, 1, tzinfo=timezone.utc): 35.2,
+    datetime(2002, 9, 1, tzinfo=UTC): 35.2,
     # https://www.legis.md/cautare/getResults?doc_id=42701&lang=ro
-    datetime(2005, 9, 1, tzinfo=timezone.utc): 39.3,
+    datetime(2005, 9, 1, tzinfo=UTC): 39.3,
     # https://www.legis.md/cautare/getResults?doc_id=10948&lang=ro
-    datetime(2007, 8, 3, tzinfo=timezone.utc): 51.8,
+    datetime(2007, 8, 3, tzinfo=UTC): 51.8,
     # https://www.legis.md/cautare/getResults?doc_id=40130&lang=ro
-    datetime(2010, 1, 19, tzinfo=timezone.utc): 63.2,
+    datetime(2010, 1, 19, tzinfo=UTC): 63.2,
     # https://www.legis.md/cautare/getResults?doc_id=40589&lang=ro
-    datetime(2012, 5, 11, tzinfo=timezone.utc): 80.2,
+    datetime(2012, 5, 11, tzinfo=UTC): 80.2,
     # https://www.legis.md/cautare/getResults?doc_id=84436&lang=ro
-    datetime(2015, 7, 31, tzinfo=timezone.utc): 145.0,
+    datetime(2015, 7, 31, tzinfo=UTC): 145.0,
     # https://www.legis.md/cautare/getResults?doc_id=134854&lang=ro
-    datetime(2023, 12, 31, tzinfo=timezone.utc): 201.0,
+    datetime(2023, 12, 31, tzinfo=UTC): 201.0,
     # https://www.legis.md/cautare/getResults?doc_id=142391&lang=ro
-    datetime(2024, 3, 21, tzinfo=timezone.utc): 185.0,
+    datetime(2024, 3, 21, tzinfo=UTC): 185.0,
     # TODO(amv213): update as new tariffs get rolled out...
 }
 
@@ -93,12 +93,12 @@ def _get_archive_data(
     """Returns archive data in 15 mn buckets for the UTC day of interest and (optionally) previous ones."""
 
     target_utc_datetime = (
-        datetime.now(timezone.utc)
+        datetime.now(UTC)
         if target_datetime is None
-        else target_datetime.astimezone(timezone.utc)
+        else target_datetime.astimezone(UTC)
     )
 
-    target_utc_day = datetime.combine(target_utc_datetime, time(), tzinfo=timezone.utc)
+    target_utc_day = datetime.combine(target_utc_datetime, time(), tzinfo=UTC)
     target_utc_timestamp_from, target_utc_timestamp_to = (
         target_utc_day - timedelta(days=num_backlog_days),
         target_utc_day + timedelta(days=1) - timedelta(seconds=1),
@@ -125,7 +125,7 @@ def _get_archive_data(
             dt_utc = (
                 datetime.strptime(entry[0], "%Y-%m-%d %H:%M")
                 .replace(tzinfo=TZ)
-                .astimezone(timezone.utc)
+                .astimezone(UTC)
             )
 
             # filter out results outside of UTC target range
@@ -163,9 +163,9 @@ def fetch_price(
         https://moldelectrica.md/ro/activity/tariff
     """
     target_datetime = (
-        datetime.now(timezone.utc)
+        datetime.now(UTC)
         if target_datetime is None
-        else target_datetime.astimezone(timezone.utc)
+        else target_datetime.astimezone(UTC)
     )
 
     # find price band for given target datetime

--- a/parsers/NED.py
+++ b/parsers/NED.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timedelta, timezone
+from datetime import UTC, datetime, timedelta
 from enum import Enum
 from logging import Logger, getLogger
 from typing import Any
@@ -201,7 +201,7 @@ def format_data(
         # Add lag to avoid using data that is not yet complete and remove "future" data
         if (
             datetime.fromisoformat(group_df["validfrom"].iloc[0])
-            > (datetime.now(timezone.utc) - timedelta(hours=0.5))
+            > (datetime.now(UTC) - timedelta(hours=0.5))
             and not forecast
         ):
             continue
@@ -236,7 +236,7 @@ def fetch_production(
     logger: Logger = getLogger(__name__),
 ) -> list:
     session = session or Session()
-    target_datetime = target_datetime or datetime.now(timezone.utc)
+    target_datetime = target_datetime or datetime.now(UTC)
 
     json_data = call_api(target_datetime)
     NED_data = format_data(json_data, logger)
@@ -244,7 +244,7 @@ def fetch_production(
     all_dates = [item.get("datetime") for item in NED_data.to_list()]
 
     if all(
-        date >= datetime(2021, 1, 1, tzinfo=timezone.utc)
+        date >= datetime(2021, 1, 1, tzinfo=UTC)
         for date in all_dates
         if date is not None
     ):
@@ -267,7 +267,7 @@ def fetch_production_forecast(
     logger: Logger = getLogger(__name__),
 ) -> list:
     session = session or Session()
-    target_datetime = target_datetime or datetime.now(timezone.utc)
+    target_datetime = target_datetime or datetime.now(UTC)
     json_data = call_api(target_datetime, forecast=True)
     NED_data = format_data(json_data, logger, forecast=True)
 

--- a/parsers/NG.py
+++ b/parsers/NG.py
@@ -4,7 +4,7 @@
 
 import re
 import urllib.parse
-from datetime import datetime, timedelta, timezone
+from datetime import UTC, datetime, timedelta
 from logging import Logger, getLogger
 from zoneinfo import ZoneInfo
 
@@ -85,7 +85,7 @@ def fetch_production(
     """Requests the last known production mix (in MW) of a given zone."""
 
     if target_datetime is None:
-        target_datetime = datetime.now(timezone.utc)
+        target_datetime = datetime.now(UTC)
     timestamp = target_datetime.replace(minute=0, second=0, microsecond=0).astimezone(
         TIMEZONE
     )

--- a/parsers/NL.py
+++ b/parsers/NL.py
@@ -1,5 +1,5 @@
 from copy import copy
-from datetime import datetime, timedelta, timezone
+from datetime import UTC, datetime, timedelta
 from logging import Logger, getLogger
 
 import pandas as pd
@@ -11,7 +11,7 @@ from parsers import DK, ENTSOE
 from parsers.lib.config import refetch_frequency
 
 ZONE_CONFIG = ZONES_CONFIG["NL"]
-UTC = timezone.utc
+UTC = UTC
 
 
 @refetch_frequency(timedelta(days=1))

--- a/parsers/NO-NO4_SE.py
+++ b/parsers/NO-NO4_SE.py
@@ -1,5 +1,5 @@
 from collections.abc import Callable
-from datetime import datetime, timedelta, timezone
+from datetime import UTC, datetime, timedelta
 from logging import Logger, getLogger
 from typing import Literal
 
@@ -31,7 +31,7 @@ def fetch_data(
     exchange_type: Literal["exchange", "exchange_forecast"],
 ) -> list[dict]:
     if target_datetime is None:
-        target_datetime = datetime.now(timezone.utc)
+        target_datetime = datetime.now(UTC)
 
     # NO-NO4 to SE-SE1
     SE1_dataList = EXCHANGE_FUNCTION_MAP[exchange_type](

--- a/parsers/NORDPOOL.py
+++ b/parsers/NORDPOOL.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass
-from datetime import datetime, timedelta, timezone
+from datetime import UTC, datetime, timedelta
 from enum import Enum
 from logging import Logger, getLogger
 
@@ -26,7 +26,7 @@ class NordpoolToken:
 
     @property
     def is_expired(self) -> bool:
-        return datetime.now(tz=timezone.utc) > self.expiration + timedelta(minutes=5)
+        return datetime.now(tz=UTC) > self.expiration + timedelta(minutes=5)
 
 
 CURRENT_TOKEN: NordpoolToken | None = None
@@ -104,8 +104,7 @@ def _generate_new_nordpool_token(session: Session) -> NordpoolToken:
     token_data = response.json()
     token = NordpoolToken(
         token=token_data["access_token"],
-        expiration=datetime.now(tz=timezone.utc)
-        + timedelta(seconds=token_data["expires_in"]),
+        expiration=datetime.now(tz=UTC) + timedelta(seconds=token_data["expires_in"]),
     )
 
     return token

--- a/parsers/NTESMO.py
+++ b/parsers/NTESMO.py
@@ -10,7 +10,7 @@ import logging
 import math
 import re
 from collections.abc import Iterable, Iterator
-from datetime import date, datetime, time, timedelta, timezone
+from datetime import UTC, date, datetime, time, timedelta
 from logging import Logger, getLogger
 from typing import Any, TypedDict
 from zoneinfo import ZoneInfo
@@ -276,9 +276,9 @@ def fetch_consumption(
     logger: Logger = getLogger(__name__),
 ):
     target_datetime = (
-        datetime.now(timezone.utc)
+        datetime.now(UTC)
         if target_datetime is None
-        else target_datetime.astimezone(timezone.utc)
+        else target_datetime.astimezone(UTC)
     )
     daily_report_data = get_daily_report_data(
         zone_key=zone_key,
@@ -303,9 +303,9 @@ def fetch_price(
     logger: Logger = getLogger(__name__),
 ):
     target_datetime = (
-        datetime.now(timezone.utc)
+        datetime.now(UTC)
         if target_datetime is None
-        else target_datetime.astimezone(timezone.utc)
+        else target_datetime.astimezone(UTC)
     )
     daily_report_data = get_daily_report_data(
         zone_key=zone_key,
@@ -330,9 +330,9 @@ def fetch_production(
     logger: Logger = getLogger(__name__),
 ):
     target_datetime = (
-        datetime.now(timezone.utc)
+        datetime.now(UTC)
         if target_datetime is None
-        else target_datetime.astimezone(timezone.utc)
+        else target_datetime.astimezone(UTC)
     )
     daily_report_data = get_daily_report_data(
         zone_key=zone_key,

--- a/parsers/NZ.py
+++ b/parsers/NZ.py
@@ -2,7 +2,7 @@
 
 # The datetime library is used to handle datetimes
 import json
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from logging import Logger, getLogger
 
 from bs4 import BeautifulSoup
@@ -61,9 +61,7 @@ def fetch_price(
             region_prices.append(price)
 
     avg_price = sum(region_prices) / len(region_prices)
-    date_time = datetime.strptime(time, "%Y-%m-%dT%H:%M:%SZ").replace(
-        tzinfo=timezone.utc
-    )
+    date_time = datetime.strptime(time, "%Y-%m-%dT%H:%M:%SZ").replace(tzinfo=UTC)
 
     return [
         {
@@ -90,7 +88,7 @@ def fetch_production(
 
     obj = fetch(session)
 
-    date_time = datetime.fromtimestamp(obj["soPgenGraph"]["timestamp"], tz=timezone.utc)
+    date_time = datetime.fromtimestamp(obj["soPgenGraph"]["timestamp"], tz=UTC)
 
     region_key = "New Zealand"
     productions = obj["soPgenGraph"]["data"][region_key]

--- a/parsers/RU.py
+++ b/parsers/RU.py
@@ -1,7 +1,7 @@
 #!/usr/bin/python3
 
 import json
-from datetime import datetime, timedelta, timezone
+from datetime import UTC, datetime, timedelta
 from functools import reduce
 from logging import Logger, getLogger
 from zoneinfo import ZoneInfo
@@ -268,7 +268,7 @@ def fetch_exchange(
     logger: Logger = getLogger(__name__),
 ) -> list:
     """Requests the last known power exchange (in MW) between two zones."""
-    today = target_datetime if target_datetime else datetime.now(timezone.utc)
+    today = target_datetime if target_datetime else datetime.now(UTC)
 
     date = today.date().isoformat()
     r = session or Session()

--- a/parsers/SEAPA.py
+++ b/parsers/SEAPA.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from logging import Logger, getLogger
 from typing import Any
 
@@ -50,7 +50,7 @@ def fetch_production(
     production_list = ProductionBreakdownList(logger=logger)
     production_list.append(
         zoneKey=zone_key,
-        datetime=datetime.now(timezone.utc),
+        datetime=datetime.now(UTC),
         production=production_mix,
         source=SOURCE,
     )

--- a/parsers/US_CA.py
+++ b/parsers/US_CA.py
@@ -2,7 +2,7 @@
 
 import io
 import zipfile
-from datetime import datetime, timedelta, timezone
+from datetime import UTC, datetime, timedelta
 from enum import Enum
 from logging import Logger, getLogger
 from typing import Any
@@ -63,7 +63,7 @@ TIMEZONE = ZoneInfo("US/Pacific")
 
 def get_target_url(target_datetime: datetime | None, kind: str) -> str:
     if target_datetime is None:
-        target_datetime = datetime.now(tz=timezone.utc)
+        target_datetime = datetime.now(tz=UTC)
         target_url = REAL_TIME_URL_MAPPING[kind]
     else:
         target_url = f"{CAISO_PROXY}/outlook/history/{target_datetime.strftime('%Y%m%d')}/{HISTORICAL_URL_MAPPING[kind]}.csv?host=https://www.caiso.com"
@@ -266,7 +266,7 @@ def fetch_consumption_forecast(
 
     # Interval of time
     if target_datetime is None:
-        target_datetime = datetime.now(tz=timezone.utc)
+        target_datetime = datetime.now(tz=UTC)
     target_datetime_gmt = target_datetime
     GMT_URL_SUFFIX = "-0000"
     END_OFFSET = timedelta(days=7)
@@ -333,7 +333,7 @@ def fetch_wind_solar_forecasts(
 
     # Interval of time: datetime is in GMT
     if target_datetime is None:
-        target_datetime = datetime.now(tz=timezone.utc)
+        target_datetime = datetime.now(tz=UTC)
     target_datetime_gmt = target_datetime
     GMT_URL_SUFFIX = "-0000"
     END_OFFSET = timedelta(days=7)

--- a/parsers/US_ERCOT.py
+++ b/parsers/US_ERCOT.py
@@ -4,7 +4,7 @@ import gzip
 import json
 import time
 import zipfile
-from datetime import datetime, timedelta, timezone
+from datetime import UTC, datetime, timedelta
 from enum import Enum
 from io import BytesIO
 from logging import Logger, getLogger
@@ -253,7 +253,7 @@ def fetch_historical_production(
     logger: Logger = getLogger(__name__),
 ) -> ProductionBreakdownList:
     if target_datetime.tzinfo is None:
-        target_datetime = target_datetime.replace(tzinfo=timezone.utc)
+        target_datetime = target_datetime.replace(tzinfo=UTC)
 
     year = target_datetime.year
     month = target_datetime.strftime("%b")
@@ -349,8 +349,8 @@ def fetch_production(
 ) -> list:
     session = session or Session()
     if target_datetime is None or target_datetime > (
-        datetime.now(tz=timezone.utc) - timedelta(days=1)
-    ).replace(tzinfo=target_datetime.tzinfo if target_datetime else timezone.utc):
+        datetime.now(tz=UTC) - timedelta(days=1)
+    ).replace(tzinfo=target_datetime.tzinfo if target_datetime else UTC):
         production = fetch_live_production(
             zone_key=zone_key, session=session, logger=logger
         )

--- a/parsers/US_NEISO.py
+++ b/parsers/US_NEISO.py
@@ -5,7 +5,7 @@
 
 import io
 import time
-from datetime import datetime, timedelta, timezone
+from datetime import UTC, datetime, timedelta
 from logging import Logger, getLogger
 from typing import Any
 from zoneinfo import ZoneInfo
@@ -52,7 +52,7 @@ def get_json_data(
 
     epoch_time = str(int(time.time()))
 
-    target_datetime = target_datetime or datetime.now(tz=timezone.utc)
+    target_datetime = target_datetime or datetime.now(tz=UTC)
     target_ne = target_datetime.astimezone(tz=ZoneInfo("America/New_York"))
     target_ne_day = target_ne.strftime("%m/%d/%Y")
 
@@ -244,9 +244,9 @@ def fetch_consumption_forecast(
     session = session or Session()
 
     target_datetime = (
-        datetime.now(timezone.utc)
+        datetime.now(UTC)
         if target_datetime is None
-        else target_datetime.astimezone(timezone.utc)
+        else target_datetime.astimezone(UTC)
     )
     target_datetime = target_datetime.astimezone(tz=ZoneInfo("America/New_York"))
     postdata = {
@@ -285,9 +285,9 @@ def fetch_wind_solar_forecasts(
 
     # Datetime
     target_datetime = (
-        datetime.now(timezone.utc)
+        datetime.now(UTC)
         if target_datetime is None
-        else target_datetime.astimezone(timezone.utc)
+        else target_datetime.astimezone(UTC)
     )
     target_datetime = target_datetime.astimezone(tz=ZoneInfo("America/New_York"))
     if (

--- a/parsers/US_PJM.py
+++ b/parsers/US_PJM.py
@@ -3,7 +3,7 @@
 import gzip
 import json
 import re
-from datetime import datetime, time, timedelta, timezone
+from datetime import UTC, datetime, time, timedelta
 from itertools import groupby
 from logging import Logger, getLogger
 from operator import itemgetter
@@ -143,7 +143,7 @@ def fetch_consumption_forecast(
         utc_datetime = elem["forecast_datetime_beginning_utc"]
         consumption_list.append(
             zoneKey=zone_key,
-            datetime=datetime.fromisoformat(utc_datetime).replace(tzinfo=timezone.utc),
+            datetime=datetime.fromisoformat(utc_datetime).replace(tzinfo=UTC),
             source=SOURCE,
             consumption=elem["forecast_load_mw"],
             sourceType=EventSourceType.forecasted,
@@ -163,9 +163,9 @@ def fetch_production(
     We assume that storage is battery storage (see https://learn.pjm.com/energy-innovations/energy-storage)
     """
     target_datetime = (
-        datetime.now(timezone.utc).replace(hour=0, minute=0, second=0, microsecond=0)
+        datetime.now(UTC).replace(hour=0, minute=0, second=0, microsecond=0)
         if target_datetime is None
-        else target_datetime.astimezone(timezone.utc)
+        else target_datetime.astimezone(UTC)
     )
 
     session = session or Session()
@@ -189,7 +189,7 @@ def fetch_production(
 
     production_breakdown_list = ProductionBreakdownList(logger)
     for key, group in groupby(items, itemgetter("datetime_beginning_utc")):
-        dt = datetime.fromisoformat(key).replace(tzinfo=timezone.utc)
+        dt = datetime.fromisoformat(key).replace(tzinfo=UTC)
         production = ProductionMix()
         storage = StorageMix()
         for data in group:
@@ -222,9 +222,9 @@ def fetch_wind_solar_forecasts(
 
     # Datetime
     target_datetime = (
-        datetime.now(timezone.utc).replace(hour=0, minute=0, second=0, microsecond=0)
+        datetime.now(UTC).replace(hour=0, minute=0, second=0, microsecond=0)
         if target_datetime is None
-        else target_datetime.astimezone(timezone.utc)
+        else target_datetime.astimezone(UTC)
     )
 
     # Config for url
@@ -271,7 +271,7 @@ def fetch_wind_solar_forecasts(
 
         production_list.append(
             zoneKey=zone_key,
-            datetime=datetime.fromisoformat(datetime_utc).replace(tzinfo=timezone.utc),
+            datetime=datetime.fromisoformat(datetime_utc).replace(tzinfo=UTC),
             production=production_mix,
             source=SOURCE,
             sourceType=EventSourceType.forecasted,

--- a/parsers/lib/quality.py
+++ b/parsers/lib/quality.py
@@ -3,7 +3,7 @@ This library contains validation functions applied to all parsers by the feeder.
 This is a higher level validation than validation.py
 """
 
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from typing import Any
 from warnings import warn
 
@@ -38,8 +38,8 @@ def validate_datapoint_format(datapoint: dict[str, Any], kind: str, zone_key: Zo
 
 
 def validate_reasonable_time(item, k):
-    data_dt = item["datetime"].astimezone(timezone.utc)
-    now = datetime.now(timezone.utc)
+    data_dt = item["datetime"].astimezone(UTC)
+    now = datetime.now(UTC)
 
     if data_dt.year < 2000:
         raise ValidationError(

--- a/parsers/test/mocks/quality_check.py
+++ b/parsers/test/mocks/quality_check.py
@@ -3,9 +3,9 @@ Test datapoints for quality.py
 Each one is designed to test some part of the validation functions.
 """
 
-from datetime import datetime, timedelta, timezone
+from datetime import UTC, datetime, timedelta
 
-dt = datetime.now(timezone.utc)
+dt = datetime.now(UTC)
 
 prod = {
     "biomass": 15.0,
@@ -69,7 +69,7 @@ e3 = {
     "source": "mysource.com",
 }
 
-future = datetime.now(timezone.utc) + timedelta(minutes=55)
+future = datetime.now(UTC) + timedelta(minutes=55)
 
 e4 = {
     "sortedZoneKeys": "DK->NO",

--- a/parsers/test/test_BG.py
+++ b/parsers/test/test_BG.py
@@ -1,5 +1,5 @@
 import json
-from datetime import datetime, timedelta, timezone
+from datetime import UTC, datetime, timedelta
 from importlib import resources
 
 import pytest
@@ -33,5 +33,5 @@ def test_fetch_production_raises_parser_exception_on_historical_data(adapter, se
     with pytest.raises(
         ParserException, match="This parser is not yet able to parse historical data"
     ):
-        historical_datetime = datetime.now(timezone.utc) - timedelta(days=1)
+        historical_datetime = datetime.now(UTC) - timedelta(days=1)
         fetch_production(target_datetime=historical_datetime, session=session)

--- a/parsers/test/test_CH.py
+++ b/parsers/test/test_CH.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 
 import pytest
 
@@ -19,5 +19,5 @@ from parsers.CH import get_solar_capacity_at
     ],
 )
 def test_get_solar_capacity(dt, expected):
-    target_datetime = datetime.fromisoformat(dt).replace(tzinfo=timezone.utc)
+    target_datetime = datetime.fromisoformat(dt).replace(tzinfo=UTC)
     assert get_solar_capacity_at(target_datetime) == expected

--- a/parsers/test/test_CL.py
+++ b/parsers/test/test_CL.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from importlib import resources
 from json import loads
 
@@ -24,7 +24,7 @@ def mock_response(adapter):
 
 
 def test_snapshot_historical_data(session, snapshot):
-    target_datetime = datetime(2024, 2, 24, 0, 0, 0, tzinfo=timezone.utc)
+    target_datetime = datetime(2024, 2, 24, 0, 0, 0, tzinfo=UTC)
 
     assert snapshot == fetch_production(
         ZoneKey("CL-SEN"),

--- a/parsers/test/test_CR.py
+++ b/parsers/test/test_CR.py
@@ -1,5 +1,5 @@
 import json
-from datetime import datetime, timedelta, timezone
+from datetime import UTC, datetime, timedelta
 from importlib import resources
 
 import pytest
@@ -38,9 +38,9 @@ def test_fetch_production_historical(adapter, session, snapshot):
         ),
     )
 
-    historical_datetime = datetime(2021, 7, 16, 16, 20, 30, tzinfo=timezone.utc)
+    historical_datetime = datetime(2021, 7, 16, 16, 20, 30, tzinfo=UTC)
     assert snapshot == fetch_production(
-        target_datetime=historical_datetime.astimezone(timezone.utc),
+        target_datetime=historical_datetime.astimezone(UTC),
         session=session,
     )
 
@@ -68,5 +68,5 @@ def test_fetch_exchange_raises_parser_exception_on_historical_data(adapter, sess
     with pytest.raises(
         ParserException, match="This parser is not yet able to parse historical data"
     ):
-        historical_datetime = datetime.now(timezone.utc) - timedelta(days=1)
+        historical_datetime = datetime.now(UTC) - timedelta(days=1)
         fetch_exchange(target_datetime=historical_datetime, session=session)

--- a/parsers/test/test_CY.py
+++ b/parsers/test/test_CY.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 
 import pytest
 from requests_mock import GET
@@ -9,7 +9,7 @@ from parsers.CY import HISTORICAL_SOURCE, REALTIME_SOURCE, fetch_production
 
 @pytest.fixture(autouse=True)
 def target_datetime():
-    yield datetime(2024, 3, 18, 0, 0, 0, tzinfo=timezone.utc)
+    yield datetime(2024, 3, 18, 0, 0, 0, tzinfo=UTC)
 
 
 @pytest.fixture(autouse=True)

--- a/parsers/test/test_EIA.py
+++ b/parsers/test/test_EIA.py
@@ -1,6 +1,6 @@
 import json
 import os
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from importlib import resources
 
 import pytest
@@ -42,9 +42,9 @@ def test_parse_hourly_interval():
     interval; ElectricityMaps stores intervals using start hour instead.
     """
     fixtures = [
-        ("2022-02-28T23", datetime(2022, 2, 28, 22, 0, 0, tzinfo=timezone.utc)),
-        ("2022-03-01T00", datetime(2022, 2, 28, 23, 0, 0, tzinfo=timezone.utc)),
-        ("2022-03-01T01", datetime(2022, 3, 1, 0, 0, 0, tzinfo=timezone.utc)),
+        ("2022-02-28T23", datetime(2022, 2, 28, 22, 0, 0, tzinfo=UTC)),
+        ("2022-03-01T00", datetime(2022, 2, 28, 23, 0, 0, tzinfo=UTC)),
+        ("2022-03-01T01", datetime(2022, 3, 1, 0, 0, 0, tzinfo=UTC)),
     ]
 
     for period, expected in fixtures:
@@ -649,9 +649,7 @@ def test_fetch_production_mix_discards_null(adapter, session):
             "storage": {"hydro": -400, "battery": -400},
         },
     ]
-    assert (
-        datetime(2022, 10, 31, 11, 0, tzinfo=timezone.utc) == data_list[0]["datetime"]
-    )
+    assert datetime(2022, 10, 31, 11, 0, tzinfo=UTC) == data_list[0]["datetime"]
     _check_production_matches(data_list, expected)
 
 
@@ -671,19 +669,19 @@ def test_fetch_exchange(adapter, session):
     expected = [
         {
             "source": "eia.gov",
-            "datetime": datetime(2022, 2, 28, 22, 0, tzinfo=timezone.utc),
+            "datetime": datetime(2022, 2, 28, 22, 0, tzinfo=UTC),
             "sortedZoneKeys": "US-NW-BPAT->US-NW-NWMT",
             "netFlow": -12,
         },
         {
             "source": "eia.gov",
-            "datetime": datetime(2022, 2, 28, 23, 0, tzinfo=timezone.utc),
+            "datetime": datetime(2022, 2, 28, 23, 0, tzinfo=UTC),
             "sortedZoneKeys": "US-NW-BPAT->US-NW-NWMT",
             "netFlow": -11,
         },
         {
             "source": "eia.gov",
-            "datetime": datetime(2022, 3, 1, 0, 0, tzinfo=timezone.utc),
+            "datetime": datetime(2022, 3, 1, 0, 0, tzinfo=UTC),
             "sortedZoneKeys": "US-NW-BPAT->US-NW-NWMT",
             "netFlow": -2,
         },
@@ -710,12 +708,12 @@ def test_fetch_consumption(adapter, session):
     expected = [
         {
             "source": "eia.gov",
-            "datetime": datetime(2023, 5, 1, 9, 0, tzinfo=timezone.utc),
+            "datetime": datetime(2023, 5, 1, 9, 0, tzinfo=UTC),
             "consumption": 4792,
         },
         {
             "source": "eia.gov",
-            "datetime": datetime(2023, 5, 1, 10, 0, tzinfo=timezone.utc),
+            "datetime": datetime(2023, 5, 1, 10, 0, tzinfo=UTC),
             "consumption": 6215,
         },
     ]
@@ -740,12 +738,12 @@ def test_fetch_forecasted_consumption(adapter, session):
     expected = [
         {
             "source": "eia.gov",
-            "datetime": datetime(2023, 5, 1, 9, 0, tzinfo=timezone.utc),
+            "datetime": datetime(2023, 5, 1, 9, 0, tzinfo=UTC),
             "consumption": 4792,
         },
         {
             "source": "eia.gov",
-            "datetime": datetime(2023, 5, 1, 10, 0, tzinfo=timezone.utc),
+            "datetime": datetime(2023, 5, 1, 10, 0, tzinfo=UTC),
             "consumption": 6215,
         },
     ]

--- a/parsers/test/test_FO.py
+++ b/parsers/test/test_FO.py
@@ -1,5 +1,5 @@
 import json
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from importlib import resources
 
 import pytest
@@ -41,7 +41,7 @@ def test_fetch_production_historical(adapter, session, snapshot, zone, utc_offse
     """
 
     month = 2 if utc_offset == "SDT" else 7
-    target_datetime = datetime(2023, month, 16, 12, tzinfo=timezone.utc)
+    target_datetime = datetime(2023, month, 16, 12, tzinfo=UTC)
 
     adapter.register_uri(
         GET,

--- a/parsers/test/test_GB.py
+++ b/parsers/test/test_GB.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from importlib import resources
 
 import pytest
@@ -34,5 +34,5 @@ def test_fetch_price_historical(adapter, session, snapshot):
         .read_text(),
     )
 
-    historical_datetime = datetime(2022, 7, 16, 12, tzinfo=timezone.utc)
+    historical_datetime = datetime(2022, 7, 16, 12, tzinfo=UTC)
     assert snapshot == fetch_price(target_datetime=historical_datetime, session=session)

--- a/parsers/test/test_GE.py
+++ b/parsers/test/test_GE.py
@@ -1,5 +1,5 @@
 import json
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from importlib import resources
 
 import pytest
@@ -32,7 +32,7 @@ def test_fetch_production_historical(adapter, session, snapshot):
 
     adapter.register_uri(GET, ANY, content=content)
 
-    historical_datetime = datetime(2020, 1, 1, tzinfo=timezone.utc)
+    historical_datetime = datetime(2020, 1, 1, tzinfo=UTC)
 
     assert snapshot == fetch_production(
         target_datetime=historical_datetime, session=session

--- a/parsers/test/test_IEMOP.py
+++ b/parsers/test/test_IEMOP.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 
 import pytest
 from requests_mock import GET, POST
@@ -14,7 +14,7 @@ def test_production(adapter, session, snapshot, zone_key: ZoneKey):
     """
     Reports have been reduced to 14 September 2023 00:00 to 13 September 2023 22:00 for ease
     """
-    target_datetime = datetime(2023, 9, 14, 0, 0, tzinfo=timezone.utc)
+    target_datetime = datetime(2023, 9, 14, 0, 0, tzinfo=UTC)
     with open(
         "parsers/test/mocks/IEMOP/list_reports_items.json", "rb"
     ) as list_reports_items:

--- a/parsers/test/test_KPX.py
+++ b/parsers/test/test_KPX.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 
 import pytest
 from requests_mock import GET, POST
@@ -34,5 +34,5 @@ def test_fetch_production_realtime(session, snapshot, mock_response_as_realtime)
 
 
 def test_production_historical(session, snapshot, mock_response_as_historical):
-    dt = datetime(2023, 9, 1, 0, 0, 0, tzinfo=timezone.utc)
+    dt = datetime(2023, 9, 1, 0, 0, 0, tzinfo=UTC)
     assert snapshot == fetch_production(ZoneKey("KR"), session, dt)

--- a/parsers/test/test_MD.py
+++ b/parsers/test/test_MD.py
@@ -1,5 +1,5 @@
 import json
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from importlib import resources
 
 import pytest
@@ -19,7 +19,7 @@ from parsers.MD import (
 frozen_live_time = freeze_time("2024-04-11 06:32:00")
 
 # the target datetime corresponding to our mock historical API response
-historical_datetime = datetime(2021, 7, 25, 12, tzinfo=timezone.utc)
+historical_datetime = datetime(2021, 7, 25, 12, tzinfo=UTC)
 
 
 @frozen_live_time
@@ -135,17 +135,17 @@ def test_fetch_price_live(snapshot):
 @pytest.mark.parametrize(
     "historical_datetime",
     [
-        datetime(2000, 1, 1, tzinfo=timezone.utc),
-        datetime(2000, 4, 1, tzinfo=timezone.utc),
-        datetime(2001, 10, 1, tzinfo=timezone.utc),
-        datetime(2002, 9, 1, tzinfo=timezone.utc),
-        datetime(2005, 9, 1, tzinfo=timezone.utc),
-        datetime(2007, 8, 3, tzinfo=timezone.utc),
-        datetime(2010, 1, 19, tzinfo=timezone.utc),
-        datetime(2012, 5, 11, tzinfo=timezone.utc),
-        datetime(2015, 7, 31, tzinfo=timezone.utc),
-        datetime(2023, 12, 31, tzinfo=timezone.utc),
-        datetime(2024, 3, 21, tzinfo=timezone.utc),
+        datetime(2000, 1, 1, tzinfo=UTC),
+        datetime(2000, 4, 1, tzinfo=UTC),
+        datetime(2001, 10, 1, tzinfo=UTC),
+        datetime(2002, 9, 1, tzinfo=UTC),
+        datetime(2005, 9, 1, tzinfo=UTC),
+        datetime(2007, 8, 3, tzinfo=UTC),
+        datetime(2010, 1, 19, tzinfo=UTC),
+        datetime(2012, 5, 11, tzinfo=UTC),
+        datetime(2015, 7, 31, tzinfo=UTC),
+        datetime(2023, 12, 31, tzinfo=UTC),
+        datetime(2024, 3, 21, tzinfo=UTC),
     ],
 )
 def test_fetch_price_historical(snapshot, historical_datetime):

--- a/parsers/test/test_NTESMO.py
+++ b/parsers/test/test_NTESMO.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from json import loads
 from pathlib import Path
 from zoneinfo import ZoneInfo
@@ -59,7 +59,7 @@ def fixture_session_mock(adapter, session) -> tuple[requests.Session, Adapter]:
 def test_fetch_production(fixture_session_mock):
     session, adapter = fixture_session_mock
 
-    historical_datetime = datetime(year=2022, month=12, day=1, tzinfo=timezone.utc)
+    historical_datetime = datetime(year=2022, month=12, day=1, tzinfo=UTC)
     data_list = fetch_production(session=session, target_datetime=historical_datetime)
     assert data_list is not None
 
@@ -86,7 +86,7 @@ def test_fetch_production(fixture_session_mock):
 def test_fetch_price(fixture_session_mock):
     session, adapter = fixture_session_mock
 
-    historical_datetime = datetime(year=2022, month=12, day=1, tzinfo=timezone.utc)
+    historical_datetime = datetime(year=2022, month=12, day=1, tzinfo=UTC)
     data_list = fetch_price(session=session, target_datetime=historical_datetime)
 
     assert data_list is not None
@@ -117,7 +117,7 @@ def test_fetch_price(fixture_session_mock):
 def test_fetch_consumption(fixture_session_mock):
     session, adapter = fixture_session_mock
 
-    historical_datetime = datetime(year=2022, month=12, day=1, tzinfo=timezone.utc)
+    historical_datetime = datetime(year=2022, month=12, day=1, tzinfo=UTC)
     data_list = fetch_consumption(session=session, target_datetime=historical_datetime)
 
     assert data_list is not None

--- a/parsers/test/test_OPENNEM.py
+++ b/parsers/test/test_OPENNEM.py
@@ -1,5 +1,5 @@
 import json
-from datetime import datetime, timedelta, timezone
+from datetime import UTC, datetime, timedelta
 from importlib import resources
 
 import numpy as np
@@ -40,7 +40,7 @@ def test_sum_vector():
 
 
 def test_filter_production_objs():
-    now = datetime.now(timezone.utc)
+    now = datetime.now(UTC)
     objs = [
         {
             "datetime": now - timedelta(hours=1),

--- a/parsers/test/test_PE.py
+++ b/parsers/test/test_PE.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from urllib.parse import urlencode
 
 import pytest
@@ -39,7 +39,7 @@ def test_api_requests_are_sent_with_correct_dates(adapter, session):
     fetch_production(
         zone_key=ZoneKey("PE"),
         session=session,
-        target_datetime=datetime(2024, 2, 6, 0, 0, 0, tzinfo=timezone.utc),
+        target_datetime=datetime(2024, 2, 6, 0, 0, 0, tzinfo=UTC),
     )
 
     assert adapter.called

--- a/parsers/test/test_PF.py
+++ b/parsers/test/test_PF.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timedelta, timezone
+from datetime import UTC, datetime, timedelta
 from importlib import resources
 
 import pytest
@@ -33,5 +33,5 @@ def test_fetch_production_raises_parser_exception_on_historical_data(adapter, se
     with pytest.raises(
         ParserException, match="This parser is not yet able to parse historical data"
     ):
-        historical_datetime = datetime.now(timezone.utc) - timedelta(days=1)
+        historical_datetime = datetime.now(UTC) - timedelta(days=1)
         fetch_production(target_datetime=historical_datetime, session=session)

--- a/parsers/test/test_US_SPP.py
+++ b/parsers/test/test_US_SPP.py
@@ -1,5 +1,5 @@
 import logging
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from pathlib import Path
 from unittest.mock import patch
 from zoneinfo import ZoneInfo
@@ -28,7 +28,7 @@ def test_fetch_production():
 
     # Unknown keys must be assigned and summed.
     assert round(datapoint["production"]["unknown"], 2) == 33.1
-    assert datapoint["datetime"] == datetime(2018, 7, 27, 11, 45, tzinfo=timezone.utc)
+    assert datapoint["datetime"] == datetime(2018, 7, 27, 11, 45, tzinfo=UTC)
     assert datapoint["source"] == "spp.org"
     assert datapoint["zoneKey"] == "US-SW-AZPS"
     assert isinstance(datapoint["storage"], dict)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -117,7 +117,7 @@ exclude = [
 line-length = 88
 indent-width = 4
 
-target-version = "py310"
+target-version = "py311"
 
 [tool.ruff.lint]
 # Enable Pyflakes (`F`) and a subset of the pycodestyle (`E`)  codes by default.

--- a/test_parser.py
+++ b/test_parser.py
@@ -6,7 +6,7 @@ Usage: poetry run test_parser FR production
 import pprint
 import time
 from collections.abc import Callable
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from logging import DEBUG, basicConfig, getLogger
 from typing import Any
 
@@ -103,14 +103,14 @@ def test_parser(zone: ZoneKey, data_type: str, target_datetime: str | None):
         is False
     ), "Datetimes must be timezone aware"
 
-    last_dt = datetime.fromisoformat(f"{max(dts)}").astimezone(timezone.utc)
-    first_dt = datetime.fromisoformat(f"{min(dts)}").astimezone(timezone.utc)
+    last_dt = datetime.fromisoformat(f"{max(dts)}").astimezone(UTC)
+    first_dt = datetime.fromisoformat(f"{min(dts)}").astimezone(UTC)
     max_dt_warning = ""
     if not target_datetime:
-        now_string = datetime.now(timezone.utc).isoformat(timespec="seconds")
+        now_string = datetime.now(UTC).isoformat(timespec="seconds")
         max_dt_warning = (
             f" :( >2h from now !!! (now={now_string} UTC)"
-            if (datetime.now(timezone.utc) - last_dt).total_seconds() > 2 * 3600
+            if (datetime.now(UTC) - last_dt).total_seconds() > 2 * 3600
             else f" -- OK, <2h from now :) (now={now_string} UTC)"
         )
 


### PR DESCRIPTION
## Description

Follow up to the 3.11 python upgrade.

This pull request replaces the use of `timezone.utc` with `datetime.UTC` (introduced in Python 3.11) across the codebase for handling timezone-aware `datetime` objects. The changes affect both the core code and the associated test suite. This update simplifies the code and aligns it with modern Python practices.

### Core Code Updates:
* Updated the `LOWER_DATETIME_BOUND` constant in `electricitymap/contrib/lib/models/events.py` to use `dt.UTC` instead of `timezone.utc`.
* Replaced `timezone.utc` with `dt.UTC` in the `_validate_datetime` method to ensure consistency with the new standard.

### Test Suite Updates:
* Replaced `timezone.utc` with `UTC` in multiple test cases across `electricitymap/contrib/lib/tests/test_event_lists.py`, including tests for exchange lists, consumption lists, price lists, and production lists. [[1]](diffhunk://#diff-b67a16f8bcae4ce52656b80ffceb88faec7f490da5bdec0114b6e9e575885696L28-R34) [[2]](diffhunk://#diff-b67a16f8bcae4ce52656b80ffceb88faec7f490da5bdec0114b6e9e575885696L73-R151) [[3]](diffhunk://#diff-b67a16f8bcae4ce52656b80ffceb88faec7f490da5bdec0114b6e9e575885696L214-R220) [[4]](diffhunk://#diff-b67a16f8bcae4ce52656b80ffceb88faec7f490da5bdec0114b6e9e575885696L295-R295) [[5]](diffhunk://#diff-b67a16f8bcae4ce52656b80ffceb88faec7f490da5bdec0114b6e9e575885696L403-R451)
* Updated imports in the test file to include `UTC` directly from `datetime` for cleaner usage.