### PR TITLE
feat(data-centers): cleanup gcp regions + add azure regions 

### DIFF
--- a/config/data_centers/data_centers.json
+++ b/config/data_centers/data_centers.json
@@ -110,5 +110,461 @@
     "region": "europe-west3",
     "zoneKey": "DE",
     "status": "operational"
+  },
+  "azure-westus3": {
+    "provider": "azure",
+    "lonlat": [-111.763275, 34.395342],
+    "displayName": "West US 3",
+    "region": "West US 3",
+    "zoneKey": "US-SW-AZPS",
+    "status": "operational"
+  },
+  "azure-westus2": {
+    "provider": "azure",
+    "lonlat": [-120.212613, 47.2868352],
+    "displayName": "West US 2",
+    "region": "West US 2",
+    "zoneKey": "US-NW-BPAT",
+    "status": "operational"
+  },
+  "azure-westus": {
+    "provider": "azure",
+    "lonlat": [-118.755997, 36.7014631],
+    "displayName": "West US",
+    "region": "West US",
+    "zoneKey": "US-CAL-CISO",
+    "status": "operational"
+  },
+  "azure-westcentralus": {
+    "provider": "azure",
+    "lonlat": [-107.568534, 43.1700264],
+    "displayName": "West Central US",
+    "region": "West Central US",
+    "zoneKey": "US-NW-PACE",
+    "status": "operational"
+  },
+  "azure-southcentralus": {
+    "provider": "azure",
+    "lonlat": [-96.87744141, 29.55434513],
+    "displayName": "South Central US",
+    "region": "South Central US",
+    "zoneKey": "US-TEX-ERCO",
+    "status": "operational"
+  },
+  "azure-northcentralus": {
+    "provider": "azure",
+    "lonlat": [-89.4337288, 40.0796606],
+    "displayName": "North Central US",
+    "region": "North Central US",
+    "zoneKey": "US-MIDW-MISO",
+    "status": "operational"
+  },
+  "azure-eastus3": {
+    "provider": "azure",
+    "lonlat": [-83.716858, 32.840464],
+    "displayName": "East US 3",
+    "region": "East US 3",
+    "zoneKey": "US-SE-SOCO",
+    "status": "non operational"
+  },
+  "azure-eastus2": {
+    "provider": "azure",
+    "lonlat": [-81.12304688, 36.66841892],
+    "displayName": "East US 2",
+    "region": "East US 2",
+    "zoneKey": "US-MIDA-PJM",
+    "status": "operational"
+  },
+  "azure-eastus": {
+    "provider": "azure",
+    "lonlat": [-78.13476563, 38.75408328],
+    "displayName": "East US",
+    "region": "East US",
+    "zoneKey": "US-MIDA-PJM",
+    "status": "operational"
+  },
+  "azure-centralus": {
+    "provider": "azure",
+    "lonlat": [-94.55932617, 41.4509614],
+    "displayName": "Central US",
+    "region": "Central US",
+    "zoneKey": "US-MIDW-MISO",
+    "status": "operational"
+  },
+  "azure-ukwest": {
+    "provider": "azure",
+    "lonlat": [-3.1791934, 51.4816546],
+    "displayName": "UK West",
+    "region": "UK West",
+    "zoneKey": "GB",
+    "status": "operational"
+  },
+  "azure-uksouth": {
+    "provider": "azure",
+    "lonlat": [-0.1276474, 51.5073219],
+    "displayName": "UK South",
+    "region": "UK South",
+    "zoneKey": "GB",
+    "status": "operational"
+  },
+  "azure-uaenorth": {
+    "provider": "azure",
+    "lonlat": [55.2707065, 25.2047397],
+    "displayName": "UAE North",
+    "region": "UAE North",
+    "zoneKey": "AE",
+    "status": "operational"
+  },
+  "azure-taiwannorth": {
+    "provider": "azure",
+    "lonlat": [121.4139, 25.039666],
+    "displayName": "Taiwan North",
+    "region": "Taiwan North",
+    "zoneKey": "TW",
+    "status": "non operational"
+  },
+  "azure-switzerlandnorth": {
+    "provider": "azure",
+    "lonlat": [8.8410422, 47.2744489],
+    "displayName": "Switzerland North",
+    "region": "Switzerland North",
+    "zoneKey": "CH",
+    "status": "operational"
+  },
+  "azure-swedencentral": {
+    "provider": "azure",
+    "lonlat": [17.138836, 60.667761],
+    "displayName": "Sweden Central",
+    "region": "Sweden Central",
+    "zoneKey": "SE-SE3",
+    "status": "operational"
+  },
+  "azure-spaincentral": {
+    "provider": "azure",
+    "lonlat": [-3.7035825, 40.4167047],
+    "displayName": "Spain Central",
+    "region": "Spain Central",
+    "zoneKey": "ES",
+    "status": "operational"
+  },
+  "azure-saudiarabiaeast": {
+    "provider": "azure",
+    "lonlat": [46.6753, 24.7136],
+    "displayName": "Saudi Arabia East",
+    "region": "Saudi Arabia East",
+    "zoneKey": "SA",
+    "status": "non operational"
+  },
+  "azure-qatarcentral": {
+    "provider": "azure",
+    "lonlat": [51.5264162, 26.2856329],
+    "displayName": "Qatar Central",
+    "region": "Qatar Central",
+    "zoneKey": "QA",
+    "status": "operational"
+  },
+  "azure-polandcentral": {
+    "provider": "azure",
+    "lonlat": [21.8067249, 52.2319581],
+    "displayName": "Poland Central",
+    "region": "Poland Central",
+    "zoneKey": "PL",
+    "status": "operational"
+  },
+  "azure-norwayeast": {
+    "provider": "azure",
+    "lonlat": [10.7389701, 59.9133301],
+    "displayName": "Norway East",
+    "region": "Norway East",
+    "zoneKey": "NO-NO1",
+    "status": "operational"
+  },
+  "azure-newzealandnorth": {
+    "provider": "azure",
+    "lonlat": [174.7631803, -36.852095],
+    "displayName": "New Zealand North",
+    "region": "New Zealand North",
+    "zoneKey": "NZ",
+    "status": "operational"
+  },
+  "azure-mexicocentral": {
+    "provider": "azure",
+    "lonlat": [-99.84756, 20.8542575],
+    "displayName": "Mexico Central",
+    "region": "Mexico Central",
+    "zoneKey": "MX",
+    "status": "operational"
+  },
+  "azure-malaysiawest": {
+    "provider": "azure",
+    "lonlat": [101.809256, 4.55035],
+    "displayName": "Malaysia West",
+    "region": "Malaysia West",
+    "zoneKey": "MY-WM",
+    "status": "non operational"
+  },
+  "azure-koreacentral": {
+    "provider": "azure",
+    "lonlat": [126.9782914, 37.5666791],
+    "displayName": "Korea Central",
+    "region": "Korea Central",
+    "zoneKey": "KR",
+    "status": "operational"
+  },
+  "azure-japanwest": {
+    "provider": "azure",
+    "lonlat": [135.490357, 34.6198813],
+    "displayName": "Japan West",
+    "region": "Japan West",
+    "zoneKey": "JP-KN",
+    "status": "operational"
+  },
+  "azure-japaneast": {
+    "provider": "azure",
+    "lonlat": [139.7594549, 37.6828387],
+    "displayName": "Japan East",
+    "region": "Japan East",
+    "zoneKey": "JP-TH",
+    "status": "operational"
+  },
+  "azure-italynorth": {
+    "provider": "azure",
+    "lonlat": [9.6905, 45.2668],
+    "displayName": "Italy North",
+    "region": "Italy North",
+    "zoneKey": "IT-NO",
+    "status": "operational"
+  },
+  "azure-israelcentral": {
+    "provider": "azure",
+    "lonlat": [35.8667654, 31.5313113],
+    "displayName": "Israel Central",
+    "region": "Israel Central",
+    "zoneKey": "JO",
+    "status": "operational"
+  },
+  "azure-indonesiacentral": {
+    "provider": "azure",
+    "lonlat": [106.827183, -6.1753942],
+    "displayName": "Indonesia Central",
+    "region": "Indonesia Central",
+    "zoneKey": "ID",
+    "status": "operational"
+  },
+  "azure-southcentralindia": {
+    "provider": "azure",
+    "lonlat": [78.5, 17.34],
+    "displayName": "India South Central",
+    "region": "India South Central",
+    "zoneKey": "IN-SO",
+    "status": "non operational"
+  },
+  "azure-southindia": {
+    "provider": "azure",
+    "lonlat": [80.270186, 13.0836939],
+    "displayName": "South India",
+    "region": "South India",
+    "zoneKey": "IN-SO",
+    "status": "operational"
+  },
+  "azure-centralindia": {
+    "provider": "azure",
+    "lonlat": [75.0544541, 18.521428],
+    "displayName": "Central India",
+    "region": "Central India",
+    "zoneKey": "IN-WE",
+    "status": "operational"
+  },
+  "azure-greececentral": {
+    "provider": "azure",
+    "lonlat": [23.7283052, 37.9839412],
+    "displayName": "Greece Central",
+    "region": "Greece Central",
+    "zoneKey": "GR",
+    "status": "non operational"
+  },
+  "azure-germanywestcentral": {
+    "provider": "azure",
+    "lonlat": [8.6820917, 50.2106444],
+    "displayName": "Germany West Central",
+    "region": "Germany West Central",
+    "zoneKey": "DE",
+    "status": "operational"
+  },
+  "azure-francecentral": {
+    "provider": "azure",
+    "lonlat": [2.3514616, 48.8566969],
+    "displayName": "France Central",
+    "region": "France Central",
+    "zoneKey": "FR",
+    "status": "operational"
+  },
+  "azure-finlandcentral": {
+    "provider": "azure",
+    "lonlat": [24.874774, 60.183027],
+    "displayName": "Finland Central",
+    "region": "Finland Central",
+    "zoneKey": "FI",
+    "status": "non operational"
+  },
+  "azure-westeurope": {
+    "provider": "azure",
+    "lonlat": [7.0480821, 52.5001698],
+    "displayName": "West Europe",
+    "region": "West Europe",
+    "zoneKey": "DE",
+    "status": "operational"
+  },
+  "azure-northeurope": {
+    "provider": "azure",
+    "lonlat": [-7.9794599, 52.865196],
+    "displayName": "North Europe",
+    "region": "North Europe",
+    "zoneKey": "IE",
+    "status": "operational"
+  },
+  "azure-denmarkeast": {
+    "provider": "azure",
+    "lonlat": [12.580776, 55.664858],
+    "displayName": "Denmark East",
+    "region": "Denmark East",
+    "zoneKey": "DK-DK2",
+    "status": "non operational"
+  },
+  "azure-chinanorth3": {
+    "provider": "azure",
+    "lonlat": [116.277987, 42.710633],
+    "displayName": "China North 3",
+    "region": "China North 3",
+    "zoneKey": "CN",
+    "status": "operational"
+  },
+  "azure-chinanorth2": {
+    "provider": "azure",
+    "lonlat": [118.3976563, 39.63107677],
+    "displayName": "China North 2",
+    "region": "China North 2",
+    "zoneKey": "CN",
+    "status": "operational"
+  },
+  "azure-chinanorth": {
+    "provider": "azure",
+    "lonlat": [116.0912391, 40.5065084],
+    "displayName": "China North",
+    "region": "China North",
+    "zoneKey": "CN",
+    "status": "operational"
+  },
+  "azure-chinaeast2": {
+    "provider": "azure",
+    "lonlat": [119.9265137, 30.57015912],
+    "displayName": "China East 2",
+    "region": "China East 2",
+    "zoneKey": "CN",
+    "status": "operational"
+  },
+  "azure-chinaeast": {
+    "provider": "azure",
+    "lonlat": [121.9692071, 31.2322758],
+    "displayName": "China East",
+    "region": "China East",
+    "zoneKey": "CN",
+    "status": "operational"
+  },
+  "azure-chilecentral": {
+    "provider": "azure",
+    "lonlat": [-70.8, -33.47],
+    "displayName": "Chile Central",
+    "region": "Chile Central",
+    "zoneKey": "CL-SEN",
+    "status": "non operational"
+  },
+  "azure-canadaeast": {
+    "provider": "azure",
+    "lonlat": [-71.2352226, 46.8259601],
+    "displayName": "Canada East",
+    "region": "Canada East",
+    "zoneKey": "CA-QC",
+    "status": "operational"
+  },
+  "azure-canadacentral": {
+    "provider": "azure",
+    "lonlat": [-79.3839347, 43.6534817],
+    "displayName": "Canada Central",
+    "region": "Canada Central",
+    "zoneKey": "CA-ON",
+    "status": "operational"
+  },
+  "azure-brazilsouth": {
+    "provider": "azure",
+    "lonlat": [-46.66992188, -23.74512587],
+    "displayName": "Brazil South",
+    "region": "Brazil South",
+    "zoneKey": "BR-CS",
+    "status": "operational"
+  },
+  "azure-belgiumcentral": {
+    "provider": "azure",
+    "lonlat": [5.06, 51.35],
+    "displayName": "Belgium Central",
+    "region": "Belgium Central",
+    "zoneKey": "BE",
+    "status": "non operational"
+  },
+  "azure-austriaeast": {
+    "provider": "azure",
+    "lonlat": [16.404751, 48.599753],
+    "displayName": "Austria East",
+    "region": "Austria East",
+    "zoneKey": "AT",
+    "status": "non operational"
+  },
+  "azure-australiacentral": {
+    "provider": "azure",
+    "lonlat": [149.1012676, -35.2975906],
+    "displayName": "Australia Central",
+    "region": "Australia Central",
+    "zoneKey": "AU-NSW",
+    "status": "operational"
+  },
+  "azure-australiasoutheast": {
+    "provider": "azure",
+    "lonlat": [144.9631608, -37.8142176],
+    "displayName": "Australia Southeast",
+    "region": "Australia Southeast",
+    "zoneKey": "AU-VIC",
+    "status": "operational"
+  },
+  "azure-australiaeast": {
+    "provider": "azure",
+    "lonlat": [146.921097, -31.253218],
+    "displayName": "Australia East",
+    "region": "Australia East",
+    "zoneKey": "AU-NSW",
+    "status": "operational"
+  },
+  "azure-southeastasia": {
+    "provider": "azure",
+    "lonlat": [105.3, 1.13],
+    "displayName": "Southeast Asia",
+    "region": "Southeast Asia",
+    "zoneKey": "DK-DK2",
+    "status": "operational"
+  },
+  "azure-eastasia": {
+    "provider": "azure",
+    "lonlat": [114.109497, 22.396427],
+    "displayName": "East Asia",
+    "region": "East Asia",
+    "zoneKey": "HK",
+    "status": "operational"
+  },
+  "azure-southafricanorth": {
+    "provider": "azure",
+    "lonlat": [28.047304, -26.204103],
+    "displayName": "South Africa North",
+    "region": "South Africa North",
+    "zoneKey": "ZA",
+    "status": "operational"
   }
 }

--- a/config/data_centers/data_centers.json
+++ b/config/data_centers/data_centers.json
@@ -159,14 +159,6 @@
     "zoneKey": "US-MIDW-MISO",
     "status": "operational"
   },
-  "azure-eastus3": {
-    "provider": "azure",
-    "lonlat": [-83.716858, 32.840464],
-    "displayName": "East US 3",
-    "region": "eastus3",
-    "zoneKey": "US-SE-SOCO",
-    "status": "non operational"
-  },
   "azure-eastus2": {
     "provider": "azure",
     "lonlat": [-81.12304688, 36.66841892],
@@ -215,14 +207,6 @@
     "zoneKey": "AE",
     "status": "operational"
   },
-  "azure-taiwannorth": {
-    "provider": "azure",
-    "lonlat": [121.4139, 25.039666],
-    "displayName": "Taiwan North",
-    "region": "taiwannorth",
-    "zoneKey": "TW",
-    "status": "non operational"
-  },
   "azure-switzerlandnorth": {
     "provider": "azure",
     "lonlat": [8.8410422, 47.2744489],
@@ -246,14 +230,6 @@
     "region": "spaincentral",
     "zoneKey": "ES",
     "status": "operational"
-  },
-  "azure-saudiarabiaeast": {
-    "provider": "azure",
-    "lonlat": [46.6753, 24.7136],
-    "displayName": "Saudi Arabia East",
-    "region": "saudiarabiaeast",
-    "zoneKey": "SA",
-    "status": "non operational"
   },
   "azure-qatarcentral": {
     "provider": "azure",
@@ -294,14 +270,6 @@
     "region": "mexicocentral",
     "zoneKey": "MX",
     "status": "operational"
-  },
-  "azure-malaysiawest": {
-    "provider": "azure",
-    "lonlat": [101.809256, 4.55035],
-    "displayName": "Malaysia West",
-    "region": "malaysiawest",
-    "zoneKey": "MY-WM",
-    "status": "non operational"
   },
   "azure-koreacentral": {
     "provider": "azure",
@@ -351,14 +319,6 @@
     "zoneKey": "ID",
     "status": "operational"
   },
-  "azure-southcentralindia": {
-    "provider": "azure",
-    "lonlat": [78.5, 17.34],
-    "displayName": "India South Central",
-    "region": "southcentralindia",
-    "zoneKey": "IN-SO",
-    "status": "non operational"
-  },
   "azure-southindia": {
     "provider": "azure",
     "lonlat": [80.270186, 13.0836939],
@@ -374,14 +334,6 @@
     "region": "centralindia",
     "zoneKey": "IN-WE",
     "status": "operational"
-  },
-  "azure-greececentral": {
-    "provider": "azure",
-    "lonlat": [23.7283052, 37.9839412],
-    "displayName": "Greece Central",
-    "region": "greececentral",
-    "zoneKey": "GR",
-    "status": "non operational"
   },
   "azure-germanywestcentral": {
     "provider": "azure",
@@ -399,14 +351,6 @@
     "zoneKey": "FR",
     "status": "operational"
   },
-  "azure-finlandcentral": {
-    "provider": "azure",
-    "lonlat": [24.874774, 60.183027],
-    "displayName": "Finland Central",
-    "region": "finlandcentral",
-    "zoneKey": "FI",
-    "status": "non operational"
-  },
   "azure-westeurope": {
     "provider": "azure",
     "lonlat": [7.0480821, 52.5001698],
@@ -422,14 +366,6 @@
     "region": "northeurope",
     "zoneKey": "IE",
     "status": "operational"
-  },
-  "azure-denmarkeast": {
-    "provider": "azure",
-    "lonlat": [12.580776, 55.664858],
-    "displayName": "Denmark East",
-    "region": "denmarkeast",
-    "zoneKey": "DK-DK2",
-    "status": "non operational"
   },
   "azure-chinanorth3": {
     "provider": "azure",
@@ -471,14 +407,6 @@
     "zoneKey": "CN",
     "status": "operational"
   },
-  "azure-chilecentral": {
-    "provider": "azure",
-    "lonlat": [-70.8, -33.47],
-    "displayName": "Chile Central",
-    "region": "chilecentral",
-    "zoneKey": "CL-SEN",
-    "status": "non operational"
-  },
   "azure-canadaeast": {
     "provider": "azure",
     "lonlat": [-71.2352226, 46.8259601],
@@ -502,22 +430,6 @@
     "region": "brazilsouth",
     "zoneKey": "BR-CS",
     "status": "operational"
-  },
-  "azure-belgiumcentral": {
-    "provider": "azure",
-    "lonlat": [5.06, 51.35],
-    "displayName": "Belgium Central",
-    "region": "belgiumcentral",
-    "zoneKey": "BE",
-    "status": "non operational"
-  },
-  "azure-austriaeast": {
-    "provider": "azure",
-    "lonlat": [16.404751, 48.599753],
-    "displayName": "Austria East",
-    "region": "austriaeast",
-    "zoneKey": "AT",
-    "status": "non operational"
   },
   "azure-australiacentral": {
     "provider": "azure",

--- a/config/data_centers/data_centers.json
+++ b/config/data_centers/data_centers.json
@@ -112,371 +112,630 @@
     "status": "operational"
   },
   "azure-westus3": {
-    "provider": "azure",
-    "lonlat": [-111.763275, 34.395342],
-    "displayName": "West US 3",
-    "region": "West US 3",
-    "zoneKey": "US-SW-AZPS",
-    "status": "operational"
-  },
-  "azure-westus2": {
-    "provider": "azure",
-    "lonlat": [-120.212613, 47.2868352],
-    "displayName": "West US 2",
-    "region": "West US 2",
-    "zoneKey": "US-NW-BPAT",
-    "status": "operational"
-  },
-  "azure-westus": {
-    "provider": "azure",
-    "lonlat": [-118.755997, 36.7014631],
-    "displayName": "West US",
-    "region": "West US",
-    "zoneKey": "US-CAL-CISO",
-    "status": "operational"
-  },
-  "azure-westcentralus": {
-    "provider": "azure",
-    "lonlat": [-107.568534, 43.1700264],
-    "displayName": "West Central US",
-    "region": "West Central US",
-    "zoneKey": "US-NW-PACE",
-    "status": "operational"
-  },
-  "azure-southcentralus": {
-    "provider": "azure",
-    "lonlat": [-96.87744141, 29.55434513],
-    "displayName": "South Central US",
-    "region": "South Central US",
-    "zoneKey": "US-TEX-ERCO",
-    "status": "operational"
-  },
-  "azure-northcentralus": {
-    "provider": "azure",
-    "lonlat": [-89.4337288, 40.0796606],
-    "displayName": "North Central US",
-    "region": "North Central US",
-    "zoneKey": "US-MIDW-MISO",
-    "status": "operational"
-  },
-  "azure-eastus2": {
-    "provider": "azure",
-    "lonlat": [-81.12304688, 36.66841892],
-    "displayName": "East US 2",
-    "region": "East US 2",
-    "zoneKey": "US-MIDA-PJM",
-    "status": "operational"
-  },
-  "azure-eastus": {
-    "provider": "azure",
-    "lonlat": [-78.13476563, 38.75408328],
-    "displayName": "East US",
-    "region": "East US",
-    "zoneKey": "US-MIDA-PJM",
-    "status": "operational"
-  },
-  "azure-centralus": {
-    "provider": "azure",
-    "lonlat": [-94.55932617, 41.4509614],
-    "displayName": "Central US",
-    "region": "Central US",
-    "zoneKey": "US-MIDW-MISO",
-    "status": "operational"
-  },
-  "azure-ukwest": {
-    "provider": "azure",
-    "lonlat": [-3.1791934, 51.4816546],
-    "displayName": "UK West",
-    "region": "UK West",
-    "zoneKey": "GB",
-    "status": "operational"
-  },
-  "azure-uksouth": {
-    "provider": "azure",
-    "lonlat": [-0.1276474, 51.5073219],
-    "displayName": "UK South",
-    "region": "UK South",
-    "zoneKey": "GB",
-    "status": "operational"
-  },
-  "azure-uaenorth": {
-    "provider": "azure",
-    "lonlat": [55.2707065, 25.2047397],
-    "displayName": "UAE North",
-    "region": "UAE North",
-    "zoneKey": "AE",
-    "status": "operational"
-  },
-  "azure-switzerlandnorth": {
-    "provider": "azure",
-    "lonlat": [8.8410422, 47.2744489],
-    "displayName": "Switzerland North",
-    "region": "Switzerland North",
-    "zoneKey": "CH",
-    "status": "operational"
-  },
-  "azure-swedencentral": {
-    "provider": "azure",
-    "lonlat": [17.138836, 60.667761],
-    "displayName": "Sweden Central",
-    "region": "Sweden Central",
-    "zoneKey": "SE-SE3",
-    "status": "operational"
-  },
-  "azure-spaincentral": {
-    "provider": "azure",
-    "lonlat": [-3.7035825, 40.4167047],
-    "displayName": "Spain Central",
-    "region": "Spain Central",
-    "zoneKey": "ES",
-    "status": "operational"
-  },
-  "azure-qatarcentral": {
-    "provider": "azure",
-    "lonlat": [51.5264162, 26.2856329],
-    "displayName": "Qatar Central",
-    "region": "Qatar Central",
-    "zoneKey": "QA",
-    "status": "operational"
-  },
-  "azure-polandcentral": {
-    "provider": "azure",
-    "lonlat": [21.8067249, 52.2319581],
-    "displayName": "Poland Central",
-    "region": "Poland Central",
-    "zoneKey": "PL",
-    "status": "operational"
-  },
-  "azure-norwayeast": {
-    "provider": "azure",
-    "lonlat": [10.7389701, 59.9133301],
-    "displayName": "Norway East",
-    "region": "Norway East",
-    "zoneKey": "NO-NO1",
-    "status": "operational"
-  },
-  "azure-newzealandnorth": {
-    "provider": "azure",
-    "lonlat": [174.7631803, -36.852095],
-    "displayName": "New Zealand North",
-    "region": "New Zealand North",
-    "zoneKey": "NZ",
-    "status": "operational"
-  },
-  "azure-mexicocentral": {
-    "provider": "azure",
-    "lonlat": [-99.84756, 20.8542575],
-    "displayName": "Mexico Central",
-    "region": "Mexico Central",
-    "zoneKey": "MX",
-    "status": "operational"
-  },
-  "azure-koreacentral": {
-    "provider": "azure",
-    "lonlat": [126.9782914, 37.5666791],
-    "displayName": "Korea Central",
-    "region": "Korea Central",
-    "zoneKey": "KR",
-    "status": "operational"
-  },
-  "azure-japanwest": {
-    "provider": "azure",
-    "lonlat": [135.490357, 34.6198813],
-    "displayName": "Japan West",
-    "region": "Japan West",
-    "zoneKey": "JP-KN",
-    "status": "operational"
-  },
-  "azure-japaneast": {
-    "provider": "azure",
-    "lonlat": [139.7594549, 37.6828387],
-    "displayName": "Japan East",
-    "region": "Japan East",
-    "zoneKey": "JP-TH",
-    "status": "operational"
-  },
-  "azure-italynorth": {
-    "provider": "azure",
-    "lonlat": [9.6905, 45.2668],
-    "displayName": "Italy North",
-    "region": "Italy North",
-    "zoneKey": "IT-NO",
-    "status": "operational"
-  },
-  "azure-israelcentral": {
-    "provider": "azure",
-    "lonlat": [35.8667654, 31.5313113],
-    "displayName": "Israel Central",
-    "region": "Israel Central",
-    "zoneKey": "JO",
-    "status": "operational"
-  },
-  "azure-indonesiacentral": {
-    "provider": "azure",
-    "lonlat": [106.827183, -6.1753942],
-    "displayName": "Indonesia Central",
-    "region": "Indonesia Central",
-    "zoneKey": "ID",
-    "status": "operational"
-  },
-  "azure-southindia": {
-    "provider": "azure",
-    "lonlat": [80.270186, 13.0836939],
-    "displayName": "South India",
-    "region": "South India",
-    "zoneKey": "IN-SO",
-    "status": "operational"
-  },
-  "azure-centralindia": {
-    "provider": "azure",
-    "lonlat": [75.0544541, 18.521428],
-    "displayName": "Central India",
-    "region": "Central India",
-    "zoneKey": "IN-WE",
-    "status": "operational"
-  },
-  "azure-germanywestcentral": {
-    "provider": "azure",
-    "lonlat": [8.6820917, 50.2106444],
-    "displayName": "Germany West Central",
-    "region": "Germany West Central",
-    "zoneKey": "DE",
-    "status": "operational"
-  },
-  "azure-francecentral": {
-    "provider": "azure",
-    "lonlat": [2.3514616, 48.8566969],
-    "displayName": "France Central",
-    "region": "France Central",
-    "zoneKey": "FR",
-    "status": "operational"
-  },
-  "azure-westeurope": {
-    "provider": "azure",
-    "lonlat": [7.0480821, 52.5001698],
-    "displayName": "West Europe",
-    "region": "West Europe",
-    "zoneKey": "DE",
-    "status": "operational"
-  },
-  "azure-northeurope": {
-    "provider": "azure",
-    "lonlat": [-7.9794599, 52.865196],
-    "displayName": "North Europe",
-    "region": "North Europe",
-    "zoneKey": "IE",
-    "status": "operational"
-  },
-  "azure-chinanorth3": {
-    "provider": "azure",
-    "lonlat": [116.277987, 42.710633],
-    "displayName": "China North 3",
-    "region": "China North 3",
-    "zoneKey": "CN",
-    "status": "operational"
-  },
-  "azure-chinanorth2": {
-    "provider": "azure",
-    "lonlat": [118.3976563, 39.63107677],
-    "displayName": "China North 2",
-    "region": "China North 2",
-    "zoneKey": "CN",
-    "status": "operational"
-  },
-  "azure-chinanorth": {
-    "provider": "azure",
-    "lonlat": [116.0912391, 40.5065084],
-    "displayName": "China North",
-    "region": "China North",
-    "zoneKey": "CN",
-    "status": "operational"
-  },
-  "azure-chinaeast2": {
-    "provider": "azure",
-    "lonlat": [119.9265137, 30.57015912],
-    "displayName": "China East 2",
-    "region": "China East 2",
-    "zoneKey": "CN",
-    "status": "operational"
-  },
-  "azure-chinaeast": {
-    "provider": "azure",
-    "lonlat": [121.9692071, 31.2322758],
-    "displayName": "China East",
-    "region": "China East",
-    "zoneKey": "CN",
-    "status": "operational"
-  },
-  "azure-canadaeast": {
-    "provider": "azure",
-    "lonlat": [-71.2352226, 46.8259601],
-    "displayName": "Canada East",
-    "region": "Canada East",
-    "zoneKey": "CA-QC",
-    "status": "operational"
-  },
-  "azure-canadacentral": {
-    "provider": "azure",
-    "lonlat": [-79.3839347, 43.6534817],
-    "displayName": "Canada Central",
-    "region": "Canada Central",
-    "zoneKey": "CA-ON",
-    "status": "operational"
-  },
-  "azure-brazilsouth": {
-    "provider": "azure",
-    "lonlat": [-46.66992188, -23.74512587],
-    "displayName": "Brazil South",
-    "region": "Brazil South",
-    "zoneKey": "BR-CS",
-    "status": "operational"
-  },
-  "azure-australiacentral": {
-    "provider": "azure",
-    "lonlat": [149.1012676, -35.2975906],
-    "displayName": "Australia Central",
-    "region": "Australia Central",
-    "zoneKey": "AU-NSW",
-    "status": "operational"
-  },
-  "azure-australiasoutheast": {
-    "provider": "azure",
-    "lonlat": [144.9631608, -37.8142176],
-    "displayName": "Australia Southeast",
-    "region": "Australia Southeast",
-    "zoneKey": "AU-VIC",
-    "status": "operational"
-  },
-  "azure-australiaeast": {
-    "provider": "azure",
-    "lonlat": [146.921097, -31.253218],
-    "displayName": "Australia East",
-    "region": "Australia East",
-    "zoneKey": "AU-NSW",
-    "status": "operational"
-  },
-  "azure-southeastasia": {
-    "provider": "azure",
-    "lonlat": [105.3, 1.13],
-    "displayName": "Southeast Asia",
-    "region": "Southeast Asia",
-    "zoneKey": "DK-DK2",
-    "status": "operational"
-  },
-  "azure-eastasia": {
-    "provider": "azure",
-    "lonlat": [114.109497, 22.396427],
-    "displayName": "East Asia",
-    "region": "East Asia",
-    "zoneKey": "HK",
-    "status": "operational"
-  },
-  "azure-southafricanorth": {
-    "provider": "azure",
-    "lonlat": [28.047304, -26.204103],
-    "displayName": "South Africa North",
-    "region": "South Africa North",
-    "zoneKey": "ZA",
-    "status": "operational"
-  }
+        "provider": "azure",
+        "lonlat": [
+            -111.763275,
+            34.395342
+        ],
+        "displayName": "West US 3",
+        "region": "westus3",
+        "zoneKey": "US-SW-AZPS",
+        "status": "operational"
+    },
+    "azure-westus2": {
+        "provider": "azure",
+        "lonlat": [
+            -120.212613,
+            47.2868352
+        ],
+        "displayName": "West US 2",
+        "region": "westus2",
+        "zoneKey": "US-NW-BPAT",
+        "status": "operational"
+    },
+    "azure-westus": {
+        "provider": "azure",
+        "lonlat": [
+            -118.755997,
+            36.7014631
+        ],
+        "displayName": "West US",
+        "region": "westus",
+        "zoneKey": "US-CAL-CISO",
+        "status": "operational"
+    },
+    "azure-westcentralus": {
+        "provider": "azure",
+        "lonlat": [
+            -107.568534,
+            43.1700264
+        ],
+        "displayName": "West Central US",
+        "region": "westcentralus",
+        "zoneKey": "US-NW-PACE",
+        "status": "operational"
+    },
+    "azure-southcentralus": {
+        "provider": "azure",
+        "lonlat": [
+            -96.87744141,
+            29.55434513
+        ],
+        "displayName": "South Central US",
+        "region": "southcentralus",
+        "zoneKey": "US-TEX-ERCO",
+        "status": "operational"
+    },
+    "azure-northcentralus": {
+        "provider": "azure",
+        "lonlat": [
+            -89.4337288,
+            40.0796606
+        ],
+        "displayName": "North Central US",
+        "region": "northcentralus",
+        "zoneKey": "US-MIDW-MISO",
+        "status": "operational"
+    },
+    "azure-eastus3": {
+        "provider": "azure",
+        "lonlat": [
+            -83.716858,
+            32.840464
+        ],
+        "displayName": "East US 3",
+        "region": "eastus3",
+        "zoneKey": "US-SE-SOCO",
+        "status": "non operational"
+    },
+    "azure-eastus2": {
+        "provider": "azure",
+        "lonlat": [
+            -81.12304688,
+            36.66841892
+        ],
+        "displayName": "East US 2",
+        "region": "eastus2",
+        "zoneKey": "US-MIDA-PJM",
+        "status": "operational"
+    },
+    "azure-eastus": {
+        "provider": "azure",
+        "lonlat": [
+            -78.13476563,
+            38.75408328
+        ],
+        "displayName": "East US",
+        "region": "eastus",
+        "zoneKey": "US-MIDA-PJM",
+        "status": "operational"
+    },
+    "azure-centralus": {
+        "provider": "azure",
+        "lonlat": [
+            -94.55932617,
+            41.4509614
+        ],
+        "displayName": "Central US",
+        "region": "centralus",
+        "zoneKey": "US-MIDW-MISO",
+        "status": "operational"
+    },
+    "azure-ukwest": {
+        "provider": "azure",
+        "lonlat": [
+            -3.1791934,
+            51.4816546
+        ],
+        "displayName": "UK West",
+        "region": "ukwest",
+        "zoneKey": "GB",
+        "status": "operational"
+    },
+    "azure-uksouth": {
+        "provider": "azure",
+        "lonlat": [
+            -0.1276474,
+            51.5073219
+        ],
+        "displayName": "UK South",
+        "region": "uksouth",
+        "zoneKey": "GB",
+        "status": "operational"
+    },
+    "azure-uaenorth": {
+        "provider": "azure",
+        "lonlat": [
+            55.2707065,
+            25.2047397
+        ],
+        "displayName": "UAE North",
+        "region": "uaenorth",
+        "zoneKey": "AE",
+        "status": "operational"
+    },
+    "azure-taiwannorth": {
+        "provider": "azure",
+        "lonlat": [
+            121.4139,
+            25.039666
+        ],
+        "displayName": "Taiwan North",
+        "region": "taiwannorth",
+        "zoneKey": "TW",
+        "status": "non operational"
+    },
+    "azure-switzerlandnorth": {
+        "provider": "azure",
+        "lonlat": [
+            8.8410422,
+            47.2744489
+        ],
+        "displayName": "Switzerland North",
+        "region": "switzerlandnorth",
+        "zoneKey": "CH",
+        "status": "operational"
+    },
+    "azure-swedencentral": {
+        "provider": "azure",
+        "lonlat": [
+            17.138836,
+            60.667761
+        ],
+        "displayName": "Sweden Central",
+        "region": "swedencentral",
+        "zoneKey": "SE-SE3",
+        "status": "operational"
+    },
+    "azure-spaincentral": {
+        "provider": "azure",
+        "lonlat": [
+            -3.7035825,
+            40.4167047
+        ],
+        "displayName": "Spain Central",
+        "region": "spaincentral",
+        "zoneKey": "ES",
+        "status": "operational"
+    },
+    "azure-saudiarabiaeast": {
+        "provider": "azure",
+        "lonlat": [
+            46.6753,
+            24.7136
+        ],
+        "displayName": "Saudi Arabia East",
+        "region": "saudiarabiaeast",
+        "zoneKey": "SA",
+        "status": "non operational"
+    },
+    "azure-qatarcentral": {
+        "provider": "azure",
+        "lonlat": [
+            51.5264162,
+            26.2856329
+        ],
+        "displayName": "Qatar Central",
+        "region": "qatarcentral",
+        "zoneKey": "QA",
+        "status": "operational"
+    },
+    "azure-polandcentral": {
+        "provider": "azure",
+        "lonlat": [
+            21.8067249,
+            52.2319581
+        ],
+        "displayName": "Poland Central",
+        "region": "polandcentral",
+        "zoneKey": "PL",
+        "status": "operational"
+    },
+    "azure-norwayeast": {
+        "provider": "azure",
+        "lonlat": [
+            10.7389701,
+            59.9133301
+        ],
+        "displayName": "Norway East",
+        "region": "norwayeast",
+        "zoneKey": "NO-NO1",
+        "status": "operational"
+    },
+    "azure-newzealandnorth": {
+        "provider": "azure",
+        "lonlat": [
+            174.7631803,
+            -36.852095
+        ],
+        "displayName": "New Zealand North",
+        "region": "newzealandnorth",
+        "zoneKey": "NZ",
+        "status": "operational"
+    },
+    "azure-mexicocentral": {
+        "provider": "azure",
+        "lonlat": [
+            -99.84756,
+            20.8542575
+        ],
+        "displayName": "Mexico Central",
+        "region": "mexicocentral",
+        "zoneKey": "MX",
+        "status": "operational"
+    },
+    "azure-malaysiawest": {
+        "provider": "azure",
+        "lonlat": [
+            101.809256,
+            4.55035
+        ],
+        "displayName": "Malaysia West",
+        "region": "malaysiawest",
+        "zoneKey": "MY-WM",
+        "status": "non operational"
+    },
+    "azure-koreacentral": {
+        "provider": "azure",
+        "lonlat": [
+            126.9782914,
+            37.5666791
+        ],
+        "displayName": "Korea Central",
+        "region": "koreacentral",
+        "zoneKey": "KR",
+        "status": "operational"
+    },
+    "azure-japanwest": {
+        "provider": "azure",
+        "lonlat": [
+            135.490357,
+            34.6198813
+        ],
+        "displayName": "Japan West",
+        "region": "japanwest",
+        "zoneKey": "JP-KN",
+        "status": "operational"
+    },
+    "azure-japaneast": {
+        "provider": "azure",
+        "lonlat": [
+            139.7594549,
+            37.6828387
+        ],
+        "displayName": "Japan East",
+        "region": "japaneast",
+        "zoneKey": "JP-TH",
+        "status": "operational"
+    },
+    "azure-italynorth": {
+        "provider": "azure",
+        "lonlat": [
+            9.6905,
+            45.2668
+        ],
+        "displayName": "Italy North",
+        "region": "italynorth",
+        "zoneKey": "IT-NO",
+        "status": "operational"
+    },
+    "azure-israelcentral": {
+        "provider": "azure",
+        "lonlat": [
+            35.8667654,
+            31.5313113
+        ],
+        "displayName": "Israel Central",
+        "region": "israelcentral",
+        "zoneKey": "JO",
+        "status": "operational"
+    },
+    "azure-indonesiacentral": {
+        "provider": "azure",
+        "lonlat": [
+            106.827183,
+            -6.1753942
+        ],
+        "displayName": "Indonesia Central",
+        "region": "indonesiacentral",
+        "zoneKey": "ID",
+        "status": "operational"
+    },
+    "azure-southcentralindia": {
+        "provider": "azure",
+        "lonlat": [
+            78.5,
+            17.34
+        ],
+        "displayName": "India South Central",
+        "region": "southcentralindia",
+        "zoneKey": "IN-SO",
+        "status": "non operational"
+    },
+    "azure-southindia": {
+        "provider": "azure",
+        "lonlat": [
+            80.270186,
+            13.0836939
+        ],
+        "displayName": "South India",
+        "region": "southindia",
+        "zoneKey": "IN-SO",
+        "status": "operational"
+    },
+    "azure-centralindia": {
+        "provider": "azure",
+        "lonlat": [
+            75.0544541,
+            18.521428
+        ],
+        "displayName": "Central India",
+        "region": "centralindia",
+        "zoneKey": "IN-WE",
+        "status": "operational"
+    },
+    "azure-greececentral": {
+        "provider": "azure",
+        "lonlat": [
+            23.7283052,
+            37.9839412
+        ],
+        "displayName": "Greece Central",
+        "region": "greececentral",
+        "zoneKey": "GR",
+        "status": "non operational"
+    },
+    "azure-germanywestcentral": {
+        "provider": "azure",
+        "lonlat": [
+            8.6820917,
+            50.2106444
+        ],
+        "displayName": "Germany West Central",
+        "region": "germanywestcentral",
+        "zoneKey": "DE",
+        "status": "operational"
+    },
+    "azure-francecentral": {
+        "provider": "azure",
+        "lonlat": [
+            2.3514616,
+            48.8566969
+        ],
+        "displayName": "France Central",
+        "region": "francecentral",
+        "zoneKey": "FR",
+        "status": "operational"
+    },
+    "azure-finlandcentral": {
+        "provider": "azure",
+        "lonlat": [
+            24.874774,
+            60.183027
+        ],
+        "displayName": "Finland Central",
+        "region": "finlandcentral",
+        "zoneKey": "FI",
+        "status": "non operational"
+    },
+    "azure-westeurope": {
+        "provider": "azure",
+        "lonlat": [
+            7.0480821,
+            52.5001698
+        ],
+        "displayName": "West Europe",
+        "region": "westeurope",
+        "zoneKey": "DE",
+        "status": "operational"
+    },
+    "azure-northeurope": {
+        "provider": "azure",
+        "lonlat": [
+            -7.9794599,
+            52.865196
+        ],
+        "displayName": "North Europe",
+        "region": "northeurope",
+        "zoneKey": "IE",
+        "status": "operational"
+    },
+    "azure-denmarkeast": {
+        "provider": "azure",
+        "lonlat": [
+            12.580776,
+            55.664858
+        ],
+        "displayName": "Denmark East",
+        "region": "denmarkeast",
+        "zoneKey": "DK-DK2",
+        "status": "non operational"
+    },
+    "azure-chinanorth3": {
+        "provider": "azure",
+        "lonlat": [
+            116.277987,
+            42.710633
+        ],
+        "displayName": "China North 3",
+        "region": "chinanorth3",
+        "zoneKey": "CN",
+        "status": "operational"
+    },
+    "azure-chinanorth2": {
+        "provider": "azure",
+        "lonlat": [
+            118.3976563,
+            39.63107677
+        ],
+        "displayName": "China North 2",
+        "region": "chinanorth2",
+        "zoneKey": "CN",
+        "status": "operational"
+    },
+    "azure-chinanorth": {
+        "provider": "azure",
+        "lonlat": [
+            116.0912391,
+            40.5065084
+        ],
+        "displayName": "China North",
+        "region": "chinanorth",
+        "zoneKey": "CN",
+        "status": "operational"
+    },
+    "azure-chinaeast2": {
+        "provider": "azure",
+        "lonlat": [
+            119.9265137,
+            30.57015912
+        ],
+        "displayName": "China East 2",
+        "region": "chinaeast2",
+        "zoneKey": "CN",
+        "status": "operational"
+    },
+    "azure-chinaeast": {
+        "provider": "azure",
+        "lonlat": [
+            121.9692071,
+            31.2322758
+        ],
+        "displayName": "China East",
+        "region": "chinaeast",
+        "zoneKey": "CN",
+        "status": "operational"
+    },
+    "azure-chilecentral": {
+        "provider": "azure",
+        "lonlat": [
+            -70.8,
+            -33.47
+        ],
+        "displayName": "Chile Central",
+        "region": "chilecentral",
+        "zoneKey": "CL-SEN",
+        "status": "non operational"
+    },
+    "azure-canadaeast": {
+        "provider": "azure",
+        "lonlat": [
+            -71.2352226,
+            46.8259601
+        ],
+        "displayName": "Canada East",
+        "region": "canadaeast",
+        "zoneKey": "CA-QC",
+        "status": "operational"
+    },
+    "azure-canadacentral": {
+        "provider": "azure",
+        "lonlat": [
+            -79.3839347,
+            43.6534817
+        ],
+        "displayName": "Canada Central",
+        "region": "canadacentral",
+        "zoneKey": "CA-ON",
+        "status": "operational"
+    },
+    "azure-brazilsouth": {
+        "provider": "azure",
+        "lonlat": [
+            -46.66992188,
+            -23.74512587
+        ],
+        "displayName": "Brazil South",
+        "region": "brazilsouth",
+        "zoneKey": "BR-CS",
+        "status": "operational"
+    },
+    "azure-belgiumcentral": {
+        "provider": "azure",
+        "lonlat": [
+            5.06,
+            51.35
+        ],
+        "displayName": "Belgium Central",
+        "region": "belgiumcentral",
+        "zoneKey": "BE",
+        "status": "non operational"
+    },
+    "azure-austriaeast": {
+        "provider": "azure",
+        "lonlat": [
+            16.404751,
+            48.599753
+        ],
+        "displayName": "Austria East",
+        "region": "austriaeast",
+        "zoneKey": "AT",
+        "status": "non operational"
+    },
+    "azure-australiacentral": {
+        "provider": "azure",
+        "lonlat": [
+            149.1012676,
+            -35.2975906
+        ],
+        "displayName": "Australia Central",
+        "region": "australiacentral",
+        "zoneKey": "AU-NSW",
+        "status": "operational"
+    },
+    "azure-australiasoutheast": {
+        "provider": "azure",
+        "lonlat": [
+            144.9631608,
+            -37.8142176
+        ],
+        "displayName": "Australia Southeast",
+        "region": "australiasoutheast",
+        "zoneKey": "AU-VIC",
+        "status": "operational"
+    },
+    "azure-australiaeast": {
+        "provider": "azure",
+        "lonlat": [
+            146.921097,
+            -31.253218
+        ],
+        "displayName": "Australia East",
+        "region": "australiaeast",
+        "zoneKey": "AU-NSW",
+        "status": "operational"
+    },
+    "azure-southeastasia": {
+        "provider": "azure",
+        "lonlat": [
+            105.3,
+            1.13
+        ],
+        "displayName": "Southeast Asia",
+        "region": "southeastasia",
+        "zoneKey": "DK-DK2",
+        "status": "operational"
+    },
+    "azure-eastasia": {
+        "provider": "azure",
+        "lonlat": [
+            114.109497,
+            22.396427
+        ],
+        "displayName": "East Asia",
+        "region": "eastasia",
+        "zoneKey": "HK",
+        "status": "operational"
+    },
+    "azure-southafricanorth": {
+        "provider": "azure",
+        "lonlat": [
+            28.047304,
+            -26.204103
+        ],
+        "displayName": "South Africa North",
+        "region": "southafricanorth",
+        "zoneKey": "ZA",
+        "status": "operational"
+    }
 }

--- a/config/data_centers/data_centers.json
+++ b/config/data_centers/data_centers.json
@@ -112,630 +112,459 @@
     "status": "operational"
   },
   "azure-westus3": {
-        "provider": "azure",
-        "lonlat": [
-            -111.763275,
-            34.395342
-        ],
-        "displayName": "West US 3",
-        "region": "westus3",
-        "zoneKey": "US-SW-AZPS",
-        "status": "operational"
-    },
-    "azure-westus2": {
-        "provider": "azure",
-        "lonlat": [
-            -120.212613,
-            47.2868352
-        ],
-        "displayName": "West US 2",
-        "region": "westus2",
-        "zoneKey": "US-NW-BPAT",
-        "status": "operational"
-    },
-    "azure-westus": {
-        "provider": "azure",
-        "lonlat": [
-            -118.755997,
-            36.7014631
-        ],
-        "displayName": "West US",
-        "region": "westus",
-        "zoneKey": "US-CAL-CISO",
-        "status": "operational"
-    },
-    "azure-westcentralus": {
-        "provider": "azure",
-        "lonlat": [
-            -107.568534,
-            43.1700264
-        ],
-        "displayName": "West Central US",
-        "region": "westcentralus",
-        "zoneKey": "US-NW-PACE",
-        "status": "operational"
-    },
-    "azure-southcentralus": {
-        "provider": "azure",
-        "lonlat": [
-            -96.87744141,
-            29.55434513
-        ],
-        "displayName": "South Central US",
-        "region": "southcentralus",
-        "zoneKey": "US-TEX-ERCO",
-        "status": "operational"
-    },
-    "azure-northcentralus": {
-        "provider": "azure",
-        "lonlat": [
-            -89.4337288,
-            40.0796606
-        ],
-        "displayName": "North Central US",
-        "region": "northcentralus",
-        "zoneKey": "US-MIDW-MISO",
-        "status": "operational"
-    },
-    "azure-eastus3": {
-        "provider": "azure",
-        "lonlat": [
-            -83.716858,
-            32.840464
-        ],
-        "displayName": "East US 3",
-        "region": "eastus3",
-        "zoneKey": "US-SE-SOCO",
-        "status": "non operational"
-    },
-    "azure-eastus2": {
-        "provider": "azure",
-        "lonlat": [
-            -81.12304688,
-            36.66841892
-        ],
-        "displayName": "East US 2",
-        "region": "eastus2",
-        "zoneKey": "US-MIDA-PJM",
-        "status": "operational"
-    },
-    "azure-eastus": {
-        "provider": "azure",
-        "lonlat": [
-            -78.13476563,
-            38.75408328
-        ],
-        "displayName": "East US",
-        "region": "eastus",
-        "zoneKey": "US-MIDA-PJM",
-        "status": "operational"
-    },
-    "azure-centralus": {
-        "provider": "azure",
-        "lonlat": [
-            -94.55932617,
-            41.4509614
-        ],
-        "displayName": "Central US",
-        "region": "centralus",
-        "zoneKey": "US-MIDW-MISO",
-        "status": "operational"
-    },
-    "azure-ukwest": {
-        "provider": "azure",
-        "lonlat": [
-            -3.1791934,
-            51.4816546
-        ],
-        "displayName": "UK West",
-        "region": "ukwest",
-        "zoneKey": "GB",
-        "status": "operational"
-    },
-    "azure-uksouth": {
-        "provider": "azure",
-        "lonlat": [
-            -0.1276474,
-            51.5073219
-        ],
-        "displayName": "UK South",
-        "region": "uksouth",
-        "zoneKey": "GB",
-        "status": "operational"
-    },
-    "azure-uaenorth": {
-        "provider": "azure",
-        "lonlat": [
-            55.2707065,
-            25.2047397
-        ],
-        "displayName": "UAE North",
-        "region": "uaenorth",
-        "zoneKey": "AE",
-        "status": "operational"
-    },
-    "azure-taiwannorth": {
-        "provider": "azure",
-        "lonlat": [
-            121.4139,
-            25.039666
-        ],
-        "displayName": "Taiwan North",
-        "region": "taiwannorth",
-        "zoneKey": "TW",
-        "status": "non operational"
-    },
-    "azure-switzerlandnorth": {
-        "provider": "azure",
-        "lonlat": [
-            8.8410422,
-            47.2744489
-        ],
-        "displayName": "Switzerland North",
-        "region": "switzerlandnorth",
-        "zoneKey": "CH",
-        "status": "operational"
-    },
-    "azure-swedencentral": {
-        "provider": "azure",
-        "lonlat": [
-            17.138836,
-            60.667761
-        ],
-        "displayName": "Sweden Central",
-        "region": "swedencentral",
-        "zoneKey": "SE-SE3",
-        "status": "operational"
-    },
-    "azure-spaincentral": {
-        "provider": "azure",
-        "lonlat": [
-            -3.7035825,
-            40.4167047
-        ],
-        "displayName": "Spain Central",
-        "region": "spaincentral",
-        "zoneKey": "ES",
-        "status": "operational"
-    },
-    "azure-saudiarabiaeast": {
-        "provider": "azure",
-        "lonlat": [
-            46.6753,
-            24.7136
-        ],
-        "displayName": "Saudi Arabia East",
-        "region": "saudiarabiaeast",
-        "zoneKey": "SA",
-        "status": "non operational"
-    },
-    "azure-qatarcentral": {
-        "provider": "azure",
-        "lonlat": [
-            51.5264162,
-            26.2856329
-        ],
-        "displayName": "Qatar Central",
-        "region": "qatarcentral",
-        "zoneKey": "QA",
-        "status": "operational"
-    },
-    "azure-polandcentral": {
-        "provider": "azure",
-        "lonlat": [
-            21.8067249,
-            52.2319581
-        ],
-        "displayName": "Poland Central",
-        "region": "polandcentral",
-        "zoneKey": "PL",
-        "status": "operational"
-    },
-    "azure-norwayeast": {
-        "provider": "azure",
-        "lonlat": [
-            10.7389701,
-            59.9133301
-        ],
-        "displayName": "Norway East",
-        "region": "norwayeast",
-        "zoneKey": "NO-NO1",
-        "status": "operational"
-    },
-    "azure-newzealandnorth": {
-        "provider": "azure",
-        "lonlat": [
-            174.7631803,
-            -36.852095
-        ],
-        "displayName": "New Zealand North",
-        "region": "newzealandnorth",
-        "zoneKey": "NZ",
-        "status": "operational"
-    },
-    "azure-mexicocentral": {
-        "provider": "azure",
-        "lonlat": [
-            -99.84756,
-            20.8542575
-        ],
-        "displayName": "Mexico Central",
-        "region": "mexicocentral",
-        "zoneKey": "MX",
-        "status": "operational"
-    },
-    "azure-malaysiawest": {
-        "provider": "azure",
-        "lonlat": [
-            101.809256,
-            4.55035
-        ],
-        "displayName": "Malaysia West",
-        "region": "malaysiawest",
-        "zoneKey": "MY-WM",
-        "status": "non operational"
-    },
-    "azure-koreacentral": {
-        "provider": "azure",
-        "lonlat": [
-            126.9782914,
-            37.5666791
-        ],
-        "displayName": "Korea Central",
-        "region": "koreacentral",
-        "zoneKey": "KR",
-        "status": "operational"
-    },
-    "azure-japanwest": {
-        "provider": "azure",
-        "lonlat": [
-            135.490357,
-            34.6198813
-        ],
-        "displayName": "Japan West",
-        "region": "japanwest",
-        "zoneKey": "JP-KN",
-        "status": "operational"
-    },
-    "azure-japaneast": {
-        "provider": "azure",
-        "lonlat": [
-            139.7594549,
-            37.6828387
-        ],
-        "displayName": "Japan East",
-        "region": "japaneast",
-        "zoneKey": "JP-TH",
-        "status": "operational"
-    },
-    "azure-italynorth": {
-        "provider": "azure",
-        "lonlat": [
-            9.6905,
-            45.2668
-        ],
-        "displayName": "Italy North",
-        "region": "italynorth",
-        "zoneKey": "IT-NO",
-        "status": "operational"
-    },
-    "azure-israelcentral": {
-        "provider": "azure",
-        "lonlat": [
-            35.8667654,
-            31.5313113
-        ],
-        "displayName": "Israel Central",
-        "region": "israelcentral",
-        "zoneKey": "JO",
-        "status": "operational"
-    },
-    "azure-indonesiacentral": {
-        "provider": "azure",
-        "lonlat": [
-            106.827183,
-            -6.1753942
-        ],
-        "displayName": "Indonesia Central",
-        "region": "indonesiacentral",
-        "zoneKey": "ID",
-        "status": "operational"
-    },
-    "azure-southcentralindia": {
-        "provider": "azure",
-        "lonlat": [
-            78.5,
-            17.34
-        ],
-        "displayName": "India South Central",
-        "region": "southcentralindia",
-        "zoneKey": "IN-SO",
-        "status": "non operational"
-    },
-    "azure-southindia": {
-        "provider": "azure",
-        "lonlat": [
-            80.270186,
-            13.0836939
-        ],
-        "displayName": "South India",
-        "region": "southindia",
-        "zoneKey": "IN-SO",
-        "status": "operational"
-    },
-    "azure-centralindia": {
-        "provider": "azure",
-        "lonlat": [
-            75.0544541,
-            18.521428
-        ],
-        "displayName": "Central India",
-        "region": "centralindia",
-        "zoneKey": "IN-WE",
-        "status": "operational"
-    },
-    "azure-greececentral": {
-        "provider": "azure",
-        "lonlat": [
-            23.7283052,
-            37.9839412
-        ],
-        "displayName": "Greece Central",
-        "region": "greececentral",
-        "zoneKey": "GR",
-        "status": "non operational"
-    },
-    "azure-germanywestcentral": {
-        "provider": "azure",
-        "lonlat": [
-            8.6820917,
-            50.2106444
-        ],
-        "displayName": "Germany West Central",
-        "region": "germanywestcentral",
-        "zoneKey": "DE",
-        "status": "operational"
-    },
-    "azure-francecentral": {
-        "provider": "azure",
-        "lonlat": [
-            2.3514616,
-            48.8566969
-        ],
-        "displayName": "France Central",
-        "region": "francecentral",
-        "zoneKey": "FR",
-        "status": "operational"
-    },
-    "azure-finlandcentral": {
-        "provider": "azure",
-        "lonlat": [
-            24.874774,
-            60.183027
-        ],
-        "displayName": "Finland Central",
-        "region": "finlandcentral",
-        "zoneKey": "FI",
-        "status": "non operational"
-    },
-    "azure-westeurope": {
-        "provider": "azure",
-        "lonlat": [
-            7.0480821,
-            52.5001698
-        ],
-        "displayName": "West Europe",
-        "region": "westeurope",
-        "zoneKey": "DE",
-        "status": "operational"
-    },
-    "azure-northeurope": {
-        "provider": "azure",
-        "lonlat": [
-            -7.9794599,
-            52.865196
-        ],
-        "displayName": "North Europe",
-        "region": "northeurope",
-        "zoneKey": "IE",
-        "status": "operational"
-    },
-    "azure-denmarkeast": {
-        "provider": "azure",
-        "lonlat": [
-            12.580776,
-            55.664858
-        ],
-        "displayName": "Denmark East",
-        "region": "denmarkeast",
-        "zoneKey": "DK-DK2",
-        "status": "non operational"
-    },
-    "azure-chinanorth3": {
-        "provider": "azure",
-        "lonlat": [
-            116.277987,
-            42.710633
-        ],
-        "displayName": "China North 3",
-        "region": "chinanorth3",
-        "zoneKey": "CN",
-        "status": "operational"
-    },
-    "azure-chinanorth2": {
-        "provider": "azure",
-        "lonlat": [
-            118.3976563,
-            39.63107677
-        ],
-        "displayName": "China North 2",
-        "region": "chinanorth2",
-        "zoneKey": "CN",
-        "status": "operational"
-    },
-    "azure-chinanorth": {
-        "provider": "azure",
-        "lonlat": [
-            116.0912391,
-            40.5065084
-        ],
-        "displayName": "China North",
-        "region": "chinanorth",
-        "zoneKey": "CN",
-        "status": "operational"
-    },
-    "azure-chinaeast2": {
-        "provider": "azure",
-        "lonlat": [
-            119.9265137,
-            30.57015912
-        ],
-        "displayName": "China East 2",
-        "region": "chinaeast2",
-        "zoneKey": "CN",
-        "status": "operational"
-    },
-    "azure-chinaeast": {
-        "provider": "azure",
-        "lonlat": [
-            121.9692071,
-            31.2322758
-        ],
-        "displayName": "China East",
-        "region": "chinaeast",
-        "zoneKey": "CN",
-        "status": "operational"
-    },
-    "azure-chilecentral": {
-        "provider": "azure",
-        "lonlat": [
-            -70.8,
-            -33.47
-        ],
-        "displayName": "Chile Central",
-        "region": "chilecentral",
-        "zoneKey": "CL-SEN",
-        "status": "non operational"
-    },
-    "azure-canadaeast": {
-        "provider": "azure",
-        "lonlat": [
-            -71.2352226,
-            46.8259601
-        ],
-        "displayName": "Canada East",
-        "region": "canadaeast",
-        "zoneKey": "CA-QC",
-        "status": "operational"
-    },
-    "azure-canadacentral": {
-        "provider": "azure",
-        "lonlat": [
-            -79.3839347,
-            43.6534817
-        ],
-        "displayName": "Canada Central",
-        "region": "canadacentral",
-        "zoneKey": "CA-ON",
-        "status": "operational"
-    },
-    "azure-brazilsouth": {
-        "provider": "azure",
-        "lonlat": [
-            -46.66992188,
-            -23.74512587
-        ],
-        "displayName": "Brazil South",
-        "region": "brazilsouth",
-        "zoneKey": "BR-CS",
-        "status": "operational"
-    },
-    "azure-belgiumcentral": {
-        "provider": "azure",
-        "lonlat": [
-            5.06,
-            51.35
-        ],
-        "displayName": "Belgium Central",
-        "region": "belgiumcentral",
-        "zoneKey": "BE",
-        "status": "non operational"
-    },
-    "azure-austriaeast": {
-        "provider": "azure",
-        "lonlat": [
-            16.404751,
-            48.599753
-        ],
-        "displayName": "Austria East",
-        "region": "austriaeast",
-        "zoneKey": "AT",
-        "status": "non operational"
-    },
-    "azure-australiacentral": {
-        "provider": "azure",
-        "lonlat": [
-            149.1012676,
-            -35.2975906
-        ],
-        "displayName": "Australia Central",
-        "region": "australiacentral",
-        "zoneKey": "AU-NSW",
-        "status": "operational"
-    },
-    "azure-australiasoutheast": {
-        "provider": "azure",
-        "lonlat": [
-            144.9631608,
-            -37.8142176
-        ],
-        "displayName": "Australia Southeast",
-        "region": "australiasoutheast",
-        "zoneKey": "AU-VIC",
-        "status": "operational"
-    },
-    "azure-australiaeast": {
-        "provider": "azure",
-        "lonlat": [
-            146.921097,
-            -31.253218
-        ],
-        "displayName": "Australia East",
-        "region": "australiaeast",
-        "zoneKey": "AU-NSW",
-        "status": "operational"
-    },
-    "azure-southeastasia": {
-        "provider": "azure",
-        "lonlat": [
-            105.3,
-            1.13
-        ],
-        "displayName": "Southeast Asia",
-        "region": "southeastasia",
-        "zoneKey": "DK-DK2",
-        "status": "operational"
-    },
-    "azure-eastasia": {
-        "provider": "azure",
-        "lonlat": [
-            114.109497,
-            22.396427
-        ],
-        "displayName": "East Asia",
-        "region": "eastasia",
-        "zoneKey": "HK",
-        "status": "operational"
-    },
-    "azure-southafricanorth": {
-        "provider": "azure",
-        "lonlat": [
-            28.047304,
-            -26.204103
-        ],
-        "displayName": "South Africa North",
-        "region": "southafricanorth",
-        "zoneKey": "ZA",
-        "status": "operational"
-    }
+    "provider": "azure",
+    "lonlat": [-111.763275, 34.395342],
+    "displayName": "West US 3",
+    "region": "westus3",
+    "zoneKey": "US-SW-AZPS",
+    "status": "operational"
+  },
+  "azure-westus2": {
+    "provider": "azure",
+    "lonlat": [-120.212613, 47.2868352],
+    "displayName": "West US 2",
+    "region": "westus2",
+    "zoneKey": "US-NW-BPAT",
+    "status": "operational"
+  },
+  "azure-westus": {
+    "provider": "azure",
+    "lonlat": [-118.755997, 36.7014631],
+    "displayName": "West US",
+    "region": "westus",
+    "zoneKey": "US-CAL-CISO",
+    "status": "operational"
+  },
+  "azure-westcentralus": {
+    "provider": "azure",
+    "lonlat": [-107.568534, 43.1700264],
+    "displayName": "West Central US",
+    "region": "westcentralus",
+    "zoneKey": "US-NW-PACE",
+    "status": "operational"
+  },
+  "azure-southcentralus": {
+    "provider": "azure",
+    "lonlat": [-96.87744141, 29.55434513],
+    "displayName": "South Central US",
+    "region": "southcentralus",
+    "zoneKey": "US-TEX-ERCO",
+    "status": "operational"
+  },
+  "azure-northcentralus": {
+    "provider": "azure",
+    "lonlat": [-89.4337288, 40.0796606],
+    "displayName": "North Central US",
+    "region": "northcentralus",
+    "zoneKey": "US-MIDW-MISO",
+    "status": "operational"
+  },
+  "azure-eastus3": {
+    "provider": "azure",
+    "lonlat": [-83.716858, 32.840464],
+    "displayName": "East US 3",
+    "region": "eastus3",
+    "zoneKey": "US-SE-SOCO",
+    "status": "non operational"
+  },
+  "azure-eastus2": {
+    "provider": "azure",
+    "lonlat": [-81.12304688, 36.66841892],
+    "displayName": "East US 2",
+    "region": "eastus2",
+    "zoneKey": "US-MIDA-PJM",
+    "status": "operational"
+  },
+  "azure-eastus": {
+    "provider": "azure",
+    "lonlat": [-78.13476563, 38.75408328],
+    "displayName": "East US",
+    "region": "eastus",
+    "zoneKey": "US-MIDA-PJM",
+    "status": "operational"
+  },
+  "azure-centralus": {
+    "provider": "azure",
+    "lonlat": [-94.55932617, 41.4509614],
+    "displayName": "Central US",
+    "region": "centralus",
+    "zoneKey": "US-MIDW-MISO",
+    "status": "operational"
+  },
+  "azure-ukwest": {
+    "provider": "azure",
+    "lonlat": [-3.1791934, 51.4816546],
+    "displayName": "UK West",
+    "region": "ukwest",
+    "zoneKey": "GB",
+    "status": "operational"
+  },
+  "azure-uksouth": {
+    "provider": "azure",
+    "lonlat": [-0.1276474, 51.5073219],
+    "displayName": "UK South",
+    "region": "uksouth",
+    "zoneKey": "GB",
+    "status": "operational"
+  },
+  "azure-uaenorth": {
+    "provider": "azure",
+    "lonlat": [55.2707065, 25.2047397],
+    "displayName": "UAE North",
+    "region": "uaenorth",
+    "zoneKey": "AE",
+    "status": "operational"
+  },
+  "azure-taiwannorth": {
+    "provider": "azure",
+    "lonlat": [121.4139, 25.039666],
+    "displayName": "Taiwan North",
+    "region": "taiwannorth",
+    "zoneKey": "TW",
+    "status": "non operational"
+  },
+  "azure-switzerlandnorth": {
+    "provider": "azure",
+    "lonlat": [8.8410422, 47.2744489],
+    "displayName": "Switzerland North",
+    "region": "switzerlandnorth",
+    "zoneKey": "CH",
+    "status": "operational"
+  },
+  "azure-swedencentral": {
+    "provider": "azure",
+    "lonlat": [17.138836, 60.667761],
+    "displayName": "Sweden Central",
+    "region": "swedencentral",
+    "zoneKey": "SE-SE3",
+    "status": "operational"
+  },
+  "azure-spaincentral": {
+    "provider": "azure",
+    "lonlat": [-3.7035825, 40.4167047],
+    "displayName": "Spain Central",
+    "region": "spaincentral",
+    "zoneKey": "ES",
+    "status": "operational"
+  },
+  "azure-saudiarabiaeast": {
+    "provider": "azure",
+    "lonlat": [46.6753, 24.7136],
+    "displayName": "Saudi Arabia East",
+    "region": "saudiarabiaeast",
+    "zoneKey": "SA",
+    "status": "non operational"
+  },
+  "azure-qatarcentral": {
+    "provider": "azure",
+    "lonlat": [51.5264162, 26.2856329],
+    "displayName": "Qatar Central",
+    "region": "qatarcentral",
+    "zoneKey": "QA",
+    "status": "operational"
+  },
+  "azure-polandcentral": {
+    "provider": "azure",
+    "lonlat": [21.8067249, 52.2319581],
+    "displayName": "Poland Central",
+    "region": "polandcentral",
+    "zoneKey": "PL",
+    "status": "operational"
+  },
+  "azure-norwayeast": {
+    "provider": "azure",
+    "lonlat": [10.7389701, 59.9133301],
+    "displayName": "Norway East",
+    "region": "norwayeast",
+    "zoneKey": "NO-NO1",
+    "status": "operational"
+  },
+  "azure-newzealandnorth": {
+    "provider": "azure",
+    "lonlat": [174.7631803, -36.852095],
+    "displayName": "New Zealand North",
+    "region": "newzealandnorth",
+    "zoneKey": "NZ",
+    "status": "operational"
+  },
+  "azure-mexicocentral": {
+    "provider": "azure",
+    "lonlat": [-99.84756, 20.8542575],
+    "displayName": "Mexico Central",
+    "region": "mexicocentral",
+    "zoneKey": "MX",
+    "status": "operational"
+  },
+  "azure-malaysiawest": {
+    "provider": "azure",
+    "lonlat": [101.809256, 4.55035],
+    "displayName": "Malaysia West",
+    "region": "malaysiawest",
+    "zoneKey": "MY-WM",
+    "status": "non operational"
+  },
+  "azure-koreacentral": {
+    "provider": "azure",
+    "lonlat": [126.9782914, 37.5666791],
+    "displayName": "Korea Central",
+    "region": "koreacentral",
+    "zoneKey": "KR",
+    "status": "operational"
+  },
+  "azure-japanwest": {
+    "provider": "azure",
+    "lonlat": [135.490357, 34.6198813],
+    "displayName": "Japan West",
+    "region": "japanwest",
+    "zoneKey": "JP-KN",
+    "status": "operational"
+  },
+  "azure-japaneast": {
+    "provider": "azure",
+    "lonlat": [139.7594549, 37.6828387],
+    "displayName": "Japan East",
+    "region": "japaneast",
+    "zoneKey": "JP-TH",
+    "status": "operational"
+  },
+  "azure-italynorth": {
+    "provider": "azure",
+    "lonlat": [9.6905, 45.2668],
+    "displayName": "Italy North",
+    "region": "italynorth",
+    "zoneKey": "IT-NO",
+    "status": "operational"
+  },
+  "azure-israelcentral": {
+    "provider": "azure",
+    "lonlat": [35.8667654, 31.5313113],
+    "displayName": "Israel Central",
+    "region": "israelcentral",
+    "zoneKey": "JO",
+    "status": "operational"
+  },
+  "azure-indonesiacentral": {
+    "provider": "azure",
+    "lonlat": [106.827183, -6.1753942],
+    "displayName": "Indonesia Central",
+    "region": "indonesiacentral",
+    "zoneKey": "ID",
+    "status": "operational"
+  },
+  "azure-southcentralindia": {
+    "provider": "azure",
+    "lonlat": [78.5, 17.34],
+    "displayName": "India South Central",
+    "region": "southcentralindia",
+    "zoneKey": "IN-SO",
+    "status": "non operational"
+  },
+  "azure-southindia": {
+    "provider": "azure",
+    "lonlat": [80.270186, 13.0836939],
+    "displayName": "South India",
+    "region": "southindia",
+    "zoneKey": "IN-SO",
+    "status": "operational"
+  },
+  "azure-centralindia": {
+    "provider": "azure",
+    "lonlat": [75.0544541, 18.521428],
+    "displayName": "Central India",
+    "region": "centralindia",
+    "zoneKey": "IN-WE",
+    "status": "operational"
+  },
+  "azure-greececentral": {
+    "provider": "azure",
+    "lonlat": [23.7283052, 37.9839412],
+    "displayName": "Greece Central",
+    "region": "greececentral",
+    "zoneKey": "GR",
+    "status": "non operational"
+  },
+  "azure-germanywestcentral": {
+    "provider": "azure",
+    "lonlat": [8.6820917, 50.2106444],
+    "displayName": "Germany West Central",
+    "region": "germanywestcentral",
+    "zoneKey": "DE",
+    "status": "operational"
+  },
+  "azure-francecentral": {
+    "provider": "azure",
+    "lonlat": [2.3514616, 48.8566969],
+    "displayName": "France Central",
+    "region": "francecentral",
+    "zoneKey": "FR",
+    "status": "operational"
+  },
+  "azure-finlandcentral": {
+    "provider": "azure",
+    "lonlat": [24.874774, 60.183027],
+    "displayName": "Finland Central",
+    "region": "finlandcentral",
+    "zoneKey": "FI",
+    "status": "non operational"
+  },
+  "azure-westeurope": {
+    "provider": "azure",
+    "lonlat": [7.0480821, 52.5001698],
+    "displayName": "West Europe",
+    "region": "westeurope",
+    "zoneKey": "DE",
+    "status": "operational"
+  },
+  "azure-northeurope": {
+    "provider": "azure",
+    "lonlat": [-7.9794599, 52.865196],
+    "displayName": "North Europe",
+    "region": "northeurope",
+    "zoneKey": "IE",
+    "status": "operational"
+  },
+  "azure-denmarkeast": {
+    "provider": "azure",
+    "lonlat": [12.580776, 55.664858],
+    "displayName": "Denmark East",
+    "region": "denmarkeast",
+    "zoneKey": "DK-DK2",
+    "status": "non operational"
+  },
+  "azure-chinanorth3": {
+    "provider": "azure",
+    "lonlat": [116.277987, 42.710633],
+    "displayName": "China North 3",
+    "region": "chinanorth3",
+    "zoneKey": "CN",
+    "status": "operational"
+  },
+  "azure-chinanorth2": {
+    "provider": "azure",
+    "lonlat": [118.3976563, 39.63107677],
+    "displayName": "China North 2",
+    "region": "chinanorth2",
+    "zoneKey": "CN",
+    "status": "operational"
+  },
+  "azure-chinanorth": {
+    "provider": "azure",
+    "lonlat": [116.0912391, 40.5065084],
+    "displayName": "China North",
+    "region": "chinanorth",
+    "zoneKey": "CN",
+    "status": "operational"
+  },
+  "azure-chinaeast2": {
+    "provider": "azure",
+    "lonlat": [119.9265137, 30.57015912],
+    "displayName": "China East 2",
+    "region": "chinaeast2",
+    "zoneKey": "CN",
+    "status": "operational"
+  },
+  "azure-chinaeast": {
+    "provider": "azure",
+    "lonlat": [121.9692071, 31.2322758],
+    "displayName": "China East",
+    "region": "chinaeast",
+    "zoneKey": "CN",
+    "status": "operational"
+  },
+  "azure-chilecentral": {
+    "provider": "azure",
+    "lonlat": [-70.8, -33.47],
+    "displayName": "Chile Central",
+    "region": "chilecentral",
+    "zoneKey": "CL-SEN",
+    "status": "non operational"
+  },
+  "azure-canadaeast": {
+    "provider": "azure",
+    "lonlat": [-71.2352226, 46.8259601],
+    "displayName": "Canada East",
+    "region": "canadaeast",
+    "zoneKey": "CA-QC",
+    "status": "operational"
+  },
+  "azure-canadacentral": {
+    "provider": "azure",
+    "lonlat": [-79.3839347, 43.6534817],
+    "displayName": "Canada Central",
+    "region": "canadacentral",
+    "zoneKey": "CA-ON",
+    "status": "operational"
+  },
+  "azure-brazilsouth": {
+    "provider": "azure",
+    "lonlat": [-46.66992188, -23.74512587],
+    "displayName": "Brazil South",
+    "region": "brazilsouth",
+    "zoneKey": "BR-CS",
+    "status": "operational"
+  },
+  "azure-belgiumcentral": {
+    "provider": "azure",
+    "lonlat": [5.06, 51.35],
+    "displayName": "Belgium Central",
+    "region": "belgiumcentral",
+    "zoneKey": "BE",
+    "status": "non operational"
+  },
+  "azure-austriaeast": {
+    "provider": "azure",
+    "lonlat": [16.404751, 48.599753],
+    "displayName": "Austria East",
+    "region": "austriaeast",
+    "zoneKey": "AT",
+    "status": "non operational"
+  },
+  "azure-australiacentral": {
+    "provider": "azure",
+    "lonlat": [149.1012676, -35.2975906],
+    "displayName": "Australia Central",
+    "region": "australiacentral",
+    "zoneKey": "AU-NSW",
+    "status": "operational"
+  },
+  "azure-australiasoutheast": {
+    "provider": "azure",
+    "lonlat": [144.9631608, -37.8142176],
+    "displayName": "Australia Southeast",
+    "region": "australiasoutheast",
+    "zoneKey": "AU-VIC",
+    "status": "operational"
+  },
+  "azure-australiaeast": {
+    "provider": "azure",
+    "lonlat": [146.921097, -31.253218],
+    "displayName": "Australia East",
+    "region": "australiaeast",
+    "zoneKey": "AU-NSW",
+    "status": "operational"
+  },
+  "azure-southeastasia": {
+    "provider": "azure",
+    "lonlat": [105.3, 1.13],
+    "displayName": "Southeast Asia",
+    "region": "southeastasia",
+    "zoneKey": "DK-DK2",
+    "status": "operational"
+  },
+  "azure-eastasia": {
+    "provider": "azure",
+    "lonlat": [114.109497, 22.396427],
+    "displayName": "East Asia",
+    "region": "eastasia",
+    "zoneKey": "HK",
+    "status": "operational"
+  },
+  "azure-southafricanorth": {
+    "provider": "azure",
+    "lonlat": [28.047304, -26.204103],
+    "displayName": "South Africa North",
+    "region": "southafricanorth",
+    "zoneKey": "ZA",
+    "status": "operational"
+  }
 }

--- a/config/data_centers/data_centers.json
+++ b/config/data_centers/data_centers.json
@@ -1,7 +1,7 @@
 {
   "gcp-us-central1": {
     "provider": "gcp",
-    "lonlat": [41.1755951, -95.8028031],
+    "lonlat": [-95.8028031, 41.1755951],
     "displayName": "Southlands Campus  (us-central1)",
     "region": "us-central1",
     "zoneKey": "US-CENT-SWPP",
@@ -9,7 +9,7 @@
   },
   "gcp-us-east1": {
     "provider": "gcp",
-    "lonlat": [33.105486, -80.088472],
+    "lonlat": [-80.088472, 33.105486],
     "displayName": "Berkeley County  (us-east1)",
     "region": "us-east1",
     "zoneKey": "US-CAR-SCEG",
@@ -17,7 +17,7 @@
   },
   "gcp-us-west1": {
     "provider": "gcp",
-    "lonlat": [45.6317898, -121.2009427],
+    "lonlat": [-121.2009427, 45.6317898],
     "displayName": "The Dalles  (us-west1)",
     "region": "us-west1",
     "zoneKey": "US-NW-PACW",
@@ -25,7 +25,7 @@
   },
   "gcp-northamerica-northeast2": {
     "provider": "gcp",
-    "lonlat": [41.0233277, -85.0337392],
+    "lonlat": [-85.0337392, 41.0233277],
     "displayName": "Fort Wayne Campus  (northamerica-northeast2)",
     "region": "northamerica-northeast2",
     "zoneKey": "US-MIDA-PJM",
@@ -33,7 +33,7 @@
   },
   "gcp-us-east4": {
     "provider": "gcp",
-    "lonlat": [39.7261137, -82.6833958],
+    "lonlat": [-82.6833958, 39.7261137],
     "displayName": "Lancaster Data Center  (us-east4)",
     "region": "us-east4",
     "zoneKey": "US-MIDA-PJM",
@@ -41,7 +41,7 @@
   },
   "gcp-europe-west1": {
     "provider": "gcp",
-    "lonlat": [50.4663049, 3.8580813],
+    "lonlat": [3.8580813, 50.4663049],
     "displayName": "St Ghislain  (europe-west1)",
     "region": "europe-west1",
     "zoneKey": "BE",
@@ -49,7 +49,7 @@
   },
   "gcp-us-west2": {
     "provider": "gcp",
-    "lonlat": [33.3504314, -111.6706104],
+    "lonlat": [-111.6706104, 33.3504314],
     "displayName": "Mesa Campus  (us-west2)",
     "region": "us-west2",
     "zoneKey": "US-SW-SRP",
@@ -57,7 +57,7 @@
   },
   "gcp-europe-west4": {
     "provider": "gcp",
-    "lonlat": [52.7954802, 5.0421531],
+    "lonlat": [5.0421531, 52.7954802],
     "displayName": "Middenmeer  (europe-west4)",
     "region": "europe-west4",
     "zoneKey": "NL",
@@ -65,7 +65,7 @@
   },
   "gcp-southamerica-west1": {
     "provider": "gcp",
-    "lonlat": [-33.3584722, -70.6973317],
+    "lonlat": [-70.6973317, -33.3584722],
     "displayName": "Quilicura  (southamerica-west1)",
     "region": "southamerica-west1",
     "zoneKey": "CL-SEN",
@@ -73,7 +73,7 @@
   },
   "gcp-asia-northeast1": {
     "provider": "gcp",
-    "lonlat": [35.6420573, 140.1144645],
+    "lonlat": [140.1144645, 35.6420573],
     "displayName": "Inzai  (asia-northeast1)",
     "region": "asia-northeast1",
     "zoneKey": "JP-TK",
@@ -81,7 +81,7 @@
   },
   "gcp-europe-north1": {
     "provider": "gcp",
-    "lonlat": [60.53985, 27.125318],
+    "lonlat": [27.125318, 60.53985],
     "displayName": "Hamina Finland Data Center  (europe-north1)",
     "region": "europe-north1",
     "zoneKey": "FI",
@@ -89,7 +89,7 @@
   },
   "gcp-asia-southeast1": {
     "provider": "gcp",
-    "lonlat": [1.3512738, 103.7095924],
+    "lonlat": [103.7095924, 1.3512738],
     "displayName": "Jurong West Campus  (asia-southeast1)",
     "region": "asia-southeast1",
     "zoneKey": "SG",
@@ -97,7 +97,7 @@
   },
   "gcp-asia-east1": {
     "provider": "gcp",
-    "lonlat": [24.1404245, 120.4268396],
+    "lonlat": [120.4268396, 24.1404245],
     "displayName": "Changhua Taiwan Data Center  (asia-east1)",
     "region": "asia-east1",
     "zoneKey": "TW",
@@ -105,7 +105,7 @@
   },
   "gcp-europe-west3": {
     "provider": "gcp",
-    "lonlat": [50.1239022, 8.9713297],
+    "lonlat": [8.9713297, 50.1239022],
     "displayName": "Hanau Data Center  (europe-west3)",
     "region": "europe-west3",
     "zoneKey": "DE",

--- a/config/data_centers/data_centers.json
+++ b/config/data_centers/data_centers.json
@@ -2,127 +2,63 @@
   "gcp-us-central1": {
     "provider": "gcp",
     "lonlat": [41.1755951, -95.8028031],
-    "displayName": "Southlands Campus (us-central1)",
+    "displayName": "Southlands Campus  (us-central1)",
     "region": "us-central1",
-    "zoneKey": "US-CENT-SWPP",
-    "status": "operational"
-  },
-  "gcp-us-central2": {
-    "provider": "gcp",
-    "lonlat": [36.6205022, -87.2619951],
-    "displayName": "Montgomery County (us-central2)",
-    "region": "us-central2",
-    "zoneKey": "US-TEN-TVA",
-    "status": "operational"
-  },
-  "gcp-us-west1": {
-    "provider": "gcp",
-    "lonlat": [45.6317898, -121.2009427],
-    "displayName": "The Dalles (us-west1)",
-    "region": "us-west1",
-    "zoneKey": "US-NW-PACW",
-    "status": "operational"
-  },
-  "gcp-us-east5": {
-    "provider": "gcp",
-    "lonlat": [39.7261137, -82.6833958],
-    "displayName": "Lancaster Data Center (us-east5)",
-    "region": "us-east5",
-    "zoneKey": "US-MIDA-PJM",
-    "status": "operational"
-  },
-  "gcp-us-south1": {
-    "provider": "gcp",
-    "lonlat": [32.442994, -97.048836],
-    "displayName": "Midlothian (us-south1)",
-    "region": "us-south1",
-    "zoneKey": "US-TEX-ERCO",
-    "status": "operational"
-  },
-  "gcp-us-central3": {
-    "provider": "gcp",
-    "lonlat": [41.1332915, -96.144178],
-    "displayName": "Papillion (us-central3)",
-    "region": "us-central3",
     "zoneKey": "US-CENT-SWPP",
     "status": "operational"
   },
   "gcp-us-east1": {
     "provider": "gcp",
-    "lonlat": [33.7761155, -84.5629011],
-    "displayName": "Douglas County (us-east1)",
+    "lonlat": [33.105486, -80.088472],
+    "displayName": "Berkeley County  (us-east1)",
     "region": "us-east1",
-    "zoneKey": "US-SE-SOCO",
+    "zoneKey": "US-CAR-SCEG",
+    "status": "operational"
+  },
+  "gcp-us-west1": {
+    "provider": "gcp",
+    "lonlat": [45.6317898, -121.2009427],
+    "displayName": "The Dalles  (us-west1)",
+    "region": "us-west1",
+    "zoneKey": "US-NW-PACW",
+    "status": "operational"
+  },
+  "gcp-northamerica-northeast2": {
+    "provider": "gcp",
+    "lonlat": [41.0233277, -85.0337392],
+    "displayName": "Fort Wayne Campus  (northamerica-northeast2)",
+    "region": "northamerica-northeast2",
+    "zoneKey": "US-MIDA-PJM",
     "status": "operational"
   },
   "gcp-us-east4": {
     "provider": "gcp",
-    "lonlat": [38.9430159, -77.5242442],
-    "displayName": "Arcola Campus (us-east4)",
+    "lonlat": [39.7261137, -82.6833958],
+    "displayName": "Lancaster Data Center  (us-east4)",
     "region": "us-east4",
     "zoneKey": "US-MIDA-PJM",
     "status": "operational"
   },
   "gcp-europe-west1": {
     "provider": "gcp",
-    "lonlat": [53.313637, -6.4474062],
-    "displayName": "Dublin Campus (europe-west1)",
+    "lonlat": [50.4663049, 3.8580813],
+    "displayName": "St Ghislain  (europe-west1)",
     "region": "europe-west1",
-    "zoneKey": "IE",
+    "zoneKey": "BE",
     "status": "operational"
   },
-  "gcp-us-east2": {
+  "gcp-us-west2": {
     "provider": "gcp",
-    "lonlat": [34.9204032, -85.7449262],
-    "displayName": "Jackson County (us-east2)",
-    "region": "us-east2",
-    "zoneKey": "US-TEN-TVA",
-    "status": "operational"
-  },
-  "gcp-us-east3": {
-    "provider": "gcp",
-    "lonlat": [35.898352, -81.547544],
-    "displayName": "Lenoir (us-east3)",
-    "region": "us-east3",
-    "zoneKey": "US-CAR-DUK",
-    "status": "operational"
-  },
-  "gcp-europe-west3": {
-    "provider": "gcp",
-    "lonlat": [50.1239022, 8.9713297],
-    "displayName": "Hanau Data Center (europe-west3)",
-    "region": "europe-west3",
-    "zoneKey": "DE",
-    "status": "operational"
-  },
-  "gcp-us-west3": {
-    "provider": "gcp",
-    "lonlat": [36.0561599, -115.009056],
-    "displayName": "Henderson (us-west3)",
-    "region": "us-west3",
-    "zoneKey": "US-NW-NEVP",
-    "status": "operational"
-  },
-  "gcp-us-east6": {
-    "provider": "gcp",
-    "lonlat": [33.105486, -80.088472],
-    "displayName": "Berkeley County (us-east6)",
-    "region": "us-east6",
-    "zoneKey": "US-CAR-SCEG",
-    "status": "operational"
-  },
-  "gcp-europe-north1": {
-    "provider": "gcp",
-    "lonlat": [55.5582552, 9.6560132],
-    "displayName": "Fredericia (europe-north1)",
-    "region": "europe-north1",
-    "zoneKey": "DK-DK1",
+    "lonlat": [33.3504314, -111.6706104],
+    "displayName": "Mesa Campus  (us-west2)",
+    "region": "us-west2",
+    "zoneKey": "US-SW-SRP",
     "status": "operational"
   },
   "gcp-europe-west4": {
     "provider": "gcp",
     "lonlat": [52.7954802, 5.0421531],
-    "displayName": "Middenmeer (europe-west4)",
+    "displayName": "Middenmeer  (europe-west4)",
     "region": "europe-west4",
     "zoneKey": "NL",
     "status": "operational"
@@ -130,7 +66,7 @@
   "gcp-southamerica-west1": {
     "provider": "gcp",
     "lonlat": [-33.3584722, -70.6973317],
-    "displayName": "Quilicura (southamerica-west1)",
+    "displayName": "Quilicura  (southamerica-west1)",
     "region": "southamerica-west1",
     "zoneKey": "CL-SEN",
     "status": "operational"
@@ -138,65 +74,41 @@
   "gcp-asia-northeast1": {
     "provider": "gcp",
     "lonlat": [35.6420573, 140.1144645],
-    "displayName": "Inzai (asia-northeast1)",
+    "displayName": "Inzai  (asia-northeast1)",
     "region": "asia-northeast1",
     "zoneKey": "JP-TK",
     "status": "operational"
   },
-  "gcp-europe-north2": {
+  "gcp-europe-north1": {
     "provider": "gcp",
     "lonlat": [60.53985, 27.125318],
-    "displayName": "Hamina Finland Data Center (europe-north2)",
-    "region": "europe-north2",
+    "displayName": "Hamina Finland Data Center  (europe-north1)",
+    "region": "europe-north1",
     "zoneKey": "FI",
     "status": "operational"
   },
   "gcp-asia-southeast1": {
     "provider": "gcp",
     "lonlat": [1.3512738, 103.7095924],
-    "displayName": "Jurong West Campus (asia-southeast1)",
+    "displayName": "Jurong West Campus  (asia-southeast1)",
     "region": "asia-southeast1",
     "zoneKey": "SG",
-    "status": "operational"
-  },
-  "gcp-us-west2": {
-    "provider": "gcp",
-    "lonlat": [39.5349112, -119.7526886],
-    "displayName": "Storey County (us-west2)",
-    "region": "us-west2",
-    "zoneKey": "US-NW-PACW",
-    "status": "operational"
-  },
-  "gcp-us-east7": {
-    "provider": "gcp",
-    "lonlat": [40.7411092, -74.0022032],
-    "displayName": "111 Eight Avenue (us-east7)",
-    "region": "us-east7",
-    "zoneKey": "US-NY-NYIS",
     "status": "operational"
   },
   "gcp-asia-east1": {
     "provider": "gcp",
     "lonlat": [24.1404245, 120.4268396],
-    "displayName": "Changhua Taiwan Data Center (asia-east1)",
+    "displayName": "Changhua Taiwan Data Center  (asia-east1)",
     "region": "asia-east1",
     "zoneKey": "TW",
     "status": "operational"
   },
-  "gcp-us-west4": {
+  "gcp-europe-west3": {
     "provider": "gcp",
-    "lonlat": [33.3504314, -111.6706104],
-    "displayName": "Mesa Campus (us-west4)",
-    "region": "us-west4",
-    "zoneKey": "US-SW-SRP",
-    "status": "operational"
-  },
-  "gcp-us-east8": {
-    "provider": "gcp",
-    "lonlat": [41.0233277, -85.0337392],
-    "displayName": "Fort Wayne Campus (us-east8)",
-    "region": "us-east8",
-    "zoneKey": "US-MIDA-PJM",
+    "lonlat": [50.1239022, 8.9713297],
+    "displayName": "Hanau Data Center  (europe-west3)",
+    "region": "europe-west3",
+    "zoneKey": "DE",
     "status": "operational"
   }
 }

--- a/config/data_centers/data_centers.json
+++ b/config/data_centers/data_centers.json
@@ -2,7 +2,7 @@
   "gcp-us-central1": {
     "provider": "gcp",
     "lonlat": [-95.8028031, 41.1755951],
-    "displayName": "Southlands Campus  (us-central1)",
+    "displayName": "Southlands Campus (us-central1)",
     "region": "us-central1",
     "zoneKey": "US-CENT-SWPP",
     "status": "operational"
@@ -10,7 +10,7 @@
   "gcp-us-east1": {
     "provider": "gcp",
     "lonlat": [-80.088472, 33.105486],
-    "displayName": "Berkeley County  (us-east1)",
+    "displayName": "Berkeley County (us-east1)",
     "region": "us-east1",
     "zoneKey": "US-CAR-SCEG",
     "status": "operational"
@@ -18,7 +18,7 @@
   "gcp-us-west1": {
     "provider": "gcp",
     "lonlat": [-121.2009427, 45.6317898],
-    "displayName": "The Dalles  (us-west1)",
+    "displayName": "The Dalles (us-west1)",
     "region": "us-west1",
     "zoneKey": "US-NW-PACW",
     "status": "operational"
@@ -26,7 +26,7 @@
   "gcp-northamerica-northeast2": {
     "provider": "gcp",
     "lonlat": [-85.0337392, 41.0233277],
-    "displayName": "Fort Wayne Campus  (northamerica-northeast2)",
+    "displayName": "Fort Wayne Campus (northamerica-northeast2)",
     "region": "northamerica-northeast2",
     "zoneKey": "US-MIDA-PJM",
     "status": "operational"
@@ -34,7 +34,7 @@
   "gcp-us-east4": {
     "provider": "gcp",
     "lonlat": [-82.6833958, 39.7261137],
-    "displayName": "Lancaster Data Center  (us-east4)",
+    "displayName": "Lancaster Data Center (us-east4)",
     "region": "us-east4",
     "zoneKey": "US-MIDA-PJM",
     "status": "operational"
@@ -42,7 +42,7 @@
   "gcp-europe-west1": {
     "provider": "gcp",
     "lonlat": [3.8580813, 50.4663049],
-    "displayName": "St Ghislain  (europe-west1)",
+    "displayName": "St Ghislain (europe-west1)",
     "region": "europe-west1",
     "zoneKey": "BE",
     "status": "operational"
@@ -50,7 +50,7 @@
   "gcp-us-west2": {
     "provider": "gcp",
     "lonlat": [-111.6706104, 33.3504314],
-    "displayName": "Mesa Campus  (us-west2)",
+    "displayName": "Mesa Campus (us-west2)",
     "region": "us-west2",
     "zoneKey": "US-SW-SRP",
     "status": "operational"
@@ -58,7 +58,7 @@
   "gcp-europe-west4": {
     "provider": "gcp",
     "lonlat": [5.0421531, 52.7954802],
-    "displayName": "Middenmeer  (europe-west4)",
+    "displayName": "Middenmeer (europe-west4)",
     "region": "europe-west4",
     "zoneKey": "NL",
     "status": "operational"
@@ -66,7 +66,7 @@
   "gcp-southamerica-west1": {
     "provider": "gcp",
     "lonlat": [-70.6973317, -33.3584722],
-    "displayName": "Quilicura  (southamerica-west1)",
+    "displayName": "Quilicura (southamerica-west1)",
     "region": "southamerica-west1",
     "zoneKey": "CL-SEN",
     "status": "operational"
@@ -74,7 +74,7 @@
   "gcp-asia-northeast1": {
     "provider": "gcp",
     "lonlat": [140.1144645, 35.6420573],
-    "displayName": "Inzai  (asia-northeast1)",
+    "displayName": "Inzai (asia-northeast1)",
     "region": "asia-northeast1",
     "zoneKey": "JP-TK",
     "status": "operational"
@@ -82,7 +82,7 @@
   "gcp-europe-north1": {
     "provider": "gcp",
     "lonlat": [27.125318, 60.53985],
-    "displayName": "Hamina Finland Data Center  (europe-north1)",
+    "displayName": "Hamina Finland Data Center (europe-north1)",
     "region": "europe-north1",
     "zoneKey": "FI",
     "status": "operational"
@@ -90,7 +90,7 @@
   "gcp-asia-southeast1": {
     "provider": "gcp",
     "lonlat": [103.7095924, 1.3512738],
-    "displayName": "Jurong West Campus  (asia-southeast1)",
+    "displayName": "Jurong West Campus (asia-southeast1)",
     "region": "asia-southeast1",
     "zoneKey": "SG",
     "status": "operational"
@@ -98,7 +98,7 @@
   "gcp-asia-east1": {
     "provider": "gcp",
     "lonlat": [120.4268396, 24.1404245],
-    "displayName": "Changhua Taiwan Data Center  (asia-east1)",
+    "displayName": "Changhua Taiwan Data Center (asia-east1)",
     "region": "asia-east1",
     "zoneKey": "TW",
     "status": "operational"
@@ -106,7 +106,7 @@
   "gcp-europe-west3": {
     "provider": "gcp",
     "lonlat": [8.9713297, 50.1239022],
-    "displayName": "Hanau Data Center  (europe-west3)",
+    "displayName": "Hanau Data Center (europe-west3)",
     "region": "europe-west3",
     "zoneKey": "DE",
     "status": "operational"

--- a/config/data_centers/data_centers.json
+++ b/config/data_centers/data_centers.json
@@ -159,14 +159,6 @@
     "zoneKey": "US-MIDW-MISO",
     "status": "operational"
   },
-  "azure-eastus3": {
-    "provider": "azure",
-    "lonlat": [-83.716858, 32.840464],
-    "displayName": "East US 3",
-    "region": "East US 3",
-    "zoneKey": "US-SE-SOCO",
-    "status": "non operational"
-  },
   "azure-eastus2": {
     "provider": "azure",
     "lonlat": [-81.12304688, 36.66841892],
@@ -215,14 +207,6 @@
     "zoneKey": "AE",
     "status": "operational"
   },
-  "azure-taiwannorth": {
-    "provider": "azure",
-    "lonlat": [121.4139, 25.039666],
-    "displayName": "Taiwan North",
-    "region": "Taiwan North",
-    "zoneKey": "TW",
-    "status": "non operational"
-  },
   "azure-switzerlandnorth": {
     "provider": "azure",
     "lonlat": [8.8410422, 47.2744489],
@@ -246,14 +230,6 @@
     "region": "Spain Central",
     "zoneKey": "ES",
     "status": "operational"
-  },
-  "azure-saudiarabiaeast": {
-    "provider": "azure",
-    "lonlat": [46.6753, 24.7136],
-    "displayName": "Saudi Arabia East",
-    "region": "Saudi Arabia East",
-    "zoneKey": "SA",
-    "status": "non operational"
   },
   "azure-qatarcentral": {
     "provider": "azure",
@@ -294,14 +270,6 @@
     "region": "Mexico Central",
     "zoneKey": "MX",
     "status": "operational"
-  },
-  "azure-malaysiawest": {
-    "provider": "azure",
-    "lonlat": [101.809256, 4.55035],
-    "displayName": "Malaysia West",
-    "region": "Malaysia West",
-    "zoneKey": "MY-WM",
-    "status": "non operational"
   },
   "azure-koreacentral": {
     "provider": "azure",
@@ -351,14 +319,6 @@
     "zoneKey": "ID",
     "status": "operational"
   },
-  "azure-southcentralindia": {
-    "provider": "azure",
-    "lonlat": [78.5, 17.34],
-    "displayName": "India South Central",
-    "region": "India South Central",
-    "zoneKey": "IN-SO",
-    "status": "non operational"
-  },
   "azure-southindia": {
     "provider": "azure",
     "lonlat": [80.270186, 13.0836939],
@@ -374,14 +334,6 @@
     "region": "Central India",
     "zoneKey": "IN-WE",
     "status": "operational"
-  },
-  "azure-greececentral": {
-    "provider": "azure",
-    "lonlat": [23.7283052, 37.9839412],
-    "displayName": "Greece Central",
-    "region": "Greece Central",
-    "zoneKey": "GR",
-    "status": "non operational"
   },
   "azure-germanywestcentral": {
     "provider": "azure",
@@ -399,14 +351,6 @@
     "zoneKey": "FR",
     "status": "operational"
   },
-  "azure-finlandcentral": {
-    "provider": "azure",
-    "lonlat": [24.874774, 60.183027],
-    "displayName": "Finland Central",
-    "region": "Finland Central",
-    "zoneKey": "FI",
-    "status": "non operational"
-  },
   "azure-westeurope": {
     "provider": "azure",
     "lonlat": [7.0480821, 52.5001698],
@@ -422,14 +366,6 @@
     "region": "North Europe",
     "zoneKey": "IE",
     "status": "operational"
-  },
-  "azure-denmarkeast": {
-    "provider": "azure",
-    "lonlat": [12.580776, 55.664858],
-    "displayName": "Denmark East",
-    "region": "Denmark East",
-    "zoneKey": "DK-DK2",
-    "status": "non operational"
   },
   "azure-chinanorth3": {
     "provider": "azure",
@@ -471,14 +407,6 @@
     "zoneKey": "CN",
     "status": "operational"
   },
-  "azure-chilecentral": {
-    "provider": "azure",
-    "lonlat": [-70.8, -33.47],
-    "displayName": "Chile Central",
-    "region": "Chile Central",
-    "zoneKey": "CL-SEN",
-    "status": "non operational"
-  },
   "azure-canadaeast": {
     "provider": "azure",
     "lonlat": [-71.2352226, 46.8259601],
@@ -502,22 +430,6 @@
     "region": "Brazil South",
     "zoneKey": "BR-CS",
     "status": "operational"
-  },
-  "azure-belgiumcentral": {
-    "provider": "azure",
-    "lonlat": [5.06, 51.35],
-    "displayName": "Belgium Central",
-    "region": "Belgium Central",
-    "zoneKey": "BE",
-    "status": "non operational"
-  },
-  "azure-austriaeast": {
-    "provider": "azure",
-    "lonlat": [16.404751, 48.599753],
-    "displayName": "Austria East",
-    "region": "Austria East",
-    "zoneKey": "AT",
-    "status": "non operational"
   },
   "azure-australiacentral": {
     "provider": "azure",


### PR DESCRIPTION
## Issue

There were too many data centers that we found for Google that did not correspond to any of the available gcp regions. We also did not have any regions for Azure.

## Description
We clean up gcp regions to only those available from gcp data source. 
We include azure regions that are operating. 

### Double check

- [ ] I have tested my parser changes locally with `poetry run test_parser "zone_key"`
- [x] I have run `pnpx prettier@2 --write .` and `poetry run format` in the top level directory to format my changes.
