### PR TITLE
fix: display response status code from noga-iso fetch

### DIFF
--- a/parsers/IL.py
+++ b/parsers/IL.py
@@ -112,7 +112,7 @@ def fetch_noga_iso_data(session: Session, logger: Logger):
     if not response.ok:
         logger.warning(
             "IL.py",
-            "Failed to fetch data from www.noga-iso.co.il with error: {response.status_code}",
+            f"Failed to fetch data from www.noga-iso.co.il with error: {response.status_code}",
         )
 
     data = response.json()


### PR DESCRIPTION
## Issue


## Description
This small PR evalautes and displays the response status code from `noga-iso` fetch.
### Preview


### Double check

- [x] I have tested my parser changes locally with `poetry run test_parser "zone_key"`
- [x] I have run `pnpx prettier@2 --write .` and `poetry run format` in the top level directory to format my changes.
