### PR TITLE
feat(parsers): add demand data for GB Elexon

### DIFF
--- a/config/zones/GB.yaml
+++ b/config/zones/GB.yaml
@@ -404,7 +404,7 @@ fallbackZoneMixes:
         unknown: 0.01229548242156918
         wind: 0.324336935214777
 parsers:
-  consumption: ENTSOE.fetch_consumption
+  consumption: ELEXON.fetch_consumption
   consumptionForecast: ENTSOE.fetch_consumption_forecast
   generationForecast: ENTSOE.fetch_generation_forecast
   price: NORDPOOL.fetch_price

--- a/parsers/ELEXON.py
+++ b/parsers/ELEXON.py
@@ -37,7 +37,7 @@ ELEXON_URLS = {
     "balancing": "/".join((ELEXON_API_ENDPOINT, "balancing/physical")),
     "actual_load": "/".join(
         (ELEXON_API_ENDPOINT, "datasets/ATL/stream")
-    ),  # B0610 - Actual Total Load
+    ),  # B0610 - Actual Total Load https://bmrs.elexon.co.uk/api-documentation/endpoint/datasets/ATL
 }
 ELEXON_START_DATE = datetime(
     2019, 1, 1, tzinfo=timezone.utc

--- a/parsers/ELEXON.py
+++ b/parsers/ELEXON.py
@@ -20,8 +20,9 @@ from requests import Response, Session
 from electricitymap.contrib.lib.models.event_lists import (
     ExchangeList,
     ProductionBreakdownList,
+    TotalConsumptionList,
 )
-from electricitymap.contrib.lib.models.events import ProductionMix, StorageMix
+from electricitymap.contrib.lib.models.events import ProductionMix, StorageMix, TotalConsumption
 from electricitymap.contrib.lib.types import ZoneKey
 from parsers.lib.config import refetch_frequency
 from parsers.lib.exceptions import ParserException
@@ -31,6 +32,7 @@ ELEXON_URLS = {
     "production_fuelhh": "/".join((ELEXON_API_ENDPOINT, "datasets/FUELINST/stream")),
     "exchange": "/".join((ELEXON_API_ENDPOINT, "generation/outturn/interconnectors")),
     "balancing": "/".join((ELEXON_API_ENDPOINT, "balancing/physical")),
+    "actual_load": "/".join((ELEXON_API_ENDPOINT, "datasets/ATL/stream")),  # B0610 - Actual Total Load
 }
 ELEXON_START_DATE = datetime(
     2019, 1, 1, tzinfo=timezone.utc
@@ -405,6 +407,65 @@ def query_exchange(
             all_exchanges.append(exchange_list)
     return ExchangeList.merge_exchanges(all_exchanges, logger)
 
+def query_actual_demand(
+    session: Session, target_datetime: datetime, logger: Logger
+) -> list[dict[str, Any]]:
+    """Fetches actual electrical demand data from the ATL (Actual Total Load) endpoint."""
+    params = {
+        "publishDateTimeFrom": (target_datetime - timedelta(days=1)).strftime("%Y-%m-%dT%H:%M:%SZ"),
+        "publishDateTimeTo": target_datetime.strftime("%Y-%m-%dT%H:%M:%SZ"),
+        "format": "json",
+    }
+
+    demand_data = query_elexon(ELEXON_URLS["actual_load"], session, params)
+    return demand_data if isinstance(demand_data, list) else []
+
+def parse_demand_data(
+    demand_data: list[dict[str, Any]], logger: Logger
+) -> TotalConsumptionList:
+    """Parses demand data from the ELEXON API."""
+    consumption_list = TotalConsumptionList(logger=logger)
+
+    for event in demand_data:
+        event_datetime_str = event.get("startTime")
+        consumption_value = get_event_value(event, "quantity")  # or whatever the demand field is called
+
+        if event_datetime_str and consumption_value is not None:
+            event_datetime = datetime.fromisoformat(zulu_to_utc(event_datetime_str))
+            consumption_list.append(
+                zoneKey=ZoneKey("GB"),
+                consumption=consumption_value,
+                source=ELEXON_SOURCE,
+                datetime=event_datetime,
+            )
+    return consumption_list
+
+@refetch_frequency(timedelta(hours=1))
+def fetch_consumption(
+    zone_key: ZoneKey = ZoneKey("GB"),
+    session: Session | None = None,
+    target_datetime: datetime | None = None,
+    logger: Logger = getLogger(__name__),
+) -> list[dict]:
+    session = session or Session()
+    if target_datetime is None:
+        target_datetime = datetime.now(tz=timezone.utc)
+    else:
+        target_datetime = target_datetime.astimezone(timezone.utc)
+
+    if target_datetime < ELEXON_START_DATE:
+        raise ParserException(
+            parser="ELEXON.py",
+            message=f"Demand data is not available before {ELEXON_START_DATE.date()}",
+        )
+    demand_data = query_actual_demand(session, target_datetime, logger)
+    parsed_demand = parse_demand_data(demand_data, logger)
+    if not parsed_demand:
+        raise ParserException(
+            parser="ELEXON.py",
+            message=f"No demand data found for {target_datetime.date()}",
+        )
+    return parsed_demand.to_list()
 
 @refetch_frequency(timedelta(days=1))
 def fetch_exchange(


### PR DESCRIPTION
## Issue

We don't get data anymore from ENTSOE for GB demand real-time data. 

## Description

We get this data from Elexon. 
All context can be found here: GMM-788

I used the documentation here to get the Actual total load from Elexon: https://bmrs.elexon.co.uk/api-documentation/endpoint/datasets/ATL 

### Preview

![image](https://github.com/user-attachments/assets/c3c2aee0-582d-40b8-a2b0-24a8b13f8c45)

### Double check

- [x] I have tested my parser changes locally with `poetry run test_parser "zone_key"`
- [X] I have run `pnpx prettier@2 --write .` and `poetry run format` in the top level directory to format my changes.
