### PR TITLE
fix: move all basicConfig calls into scopes to prevent import sideeff…

### DIFF
--- a/capacity_update.py
+++ b/capacity_update.py
@@ -2,8 +2,8 @@
 Usage: poetry run update_capacity --zone FR --target_datetime "2022-01-01"
 """
 
+import logging
 from datetime import datetime
-from logging import DEBUG, basicConfig, getLogger
 
 import click
 from requests import Session
@@ -12,8 +12,7 @@ from electricitymap.contrib.lib.types import ZoneKey
 from scripts.update_capacity_configuration import update_source, update_zone
 from scripts.utils import ROOT_PATH, run_shell_command
 
-logger = getLogger(__name__)
-basicConfig(level=DEBUG, format="%(asctime)s %(levelname)-8s %(name)-30s %(message)s")
+logger = logging.getLogger(__name__)
 
 
 @click.command()
@@ -37,6 +36,11 @@ def capacity_update(
     >>> poetry run capacity_update --zone FR --target_datetime "2022-01-01"
     >>> poetry run capacity_update --source ENTSOE --target_datetime "2022-01-01"
     """
+    logging.basicConfig(
+        level=logging.debug,
+        format="%(asctime)s %(levelname)-8s %(name)-30s %(message)s",
+    )
+
     assert zone is not None or source is not None, "Either zone or source must be set"
     assert not (zone is None and source is None), "Zone and source cannot be both set"
 

--- a/electricitymap/contrib/capacity_parsers/CA_ON.py
+++ b/electricitymap/contrib/capacity_parsers/CA_ON.py
@@ -1,5 +1,5 @@
+import logging
 from datetime import datetime
-from logging import INFO, basicConfig, getLogger
 from typing import Any
 
 import pandas as pd
@@ -7,8 +7,7 @@ from requests import Response, Session
 
 from electricitymap.contrib.config import ZoneKey
 
-logger = getLogger(__name__)
-basicConfig(level=INFO)
+logger = logging.getLogger(__name__)
 
 MODE_MAPPING = {
     "Nuclear": "nuclear",
@@ -62,4 +61,5 @@ def fetch_production_capacity(
 
 
 if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO)
     fetch_production_capacity(ZoneKey("CA_ON"), datetime(2023, 3, 1), Session())

--- a/electricitymap/contrib/capacity_parsers/CL_SEN.py
+++ b/electricitymap/contrib/capacity_parsers/CL_SEN.py
@@ -1,5 +1,5 @@
+import logging
 from datetime import datetime
-from logging import INFO, basicConfig, getLogger
 from typing import Any
 
 import pandas as pd
@@ -8,8 +8,7 @@ from requests import Response, Session
 
 from electricitymap.contrib.config import ZoneKey
 
-logger = getLogger(__name__)
-basicConfig(level=INFO)
+logger = logging.getLogger(__name__)
 
 # Mapping conventional thermal as unknown as the production parser data is aggregated
 MODE_MAPPING = {
@@ -75,4 +74,5 @@ def fetch_production_capacity(
 
 
 if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO)
     fetch_production_capacity("CL-SEN", datetime(2022, 1, 1), Session())

--- a/electricitymap/contrib/capacity_parsers/DE.py
+++ b/electricitymap/contrib/capacity_parsers/DE.py
@@ -1,13 +1,12 @@
+import logging
 from datetime import datetime
-from logging import INFO, basicConfig, getLogger
 from typing import Any
 
 from requests import Response, Session
 
 from electricitymap.contrib.config import ZoneKey
 
-logger = getLogger(__name__)
-basicConfig(level=INFO)
+logger = logging.getLogger(__name__)
 
 MODE_MAPPING = {
     "Nuclear": "nuclear",
@@ -90,4 +89,5 @@ def update_capacity_breakdown(
 
 
 if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO)
     fetch_production_capacity(ZoneKey("DE"), datetime(2023, 1, 1), Session())

--- a/electricitymap/contrib/capacity_parsers/MY_WM.py
+++ b/electricitymap/contrib/capacity_parsers/MY_WM.py
@@ -1,6 +1,6 @@
 import json
+import logging
 from datetime import datetime
-from logging import INFO, basicConfig, getLogger
 from typing import Any
 
 import pandas as pd
@@ -10,8 +10,7 @@ from requests import Response, Session
 
 from electricitymap.contrib.config import ZoneKey
 
-logger = getLogger(__name__)
-basicConfig(level=INFO)
+logger = logging.getLogger(__name__)
 
 """Disclaimer: only valid for real-time data, historical capacity is not available"""
 
@@ -74,4 +73,5 @@ def fetch_production_capacity(
 
 
 if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO)
     fetch_production_capacity(ZoneKey("MY-WM"), Session())

--- a/parsers/CA_QC.py
+++ b/parsers/CA_QC.py
@@ -106,7 +106,7 @@ def _fetch_quebec_consumption(
 if __name__ == "__main__":
     """Main method, never used by the Electricity Map backend, but handy for testing."""
 
-    test_logger = getLogger()
+    test_logger = getLogger(__name__)
 
     print("fetch_production() ->")
     pprint(fetch_production(logger=test_logger))

--- a/scripts/update_capacity_configuration.py
+++ b/scripts/update_capacity_configuration.py
@@ -1,7 +1,7 @@
 import importlib
+import logging
 from copy import deepcopy
 from datetime import datetime
-from logging import INFO, basicConfig, getLogger
 from operator import itemgetter
 from typing import Any
 
@@ -15,8 +15,7 @@ from electricitymap.contrib.lib.types import ZoneKey
 from parsers.lib.parsers import PARSER_DATA_TYPE_TO_DICT
 from scripts.utils import write_zone_config
 
-logger = getLogger(__name__)
-basicConfig(level=INFO)
+logger = logging.getLogger(__name__)
 ZONES_CONFIG = read_zones_config(CONFIG_DIR)
 CAPACITY_MODES = PRODUCTION_MODES + [f"{mode} storage" for mode in STORAGE_MODES]
 

--- a/test_parser.py
+++ b/test_parser.py
@@ -3,11 +3,11 @@
 Usage: poetry run test_parser FR production
 """
 
+import logging
 import pprint
 import time
 from collections.abc import Callable
 from datetime import datetime, timezone
-from logging import DEBUG, basicConfig, getLogger
 from typing import Any
 
 import click
@@ -22,8 +22,7 @@ from parsers.lib.quality import (
     validate_production,
 )
 
-logger = getLogger(__name__)
-basicConfig(level=DEBUG, format="%(asctime)s %(levelname)-8s %(name)-30s %(message)s")
+logger = logging.getLogger(__name__)
 
 
 @click.command()
@@ -73,8 +72,6 @@ def test_parser(zone: ZoneKey, data_type: str, target_datetime: str | None):
         else [zone]
     )
 
-    logger = getLogger(__name__)
-    logger.setLevel(DEBUG)
     res = parser(*args, target_datetime=parsed_target_datetime, logger=logger)
 
     if not res:
@@ -143,5 +140,9 @@ def test_parser(zone: ZoneKey, data_type: str, target_datetime: str | None):
 
 
 if __name__ == "__main__":
+    logging.basicConfig(
+        level=logging.DEBUG,
+        format="%(asctime)s %(levelname)-8s %(name)-30s %(message)s",
+    )
     # pylint: disable=no-value-for-parameter
     print(test_parser())


### PR DESCRIPTION
One of the calls to .basicConfig was causing duplicated logs in feeder-electricity

This was logging is configured inside each separate endpoint, or if code is used as a library then whoever is using the code is responsible for configuring logging. This makes these files safe to import with a different logging setup
