### PR TITLE
feat(parsers): Circumvent geoblocking PJM

### DIFF
--- a/parsers/US_PJM.py
+++ b/parsers/US_PJM.py
@@ -105,8 +105,6 @@ def _fetch_api_data(
         "Accept-Encoding": "identity",
     }
     url = f"{US_PROXY}/{DATA_PATH}/{kind}"
-    breakpoint()
-    # 'https://us-ca-proxy-jfnx5klx2a-uw.a.run.app/api/v1/gen_by_fuel'
     resp: Response = session.get(
         url=url, params={"host": "https://api.pjm.com", **params}, headers=headers
     )


### PR DESCRIPTION
## Issue

* PJM parser for grid alerts fails in the feeder, without giving many hints as to what happens

## Description

* Send the request through our US proxy
* Improve error handling and logging

### Preview

Still works locally, going through the proxy

### Double check

- [ ] I have tested my parser changes locally with `poetry run test_parser "zone_key"`
- [ ] I have run `pnpx prettier@2 --write .` and `poetry run format` in the top level directory to format my changes.
