### PR TITLE
fix(parsers): fix DK-DK1 -> DK-DK2 parser errors

### DIFF
--- a/parsers/DK.py
+++ b/parsers/DK.py
@@ -118,7 +118,7 @@ def flow(sorted_keys: ZoneKey, datapoint: dict) -> int | float | None:
         return (
             datapoint[EXCHANGE_MAPPING[sorted_keys]["id"]]
             * EXCHANGE_MAPPING[sorted_keys]["direction"]
-            if datapoint[EXCHANGE_MAPPING[sorted_keys]["id"]]
+            if datapoint[EXCHANGE_MAPPING[sorted_keys]["id"]] is not None
             else None
         )
 


### PR DESCRIPTION
## Issue

<!-- If you want to close an issue automatically when your PR is merged, write "Closes X" where X is the issue number. For example: Closes #000 -->
[Linear issue pointing to the log errors](https://linear.app/electricitymaps/issue/GMM-813/dk1-dk2-exchange-parser)

## Description

<!-- Explains the goal of this PR -->
This PR makes the if check more explicit so that it does not catch a 0 value.

### Preview

<!-- Please add screenshots and/or gif that shows visual changes (if applicable) -->
Before:
![Screenshot 2025-06-13 at 14 10 05](https://github.com/user-attachments/assets/9b5610af-ba64-449b-88d6-1fb6785f19d8)

After:

![image](https://github.com/user-attachments/assets/ef423b86-da9e-4ce7-8deb-bf570137e687)

### Double check

- [ ] I have tested my parser changes locally with `poetry run test_parser "zone_key"`
- [ ] I have run `pnpx prettier@2 --write .` and `poetry run format` in the top level directory to format my changes.
