### PR TITLE
fix(opennem): filter out data points with only solar

### DIFF
--- a/parsers/OPENNEM.py
+++ b/parsers/OPENNEM.py
@@ -107,18 +107,14 @@ def filter_production_objs(
             and obj["production"]["solar"] is not None
         )
 
-    # The latest data points for AU-TAS are regularly containing only 0 values for solar
-    # and no other production values. This is not a valid production object, so we filter it out.
-    def only_zero_solar_production(obj: dict) -> bool:
+    # The latest data points for AU-TAS are regularly containing only values for solar
+    # and no other production values. This is likely an invalid report, so we filter it out.
+    def only_solar_production(obj: dict) -> bool:
         return not (
             all(v is None for k, v in obj.get("production", {}).items() if k != "solar")
-            and (
-                obj.get("production", {}).get("solar") is None
-                or obj.get("production", {}).get("solar") == 0
-            )
         )
 
-    all_filters = [filter_solar_production, only_zero_solar_production]
+    all_filters = [filter_solar_production, only_solar_production]
 
     filtered_objs = []
     for obj in objs:


### PR DESCRIPTION
## Issue

Fix in https://github.com/electricitymaps/electricitymaps-contrib/pull/8215 does not fully solve the issue of AU-TAS reporting data with only solar with very low values. 

## Description
We exclude the data points that only contains solar production data.

### Preview

Without filter : 
![Screenshot 2025-06-18 at 09 09 31](https://github.com/user-attachments/assets/16af2a7c-251b-4254-9e43-fc3be14383e9)

With filter : 
![Screenshot 2025-06-18 at 09 09 56](https://github.com/user-attachments/assets/3d9eb83f-a85d-40fa-b799-c0c63ee1e4fb)

### Double check

- [x] I have tested my parser changes locally with `poetry run test_parser "zone_key"`
- [x] I have run `pnpx prettier@2 --write .` and `poetry run format` in the top level directory to format my changes.
