### PR TITLE
fix(parsers): EIA consumption forecasts in the future

### DIFF
--- a/parsers/EIA.py
+++ b/parsers/EIA.py
@@ -409,7 +409,7 @@ def fetch_production(
     target_datetime: datetime | None = None,
     logger: Logger = getLogger(__name__),
 ):
-    return _fetch(
+    return _fetch_historical(
         zone_key,
         PRODUCTION.format(REGIONS[zone_key]),
         session=session,
@@ -426,7 +426,7 @@ def fetch_consumption(
     logger: Logger = getLogger(__name__),
 ) -> list[dict[str, Any]]:
     consumption_list = TotalConsumptionList(logger)
-    consumption = _fetch(
+    consumption = _fetch_historical(
         zone_key,
         CONSUMPTION.format(REGIONS[zone_key]),
         session=session,
@@ -452,7 +452,7 @@ def fetch_consumption_forecast(
     logger: Logger = getLogger(__name__),
 ):
     consumptions = TotalConsumptionList(logger)
-    consumption_forecasts = _fetch(
+    consumption_forecasts = _fetch_forecast(
         zone_key,
         CONSUMPTION_FORECAST.format(REGIONS[zone_key]),
         session=session,
@@ -515,7 +515,7 @@ def fetch_production_mix(
         )
         production_breakdown = ProductionBreakdownList(logger)
         url_prefix = PRODUCTION_MIX.format(REGIONS[zone_key], code)
-        production_and_storage_values = _fetch(
+        production_and_storage_values = _fetch_historical(
             zone_key,
             url_prefix,
             session=session,
@@ -583,7 +583,7 @@ def fetch_production_mix(
         for zone, percentage in zones_to_integrate.items():
             url_prefix = PRODUCTION_MIX.format(REGIONS[zone], code)
             additional_breakdown = ProductionBreakdownList(logger)
-            additional_production = _fetch(
+            additional_production = _fetch_historical(
                 zone,
                 url_prefix,
                 session=session,
@@ -656,7 +656,7 @@ def fetch_exchange(
 ) -> list[dict[str, Any]]:
     sortedcodes = "->".join(sorted([zone_key1, zone_key2]))
     exchange_list = ExchangeList(logger)
-    exchange = _fetch(
+    exchange = _fetch_historical(
         sortedcodes,
         url_prefix=EXCHANGE.format(EXCHANGES[sortedcodes]),
         session=session,
@@ -677,7 +677,7 @@ def fetch_exchange(
     remapped_exchanges = EXCHANGE_TRANSFERS.get(sortedcodes, {})
     remapped_exchange_list = ExchangeList(logger)
     for remapped_exchange in remapped_exchanges:
-        exchange = _fetch(
+        exchange = _fetch_historical(
             remapped_exchange,
             url_prefix=EXCHANGE.format(EXCHANGES[remapped_exchange]),
             session=session,
@@ -701,29 +701,19 @@ def fetch_exchange(
     return exchange_list.to_list()
 
 
-def _fetch(
+def _fetch_any(
     zone_key: str,
     url_prefix: str,
+    start_datetime: datetime,
+    end_datetime: datetime,
     session: Session | None = None,
-    target_datetime: datetime | None = None,
     logger: Logger = getLogger(__name__),
-):
-    # get EIA API key
+) -> list[dict[str, Any]]:
+     # get EIA API key
     API_KEY = get_token("EIA_KEY")
 
-    start, end = None, None
-    if target_datetime:
-        utc = tz.gettz("UTC")
-        end = target_datetime.astimezone(utc) + timedelta(hours=1)
-        start = end - timedelta(days=1)
-    else:
-        end = datetime.now(tz=tz.gettz("UTC")).replace(
-            minute=0, second=0, microsecond=0
-        ) + timedelta(hours=1)
-        start = end - timedelta(hours=72)
-
     eia_ts_format = "%Y-%m-%dT%H"
-    url = f"{url_prefix}&api_key={API_KEY}&start={start.strftime(eia_ts_format)}&end={end.strftime(eia_ts_format)}"
+    url = f"{url_prefix}&api_key={API_KEY}&start={start_datetime.strftime(eia_ts_format)}&end={end_datetime.strftime(eia_ts_format)}"
 
     s = session or Session()
     req = s.get(url)
@@ -739,6 +729,50 @@ def _fetch(
         }
         for datapoint in raw_data["response"]["data"]
     ]
+
+def _fetch_historical(
+    zone_key: str,
+    url_prefix: str,
+    session: Session | None = None,
+    target_datetime: datetime | None = None,
+    logger: Logger = getLogger(__name__),
+) -> list[dict[str, Any]]:
+
+    start, end = None, None
+    if target_datetime:
+        utc = tz.gettz("UTC")
+        end = target_datetime.astimezone(utc) + timedelta(hours=1)
+        start = end - timedelta(days=1)
+    else:
+        end = datetime.now(tz=tz.gettz("UTC")).replace(
+            minute=0, second=0, microsecond=0
+        ) + timedelta(hours=1)
+        start = end - timedelta(hours=72)
+
+    return _fetch_any(zone_key, url_prefix, start, end, session, logger)
+
+
+def _fetch_forecast(
+    zone_key: str,
+    url_prefix: str,
+    session: Session | None = None,
+    target_datetime: datetime | None = None,
+    logger: Logger = getLogger(__name__),
+) -> list[dict[str, Any]]:
+    LOOKAHEAD = timedelta(days=15)
+
+    start, end = None, None
+    if target_datetime:
+        utc = tz.gettz("UTC")
+        start = target_datetime.astimezone(utc).replace(minute=0, second=0, microsecond=0)
+        end = start + LOOKAHEAD
+    else:
+        start = datetime.now(tz=tz.gettz("UTC")).replace(
+            minute=0, second=0, microsecond=0
+        )
+        end = start + LOOKAHEAD
+
+    return _fetch_any(zone_key, url_prefix, start, end, session, logger)
 
 
 def _parse_hourly_interval(period: str):

--- a/parsers/EIA.py
+++ b/parsers/EIA.py
@@ -709,7 +709,7 @@ def _fetch_any(
     session: Session | None = None,
     logger: Logger = getLogger(__name__),
 ) -> list[dict[str, Any]]:
-     # get EIA API key
+    # get EIA API key
     API_KEY = get_token("EIA_KEY")
 
     eia_ts_format = "%Y-%m-%dT%H"
@@ -730,6 +730,7 @@ def _fetch_any(
         for datapoint in raw_data["response"]["data"]
     ]
 
+
 def _fetch_historical(
     zone_key: str,
     url_prefix: str,
@@ -737,7 +738,6 @@ def _fetch_historical(
     target_datetime: datetime | None = None,
     logger: Logger = getLogger(__name__),
 ) -> list[dict[str, Any]]:
-
     start, end = None, None
     if target_datetime:
         utc = tz.gettz("UTC")
@@ -764,7 +764,9 @@ def _fetch_forecast(
     start, end = None, None
     if target_datetime:
         utc = tz.gettz("UTC")
-        start = target_datetime.astimezone(utc).replace(minute=0, second=0, microsecond=0)
+        start = target_datetime.astimezone(utc).replace(
+            minute=0, second=0, microsecond=0
+        )
         end = start + LOOKAHEAD
     else:
         start = datetime.now(tz=tz.gettz("UTC")).replace(


### PR DESCRIPTION
## Issue

We realised that we were only parsing consumption forecasts from the EIA in the past. The reason is simply the parametrisation of the API call..

## Description

Fixes the parametrisation to actually call for data in the future, not the past

### Preview

Note that not all BAs have demand forecasts!

Some do, ex:
US-CAL-BANC
<img width="837" alt="Screenshot 2025-06-18 at 13 23 23" src="https://github.com/user-attachments/assets/f4e086e8-e179-465b-9cbe-baaffd1ec759" />
![Balancing Authority of Northern California (BANC) electricity overview (demand, forecast demand, net generation, and total interchange) 6-11-2025 – 6-18-2025, Pacific Time](https://github.com/user-attachments/assets/f4a118f4-7867-4756-a79f-8ca141dd4430)

Others don't
US-SE-SOCO
<img width="793" alt="Screenshot 2025-06-18 at 13 27 06" src="https://github.com/user-attachments/assets/8fe0f3f4-4d42-4176-b20f-dddda1d95b21" />
![Southern Company Services, Inc  - Trans (SOCO) electricity overview (demand, forecast demand, net generation, and total interchange) 6-11-2025 – 6-18-2025, Central Time](https://github.com/user-attachments/assets/a41139f2-e562-47ba-9e17-9ee28c911f4e)

### Double check

- [x] I have tested my parser changes locally with `poetry run test_parser "zone_key"`
- [x] I have run `pnpx prettier@2 --write .` and `poetry run format` in the top level directory to format my changes.
