### PR TITLE
I18next migration dryrun

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -9,6 +9,7 @@
   "license": "AGPL-3.0-or-later",
   "type": "module",
   "scripts": {
+    "migrate-i18next": "pnpm dlx jscodeshift --parser=tsx --no-babel -t src/migrate-i18next.cjs src && pnpm format",
     "mockserver": "cd ../mockserver && pnpm run start",
     "prebuild": "pnpm run create-generated-files",
     "build": "vite build",

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -135,7 +135,6 @@ export default function App(): ReactElement {
   return (
     <Suspense fallback={<div />}>
       <GtmPageTracker />
-
       <Helmet
         htmlAttributes={{
           lang: i18n.languages[0],
@@ -144,7 +143,7 @@ export default function App(): ReactElement {
         }}
         prioritizeSeoTags
       >
-        <title>{t('misc.maintitle') + metaTitleSuffix}</title>
+        <title>{t(($) => $.misc.maintitle) + metaTitleSuffix}</title>
         <meta property="og:locale" content={i18n.languages[0]} />
         <link rel="canonical" href={canonicalUrl} />
       </Helmet>

--- a/web/src/components/AppStoreBanner.tsx
+++ b/web/src/components/AppStoreBanner.tsx
@@ -46,7 +46,7 @@ export function AppStoreBanner({
           </div>
           <div className="content-center text-neutral-600 dark:text-neutral-300">
             <h3>Electricity Maps</h3>
-            <p className="text-xs">{t('app-banner.description')}</p>
+            <p className="text-xs">{t(($) => $['app-banner'].description)}</p>
           </div>
         </div>
         <Button
@@ -55,7 +55,7 @@ export function AppStoreBanner({
           href={appStoreUrl}
           onClick={closeBanner}
         >
-          {t('app-banner.cta')}
+          {t(($) => $['app-banner'].cta)}
         </Button>
       </div>
     )

--- a/web/src/components/CarbonIntensitySquare.tsx
+++ b/web/src/components/CarbonIntensitySquare.tsx
@@ -82,7 +82,7 @@ function CarbonIntensitySquare({
         </div>
       </TooltipWrapper>
       <p className="text-xs font-semibold text-neutral-600 dark:text-neutral-400">
-        {t('country-panel.carbonintensity')}
+        {t(($) => $['country-panel'].carbonintensity)}
       </p>
     </div>
   );

--- a/web/src/components/DefaultCloseButton.tsx
+++ b/web/src/components/DefaultCloseButton.tsx
@@ -15,7 +15,7 @@ export function DefaultCloseButton({
   const { t } = useTranslation();
   return (
     <button
-      aria-label={t('misc.dismiss')}
+      aria-label={t(($) => $.misc.dismiss)}
       data-testid="dismiss-btn"
       onClick={onClose}
       className={twMerge(

--- a/web/src/components/LoadingSpinner.tsx
+++ b/web/src/components/LoadingSpinner.tsx
@@ -19,7 +19,7 @@ export default function LoadingSpinner({
       </div>
       {showReloadButton && (
         <>
-          <p>{t('misc.slow-loading-text')}</p>
+          <p>{t(($) => $.misc['slow-loading-text'])}</p>
           <Button
             size="lg"
             type="secondary"
@@ -27,7 +27,7 @@ export default function LoadingSpinner({
             backgroundClasses="min-w-[330px] my-2"
             onClick={() => window.location.reload()}
           >
-            {t('misc.reload')}
+            {t(($) => $.misc.reload)}
           </Button>
         </>
       )}

--- a/web/src/components/MoreOptionsDropdown.tsx
+++ b/web/src/components/MoreOptionsDropdown.tsx
@@ -73,7 +73,7 @@ export function MoreOptionsDropdown({
     [downloadUrl, trackCsvLink]
   );
 
-  const summary = t('more-options-dropdown.summary');
+  const summary = t(($) => $['more-options-dropdown'].summary);
 
   const { onShare, copyShareUrl } = useMemo(() => {
     const toastMessageCallback = (message: string) => {
@@ -99,10 +99,11 @@ export function MoreOptionsDropdown({
     };
   }, [reference, shareUrl, summary, share, copyToClipboard, trackSocialShareDirectLink]);
 
-  const dropdownTitle = title || t('more-options-dropdown.title');
+  const dropdownTitle = title || t(($) => $['more-options-dropdown'].title);
 
   const copyLinkText = t(
-    `more-options-dropdown.${id === 'zone' ? 'copy-zone-link' : 'copy-chart-link'}`
+    ($) =>
+      $['more-options-dropdown'][id === 'zone' ? 'copy-zone-link' : 'copy-chart-link']
   );
 
   return (
@@ -117,7 +118,7 @@ export function MoreOptionsDropdown({
         >
           {isEstimated && (
             <div className="w-full rounded-t-2xl bg-warning/10 p-3 text-xs font-semibold text-warning dark:bg-warning-dark/10 dark:text-warning-dark">
-              <p>{t('more-options-dropdown.preliminary-data')}</p>
+              <p>{t(($) => $['more-options-dropdown']['preliminary-data'])}</p>
             </div>
           )}
           <div className="px-2 py-2">
@@ -130,7 +131,7 @@ export function MoreOptionsDropdown({
                 <div className="my-auto flex items-center">
                   <FileDownIcon size={DEFAULT_ICON_SIZE} />
                   <div className="ml-2 text-sm font-semibold">
-                    {t('more-options-dropdown.download')}
+                    {t(($) => $['more-options-dropdown'].download)}
                   </div>
                 </div>
                 <ExternalLink
@@ -157,7 +158,7 @@ export function MoreOptionsDropdown({
                 <DropdownMenu.Item className={dropdownItemStyle} onSelect={onShare}>
                   <MemoizedShareIcon />
                   <p className={dropdownContentStyle}>
-                    {t('more-options-dropdown.mobile-share-via')}
+                    {t(($) => $['more-options-dropdown']['mobile-share-via'])}
                   </p>
                 </DropdownMenu.Item>
               )}
@@ -174,7 +175,9 @@ export function MoreOptionsDropdown({
                   >
                     <DropdownMenu.Item className={dropdownItemStyle}>
                       <FaSquareXTwitter size={DEFAULT_ICON_SIZE} />
-                      <p className={dropdownContentStyle}>{t('button.twitter-share')}</p>
+                      <p className={dropdownContentStyle}>
+                        {t(($) => $.button['twitter-share'])}
+                      </p>
                     </DropdownMenu.Item>
                   </a>
                   <a
@@ -188,7 +191,9 @@ export function MoreOptionsDropdown({
                   >
                     <DropdownMenu.Item className={dropdownItemStyle}>
                       <FaFacebook size={DEFAULT_ICON_SIZE} />
-                      <p className={dropdownContentStyle}>{t('button.facebook-share')}</p>
+                      <p className={dropdownContentStyle}>
+                        {t(($) => $.button['facebook-share'])}
+                      </p>
                     </DropdownMenu.Item>
                   </a>
                   <a
@@ -200,7 +205,9 @@ export function MoreOptionsDropdown({
                   >
                     <DropdownMenu.Item className={dropdownItemStyle}>
                       <FaLinkedin size={DEFAULT_ICON_SIZE} />
-                      <p className={dropdownContentStyle}>{t('button.linkedin-share')}</p>
+                      <p className={dropdownContentStyle}>
+                        {t(($) => $.button['linkedin-share'])}
+                      </p>
                     </DropdownMenu.Item>
                   </a>
                   <a
@@ -212,7 +219,9 @@ export function MoreOptionsDropdown({
                   >
                     <DropdownMenu.Item className={dropdownItemStyle}>
                       <FaReddit size={DEFAULT_ICON_SIZE} />
-                      <p className={dropdownContentStyle}>{t('button.reddit-share')}</p>
+                      <p className={dropdownContentStyle}>
+                        {t(($) => $.button['reddit-share'])}
+                      </p>
                     </DropdownMenu.Item>
                   </a>
                 </>
@@ -225,7 +234,7 @@ export function MoreOptionsDropdown({
         ref={reference}
         description={toastMessage}
         isCloseable={true}
-        toastCloseText={t('misc.dismiss')}
+        toastCloseText={t(($) => $.misc.dismiss)}
         duration={DEFAULT_TOAST_DURATION}
       />
     </>

--- a/web/src/components/NewFeaturePopover/NewFeaturePopoverContent.tsx
+++ b/web/src/components/NewFeaturePopover/NewFeaturePopoverContent.tsx
@@ -8,9 +8,9 @@ export function NewFeaturePopoverContent() {
     <div className="flex flex-col text-left">
       <div className="flex flex-row items-center gap-2">
         <Clock size={16} />
-        <h3>{t(`new-feature-popover.title`)}</h3>
+        <h3>{t(($) => $['new-feature-popover'].title)}</h3>
       </div>
-      <p>{t(`new-feature-popover.content`)}</p>
+      <p>{t(($) => $['new-feature-popover'].content)}</p>
     </div>
   );
 }

--- a/web/src/components/NoDataBadge.tsx
+++ b/web/src/components/NoDataBadge.tsx
@@ -4,5 +4,5 @@ import { useTranslation } from 'react-i18next';
 export default function NoDataBadge() {
   const { t } = useTranslation();
 
-  return <Badge pillText={t('tooltips.noParserInfo')} />;
+  return <Badge pillText={t(($) => $.tooltips.noParserInfo)} />;
 }

--- a/web/src/components/OutageBadge.tsx
+++ b/web/src/components/OutageBadge.tsx
@@ -9,7 +9,7 @@ export default function OutageBadge() {
     <Badge
       type={'warning'}
       icon={<TriangleAlert size={12} />}
-      pillText={t('estimation-badge.outage')}
+      pillText={t(($) => $['estimation-badge'].outage)}
     />
   );
 }

--- a/web/src/components/TimeRangeSelector.tsx
+++ b/web/src/components/TimeRangeSelector.tsx
@@ -9,7 +9,7 @@ import { useDropdownCtl } from './MoreOptionsDropdown';
 
 const createOption = (time: TimeRange, t: TFunction) => ({
   value: time,
-  label: t(`time-controller.${time}`),
+  label: t(($) => $['time-controller'][time]),
   dataTestId: `time-controller-${time}`,
 });
 

--- a/web/src/components/Toast.tsx
+++ b/web/src/components/Toast.tsx
@@ -139,7 +139,7 @@ export const Toast = forwardRef<ToastController, ToastProps>(function Toast(
             <ToastPrimitive.Close
               className="mx-2 flex items-center justify-center text-black dark:text-white"
               onClick={handleToastClose}
-              aria-label={toastCloseText ?? t('misc.dismiss')}
+              aria-label={toastCloseText ?? t(($) => $.misc.dismiss)}
               data-testid="toast-dismiss"
             >
               <X size={16} />

--- a/web/src/components/ToggleButton.tsx
+++ b/web/src/components/ToggleButton.tsx
@@ -56,7 +56,6 @@ function ToggleButton<T extends string>({
       )}
     >
       {transparentBackground && <GlassBackdrop />}
-
       <ToggleGroupRoot
         className={'flex grow flex-row items-center justify-between rounded-full'}
         type="single"
@@ -77,7 +76,7 @@ function ToggleButton<T extends string>({
             )}
           >
             <p className="grow select-none text-sm capitalize dark:text-white">
-              {t(translationKey)}
+              {t(($) => $[translationKey])}
             </p>
           </ToggleGroupItem>
         ))}
@@ -107,7 +106,7 @@ function ToggleButton<T extends string>({
                 onPointerDownOutside={onToolTipClick}
               >
                 <GlassBackdrop />
-                <div dangerouslySetInnerHTML={{ __html: t(tooltipKey) }} />
+                <div dangerouslySetInnerHTML={{ __html: t(($) => $[tooltipKey]) }} />
               </TooltipContent>
             </TooltipPortal>
           </TooltipRoot>

--- a/web/src/components/ZoneGauges.tsx
+++ b/web/src/components/ZoneGauges.tsx
@@ -30,22 +30,24 @@ function ZoneGaugesWithCO2Square({
         data-testid="co2-square-value"
         intensity={intensity}
         tooltipContent={
-          withTooltips ? <p>{t('tooltips.zoneHeader.carbonIntensity')}</p> : undefined
+          withTooltips ? (
+            <p>{t(($) => $.tooltips.zoneHeader.carbonIntensity)}</p>
+          ) : undefined
         }
       />
       <CircularGauge
-        name={t('country-panel.lowcarbon')}
+        name={t(($) => $['country-panel'].lowcarbon)}
         ratio={fossilFuelPercentage}
         tooltipContent={
-          withTooltips ? <p>{t('tooltips.zoneHeader.lowcarbon')}</p> : undefined
+          withTooltips ? <p>{t(($) => $.tooltips.zoneHeader.lowcarbon)}</p> : undefined
         }
         testId="zone-header-lowcarbon-gauge"
       />
       <CircularGauge
-        name={t('country-panel.renewable')}
+        name={t(($) => $['country-panel'].renewable)}
         ratio={renewable}
         tooltipContent={
-          withTooltips ? <p>{t('tooltips.zoneHeader.renewable')}</p> : undefined
+          withTooltips ? <p>{t(($) => $.tooltips.zoneHeader.renewable)}</p> : undefined
         }
         testId="zone-header-renewable-gauge"
       />

--- a/web/src/components/app-survey/FeedbackCard.tsx
+++ b/web/src/components/app-survey/FeedbackCard.tsx
@@ -73,9 +73,9 @@ export default function FeedbackCard({
     }
   };
   const { t } = useTranslation();
-  const title = t('feedback-card.title');
-  const successMessage = t('feedback-card.success-message');
-  const successSubtitle = t('feedback-card.success-subtitle');
+  const title = t(($) => $['feedback-card'].title);
+  const successMessage = t(($) => $['feedback-card']['success-message']);
+  const successSubtitle = t(($) => $['feedback-card']['success-subtitle']);
   const isFeedbackSubmitted = feedbackState === FeedbackState.SUCCESS;
 
   const feedbackCardReference = useRef<HTMLDivElement>(null);
@@ -170,8 +170,8 @@ function InputField({
   isRequired?: boolean;
 }) {
   const { t } = useTranslation();
-  const inputPlaceholder = t('feedback-card.placeholder');
-  const optional = t('feedback-card.optional');
+  const inputPlaceholder = t(($) => $['feedback-card'].placeholder);
+  const optional = t(($) => $['feedback-card'].optional);
 
   return (
     <div>
@@ -198,7 +198,7 @@ function InputField({
 
 function SubmitButton({ handleSave }: { handleSave: () => void }) {
   const { t } = useTranslation();
-  const buttonText = t('feedback-card.submit');
+  const buttonText = t(($) => $['feedback-card'].submit);
 
   return <Pill text={buttonText} onClick={handleSave} />;
 }
@@ -307,11 +307,13 @@ function ActionPills({
 }) {
   const { t } = useTranslation();
   const isMapSurvey = surveyReference === 'Map Survey';
-  const agreeText = isMapSurvey ? t('feedback-card.satisfied') : t('feedback-card.agree');
+  const agreeText = isMapSurvey
+    ? t(($) => $['feedback-card'].satisfied)
+    : t(($) => $['feedback-card'].agree);
   const [pillContent] = useState(['1', '2', '3', '4', '5']);
   const disagreeText = isMapSurvey
-    ? t('feedback-card.unsatisfied')
-    : t('feedback-card.disagree');
+    ? t(($) => $['feedback-card'].unsatisfied)
+    : t(($) => $['feedback-card'].disagree);
   const [currentPillNumber, setPillNumber] = useState('');
 
   const handlePillClick = (identifier: string) => {

--- a/web/src/components/app-survey/SurveyCard.tsx
+++ b/web/src/components/app-survey/SurveyCard.tsx
@@ -69,9 +69,9 @@ export default function SurveyCard({ isUsSurvey }: { isUsSurvey?: boolean }) {
         <FeedbackCard
           surveyReference={'Map Survey'}
           postSurveyResponse={postSurveyResponse}
-          primaryQuestion={t('feedback-card.primary-question')}
-          secondaryQuestionHigh={t('feedback-card.secondary-question-high')}
-          secondaryQuestionLow={t('feedback-card.secondary-question-low')}
+          primaryQuestion={t(($) => $['feedback-card']['primary-question'])}
+          secondaryQuestionHigh={t(($) => $['feedback-card']['secondary-question-high'])}
+          secondaryQuestionLow={t(($) => $['feedback-card']['secondary-question-low'])}
         />
       )}
     </div>

--- a/web/src/components/buttons/ApiButton.tsx
+++ b/web/src/components/buttons/ApiButton.tsx
@@ -19,7 +19,7 @@ function ApiButton({ iconSize = 20, type, onClick, ...restProps }: ApiButtonProp
       href="https://electricitymaps.com/pricing?utm_source=app.electricitymaps.com&utm_medium=referral&utm_campaign=api-cta"
       {...restProps}
     >
-      {t('button.api')}
+      {t(($) => $.button.api)}
     </Button>
   );
 }

--- a/web/src/components/buttons/BlueskyButton.tsx
+++ b/web/src/components/buttons/BlueskyButton.tsx
@@ -27,8 +27,8 @@ export function BlueskyButton({
       foregroundClasses="text-white dark:text-white focus-visible:outline-[#1185fe]"
       href={
         isShareLink
-          ? `https://bsky.app/intent/compose?text=${t('button.bluesky-share', {
-              baseUrl,
+          ? `https://bsky.app/intent/compose?text=${t(($) => $.button['bluesky-share'], {
+              baseUrl: baseUrl,
             })}`
           : undefined
       }

--- a/web/src/components/buttons/DocumentationButton.tsx
+++ b/web/src/components/buttons/DocumentationButton.tsx
@@ -23,7 +23,7 @@ export function DocumentationButton({
       {...restProps}
       icon={<FileText size={iconSize} />}
     >
-      {t('button.docs')}
+      {t(($) => $.button.docs)}
     </Button>
   );
 }

--- a/web/src/components/buttons/FeedbackButton.tsx
+++ b/web/src/components/buttons/FeedbackButton.tsx
@@ -24,7 +24,7 @@ export function FeedbackButton({
       icon={<MessageSquareText size={iconSize} />}
       {...restProps}
     >
-      {isIconOnly ? undefined : t('button.feedback')}
+      {isIconOnly ? undefined : t(($) => $.button.feedback)}
     </Button>
   );
 }

--- a/web/src/components/buttons/GithubButton.tsx
+++ b/web/src/components/buttons/GithubButton.tsx
@@ -26,7 +26,7 @@ export function GithubButton({
       icon={<FaGithub size={iconSize} />}
       {...restProps}
     >
-      {isIconOnly ? undefined : t('button.github')}
+      {isIconOnly ? undefined : t(($) => $.button.github)}
     </Button>
   );
 }

--- a/web/src/components/buttons/LegalNoticeButton.tsx
+++ b/web/src/components/buttons/LegalNoticeButton.tsx
@@ -21,7 +21,7 @@ export function LegalNoticeButton({ ...restProps }: LegalNoticeButtonProps) {
       href="https://www.electricitymaps.com/legal-notice/"
       {...restProps}
     >
-      {t('button.legal-notice')}
+      {t(($) => $.button['legal-notice'])}
     </Button>
   );
 }

--- a/web/src/components/buttons/PrivacyPolicyButton.tsx
+++ b/web/src/components/buttons/PrivacyPolicyButton.tsx
@@ -21,7 +21,7 @@ export function PrivacyPolicyButton({ ...restProps }: PrivacyPolicyButtonProps) 
       href="https://www.electricitymaps.com/privacy-policy/"
       {...restProps}
     >
-      {t('button.privacy-policy')}
+      {t(($) => $.button['privacy-policy'])}
     </Button>
   );
 }

--- a/web/src/components/legend/Co2Legend.tsx
+++ b/web/src/components/legend/Co2Legend.tsx
@@ -11,7 +11,7 @@ function Co2Legend(): ReactElement {
   const co2ColorScale = useCo2ColorScale();
   return (
     <LegendItem
-      label={t('legends.carbonintensity')}
+      label={t(($) => $.legends.carbonintensity)}
       unit={CarbonUnits.GRAMS_CO2EQ_PER_KILOWATT_HOUR}
     >
       <HorizontalColorbar colorScale={co2ColorScale} ticksCount={6} id={'co2'} />

--- a/web/src/components/legend/SolarLegend.tsx
+++ b/web/src/components/legend/SolarLegend.tsx
@@ -8,7 +8,7 @@ import { LegendItem } from './LegendItem';
 function SolarLegend(): ReactElement {
   const { t } = useTranslation();
   return (
-    <LegendItem label={t('legends.solarpotential')} unit="W/m²">
+    <LegendItem label={t(($) => $.legends.solarpotential)} unit="W/m²">
       <HorizontalColorbar colorScale={solarColor} id="solar" ticksCount={5} />
     </LegendItem>
   );

--- a/web/src/components/legend/WindLegend.tsx
+++ b/web/src/components/legend/WindLegend.tsx
@@ -8,7 +8,7 @@ import { LegendItem } from './LegendItem';
 function WindLegend(): ReactElement {
   const { t } = useTranslation();
   return (
-    <LegendItem label={t('legends.windpotential')} unit="m/s">
+    <LegendItem label={t(($) => $.legends.windpotential)} unit="m/s">
       <HorizontalColorbar colorScale={windColor} id="wind" ticksCount={6} />
     </LegendItem>
   );

--- a/web/src/components/modals/OnboardingModal.tsx
+++ b/web/src/components/modals/OnboardingModal.tsx
@@ -22,16 +22,16 @@ const BODY_STYLE = 'text-sm px-4 sm:text-base pb-4';
 function ViewContent({ t, translationKey, isDangerouslySet = false }: ViewContentProps) {
   return (
     <>
-      <h1 className="mb-4">{t(`${translationKey}.header`)}</h1>
+      <h1 className="mb-4">{t(($) => $[translationKey].header)}</h1>
       {isDangerouslySet ? (
         <p
           dangerouslySetInnerHTML={{
-            __html: t(`${translationKey}.text`),
+            __html: t(($) => $[translationKey].text),
           }}
           className={BODY_STYLE}
         />
       ) : (
-        <p className={BODY_STYLE}>{t(`${translationKey}.text`)}</p>
+        <p className={BODY_STYLE}>{t(($) => $[translationKey].text)}</p>
       )}
     </>
   );

--- a/web/src/features/charts/CarbonChart.tsx
+++ b/web/src/features/charts/CarbonChart.tsx
@@ -49,7 +49,7 @@ function CarbonChart({ datetimes, timeRange }: CarbonChartProps) {
   return (
     <RoundedCard className="pb-2">
       <ChartTitle
-        titleText={t(`country-history.carbonintensity.${timeRange}`)}
+        titleText={t(($) => $['country-history'].carbonintensity[timeRange])}
         isEstimated={someEstimated}
         unit={someEstimated ? undefined : valueAxisLabel}
         id={Charts.CARBON_INTENSITY_CHART}

--- a/web/src/features/charts/ChartTitle.tsx
+++ b/web/src/features/charts/ChartTitle.tsx
@@ -41,7 +41,7 @@ export function ChartTitle({
         {badge}
         {showMoreOptions && (
           <MoreOptionsDropdown
-            title={t(`more-options-dropdown.chart-title`)}
+            title={t(($) => $['more-options-dropdown']['chart-title'])}
             isEstimated={isEstimated}
             id={id}
             shareUrl={shareUrl}

--- a/web/src/features/charts/DataSources.tsx
+++ b/web/src/features/charts/DataSources.tsx
@@ -47,7 +47,7 @@ export function DataSources({
                 <EmissionFactorTooltip t={t} />
               ) : (
                 <LabelTooltip className="max-w-[400px] text-start">
-                  {t('country-panel.emissionFactorDataSourcesTooltip')}
+                  {t(($) => $['country-panel'].emissionFactorDataSourcesTooltip)}
                 </LabelTooltip>
               )
             }
@@ -85,7 +85,7 @@ function EmissionFactorTooltip({ t }: { t: TFunction<'translation', undefined> }
   return (
     <Portal.Root className="pointer-events-none absolute left-0 top-0 z-50 flex h-full w-full flex-col content-center items-center justify-center gap-2 bg-black/20 pb-40">
       <div className="dark:border-1 relative mx-6 h-auto min-w-64 rounded-xl border bg-zinc-50 p-4 text-left text-sm opacity-80 shadow-md dark:border-neutral-700 dark:bg-neutral-900">
-        {t('country-panel.emissionFactorDataSourcesTooltip')}
+        {t(($) => $['country-panel'].emissionFactorDataSourcesTooltip)}
       </div>
       <Button icon={<X />} type="secondary" backgroundClasses="pointer-events-auto" />
     </Portal.Root>

--- a/web/src/features/charts/EmissionChart.tsx
+++ b/web/src/features/charts/EmissionChart.tsx
@@ -39,7 +39,7 @@ function EmissionChart({ timeRange, datetimes }: EmissionChartProps) {
   return (
     <RoundedCard className="pb-2">
       <ChartTitle
-        titleText={t(`country-history.emissions.${timeRange}`)}
+        titleText={t(($) => $['country-history'].emissions[timeRange])}
         unit={someEstimated ? undefined : valueAxisLabel}
         id={Charts.EMISSION_CHART}
         subtitle={<ChartSubtitle datetimes={datetimes} timeRange={timeRange} />}

--- a/web/src/features/charts/FuturePrice.tsx
+++ b/web/src/features/charts/FuturePrice.tsx
@@ -59,8 +59,8 @@ export const FuturePrice = memo(function FuturePrice({
     <div className="pt-2">
       <Accordion
         isCollapsed={isCollapsed}
-        title={t(`country-panel.price-chart.see`)}
-        expandedTitle={t(`country-panel.price-chart.hide`)}
+        title={t(($) => $['country-panel']['price-chart'].see)}
+        expandedTitle={t(($) => $['country-panel']['price-chart'].hide)}
         className="text-success dark:text-success-dark"
         expandedIcon={ChevronsUpDownIcon}
         collapsedIcon={ChevronsDownUpIcon}
@@ -167,7 +167,7 @@ function TommorowLabel({ date, t, i18n }: { date: string; t: TFunction; i18n: i1
 
   return (
     <p className="py-1 font-semibold">
-      {`${t('country-panel.price-chart.tomorrow')}, ${formattedDate}`}
+      {`${t(($) => $['country-panel']['price-chart'].tomorrow)}, ${formattedDate}`}
     </p>
   );
 }
@@ -227,7 +227,7 @@ function TimeDisplay({ date, granularity }: { date: string; granularity: number 
   if (isNow(date, granularity)) {
     return (
       <p className={`min-w-18 pl-1 text-sm font-semibold`} data-testid="now-label">
-        {t(`country-panel.price-chart.now`)}
+        {t(($) => $['country-panel']['price-chart'].now)}
       </p>
     );
   }
@@ -246,7 +246,7 @@ function PriceDisclaimer() {
     <Disclaimer
       testId="price-disclaimer"
       Icon={<Info size={16} />}
-      text={t('country-panel.price-chart.price-disclaimer')}
+      text={t(($) => $['country-panel']['price-chart']['price-disclaimer'])}
       className="flex flex-row py-2 text-amber-700 dark:text-amber-500"
     />
   );
@@ -262,7 +262,9 @@ function TimeDisclaimer() {
   return (
     <Disclaimer
       Icon={<Clock3 size={16} />}
-      text={`${t('country-panel.price-chart.time-disclaimer')} ${date.at(-1)?.value}.`}
+      text={`${t(($) => $['country-panel']['price-chart']['time-disclaimer'])} ${
+        date.at(-1)?.value
+      }.`}
       className="flex flex-row pb-3 text-neutral-600 dark:text-neutral-300"
       testId="time-disclaimer"
     />

--- a/web/src/features/charts/LoadChart.tsx
+++ b/web/src/features/charts/LoadChart.tsx
@@ -50,7 +50,7 @@ function LoadChart({ datetimes, timeRange }: LoadChartProps) {
   return (
     <RoundedCard>
       <ChartTitle
-        titleText={t(`country-history.electricityLoad.${timeRange}`)}
+        titleText={t(($) => $['country-history'].electricityLoad[timeRange])}
         unit={someEstimated ? undefined : valueAxisLabel}
         id={Charts.ELECTRICITY_LOAD_CHART}
         subtitle={<ChartSubtitle datetimes={datetimes} timeRange={timeRange} />}

--- a/web/src/features/charts/MissingExchangeData.tsx
+++ b/web/src/features/charts/MissingExchangeData.tsx
@@ -44,7 +44,7 @@ export function MissingExchangeDataDisclaimer() {
         className="prose my-1 rounded bg-neutral-200 p-2 text-xs leading-snug dark:bg-neutral-800 dark:text-white dark:prose-a:text-white"
         style={{ width: `calc(100% - ${MARGIN}px)` }}
       >
-        {t('country-history.exchange-delay')}
+        {t(($) => $['country-history']['exchange-delay'])}
       </p>
     );
   }

--- a/web/src/features/charts/NetExchangeChart.tsx
+++ b/web/src/features/charts/NetExchangeChart.tsx
@@ -56,7 +56,7 @@ function NetExchangeChart({ datetimes, timeRange }: NetExchangeChartProps) {
   return (
     <RoundedCard className="pb-2">
       <ChartTitle
-        titleText={t(`country-history.netExchange.${timeRange}`)}
+        titleText={t(($) => $['country-history'].netExchange[timeRange])}
         unit={someEstimated ? undefined : valueAxisLabel}
         id={Charts.ELECTRTICITY_FLOW_CHART}
         subtitle={<ChartSubtitle datetimes={datetimes} timeRange={timeRange} />}

--- a/web/src/features/charts/NotEnoughDataMessage.tsx
+++ b/web/src/features/charts/NotEnoughDataMessage.tsx
@@ -9,7 +9,7 @@ export function NotEnoughDataMessage({ title, id }: { title: string; id: Charts 
     <div className="w-full">
       <ChartTitle titleText={title} id={id} />
       <div className="my-2 rounded bg-neutral-200 py-4 text-center text-sm dark:bg-neutral-800">
-        <p>{t('country-history.not-enough-data')}</p>
+        <p>{t(($) => $['country-history']['not-enough-data'])}</p>
       </div>
     </div>
   );

--- a/web/src/features/charts/OriginChart.tsx
+++ b/web/src/features/charts/OriginChart.tsx
@@ -106,7 +106,9 @@ function OriginChart({ displayByEmissions, datetimes, timeRange }: OriginChartPr
   return (
     <RoundedCard>
       <ChartTitle
-        titleText={t(`country-history.${titleDisplayMode}${titleMixMode}.${timeRange}`)}
+        titleText={t(
+          ($) => $['country-history'][titleDisplayMode][titleMixMode][timeRange]
+        )}
         isEstimated={someEstimated}
         unit={someEstimated ? undefined : valueAxisLabel}
         id={Charts.ELECTRICITY_MIX_CHART}
@@ -141,7 +143,9 @@ function OriginChart({ displayByEmissions, datetimes, timeRange }: OriginChartPr
       {isConsumptionAndAggregatedResolution && (
         <div
           className="prose my-1 rounded bg-neutral-200 p-2 text-xs leading-snug dark:bg-neutral-800 dark:text-white dark:prose-a:text-white"
-          dangerouslySetInnerHTML={{ __html: t('country-panel.exchangesAreMissing') }}
+          dangerouslySetInnerHTML={{
+            __html: t(($) => $['country-panel'].exchangesAreMissing),
+          }}
         />
       )}
       <MissingExchangeDataDisclaimer />

--- a/web/src/features/charts/PriceChart.tsx
+++ b/web/src/features/charts/PriceChart.tsx
@@ -62,7 +62,7 @@ function PriceChart({ datetimes, timeRange }: PriceChartProps) {
   return (
     <RoundedCard>
       <ChartTitle
-        titleText={t(`country-history.electricityprices.${timeRange}`)}
+        titleText={t(($) => $['country-history'].electricityprices[timeRange])}
         unit={valueAxisLabel}
         id={Charts.ELECTRICITY_PRICE_CHART}
         subtitle={<ChartSubtitle datetimes={datetimes} timeRange={timeRange} />}
@@ -70,7 +70,9 @@ function PriceChart({ datetimes, timeRange }: PriceChartProps) {
       <div className="relative">
         {isPriceDisabled && (
           <DisabledMessage
-            message={t(`country-panel.disabledPriceReasons.${priceDisabledReason}`)}
+            message={t(
+              ($) => $['country-panel'].disabledPriceReasons[priceDisabledReason]
+            )}
           />
         )}
         <AreaGraph

--- a/web/src/features/charts/bar-breakdown/BarBreakdownChart.tsx
+++ b/web/src/features/charts/bar-breakdown/BarBreakdownChart.tsx
@@ -126,7 +126,7 @@ function BarBreakdownChart({
         <EmptyBarBreakdownChart
           height={height}
           width={width}
-          overLayText={t('country-panel.noDataAtTimestamp')}
+          overLayText={t(($) => $['country-panel'].noDataAtTimestamp)}
           isMobile={isMobile}
         />
       </RoundedCard>
@@ -156,7 +156,7 @@ function BarBreakdownChart({
       </div>
       {!displayByEmissions && isHourly && (
         <CapacityLegend
-          text={t('country-panel.graph-legends.installed-capacity')}
+          text={t(($) => $['country-panel']['graph-legends']['installed-capacity'])}
           unit={graphUnit}
         />
       )}
@@ -238,14 +238,14 @@ export const getText = (
 ) => {
   const translations = {
     hourly: {
-      emissions: t('country-panel.by-source.emissions'),
-      production: t('country-panel.by-source.electricity-mix'),
-      consumption: t('country-panel.by-source.electricity-mix'),
+      emissions: t(($) => $['country-panel']['by-source'].emissions),
+      production: t(($) => $['country-panel']['by-source']['electricity-mix']),
+      consumption: t(($) => $['country-panel']['by-source']['electricity-mix']),
     },
     default: {
-      emissions: t('country-panel.by-source.total-emissions'),
-      production: t('country-panel.by-source.total-electricity-mix'),
-      consumption: t('country-panel.by-source.total-electricity-mix'),
+      emissions: t(($) => $['country-panel']['by-source']['total-emissions']),
+      production: t(($) => $['country-panel']['by-source']['total-electricity-mix']),
+      consumption: t(($) => $['country-panel']['by-source']['total-electricity-mix']),
     },
   };
   const period = timePeriod === TimeRange.H72 ? 'hourly' : 'default';

--- a/web/src/features/charts/bar-breakdown/BarElectricityExchangeChart.tsx
+++ b/web/src/features/charts/bar-breakdown/BarElectricityExchangeChart.tsx
@@ -44,7 +44,7 @@ export default function BarElectricityExchangeChart({
   return (
     <>
       <CapacityLegend
-        text={t('country-panel.graph-legends.exchange-capacity')}
+        text={t(($) => $['country-panel']['graph-legends']['exchange-capacity'])}
         unit={graphUnit}
       />
       <svg className="w-full overflow-visible" height={height}>
@@ -52,8 +52,8 @@ export default function BarElectricityExchangeChart({
           formatTick={formatTick}
           height={height}
           scale={powerScale}
-          axisLegendTextLeft={t('country-panel.graph-legends.exported')}
-          axisLegendTextRight={t('country-panel.graph-legends.imported')}
+          axisLegendTextLeft={t(($) => $['country-panel']['graph-legends'].exported)}
+          axisLegendTextRight={t(($) => $['country-panel']['graph-legends'].imported)}
         />
         <g transform={`translate(0, ${EXCHANGE_PADDING})`}>
           {exchangeData.map((d, index) => (
@@ -86,7 +86,8 @@ export default function BarElectricityExchangeChart({
       </svg>
       <div className="pb-2 pt-6">
         <div className="mb-1 text-xs font-medium text-neutral-600 dark:text-neutral-300">
-          {t('legends.carbonintensity')} ({CarbonUnits.GRAMS_CO2EQ_PER_KILOWATT_HOUR})
+          {t(($) => $.legends.carbonintensity)} (
+          {CarbonUnits.GRAMS_CO2EQ_PER_KILOWATT_HOUR})
         </div>
         <HorizontalColorbar colorScale={co2ColorScale} ticksCount={6} id={'co2'} />
       </div>

--- a/web/src/features/charts/bar-breakdown/BarElectricityProductionChart.tsx
+++ b/web/src/features/charts/bar-breakdown/BarElectricityProductionChart.tsx
@@ -41,8 +41,8 @@ function BarElectricityProductionChart({
         formatTick={formatTick}
         height={height}
         scale={powerScale}
-        axisLegendTextLeft={t('country-panel.graph-legends.stored')}
-        axisLegendTextRight={t('country-panel.graph-legends.produced')}
+        axisLegendTextLeft={t(($) => $['country-panel']['graph-legends'].stored)}
+        axisLegendTextRight={t(($) => $['country-panel']['graph-legends'].produced)}
       />
       <g transform={`translate(0, ${productionY})`}>
         {productionData.map((d, index) => (

--- a/web/src/features/charts/bar-breakdown/BarEmissionExchangeChart.tsx
+++ b/web/src/features/charts/bar-breakdown/BarEmissionExchangeChart.tsx
@@ -41,8 +41,8 @@ export default function BarEmissionExchangeChart({
           formatTick={formatTick}
           height={height}
           scale={co2Scale}
-          axisLegendTextLeft={t('country-panel.graph-legends.exported')}
-          axisLegendTextRight={t('country-panel.graph-legends.imported')}
+          axisLegendTextLeft={t(($) => $['country-panel']['graph-legends'].exported)}
+          axisLegendTextRight={t(($) => $['country-panel']['graph-legends'].imported)}
         />
         <g transform={`translate(0, ${EXCHANGE_PADDING})`}>
           {exchangeData.map((d, index) => (

--- a/web/src/features/charts/bar-breakdown/elements/Row.tsx
+++ b/web/src/features/charts/bar-breakdown/elements/Row.tsx
@@ -140,10 +140,9 @@ export function ProductionSourceRow({
       width={width}
     >
       <g className="pointer-events-none">
-        <TextElement text={t(productionMode)} />
+        <TextElement text={t(($) => $[productionMode])} />
         <ProductionSourceLegend electricityType={productionMode} />
       </g>
-
       {/* Row content */}
       {children}
     </BaseRow>

--- a/web/src/features/charts/tooltips/BreakdownChartTooltip.tsx
+++ b/web/src/features/charts/tooltips/BreakdownChartTooltip.tsx
@@ -66,12 +66,12 @@ function Headline({
 
   return (
     <div>
-      <b>{percentageUsage} %</b> {t(availabilityKey)}
+      <b>{percentageUsage} %</b> {t(($) => $[availabilityKey])}
       <span className="mx-1 inline-flex">
         <CountryFlag className="shadow-3xl" zoneId={zoneKey} />
       </span>
-      <b>{getZoneName(zoneKey)}</b> {t(dataActionKey)}
-      {!isExchange && ` ${t(selectedLayerKey)}`}
+      <b>{getZoneName(zoneKey)}</b> {t(($) => $[dataActionKey])}
+      {!isExchange && ` ${t(($) => $[selectedLayerKey])}`}
       {isExchange && (
         <>
           <span className="mx-1 inline-flex">
@@ -196,7 +196,9 @@ export function BreakdownChartTooltipContent({
 
   const title = isExchange
     ? getZoneName(selectedLayerKey)
-    : t(selectedLayerKey).charAt(0).toUpperCase() + t(selectedLayerKey).slice(1);
+    : t(($) => $[selectedLayerKey])
+        .charAt(0)
+        .toUpperCase() + t(($) => $[selectedLayerKey]).slice(1);
   return (
     <div className="w-full rounded-md bg-white p-3 text-sm shadow-3xl dark:border dark:border-neutral-700 dark:bg-neutral-800 sm:w-[410px]">
       <AreaGraphToolTipHeader
@@ -227,11 +229,10 @@ export function BreakdownChartTooltipContent({
           value={emissions}
           total={totalEmissions}
           format={formatCo2}
-          label={t('ofCO2eq')}
+          label={t(($) => $.ofCO2eq)}
           useTotalUnit
         />
       )}
-
       {!displayByEmissions && (
         // Used to prevent browser translation crashes on edge, see #6809
         <div translate="no">
@@ -245,8 +246,8 @@ export function BreakdownChartTooltipContent({
           {isHourly && (
             <>
               <br />
-              {t('tooltips.utilizing')} <b>{getRatioPercent(usage, capacity)} %</b>{' '}
-              {t('tooltips.ofinstalled')}
+              {t(($) => $.tooltips.utilizing)} <b>{getRatioPercent(usage, capacity)} %</b>{' '}
+              {t(($) => $.tooltips.ofinstalled)}
               <br />
               <MetricRatio
                 value={usage}
@@ -257,22 +258,22 @@ export function BreakdownChartTooltipContent({
               {capacitySource && (
                 <small>
                   {' '}
-                  ({t('country-panel.source')}: {capacitySource})
+                  ({t(($) => $['country-panel'].source)}: {capacitySource})
                 </small>
               )}
               <br />
             </>
           )}
           <br />
-          {t('tooltips.representing')}{' '}
+          {t(($) => $.tooltips.representing)}{' '}
           <b>{getRatioPercent(emissions, totalEmissions)} %</b>{' '}
-          {t('tooltips.ofemissions')}
+          {t(($) => $.tooltips.ofemissions)}
           <br />
           <MetricRatio
             value={emissions}
             total={totalEmissions}
             format={formatCo2}
-            label={t('ofCO2eq')}
+            label={t(($) => $.ofCO2eq)}
             useTotalUnit
           />
         </div>
@@ -280,7 +281,7 @@ export function BreakdownChartTooltipContent({
       {!displayByEmissions && (Number.isFinite(co2Intensity) || usage !== 0) && (
         <>
           <br />
-          {t('tooltips.withcarbonintensity')}
+          {t(($) => $.tooltips.withcarbonintensity)}
           <br />
           <div className="flex-wrap">
             <div className="inline-flex items-center gap-x-1">
@@ -289,7 +290,7 @@ export function BreakdownChartTooltipContent({
             {!isExchange && (
               <small>
                 {' '}
-                ({t('country-panel.source')}: {co2IntensitySource || '?'})
+                ({t(($) => $['country-panel'].source)}: {co2IntensitySource || '?'})
               </small>
             )}
           </div>

--- a/web/src/features/charts/tooltips/CarbonChartTooltip.tsx
+++ b/web/src/features/charts/tooltips/CarbonChartTooltip.tsx
@@ -41,7 +41,7 @@ export default function CarbonChartTooltip({ zoneDetail }: InnerAreaGraphTooltip
         datetime={new Date(stateDatetime)}
         timeRange={timeRange}
         squareColor={co2ColorScale(intensity)}
-        title={t('tooltips.carbonintensity')}
+        title={t(($) => $.tooltips.carbonintensity)}
         hasEstimationOrAggregationPill={hasEstimationOrAggregationPill}
         estimatedPercentage={roundedEstimatedPercentage}
         estimationMethod={estimationMethod}

--- a/web/src/features/charts/tooltips/EmissionChartTooltip.tsx
+++ b/web/src/features/charts/tooltips/EmissionChartTooltip.tsx
@@ -29,13 +29,14 @@ export default function EmissionChartTooltip({ zoneDetail }: InnerAreaGraphToolt
         datetime={new Date(stateDatetime)}
         timeRange={timeRange}
         squareColor="#a5292a"
-        title={t('country-panel.emissions')}
+        title={t(($) => $['country-panel'].emissions)}
         hasEstimationOrAggregationPill={hasEstimationOrAggregationPill}
         estimatedPercentage={roundedEstimatedPercentage}
         estimationMethod={estimationMethod}
       />
       <p className="flex justify-center text-base">
-        <b className="mr-1">{formatCo2({ value: totalEmissions })}</b> {t('ofCO2eq')}
+        <b className="mr-1">{formatCo2({ value: totalEmissions })}</b>{' '}
+        {t(($) => $.ofCO2eq)}
       </p>
     </div>
   );

--- a/web/src/features/charts/tooltips/LoadChartTooltip.tsx
+++ b/web/src/features/charts/tooltips/LoadChartTooltip.tsx
@@ -32,7 +32,7 @@ export default function LoadChartTooltip({ zoneDetail }: InnerAreaGraphTooltipPr
         datetime={new Date(stateDatetime)}
         timeRange={timeRange}
         squareColor="#7f7f7f"
-        title={t('tooltips.load')}
+        title={t(($) => $.tooltips.load)}
         hasEstimationOrAggregationPill={hasEstimationOrAggregationPill}
         estimatedPercentage={roundedEstimatedPercentage}
         estimationMethod={estimationMethod}

--- a/web/src/features/charts/tooltips/NetExchangeChartTooltip.tsx
+++ b/web/src/features/charts/tooltips/NetExchangeChartTooltip.tsx
@@ -24,7 +24,7 @@ export default function NetExchangeChartTooltip({
   const netExchange = getNetExchange(zoneDetail, displayByEmissions);
   const { formattingFactor, unit: powerUnit } = scalePower(netExchange, isHourly);
 
-  const unit = displayByEmissions ? t('ofCO2eq') : powerUnit;
+  const unit = displayByEmissions ? t(($) => $.ofCO2eq) : powerUnit;
   const value = displayByEmissions
     ? formatCo2({ value: Math.abs(netExchange) })
     : Math.abs(round(netExchange / formattingFactor));
@@ -37,13 +37,15 @@ export default function NetExchangeChartTooltip({
         datetime={new Date(stateDatetime)}
         timeRange={timeRange}
         squareColor="#7f7f7f"
-        title={t('tooltips.netExchange')}
+        title={t(($) => $.tooltips.netExchange)}
         hasEstimationOrAggregationPill={hasEstimationOrAggregationPill}
         estimatedPercentage={roundedEstimatedPercentage}
         estimationMethod={estimationMethod}
       />
       <p className="flex justify-center text-base">
-        {netExchange >= 0 ? t('tooltips.importing') : t('tooltips.exporting')}{' '}
+        {netExchange >= 0
+          ? t(($) => $.tooltips.importing)
+          : t(($) => $.tooltips.exporting)}{' '}
         <b className="mx-1">{Number.isFinite(value) ? value : '?'}</b> {unit}
       </p>
     </div>

--- a/web/src/features/charts/tooltips/PriceChartTooltip.tsx
+++ b/web/src/features/charts/tooltips/PriceChartTooltip.tsx
@@ -29,7 +29,7 @@ export default function PriceChartTooltip({ zoneDetail }: InnerAreaGraphTooltipP
         datetime={new Date(stateDatetime)}
         timeRange={timeRange}
         squareColor="#7f7f7f" // TODO: use price scale color
-        title={t('tooltips.price')}
+        title={t(($) => $.tooltips.price)}
       />
       <p className="flex justify-center text-base">
         <b className="mr-1">{price}</b>

--- a/web/src/features/exchanges/ExchangeTooltip.tsx
+++ b/web/src/features/exchanges/ExchangeTooltip.tsx
@@ -35,7 +35,7 @@ export default function ExchangeTooltip({
       className={twMerge('relative h-auto  rounded-2xl px-3 py-2', className)}
     >
       <div className="text-start text-base font-medium" data-testid="exchange-tooltip">
-        {t('tooltips.crossborderexport')}
+        {t(($) => $.tooltips.crossborderexport)}
         {isMobile ? '' : ':'}{' '}
         <b className="font-bold">
           {isHourly
@@ -49,14 +49,16 @@ export default function ExchangeTooltip({
             <ZoneName zone={zoneTo} textStyle="max-w-[165px]" />
           </div>
         </div>
-        {t('tooltips.carbonintensityexport')}:
+        {t(($) => $.tooltips.carbonintensityexport)}:
         <div className="pt-1">
           {co2intensity > 0 ? (
             <div className="inline-flex items-center gap-x-1">
               <CarbonIntensityDisplay withSquare co2Intensity={co2intensity} />
             </div>
           ) : (
-            <p className="text-neutral-400">{t('tooltips.temporarilyUnavailable')}</p>
+            <p className="text-neutral-400">
+              {t(($) => $.tooltips.temporarilyUnavailable)}
+            </p>
           )}
         </div>
       </div>

--- a/web/src/features/map-controls/MapButtons.tsx
+++ b/web/src/features/map-controls/MapButtons.tsx
@@ -56,19 +56,19 @@ export default function MapButtons(): ReactElement {
       <div className="pointer-events-auto flex flex-col gap-2">
         <MapButton
           icon={<SettingsIcon size={20} />}
-          tooltipText={t('settings-modal.title')}
+          tooltipText={t(($) => $['settings-modal'].title)}
           onClick={handleToggleSettingsModal}
           dataTestId="settings-button"
-          ariaLabel={t('aria.label.settings')}
+          ariaLabel={t(($) => $.aria.label.settings)}
           tooltipRef={settingsTooltipReference}
         />
         {shouldShowLayersButton && (
           <MapButton
             icon={<LayersIcon size={20} />}
-            tooltipText={t('tooltips.layers')}
+            tooltipText={t(($) => $.tooltips.layers)}
             onClick={handleToggleLayersModal}
             dataTestId="layers-button"
-            ariaLabel={t('aria.label.layers')}
+            ariaLabel={t(($) => $.aria.label.layers)}
             tooltipRef={layersTooltipReference}
           />
         )}

--- a/web/src/features/modals/InfoText.tsx
+++ b/web/src/features/modals/InfoText.tsx
@@ -9,7 +9,7 @@ export default function InfoText() {
         <Link href="https://electricitymaps.com/?utm_source=app.electricitymaps.com&utm_medium=referral&utm_campaign=about-section">
           Electricity Maps
         </Link>{' '}
-        {t('info.text')}
+        {t(($) => $.info.text)}
       </p>
     </div>
   );

--- a/web/src/features/modals/LayersModal.tsx
+++ b/web/src/features/modals/LayersModal.tsx
@@ -38,10 +38,9 @@ function WeatherToggleSwitch({
       <div className="flex items-center">
         <Icon size={20} className="mr-2 text-secondary dark:text-secondary-dark" />
         <span className="text-sm font-medium text-secondary dark:text-secondary-dark">
-          {t(`${typeAsTitlecase} layer`)}
+          {t(($) => $[typeAsTitlecase][' layer'])}
         </span>
       </div>
-
       <div className="relative">
         <SwitchToggle
           isEnabled={isEnabled}
@@ -49,7 +48,7 @@ function WeatherToggleSwitch({
           className={` ${
             !allowed || isLoadingLayer ? 'cursor-not-allowed opacity-50' : ''
           }`}
-          ariaLabel={t(`Toggle ${typeAsTitlecase} layer`)}
+          ariaLabel={t(($) => $['Toggle '][typeAsTitlecase][' layer'])}
         />
         {isLoadingLayer && (
           <span className="absolute inset-0 mb-[6px] ml-4 flex items-center justify-center">
@@ -83,7 +82,7 @@ function MobileDismissButton({ onClick }: { onClick: () => void }) {
   return (
     <div className="absolute inset-x-0 top-36 mx-auto flex justify-center md:hidden">
       <GlassContainer className="flex h-9 w-9 items-center justify-center rounded-full ">
-        <button aria-label={t('misc.dismiss')} onClick={onClick}>
+        <button aria-label={t(($) => $.misc.dismiss)} onClick={onClick}>
           <XIcon size={20} />
         </button>
       </GlassContainer>

--- a/web/src/features/modals/SettingsModal.tsx
+++ b/web/src/features/modals/SettingsModal.tsx
@@ -43,12 +43,12 @@ function ElectricityFlowsToggle() {
     <div className="flex w-full flex-col space-y-1 p-2">
       <div className="flex items-center justify-between">
         <span className="text-sm font-medium text-secondary dark:text-secondary-dark">
-          {t('settings-modal.flows')}
+          {t(($) => $['settings-modal'].flows)}
         </span>
         <SwitchToggle
           isEnabled={mode === Mode.CONSUMPTION}
           onChange={onToggle}
-          ariaLabel={t('settings-modal.flows')}
+          ariaLabel={t(($) => $['settings-modal'].flows)}
         />
       </div>
       <span className="text-xs text-secondary dark:text-secondary-dark">
@@ -97,7 +97,7 @@ function ThemeToggleGroup() {
   return (
     <div className="flex w-full items-center justify-between p-2">
       <span className="text-sm font-medium text-secondary dark:text-secondary-dark">
-        {t('tooltips.changeTheme')}
+        {t(($) => $.tooltips.changeTheme)}
       </span>
       <div className="flex space-x-1">
         <ThemeToggle
@@ -140,12 +140,12 @@ function ColorblindModeToggle() {
   return (
     <div className="flex w-full items-center justify-between p-2">
       <span className="text-sm font-medium text-secondary dark:text-secondary-dark">
-        {t('legends.colorblindmode')}
+        {t(($) => $.legends.colorblindmode)}
       </span>
       <SwitchToggle
         isEnabled={isEnabled}
         onChange={onToggle}
-        ariaLabel={t('legends.colorblindmode')}
+        ariaLabel={t(($) => $.legends.colorblindmode)}
       />
     </div>
   );
@@ -179,7 +179,7 @@ function LanguageSelectorToggle() {
         onKeyDown={handleKeyDown}
       >
         <span className="text-sm font-medium text-secondary dark:text-secondary-dark">
-          {t('Language')}
+          {t(($) => $.Language)}
         </span>
         <span className="text-sm text-secondary dark:text-secondary-dark">
           {selectedLanguage}
@@ -198,7 +198,9 @@ function AboutElectricityMaps() {
     <div className="w-full px-2 pt-2">
       <Accordion
         title={
-          <p className="text-secondary dark:text-secondary-dark">{t('info.title')}</p>
+          <p className="text-secondary dark:text-secondary-dark">
+            {t(($) => $.info.title)}
+          </p>
         }
         isCollapsed={isCollapsed}
         setState={setIsCollapsed}
@@ -211,18 +213,20 @@ function AboutElectricityMaps() {
 
           <div className="mb-2">
             <Link isExternal href="https://electricitymaps.com/privacy-policy">
-              {t('button.privacy-policy')}
+              {t(($) => $.button['privacy-policy'])}
             </Link>
           </div>
 
           <div className="mb-4">
             <Link isExternal href="https://electricitymaps.com/legal-notice">
-              {t('button.legal-notice')}
+              {t(($) => $.button['legal-notice'])}
             </Link>
           </div>
 
           <p className="pb-2 text-xs text-secondary dark:text-secondary-dark">
-            {t('info.version', { version: APP_VERSION })}
+            {t(($) => $.info.version, {
+              version: APP_VERSION,
+            })}
           </p>
         </div>
       </Accordion>
@@ -237,7 +241,7 @@ export function SettingsModalContent() {
       <div className="flex w-full flex-col">
         <SpatialAggregatesToggle />
         <p className="p-2 text-xs text-secondary dark:text-secondary-dark">
-          {t('tooltips.aggregateInfo')}
+          {t(($) => $.tooltips.aggregateInfo)}
         </p>
       </div>
       <HorizontalDivider />
@@ -267,7 +271,7 @@ function MobileDismissButton({
       style={style}
     >
       <GlassContainer className="flex h-9 w-9 items-center justify-center rounded-full">
-        <button aria-label={t('misc.dismiss')} onClick={onClick}>
+        <button aria-label={t(($) => $.misc.dismiss)} onClick={onClick}>
           <XIcon size={20} />
         </button>
       </GlassContainer>

--- a/web/src/features/panels/faq/FAQContent.tsx
+++ b/web/src/features/panels/faq/FAQContent.tsx
@@ -48,7 +48,7 @@ function FAQContent() {
     <Accordion.Root type="multiple" className="space-y-4 pr-2">
       {orderings.map(({ groupKey, entryOrder }) => (
         <div key={`group-${groupKey}`} className="space-y-2">
-          <h3 className="font-bold">{t(`${groupKey}.groupName`)}</h3>
+          <h3 className="font-bold">{t(($) => $[groupKey].groupName)}</h3>
           {entryOrder.map((entryKey, index) => (
             <Accordion.Item
               value={`${groupKey}-item-${index + 1}`}
@@ -58,14 +58,14 @@ function FAQContent() {
               <Accordion.Header className="w-full">
                 <Accordion.Trigger className="group flex items-center space-x-2 text-left hover:text-neutral-600 dark:hover:text-neutral-400">
                   <ChevronRight className="flex-none duration-300 group-radix-state-open:rotate-90" />{' '}
-                  <span>{t(`${groupKey}.${entryKey}-question`)}</span>
+                  <span>{t(($) => $[groupKey][entryKey]['-question'])}</span>
                 </Accordion.Trigger>
               </Accordion.Header>
               <Accordion.Content className="ml-2 border-l border-neutral-300 pl-4 radix-state-closed:animate-slide-up radix-state-open:animate-slide-down">
                 <div
                   className="text-md prose prose-sm leading-5 dark:prose-invert prose-a:text-sky-600 prose-a:no-underline hover:prose-a:underline dark:prose-a:invert md:max-w-none"
                   dangerouslySetInnerHTML={{
-                    __html: t(`${groupKey}.${entryKey}-answer`),
+                    __html: t(($) => $[groupKey][entryKey]['-answer']),
                   }}
                 />
               </Accordion.Content>

--- a/web/src/features/panels/search-panel/NoResults.tsx
+++ b/web/src/features/panels/search-panel/NoResults.tsx
@@ -8,7 +8,7 @@ export default function NoResults() {
     <div className="flex flex-col items-center justify-center gap-2 pb-6">
       <NoResultsIllustration />
       <p className="text-center text-sm text-neutral-500">
-        {t('ranking-panel.no-results')}
+        {t(($) => $['ranking-panel']['no-results'])}
       </p>
     </div>
   );

--- a/web/src/features/panels/search-panel/SearchPanel.tsx
+++ b/web/src/features/panels/search-panel/SearchPanel.tsx
@@ -48,13 +48,12 @@ export default function SearchPanel(): ReactElement {
       )}
     >
       <Helmet prioritizeSeoTags>
-        <title>{t('misc.maintitle') + metaTitleSuffix}</title>
+        <title>{t(($) => $.misc.maintitle) + metaTitleSuffix}</title>
         <link rel="canonical" href={canonicalUrl} />
       </Helmet>
-
       <div className="flex flex-grow flex-col">
         <SearchBar
-          placeholder={t('ranking-panel.search')}
+          placeholder={t(($) => $['ranking-panel'].search)}
           searchHandler={inputHandler}
           value={searchTerm}
           selectedIndex={selectedIndex}

--- a/web/src/features/panels/search-panel/getSearchData.ts
+++ b/web/src/features/panels/search-panel/getSearchData.ts
@@ -5,14 +5,13 @@ import { ZoneRowType } from './ZoneList';
 
 export const getAllZones = (language: string) => {
   // Get all zone data directly from translations
-  const zoneData = t('zoneShortName', { returnObjects: true }) as Record<
-    string,
-    ZoneRowType
-  >;
+  const zoneData = t(($) => $.zoneShortName, {
+    returnObjects: true,
+  }) as Record<string, ZoneRowType>;
 
   // If current language is not English, also get English translations
   if (language !== 'en') {
-    const englishZoneData = t('zoneShortName', {
+    const englishZoneData = t(($) => $.zoneShortName, {
       lng: 'en',
       returnObjects: true,
     }) as Record<string, ZoneRowType>;

--- a/web/src/features/panels/zone/Attribution.tsx
+++ b/web/src/features/panels/zone/Attribution.tsx
@@ -11,7 +11,9 @@ export default function Attribution({ zoneId }: { zoneId: string }) {
     <div className="flex flex-col gap-3 pt-1.5">
       {contributors.length > 0 && (
         <div className="flex flex-row justify-between">
-          <div className="text-sm font-semibold">{t('country-panel.helpfrom')}</div>
+          <div className="text-sm font-semibold">
+            {t(($) => $['country-panel'].helpfrom)}
+          </div>
           <ContributorList contributors={contributors} />
         </div>
       )}

--- a/web/src/features/panels/zone/EstimationCard.tsx
+++ b/web/src/features/panels/zone/EstimationCard.tsx
@@ -142,10 +142,16 @@ export default function EstimationCard({
             <FeedbackCard
               surveyReference={estimationMethod}
               postSurveyResponse={postSurveyResponse}
-              primaryQuestion={t('feedback-card.estimations.primary-question')}
-              secondaryQuestionHigh={t('feedback-card.estimations.secondary-question')}
-              secondaryQuestionLow={t('feedback-card.estimations.secondary-question')}
-              subtitle={t('feedback-card.estimations.subtitle')}
+              primaryQuestion={t(
+                ($) => $['feedback-card'].estimations['primary-question']
+              )}
+              secondaryQuestionHigh={t(
+                ($) => $['feedback-card'].estimations['secondary-question']
+              )}
+              secondaryQuestionLow={t(
+                ($) => $['feedback-card'].estimations['secondary-question']
+              )}
+              subtitle={t(($) => $['feedback-card'].estimations.subtitle)}
             />
           )}
         </div>
@@ -235,7 +241,7 @@ function BaseCard({
               className={`text-sm font-semibold text-black underline dark:text-white`}
               onClick={trackMissingDataMethodology}
             >
-              {t(`estimation-card.link`)}
+              {t(($) => $['estimation-card'].link)}
             </a>
           )}
         </div>
@@ -254,7 +260,11 @@ export function OutageCard({
   const { t } = useTranslation();
   const zoneMessageText =
     estimationMethod === EstimationMethods.THRESHOLD_FILTERED
-      ? { message: t(`estimation-card.${EstimationMethods.THRESHOLD_FILTERED}.body`) }
+      ? {
+          message: t(
+            ($) => $['estimation-card'][EstimationMethods.THRESHOLD_FILTERED].body
+          ),
+        }
       : zoneMessage;
   return (
     <BaseCard
@@ -331,7 +341,9 @@ function ZoneMessageBlock({ zoneMessage }: { zoneMessage?: ZoneMessage }) {
             className="inline-flex items-center gap-1 text-sm font-semibold text-black underline dark:text-white"
             href={`https://github.com/electricitymaps/electricitymaps-contrib/issues/${zoneMessage.issue}`}
           >
-            <span className="pl-1 underline">{t('estimation-card.outage-details')}</span>
+            <span className="pl-1 underline">
+              {t(($) => $['estimation-card']['outage-details'])}
+            </span>
             <FaGithub size={18} />
           </a>
         </span>

--- a/web/src/features/panels/zone/MethodologyCard.tsx
+++ b/web/src/features/panels/zone/MethodologyCard.tsx
@@ -29,7 +29,7 @@ function MethodologyCard() {
   return (
     <RoundedCard>
       <Accordion
-        title={t('left-panel.methodologies-and-data-sources.title')}
+        title={t(($) => $['left-panel']['methodologies-and-data-sources'].title)}
         className="text-md pt-2"
         isCollapsed={isCollapsed}
         setState={setIsCollapsed}
@@ -37,47 +37,49 @@ function MethodologyCard() {
         <div className="flex flex-col gap-2 py-1">
           <div className="flex items-center gap-1 py-2">
             <LogoIcon className="size-4 dark:text-white" />
-            <p className="font-semibold">{t('left-panel.applied-methodologies.title')}</p>
+            <p className="font-semibold">
+              {t(($) => $['left-panel']['applied-methodologies'].title)}
+            </p>
           </div>
           <div className="flex flex-col gap-2 pl-5">
             <Link
               href="https://www.electricitymaps.com/methodology#missing-data"
               onClick={trackMissingDataMethodology}
             >
-              {t('left-panel.applied-methodologies.estimations')}
+              {t(($) => $['left-panel']['applied-methodologies'].estimations)}
             </Link>
             <Link
               href="https://www.electricitymaps.com/methodology#data-collection-and-processing"
               onClick={trackDataCollectionMethodology}
             >
-              {t('left-panel.applied-methodologies.flowtracing')}
+              {t(($) => $['left-panel']['applied-methodologies'].flowtracing)}
             </Link>
             <Link
               href="https://www.electricitymaps.com/methodology#carbon-intensity-and-emission-factors"
               onClick={trackCarbonIntensityMethodology}
             >
-              {t('left-panel.applied-methodologies.carbonintensity')}
+              {t(($) => $['left-panel']['applied-methodologies'].carbonintensity)}
             </Link>
             <Link
               href="https://github.com/electricityMaps/electricitymaps-contrib/wiki/Historical-aggregates"
               onClick={trackHistoricalAggregatesMethodology}
             >
-              {t('left-panel.applied-methodologies.historicalAggregations')}
+              {t(($) => $['left-panel']['applied-methodologies'].historicalAggregations)}
             </Link>
           </div>
 
           <DataSources
-            title={t('data-sources.capacity')}
+            title={t(($) => $['data-sources'].capacity)}
             icon={<UtilityPole size={16} />}
             sources={capacitySources}
           />
           <DataSources
-            title={t('data-sources.power')}
+            title={t(($) => $['data-sources'].power)}
             icon={<Zap size={16} />}
             sources={powerGenerationSources}
           />
           <DataSources
-            title={t('data-sources.emission')}
+            title={t(($) => $['data-sources'].emission)}
             icon={<Factory size={16} />}
             sources={emissionFactorSources}
             emissionFactorSourcesToProductionSources={

--- a/web/src/features/panels/zone/NoInformationMessage.tsx
+++ b/web/src/features/panels/zone/NoInformationMessage.tsx
@@ -12,7 +12,7 @@ export default function NoInformationMessage() {
     <div data-testid="no-parser-message" className="pt-4 text-center text-base">
       <span
         className="prose text-sm dark:prose-invert prose-a:text-sky-600 prose-a:no-underline hover:prose-a:underline"
-        dangerouslySetInnerHTML={{ __html: t(translationName, translationObject) }}
+        dangerouslySetInnerHTML={{ __html: t(($) => $[translationName]) }}
       />
     </div>
   );

--- a/web/src/features/panels/zone/ShareButton.tsx
+++ b/web/src/features/panels/zone/ShareButton.tsx
@@ -75,7 +75,7 @@ export function ShareButton({
         ref={reference}
         description={toastMessage}
         isCloseable={true}
-        toastCloseText={t('misc.dismiss')}
+        toastCloseText={t(($) => $.misc.dismiss)}
         duration={DEFAULT_TOAST_DURATION}
       />
     </>

--- a/web/src/features/panels/zone/ZoneDetails.tsx
+++ b/web/src/features/panels/zone/ZoneDetails.tsx
@@ -102,7 +102,9 @@ export default function ZoneDetails(): JSX.Element {
           <MethodologyCard />
           <HorizontalDivider />
           <div className="flex items-center justify-between gap-2">
-            <div className="text-sm font-semibold">{t('country-panel.forecastCta')}</div>
+            <div className="text-sm font-semibold">
+              {t(($) => $['country-panel'].forecastCta)}
+            </div>
             <ApiButton size="sm" onClick={trackCtaForecast} />
           </div>
           <Attribution zoneId={zoneId} />

--- a/web/src/features/panels/zone/ZoneHeader.tsx
+++ b/web/src/features/panels/zone/ZoneHeader.tsx
@@ -36,17 +36,15 @@ export default function ZoneHeader({ zoneId, isEstimated }: ZoneHeaderTitleProps
         <link rel="canonical" href={canonicalUrl} />
       </Helmet>
       <ZoneHeaderBackButton />
-
       <div className="w-full overflow-hidden">
         <ZoneHeaderTitle zoneId={zoneId} zoneNameFull={zoneNameFull} />
       </div>
-
       {isShareButtonEnabled &&
         (showMoreOptions ? (
           <MoreOptionsDropdown
             id="zone"
             shareUrl={shareUrl}
-            title={t(`more-options-dropdown.title`) + ` ${zoneNameFull}`}
+            title={t(($) => $['more-options-dropdown'].title) + ` ${zoneNameFull}`}
             isEstimated={isEstimated}
           >
             <Ellipsis />

--- a/web/src/features/time/DateRedirectToast.tsx
+++ b/web/src/features/time/DateRedirectToast.tsx
@@ -22,8 +22,8 @@ function DateRedirectToast() {
   return (
     <Toast
       ref={reference}
-      title={t('time-controller.date-unavailable.title')}
-      description={t('time-controller.date-unavailable.description')}
+      title={t(($) => $['time-controller']['date-unavailable'].title)}
+      description={t(($) => $['time-controller']['date-unavailable'].description)}
       duration={TOAST_DURATION}
       type={ToastType.INFO}
       className="h-fit"

--- a/web/src/features/time/HistoricalTimeHeader.tsx
+++ b/web/src/features/time/HistoricalTimeHeader.tsx
@@ -90,7 +90,7 @@ function HistoricalTimeHeader({
             />
           }
         />
-        {t('time-controller.navigate')} 24h
+        {t(($) => $['time-controller'].navigate)} 24h
         <Button
           backgroundClasses="bg-transparent"
           size="sm"
@@ -118,7 +118,7 @@ function HistoricalTimeHeader({
           isDisabled={!urlDatetime}
           icon={<Radio size={20} />}
         >
-          {t('time-controller.live')}
+          {t(($) => $['time-controller'].live)}
         </Button>
         <Button
           backgroundClasses={`rounded-full bg-transparent mr-0 z-1 ${floatingStyle}`}

--- a/web/src/hooks/useShare.ts
+++ b/web/src/hooks/useShare.ts
@@ -11,10 +11,10 @@ export function useShare() {
     async (url: string, callback?: (argument: string) => void) => {
       try {
         await navigator.clipboard.writeText(url);
-        callback?.(t('share-button.clipboard'));
+        callback?.(t(($) => $['share-button'].clipboard));
       } catch (error) {
         console.error(error);
-        callback?.(t('share-button.clipboard-error'));
+        callback?.(t(($) => $['share-button']['clipboard-error']));
       }
     },
     [t]
@@ -28,7 +28,7 @@ export function useShare() {
       } catch (error) {
         if (error instanceof Error && !SHARE_ERROR_PATTERN.test(error.toString())) {
           console.error(error);
-          callback?.(t('share-button.share-error'));
+          callback?.(t(($) => $['share-button']['share-error']));
         }
         return;
       }

--- a/web/src/migrate-i18next.cjs
+++ b/web/src/migrate-i18next.cjs
@@ -1,0 +1,398 @@
+const PATTERN = {
+  identifier: /^[A-Za-z_$][A-Za-z0-9_$]*$/,
+  digit: /^\d+$/,
+};
+
+const Object_hasOwnProperty = globalThis.Object.prototype.hasOwnProperty;
+
+const notfound = Symbol.for('i18next-codemod/NotFound');
+
+const isComposite = (u) => !!u && typeof u === 'object';
+
+function hasOwn(u, key) {
+  return !isComposite(u)
+    ? typeof u === 'function' && key in u
+    : typeof key === 'symbol'
+    ? isComposite(u) && key in u
+    : Object_hasOwnProperty.call(u, key);
+}
+
+function get(x, ks) {
+  let out = x;
+  let k;
+  while ((k = ks.shift()) !== undefined) {
+    if (hasOwn(out, k)) void (out = out[k]);
+    else if (k === '') continue;
+    else return notfound;
+  }
+  return out;
+}
+
+const isKey = (u) =>
+  typeof u === 'symbol' || typeof u === 'number' || typeof u === 'string';
+
+function parsePath(xs) {
+  return Array.isArray(xs) && xs.every(isKey)
+    ? [xs, () => true]
+    : [xs.slice(0, -1), xs[xs.length - 1]];
+}
+
+function has(...args) {
+  return (u) => {
+    const [path, check] = parsePath(args);
+    const got = get(u, path);
+    return got !== notfound && check(got);
+  };
+}
+
+function isStringLiteralNode(x) {
+  return has('type', (type) => type === 'StringLiteral')(x);
+}
+
+function isTemplateLiteralNode(x) {
+  return has('type', (type) => type === 'TemplateLiteral')(x);
+}
+
+function isMemberExpressionNode(x) {
+  return has('type', (type) => type === 'MemberExpression')(x);
+}
+
+function isIdentifierNode(x) {
+  return has('type', (type) => type === 'Identifier')(x);
+}
+
+function isArrayExpressionNode(x) {
+  return has('type', (type) => type === 'ArrayExpression')(x);
+}
+
+function isObjectExpressionNode(x) {
+  return has('type', (type) => type === 'ObjectExpression')(x);
+}
+
+function isCallExpressionNode(x) {
+  return has('type', (type) => type === 'CallExpression')(x);
+}
+
+function isObjectPatternNode(x) {
+  return has('type', (type) => type === 'ObjectPattern')(x);
+}
+
+function keyToSelector(key, j) {
+  const path = key.split('.');
+  const expr = path.reduce((acc, part) => {
+    if (PATTERN.digit.test(part))
+      return j.memberExpression(acc, j.literal(Number(part)), true);
+    else if (PATTERN.identifier.test(part))
+      return j.memberExpression(acc, j.identifier(part));
+    else return j.memberExpression(acc, j.literal(part), true);
+  }, j.identifier('$'));
+  return j.arrowFunctionExpression([j.identifier('$')], expr);
+}
+
+function separateNamespaceFromPath(key) {
+  const [head, ...tail] = key.split(':');
+  return tail.length ? { ns: head, path: tail.join(':') } : { path: head };
+}
+
+function templateLiteralToTokens(template) {
+  let tokens = [];
+  template.quasis.forEach((quasi, i) => {
+    if (quasi.value.cooked) {
+      quasi.value.cooked.split('.').forEach((s) => {
+        if (s) tokens.push(s);
+      });
+    }
+    if (i < template.expressions.length) {
+      tokens.push(template.expressions[i]);
+    }
+  });
+  return tokens;
+}
+
+function tokensToSelector(tokens, j) {
+  return tokens.reduce((acc, token) => {
+    if (typeof token === 'string')
+      if (PATTERN.digit.test(token))
+        return j.memberExpression(acc, j.literal(Number(token)), true);
+      else if (PATTERN.identifier.test(token))
+        return j.memberExpression(acc, j.identifier(token));
+      else return j.memberExpression(acc, j.literal(token), true);
+    else return j.memberExpression(acc, token, true);
+  }, j.identifier('$'));
+}
+
+/**
+ * TODO: See if jscodeshift has native utilities for cloning AST nodes (since
+ * {@link globalThis.structuredClone `structuredClone`} doesn't work here).
+ */
+function clone(node) {
+  return JSON.parse(JSON.stringify(node));
+}
+
+function is18nextTFunction(callee, { tAliases, i18nAliases }) {
+  return (
+    (isIdentifierNode(callee) && tAliases.has(callee.name)) ||
+    (isMemberExpressionNode(callee) &&
+      !callee.computed &&
+      isIdentifierNode(callee.property) &&
+      callee.property.name === 't' &&
+      isIdentifierNode(callee.object) &&
+      i18nAliases.has(callee.object.name))
+  );
+}
+
+module.exports = function transform(file, api) {
+  const j = api.jscodeshift;
+  const root = j(file.source);
+
+  const i18nAliases = new Set();
+  const tAliases = new Set();
+  const useTranslationAliases = new Set();
+  const context = {
+    i18nAliases,
+    tAliases,
+  };
+
+  root.find(j.ImportDeclaration, { source: { value: 'i18next' } }).forEach((p) => {
+    (p.node.specifiers || []).forEach((s) => {
+      switch (s.type) {
+        case 'ImportDefaultSpecifier':
+        case 'ImportNamespaceSpecifier': {
+          if (s.local == null) return;
+          else i18nAliases.add(s.local.name);
+          break;
+        }
+        case 'ImportSpecifier':
+          if (s.imported.name === 't') tAliases.add(s.local ? s.local.name : 't');
+          break;
+      }
+    });
+  });
+
+  root.find(j.ImportDeclaration, { source: { value: 'react-i18next' } }).forEach((p) => {
+    (p.node.specifiers || []).forEach((s) => {
+      if (s.type === 'ImportSpecifier' && s.imported.name === 'useTranslation') {
+        useTranslationAliases.add(s.local ? s.local.name : 'useTranslation');
+      }
+    });
+  });
+
+  if (i18nAliases.size === 0 && tAliases.size === 0 && useTranslationAliases.size === 0)
+    return file.source;
+
+  root.find(j.VariableDeclarator).forEach((p) => {
+    const init = p.node.init;
+    const id = p.node.id;
+
+    /**
+     * @example
+     * const { t } = useTranslation()
+     */
+    if (
+      isObjectPatternNode(id) &&
+      isCallExpressionNode(init) &&
+      isIdentifierNode(init.callee) &&
+      useTranslationAliases.has(init.callee.name)
+    ) {
+      id.properties.forEach((prop) => {
+        if (
+          has('value', isIdentifierNode)(prop) &&
+          (has('key', 'name', (name) => name === 't')(prop) ||
+            has('key', 'value', (value) => value === 't')(prop))
+        ) {
+          tAliases.add(prop.value.name);
+        }
+      });
+    }
+
+    /**
+     * @example
+     * const t = useTranslation().t
+     */
+    if (
+      isIdentifierNode(id) &&
+      isMemberExpressionNode(init) &&
+      isCallExpressionNode(init.object) &&
+      isIdentifierNode(init.object.callee) &&
+      useTranslationAliases.has(init.object.callee.name) &&
+      isIdentifierNode(init.property) &&
+      init.property.name === 't'
+    ) {
+      tAliases.add(id.name);
+    }
+  });
+
+  root
+    .find(j.CallExpression)
+    .filter((p) => is18nextTFunction(p.node.callee, context))
+    .forEach((p) => {
+      const { node } = p;
+      const [arg0, arg1, arg2] = node.arguments;
+
+      if (
+        isArrayExpressionNode(arg0) &&
+        arg0.elements.length > 0 &&
+        arg0.elements.every(isStringLiteralNode)
+      ) {
+        const keys = arg0.elements.map((el) => el?.value);
+
+        /** Gather default value + extra option props (if any) */
+        let positionalDefaultValue = null;
+        let optionsObject = null;
+        if (isStringLiteralNode(arg1)) positionalDefaultValue = arg1;
+        if (isObjectExpressionNode(arg1)) optionsObject = arg1;
+        if (!optionsObject && isObjectExpressionNode(arg2)) optionsObject = arg2;
+
+        /** options object properties (e.g., context, val, etc., but NOT defaultValue) */
+        let toplevelOptionProperties = Array.of();
+        /** case: defaultValue passed in the options object */
+        let defaultValueFromOptions = null;
+        if (optionsObject) {
+          optionsObject.properties.forEach((prop) => {
+            if (has('key')(prop) && has('value')(prop)) {
+              const { key, value } = prop;
+              if (has('name', (name) => typeof name === 'string')(key)) {
+                const k = key.name || value;
+                if (k === 'defaultValue') {
+                  defaultValueFromOptions = prop.value;
+                } else {
+                  toplevelOptionProperties.push(prop);
+                }
+              }
+            }
+          });
+        }
+
+        const finalDefault = defaultValueFromOptions || positionalDefaultValue;
+
+        const calleeClone = clone(node.callee);
+
+        /** Recursively build nested t() calls */
+        const buildCall = (idx) => {
+          const { ns, path } = separateNamespaceFromPath(keys[idx]);
+
+          const props = [];
+
+          if (ns) props.push(j.property('init', j.identifier('ns'), j.literal(ns)));
+
+          if (idx < keys.length - 1) {
+            props.push(
+              j.property('init', j.identifier('defaultValue'), buildCall(idx + 1))
+            );
+          } else if (finalDefault) {
+            props.push(j.property('init', j.identifier('defaultValue'), finalDefault));
+          }
+
+          /** top-level props (besides nested default values) bubble up to the root selector */
+          if (idx === 0 && toplevelOptionProperties.length) {
+            props.push(...toplevelOptionProperties);
+          }
+
+          const args = [keyToSelector(path, j)];
+          if (props.length) args.push(j.objectExpression(props));
+
+          return j.callExpression(clone(calleeClone), args);
+        };
+
+        /** Replace the entire original call */
+        j(p).replaceWith(buildCall(0));
+        /** return so we don't fall through and start evaluating other branches */
+        return;
+      }
+
+      root
+        .find(j.CallExpression)
+        .filter((p) => is18nextTFunction(p.node.callee, context))
+        .forEach((p) => {
+          const { node } = p;
+          const [arg0, arg1, arg2] = p.node.arguments;
+
+          /** case: dynamic-key */
+          if (
+            isTemplateLiteralNode(arg0) ||
+            isIdentifierNode(arg0) ||
+            isMemberExpressionNode(arg0)
+          ) {
+            /* derive selector function */
+            const tokens = isTemplateLiteralNode(arg0)
+              ? templateLiteralToTokens(arg0)
+              : [arg0];
+            const selectorFn = j.arrowFunctionExpression(
+              [j.identifier('$')],
+              tokensToSelector(tokens, j)
+            );
+
+            const newArgs = [selectorFn];
+            const opts = {};
+
+            /** positional defaultValue (string) */
+            if (isStringLiteralNode(arg1)) opts.defaultValue = arg1;
+
+            /** object‑style options (2nd or 3rd arg) */
+            const optObj = [arg1, arg2].find((a) => a && a.type === 'ObjectExpression');
+            if (optObj) {
+              optObj.properties.forEach((prop) => {
+                if (has('key')(prop) && has('value')(prop)) {
+                  const { key, value } = prop;
+                  if (has('name', (name) => typeof name === 'string')(key)) {
+                    opts[key.name] = value;
+                  } else if (has('value', (value) => typeof value === 'string')(key)) {
+                    opts[key.value] = value;
+                  }
+                }
+              });
+            }
+
+            if (Object.keys(opts).length) {
+              newArgs.push(
+                j.objectExpression(
+                  Object.entries(opts).map(([k, v]) =>
+                    j.property('init', j.identifier(k), v)
+                  )
+                )
+              );
+            }
+
+            node.arguments = newArgs;
+            /** return so we don't fall through and start evaluating other branches */
+            return;
+          }
+        });
+
+      if (!isStringLiteralNode(arg0) || typeof arg0.value !== 'string') return;
+
+      const { ns, path } = separateNamespaceFromPath(arg0.value);
+      const selectorFn = keyToSelector(path, j);
+      const newArgs = [selectorFn];
+      const opts = {};
+
+      if (isStringLiteralNode(arg1)) opts.defaultValue = arg1;
+
+      const optObj = [arg1, arg2].find(isObjectExpressionNode);
+      if (optObj) {
+        optObj.properties.forEach((prop) => {
+          if (has('key')(prop) && has('value')(prop)) {
+            const { key, value } = prop;
+            if (has('name', (name) => typeof name === 'string')(key)) {
+              opts[key.name] = value;
+            } else if (has('value', (value) => typeof value === 'string')(key)) {
+              opts[key.value] = value;
+            }
+          }
+        });
+      }
+
+      if (ns && !('ns' in opts)) opts.ns = j.literal(ns);
+      if (Object.keys(opts).length) {
+        newArgs.push(
+          j.objectExpression(
+            Object.entries(opts).map(([k, v]) => j.property('init', j.identifier(k), v))
+          )
+        );
+      }
+
+      node.arguments = newArgs;
+    });
+
+  return root.toSource();
+};


### PR DESCRIPTION
**Do not merge -- this is a dry-run**

This is part 2 of a 2-part PR to test the behavior of the [i18next codemod](https://github.com/ahrjarrett/i18next-codemod).

The previous PR adds the `migrate-i18next` script.

This PR shows the diff.

Original ask: https://github.com/i18next/i18next/pull/2322#discussion_r2159908951

#### Issues

1. I did not have time to check and make sure that every `t` call was modified, will hopefully have time tomorrow
2. There's a bug in [this line](https://github.com/electricitymaps/electricitymaps-contrib/compare/master...ahrjarrett:electricitymaps-contrib-fork:i18next-migration-dryrun?expand=1#diff-b0dbae034e721018666252834e6ae0a316ce3d34de68410c45da65f567b37ea6L15-R15)
   - It looks like the codemod currently doesn't preserve the options object if the options are defined outside the scope of the call to `t`
   - Current behavior:
      ```typescript
      // Before:
      const translationName = ''
      const translationObject = {}

      t(translationName, translationObject)

      // After:
      const translationName = ''
      const translationObject = {}

      t($ => translationName)
      ```

   - Expected behavior:
      ```typescript
      // Before:
      const translationName = ''
      const translationObject = {}

      t(translationName, translationObject)

      // After:
      const translationName = ''
      const translationObject = {}

      t($ => translationName, translationObject)
      ```

I've added this bug to our [todo list](https://github.com/i18next/i18next/pull/2322), will push another commit + an update here when it's fixed