### PR TITLE
(feat) Add webshare proxy support to Cyprus (CY) parser

### DIFF
--- a/parsers/CY.py
+++ b/parsers/CY.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 import sys
-from datetime import datetime
+from datetime import datetime, timedelta
 from logging import Logger, getLogger
 from typing import Any
 from zoneinfo import ZoneInfo
@@ -9,6 +9,9 @@ from zoneinfo import ZoneInfo
 # BeautifulSoup is used to parse HTML
 from bs4 import BeautifulSoup
 from requests import Session
+
+# Local library imports
+from parsers.lib.config import refetch_frequency, use_proxy
 
 REALTIME_SOURCE = "https://tsoc.org.cy/electrical-system/total-daily-system-generation-on-the-transmission-system/"
 HISTORICAL_SOURCE = "https://tsoc.org.cy/electrical-system/archive-total-daily-system-generation-on-the-transmission-system/?startdt={}&enddt=%2B1days"
@@ -112,6 +115,8 @@ class CyprusParser:
         return data
 
 
+@refetch_frequency(timedelta(days=1))
+@use_proxy(country_code="CY")
 def fetch_production(
     zone_key: str = "CY",
     session: Session | None = None,


### PR DESCRIPTION
## Summary
Added proxy support to the Cyprus electricity parser to route requests through webshare.io proxies located in Cyprus, ensuring reliable access to the tsoc.org.cy data source.

## Changes Made
- **Added `refetch_frequency` decorator** with `timedelta(days=1)` to optimize refetch operations in the feeder-electricity project
- **Added `use_proxy` decorator** with `country_code="CY"` to automatically route requests through Cyprus-based webshare proxies
- **Added necessary imports** for `refetch_frequency` and `use_proxy` from `parsers.lib.config`
- **Added `timedelta` import** to support the refetch frequency decorator

## Technical Details
- The `use_proxy` decorator automatically configures the session to use webshare proxies when `WEBSHARE_USERNAME` and `WEBSHARE_PASSWORD` environment variables are set
- Proxy format: `http://{username}-CY-rotate:{password}@p.webshare.io:80/`
- If environment variables are not set, the parser continues without proxy and logs a warning
- Proxy configuration is automatically cleaned up after each function execution

## Testing
- ✅ Verified proxy connection through Cyprus IP (83.168.54.8, Nicosia)
- ✅ Confirmed parser successfully fetches 68 data points with production and capacity data
- ✅ Validated data quality and timezone handling (Asia/Nicosia)
- ✅ Tested both with and without proxy environment variables

## Environment Variables Required
To use the proxy, set these environment variables:
```bash
export WEBSHARE_USERNAME="your_webshare_username"
export WEBSHARE_PASSWORD="your_webshare_password"
```

## Impact
- Improves reliability of Cyprus data collection by using local proxies
- Follows the same pattern as other parsers (e.g., GSO.py for Malaysia)
- Maintains backward compatibility when proxy credentials are not available