### PR TITLE
[Capacity]: Adjust BD wind capacity

### DIFF
--- a/config/zones/BD.yaml
+++ b/config/zones/BD.yaml
@@ -104,9 +104,6 @@ capacity:
       source: Ember, Yearly electricity data
       value: 850.0
   wind:
-    - datetime: '2017-01-01'
-      source: Ember, Yearly electricity data
-      value: 0.0
     - _comment: https://en.powerchina.cn/2023-10/13/c_828590.htm
       datetime: '2023-10-12'
       source: POWERCHINA


### PR DESCRIPTION
## Issue

It's a bit hard to get a firm date on when they actually started producing energy at the first wind farm in BD. But this source has when it connected to the grid which I think we can use. That should help get rid of some outliers.

But we still have some production from before this date, roughly for 4 months. Not really sure what we should do about that. This production currently get flagged since the reported capacity from Ember is 0, this obviously is not correct as we have production so I'm kind of leaning towards removing that capacity entry and allowing them through?

