### PR TITLE
fix(parser): only get relevant text from SPP email parser

### DIFF
--- a/parsers/email_grid_alerts.py
+++ b/parsers/email_grid_alerts.py
@@ -27,6 +27,7 @@ def fetch_grid_alerts_emails(
     session = session or Session()
     MAILGUN_API_KEY = get_token("MAILGUN_TOKEN")
 
+    domain_name = "alerts.electricitymaps.com"
     # REQUEST BODY: only implemented for the last 5 hours
     nowminus5hours = (
         datetime.datetime.now(datetime.timezone.utc).replace(microsecond=0)
@@ -50,8 +51,8 @@ def fetch_grid_alerts_emails(
                     "comparator": "=",
                     "values": [
                         {
-                            "label": "alerts.electricitymaps.com",
-                            "value": "alerts.electricitymaps.com",
+                            "label": domain_name,
+                            "value": domain_name,
                         }
                     ],
                 },
@@ -100,8 +101,6 @@ def fetch_grid_alerts_emails(
 
     # Get email using storage keys # The email is stored only for a few days (less than 3 days)
     for storage_key in keys:
-        domain_name = "alerts.electricitymaps.com"
-
         API_BASE_URL2 = f"https://api.{REGION}.mailgun.net/v3/domains/{domain_name}/messages/{storage_key}"
 
         # MAKE REQUEST
@@ -113,26 +112,31 @@ def fetch_grid_alerts_emails(
 
         # Parse email
         email_json = response.json()
-        message = email_json["subject"] + "\n" + email_json["body-plain"]
-        dt_received = datetime.datetime.strptime(
-            email_json["Date"], "%a, %d %b %Y %H:%M:%S %z"
-        )
+
+        date_str = email_json["Date"].replace(" (UTC)", "")
+        dt_received = datetime.datetime.strptime(date_str, "%a, %d %b %Y %H:%M:%S %z")
+        sender = email_json["From"].lower()
 
         # Extract zone key from sender
         if (
-            ("ercot" in email_json["sender"] and zone_key == ZoneKey("US-TEX-ERCO"))
-            or (
-                "flexalert" in email_json["sender"]
-                and zone_key == ZoneKey("US-CAL-CISO")
-            )
-            or ("spp" in email_json["sender"] and zone_key == ZoneKey("US-CENT-SWPP"))
-            or ("electricitymaps" in email_json["sender"])
+            ("ercot" in sender and zone_key == ZoneKey("US-TEX-ERCO"))
+            or ("flexalert" in sender and zone_key == ZoneKey("US-CAL-CISO"))
+            or ("spp" in sender and zone_key == ZoneKey("US-CENT-SWPP"))
+            or ("electricitymaps" in sender)
         ):
+            body = ""
+            if ZoneKey("US-CENT-SWPP") == zone_key:
+                body = email_json["body-plain"].split(
+                    "The following chart shows the relative severity of"
+                )[0]
+            # add more cases when we know the format of the other emails
+
+            message = email_json["subject"] + "\n" + body
             # Add to grid_alert_list
             grid_alert_list.append(
                 zoneKey=zone_key,
                 locationRegion=None,
-                source=email_json["sender"],
+                source=sender,
                 alertType=GridAlertType.undefined,
                 message=message,
                 issuedTime=dt_received,


### PR DESCRIPTION
## Issue

<!-- If you want to close an issue automatically when your PR is merged, write "Closes X" where X is the issue number. For example: Closes #000 -->
[GMM-872](https://linear.app/electricitymaps/issue/GMM-872/parse-email-text)

## Description

<!-- Explains the goal of this PR -->
This PR only selects the relevant part of the message for the SPP email parser. When we receive emails from ERCOT and CAISO we can do the same for them

### Preview

<!-- Please add screenshots and/or gif that shows visual changes (if applicable) -->
Before:
```
 {'alertType': <GridAlertType.undefined: 'undefined'>,
  'datetime': datetime.datetime(2025, 7, 9, 14, 5, tzinfo=datetime.timezone(datetime.timedelta(seconds=7200))),
  'endTime': None,
  'issuedTime': datetime.datetime(2025, 7, 9, 14, 5, 20, tzinfo=datetime.timezone(datetime.timedelta(seconds=7200))),
  'locationRegion': None,
  'message': 'Fwd: SPP is issuing a Resource Advisory effective noon Tuesday, July 1\n'
             '*SPP is issuing a Resource Advisory* for the entire Balancing Authority\r\n'
             'effective July 1, from noon until an anticipated end of 9 p.m. CT.\r\n'
             '\r\n'
             '   - *Resource Advisories do not require the public to conserve energy* but\r\n'
             '   are issued to raise awareness of potential threats to reliability among\r\n'
             '   entities responsible for operating transmission and generation facilities.\r\n'
             '   - This Resource Advisory is being declared due to low variable energy\r\n'
             '   resource (VER) forecast and outage uncertainty.\r\n'
             '   - Individuals should contact their local utility for details specific to\r\n'
             '   their area.\r\n'
             '   - Generation and transmission operators have been provided instructions\r\n'
             '   on applicable procedures, including reporting any limitations, fuel\r\n'
             '   shortages or concerns.\r\n'
             '   - To mitigate risks to reliability associated with these factors, SPP\r\n'
             '   may use greater unit commitment notification timeframes, including making\r\n'
             '   commitments before standard day-ahead market procedures and/or committing\r\n'
             '   resources in reliability status.\r\n'
             '   - SPP will send additional information if necessary.\r\n'
             '\r\n'
             '\r\n'
             'The following chart shows the relative severity of Resource Advisories:\r\n'
             '\r\n'
             '\r\n'
             '\r\n'
             '\r\n'
             '\r\n'
             '---\r\n'
             'You are currently subscribed to the list titled gridnotice as:\r\n'
             'james.dietrich@electricitymaps.com\r\n'
             'To manage your exploder subscriptions log into SPP.org\r\n'
             '<https://www.spp.org/account/login/?returnUrl=%2f>, edit your account\r\n'
             '<https://www.spp.org/account/edit-account> and use the Exploder Lists field\r\n'
             'to indicate the lists to which you would like to be subscribed or\r\n'
             'unsubscribed.\r\n'
             '\r\n'
             'Replies to this exploder list are disabled. If you have a message you would\r\n'
             'like to send, please contact the list administrator.\r\n',
  'source': 'silke.bonnen@electricitymaps.com',
  'startTime': datetime.datetime(2025, 7, 9, 14, 5, 20, tzinfo=datetime.timezone(datetime.timedelta(seconds=7200))),
  'zoneKey': 'US-CENT-SWPP'}]
```

After:
```
{'alertType': <GridAlertType.undefined: 'undefined'>,
  'datetime': datetime.datetime(2025, 7, 9, 14, 5, tzinfo=datetime.timezone(datetime.timedelta(seconds=7200))),
  'endTime': None,
  'issuedTime': datetime.datetime(2025, 7, 9, 14, 5, 20, tzinfo=datetime.timezone(datetime.timedelta(seconds=7200))),
  'locationRegion': None,
  'message': 'Fwd: SPP is issuing a Resource Advisory effective noon Tuesday, July 1\n'
             '*SPP is issuing a Resource Advisory* for the entire Balancing Authority\r\n'
             'effective July 1, from noon until an anticipated end of 9 p.m. CT.\r\n'
             '\r\n'
             '   - *Resource Advisories do not require the public to conserve energy* but\r\n'
             '   are issued to raise awareness of potential threats to reliability among\r\n'
             '   entities responsible for operating transmission and generation facilities.\r\n'
             '   - This Resource Advisory is being declared due to low variable energy\r\n'
             '   resource (VER) forecast and outage uncertainty.\r\n'
             '   - Individuals should contact their local utility for details specific to\r\n'
             '   their area.\r\n'
             '   - Generation and transmission operators have been provided instructions\r\n'
             '   on applicable procedures, including reporting any limitations, fuel\r\n'
             '   shortages or concerns.\r\n'
             '   - To mitigate risks to reliability associated with these factors, SPP\r\n'
             '   may use greater unit commitment notification timeframes, including making\r\n'
             '   commitments before standard day-ahead market procedures and/or committing\r\n'
             '   resources in reliability status.\r\n'
             '   - SPP will send additional information if necessary.\r\n'
             '\r\n'
             '\r\n',
  'source': 'silke bonnen <silke.bonnen@electricitymaps.com>',
  'startTime': datetime.datetime(2025, 7, 9, 14, 5, 20, tzinfo=datetime.timezone(datetime.timedelta(seconds=7200))),
  'zoneKey': 'US-CENT-SWPP'}]
```

### Double check

- [ ] I have tested my parser changes locally with `poetry run test_parser "zone_key"`
- [ ] I have run `pnpx prettier@2 --write .` and `poetry run format` in the top level directory to format my changes.
