### PR TITLE
Use shorter copy for experimental card

### DIFF
--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -1,8 +1,8 @@
 {
   "experiment": {
     "5min": {
-      "title": "New feature: 5-minute resolution",
-      "description": "The 5-minute resolution feature is currently in experimental phase and available at no additional cost while we gather feedback and refine the functionality."
+      "title": "New: 5-minute resolution",
+      "description": "Currently experimental. Available at no additional cost while we gather feedback and refine the functionality."
     },
     "feedbackCta": "Leave feedback"
   },


### PR DESCRIPTION
This pull request updates the English localization file to streamline the wording for the 5-minute resolution feature. The changes simplify the title and description to make them more concise.

* [`web/src/locales/en.json`](diffhunk://#diff-7c3ddd710e34360b7b5261271001cf82fecd1ec1ba35a11816dc72043188935bL4-R5): Updated the `5min` experiment title to "New: 5-minute resolution" and shortened the description for clarity and brevity.
