### PR TITLE
Add translations for settings modal and some missing pl

### DIFF
--- a/web/src/features/modals/LayersModal.tsx
+++ b/web/src/features/modals/LayersModal.tsx
@@ -38,7 +38,7 @@ function WeatherToggleSwitch({
       <div className="flex items-center">
         <Icon size={20} className="mr-2 text-secondary dark:text-secondary-dark" />
         <span className="text-sm font-medium text-secondary dark:text-secondary-dark">
-          {t(`${typeAsTitlecase} layer`)}
+          {t(`aria.label.${type}Layer`)}
         </span>
       </div>
 
@@ -49,7 +49,7 @@ function WeatherToggleSwitch({
           className={` ${
             !allowed || isLoadingLayer ? 'cursor-not-allowed opacity-50' : ''
           }`}
-          ariaLabel={t(`Toggle ${typeAsTitlecase} layer`)}
+          ariaLabel={t(`tooltips.${isEnabled ? 'hide' : 'show'}${typeAsTitlecase}Layer`)}
         />
         {isLoadingLayer && (
           <span className="absolute inset-0 mb-[6px] ml-4 flex items-center justify-center">
@@ -63,6 +63,7 @@ function WeatherToggleSwitch({
 
 export function LayersModalContent() {
   const areWeatherLayersAllowed = useAtomValue(areWeatherLayersAllowedAtom);
+  const { t } = useTranslation();
 
   return (
     <div className="p-2">
@@ -70,8 +71,7 @@ export function LayersModalContent() {
       <WeatherToggleSwitch allowed={areWeatherLayersAllowed} type="solar" />
       {!areWeatherLayersAllowed && (
         <p className="px-4 py-2 text-sm text-secondary dark:text-secondary-dark">
-          Weather data not available for this aggregation, switch to real-time to see live
-          weather data
+          {t('settings-modal.weather-layers-disallowed')}
         </p>
       )}
     </div>

--- a/web/src/features/modals/SettingsModal.tsx
+++ b/web/src/features/modals/SettingsModal.tsx
@@ -56,10 +56,9 @@ function ElectricityFlowsToggle() {
           className="text-xs"
           href="https://www.electricitymaps.com/blog/flow-tracing"
         >
-          Flow-tracing
+          {t('settings-modal.flow-tracing-link-label')}
         </Link>{' '}
-        tracks how electricity physically moves through interconnectors that link
-        different zones
+        {t('settings-modal.flow-tracing-link-description')}
       </span>
     </div>
   );
@@ -205,8 +204,9 @@ function AboutElectricityMaps() {
       >
         <div className="mt-2 text-xs text-secondary dark:text-secondary-dark">
           <p className="mb-4">
-            <Link href="https://electricitymaps.com">Electricity Maps</Link> offers an API
-            that delivers real-time and predictive electricity grid signals.
+            <Link href="https://electricitymaps.com">Electricity Maps</Link>
+            &nbsp;
+            {t('settings-modal.home-link-description')}
           </p>
 
           <div className="mb-2">

--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -14,7 +14,11 @@
   },
   "settings-modal": {
     "title": "Settings",
-    "flows": "Electricity flows"
+    "flows": "Electricity flows",
+    "flow-tracing-link-label": "Flow-tracing",
+    "flow-tracing-link-description": "tracks how electricity physically moves through interconnectors that link different zones",
+    "home-link-description": "offers an API that delivers real-time and predictive electricity grid signals.",
+    "weather-layers-disallowed": "Weather data not available for this aggregation, switch to real-time to see live weather data"
   },
   "ranking-panel": {
     "title": "Electricity Grid Carbon Emissions",

--- a/web/src/locales/pl.json
+++ b/web/src/locales/pl.json
@@ -1815,7 +1815,7 @@
   "experiment": {
     "5min": {
       "title": "Nowa funkcjonalność: rozdzielczość 5-minutowa",
-      "description": "Funkcjonalność eksperymentalna. Dostępne bez dodatkowych opłat, gdy zbieramy opinie i dopracowujemy funkcje."
+      "description": "Funkcjonalność eksperymentalna. Dostępna bez dodatkowych opłat, gdy zbieramy opinie i dopracowujemy funkcje."
     },
     "feedbackCta": "Podziel się swoją opinią"
   },
@@ -1827,7 +1827,7 @@
     "mobile-share-via": "Udostępnij za pomocą",
     "copy-link": "Skopiuj link",
     "copy-chart-link": "Skopiuj link do wykresu",
-    "copy-zone-link": "Skopuj link to obszaru",
+    "copy-zone-link": "Skopiuj link to obszaru",
     "preliminary-data": "Wstępne dane mogą się z czasem zmieniać.",
     "summary": "Odkryj dane o energii elektrycznej w czasie rzeczywistym dzięki aplikacji Electricity Maps!"
   },
@@ -1842,7 +1842,7 @@
     "12mo": "12 miesięcy",
     "all_months": "Wszystkie miesiące",
     "all_years": "Wszystkie lata",
-    "navigate": "Naviguj",
+    "navigate": "Nawiguj",
     "live": "Na żywo",
     "date-unavailable": {
       "title": "Data niedostępna",

--- a/web/src/locales/pl.json
+++ b/web/src/locales/pl.json
@@ -1,21 +1,29 @@
 {
   "info": {
     "version": "Wersja aplikacji: {{version}}",
-    "share-app": "Podziel się aplikacją:"
+    "share-app": "Podziel się aplikacją:",
+    "title": "Informacje o Electricity Maps",
+    "text": "To platforma API, która udostępnia dane o zużyciu energii elektrycznej w czasie rzeczywistym i prognozowanym, umożliwiając urządzeniom ograniczenie kosztów i emisji poprzez informowanie o najlepszym czasie na zużycie prądu."
   },
   "settings-modal": {
-    "title": "Ustawienia"
+    "title": "Ustawienia",
+    "flows": "Przepływy energii elektrycznej",
+    "flow-tracing-link-label": "Śledzenie przepływu",
+    "flow-tracing-link-description": "pokazuje, jak energia elektryczna przekazywana jest przez połączenia między różnymi strefami",
+    "home-link-description": "oferuje API dostarczające dane z sieci energetycznej w czasie rzeczywistym i prognozowane.",
+    "weather-layers-disallowed": "Dane pogodowe niedostępne dla tej agregacji - przełącz na tryb na żywo, aby zobaczyć aktualne dane pogodowe"
   },
   "ranking-panel": {
     "title": "Wpływ na klimat według obszaru",
     "subtitle": "Podział według intensywności emisji dwutlenku węgla w zużytej energii elektrycznej (gCO₂eq/kWh)",
-    "search": "Szukaj"
+    "search": "Szukaj",
+    "no-results": "Nic nie znaleziono. Spróbuj wyszukać czegoś innego."
   },
   "button": {
     "reddit": "Dołącz do r/electricitymaps",
     "github": "Współtwórz na GitHub",
-    "twitter": "Śledź nas na Twitter",
-    "twitter-share": "Podziel się na Twitter",
+    "twitter": "Śledź nas na X (Twitter)",
+    "twitter-share": "Podziel się na X (Twitter)",
     "linkedin": "Śledź nas na LinkedIn",
     "linkedin-share": "Udostępnij na LinkedIn",
     "facebook": "Śledź nas na Facebook",
@@ -23,7 +31,11 @@
     "feedback": "Podziel się opinią",
     "faq": "FAQ",
     "privacy-policy": "Polityka prywatności",
-    "legal-notice": "Informacja prawna"
+    "legal-notice": "Informacja prawna",
+    "bluesky-share": "Sprawdź dane o globalnych emisjach energii elektrycznej w czasie rzeczywistym: {{baseUrl}}",
+    "reddit-share": "Udostępnij na Reddit",
+    "api": "Dostęp do API",
+    "docs": "Dokumentacja API"
   },
   "mobile-main-menu": {
     "map": "Electricity Maps",
@@ -260,7 +272,7 @@
   "legends": {
     "windpotential": "Potencjał wiatrowy",
     "solarpotential": "Potencjał słoneczny",
-    "colorblindmode": "tryb dla daltonistów",
+    "colorblindmode": "Tryb dla daltonistów",
     "carbonintensity": "Emisja CO₂"
   },
   "tooltips": {
@@ -279,6 +291,7 @@
     "withcarbonintensity": "z emisją CO₂",
     "zoomIn": "Powiększ",
     "zoomOut": "Pomniejsz",
+    "layers": "Warstwy mapy",
     "showWindLayer": "Pokaż warstwę wiatru",
     "hideWindLayer": "Ukryj warstwę wiatru",
     "showSolarLayer": "Pokaż warstwę słoneczną",
@@ -296,8 +309,11 @@
     "dataIsDelayed": "Dane są opóźnione",
     "price": "Cena",
     "netExchange": "Wymiana netto",
+    "load": "Pobór mocy",
     "importing": "Import",
-    "exporting": "Eksport"
+    "exporting": "Eksport",
+    "flowTraced": "Dane śledzące przepływ uwzględniają fizyczny przepływ energii elektrycznej",
+    "nonFlowTraced": "Dane bez śledzenia przepływu nie uwzględniają importu i eksportu"
   },
   "aria": {
     "label": {
@@ -307,7 +323,10 @@
       "solarLayer": "Warstwa słoneczna",
       "changeTheme": "Zmień motyw",
       "hideSidePanel": "Ukryj panel boczny",
-      "showSidePanel": "Pokaż panel boczny"
+      "showSidePanel": "Pokaż panel boczny",
+      "layers": "Warstwy mapy",
+      "zoomIn": "Powiększ",
+      "zoomOut": "Pomniejsz"
     }
   },
   "aggregateButtons": {
@@ -1791,6 +1810,43 @@
     },
     "YT": {
       "zoneName": "Majotta"
+    }
+  },
+  "experiment": {
+    "5min": {
+      "title": "Nowa funkcjonalność: rozdzielczość 5-minutowa",
+      "description": "Funkcjonalność eksperymentalna. Dostępne bez dodatkowych opłat, gdy zbieramy opinie i dopracowujemy funkcje."
+    },
+    "feedbackCta": "Podziel się swoją opinią"
+  },
+  "more-options-dropdown": {
+    "title": "Udostępnij",
+    "download": "Pobierz CSV",
+    "chart-title": "Udostępnij wykres",
+    "zone-title": "Udostępnij obszar",
+    "mobile-share-via": "Udostępnij za pomocą",
+    "copy-link": "Skopiuj link",
+    "copy-chart-link": "Skopiuj link do wykresu",
+    "copy-zone-link": "Skopuj link to obszaru",
+    "preliminary-data": "Wstępne dane mogą się z czasem zmieniać.",
+    "summary": "Odkryj dane o energii elektrycznej w czasie rzeczywistym dzięki aplikacji Electricity Maps!"
+  },
+  "new-feature-popover": {
+    "title": "Nowa funkcjonalność: widok 72-godzinny",
+    "content": "Poznaj trendy w danych na żywo i historycznych dzięki nowemu 72-godzinnemu oknu czasowemu."
+  },
+  "time-controller": {
+    "24h": "24 godziny",
+    "72h": "72 godziny",
+    "3mo": "90 dni",
+    "12mo": "12 miesięcy",
+    "all_months": "Wszystkie miesiące",
+    "all_years": "Wszystkie lata",
+    "navigate": "Naviguj",
+    "live": "Na żywo",
+    "date-unavailable": {
+      "title": "Data niedostępna",
+      "description": "Przekierowanie do danych na żywo."
     }
   }
 }


### PR DESCRIPTION
## Description

<!-- Explains the goal of this PR -->

- Moved some hardcoded texts into translations in SettingsModal 
- Use old translation values in LayersModal (I don't want to add new values if there are old ones present)
- Added some missing Polish translations

### Preview

<!-- Please add screenshots and/or gif that shows visual changes (if applicable) -->

SettingsModal:
<img width="349" height="648" alt="Screenshot 2025-07-25 at 14 55 39" src="https://github.com/user-attachments/assets/b9620812-bc82-490f-b787-6ccc6251e1c1" />

LayersModal:
<img width="357" height="181" alt="Screenshot 2025-07-25 at 14 55 23" src="https://github.com/user-attachments/assets/b65324d0-3e67-4542-9f5d-63a0e4ffd871" />

Time window selector:
<img width="538" height="347" alt="Screenshot 2025-07-25 at 09 31 46" src="https://github.com/user-attachments/assets/e42bbf2e-ec25-4398-af68-9fa938d80fa2" />
<img width="412" height="111" alt="Screenshot 2025-07-25 at 09 31 37" src="https://github.com/user-attachments/assets/ed690cc3-aea0-4189-a8b3-3143a3298fd5" />

### Double check

- [ ] I have tested my parser changes locally with `poetry run test_parser "zone_key"`
- [X] I have run `pnpx prettier@2 --write .` and `poetry run format` in the top level directory to format my changes.
