### PR TITLE
[Parser]: Clean up EIA parser

### DIFF
--- a/parsers/EIA.py
+++ b/parsers/EIA.py
@@ -386,21 +386,6 @@ PRODUCTION_MIX = (
 )
 EXCHANGE = f"{BASE_URL}/interchange-data/data/?data[]=value{{}}&frequency=hourly"
 
-FILTER_INCOMPLETE_DATA_BYPASSED_MODES = {
-    "US-TEX-ERCO": ["biomass", "geothermal", "oil"],
-    "US-NW-PGE": [
-        "biomass",
-        "geothermal",
-        "oil",
-        "solar",
-    ],  # Solar is not reported by PGE.
-    "US-NW-PACE": ["biomass", "geothermal", "oil"],
-    "US-MIDW-MISO": ["biomass", "geothermal", "oil"],
-    "US-TEN-TVA": ["biomass", "geothermal", "oil"],
-    "US-SE-SOCO": ["biomass", "geothermal", "oil", "hydro"],
-    "US-FLA-FPL": ["biomass", "geothermal", "oil"],
-}
-
 
 @refetch_frequency(timedelta(days=1))
 def fetch_production(
@@ -629,10 +614,7 @@ def fetch_production_mix(
     events = ProductionBreakdownList.merge_production_breakdowns(
         all_production_breakdowns, logger
     )
-    if zone_key in FILTER_INCOMPLETE_DATA_BYPASSED_MODES:
-        events = ProductionBreakdownList.filter_expected_modes(
-            events, by_passed_modes=FILTER_INCOMPLETE_DATA_BYPASSED_MODES[zone_key]
-        )
+
     return events.to_list()
 
 

--- a/parsers/test/test_EIA.py
+++ b/parsers/test/test_EIA.py
@@ -456,7 +456,9 @@ def test_fetch_production_mix_discards_null(adapter, session, snapshot):
             .read_text()
         ),
     )
+
     data_list = EIA.fetch_production_mix(ZoneKey("US-NW-PGE"), session)
+
     assert data_list == snapshot
 
     assert (
@@ -564,32 +566,6 @@ def test_fetch_forecasted_consumption(adapter, session):
         assert data["datetime"] == expected[i]["datetime"]
         assert data["consumption"] == expected[i]["consumption"]
         assert data["sourceType"] == EventSourceType.forecasted
-
-
-def test_texas_loses_one_mode(adapter, session):
-    """A temporary test to make sure that if texas loses one of its modes we discard the datapoint."""
-    # All modes are loaded with some data
-    adapter.register_uri(
-        GET,
-        ANY,
-        json=json.loads(
-            resources.files("parsers.test.mocks.EIA")
-            .joinpath("US_SMTH-coal.json")
-            .read_text()
-        ),
-    )
-    # Nuclear is missing data
-    adapter.register_uri(
-        GET,
-        EIA.PRODUCTION_MIX.format("ERCO", "NUC"),
-        json=json.loads(
-            resources.files("parsers.test.mocks.EIA")
-            .joinpath("US_NW_AVRN-other.json")
-            .read_text()
-        ),
-    )
-    data = EIA.fetch_production_mix(ZoneKey("US-TEX-ERCO"), session)
-    assert len(data) == 0
 
 
 def test_fetch_returns_storage(adapter, session, snapshot):


### PR DESCRIPTION
## Issue
Remove `filter_expected_modes` function from EIA parser and migrate to validation pipeline. 

> [!IMPORTANT]
> This PR should be merged after the backend PR that ensures the expectedmodes validator is run for the affected zones: [#8753](https://github.com/electricitymaps/electricitymaps/pull/8753)


## Description

In filter expected modes the following was done to zones in `FILTER_INCOMPLETE_DATA_BYPASSED_MODES `: 
1. Remove a modes as expected if it's capacity if below 2% if total capacity 
2. Remove 'bypassed modes' from now deleted `FILTER_INCOMPLETE_DATA_BYPASSED_MODES `
3. Remove storage modes as expected

The 1st does not need to be kept, the two other are implemented in with the ExpectedModes validation rule in the backend PR.

This function was used for: US-NW-PGE, US-NW-PACE, US-MIDW-MISO, US-TEN-TVA, US-SE-SOCO, US-FLA-FPL. US-TEX-ERCO was also in `FILTER_INCOMPLETE_DATA_BYPASSED_MODES ` but it now has it's own parser. 



### Double check

- [x] I have tested my parser changes locally with `poetry run test_parser "zone_key"`
- [x] I have run `pnpx prettier@2 --write .` and `poetry run format` in the top level directory to format my changes.
