### PR TITLE
Removes errornous solar capacities for AU

### DIFF
--- a/config/zones/AU-NSW.yaml
+++ b/config/zones/AU-NSW.yaml
@@ -72,9 +72,6 @@ capacity:
     - datetime: '2023-01-01'
       source: opennem.org.au
       value: 9529.31
-    - datetime: '2025-01-01'
-      source: https://openelectricity.org.au/
-      value: 5742.68
   wind:
     - datetime: '2020-01-01'
       source: opennem.org.au

--- a/config/zones/AU-QLD.yaml
+++ b/config/zones/AU-QLD.yaml
@@ -57,9 +57,6 @@ capacity:
     - datetime: '2023-01-01'
       source: opennem.org.au
       value: 8416.86
-    - datetime: '2025-01-01'
-      source: https://openelectricity.org.au/
-      value: 4364.81
   wind:
     - datetime: '2020-01-01'
       source: opennem.org.au

--- a/config/zones/AU-SA.yaml
+++ b/config/zones/AU-SA.yaml
@@ -58,9 +58,6 @@ capacity:
     - datetime: '2023-01-01'
       source: opennem.org.au
       value: 2900.52
-    - datetime: '2025-01-01'
-      source: https://openelectricity.org.au/
-      value: 735.05
   wind:
     - datetime: '2020-01-01'
       source: opennem.org.au

--- a/config/zones/AU-VIC.yaml
+++ b/config/zones/AU-VIC.yaml
@@ -55,9 +55,6 @@ capacity:
     - datetime: '2023-01-01'
       source: opennem.org.au
       value: 5611.58
-    - datetime: '2025-01-01'
-      source: https://openelectricity.org.au/
-      value: 1478.91
   wind:
     - datetime: '2020-01-01'
       source: opennem.org.au

--- a/config/zones/AU-WA.yaml
+++ b/config/zones/AU-WA.yaml
@@ -47,9 +47,6 @@ capacity:
     - datetime: '2021-01-01'
       source: opennem.org.au
       value: 2765.64
-    - datetime: '2025-01-01'
-      source: https://openelectricity.org.au/
-      value: 278.96
   wind:
     - datetime: '2020-01-01'
       source: opennem.org.au


### PR DESCRIPTION
## Issue
For some reason the capacity parser for AU was pulling way lower solar values than expected, the other modes look fine.

So let's remove these for now and look into the parser issue separately. 


### Double check

- [x] I have run `pnpx prettier@2 --write .` and `poetry run format` in the top level directory to format my changes.
