### PR TITLE
fix(parser): add User-Agent to SG parser

### DIFF
--- a/parsers/SG.py
+++ b/parsers/SG.py
@@ -68,11 +68,7 @@ def get_solar(session: Session, logger: Logger) -> float | None:
     Uses OCR (tesseract) to extract MW value.
     """
     requests_obj = session or Session()
-    requests_obj.headers.update(
-        {
-            "User-Agent": "Mozilla/5.0"
-        }
-    )
+    requests_obj.headers.update({"User-Agent": "Mozilla/5.0"})
     solar_image = Image.open(session.get(SOLAR_URL, stream=True).raw)
 
     solar_mw = __detect_output_from_solar_image(solar_image, logger)

--- a/parsers/SG.py
+++ b/parsers/SG.py
@@ -67,6 +67,12 @@ def get_solar(session: Session, logger: Logger) -> float | None:
     Fetches a graphic showing estimated solar production data.
     Uses OCR (tesseract) to extract MW value.
     """
+    requests_obj = session or Session()
+    requests_obj.headers.update(
+        {
+            "User-Agent": "Mozilla/5.0"
+        }
+    )
     solar_image = Image.open(session.get(SOLAR_URL, stream=True).raw)
 
     solar_mw = __detect_output_from_solar_image(solar_image, logger)


### PR DESCRIPTION
## Issue
SG parser is not working because requests are blocked because of User-Agent. 

## Description
Add Mozilla User-Agent

### Double check

- [x] I have tested my parser changes locally with `poetry run test_parser "zone_key"`
- [x] I have run `pnpx prettier@2 --write .` and `poetry run format` in the top level directory to format my changes.
