### PR TITLE
(fix): make PJM grid alerts more robust

### DIFF
--- a/parsers/US_PJM.py
+++ b/parsers/US_PJM.py
@@ -469,7 +469,7 @@ def fetch_grid_alerts(
         alertType = extract_alert_type(alert, i)
         message = extract_message(alert, i)
         startTime, endTime = extract_start_and_end_time(alert, i)
-        locationRegion = alert.find("span", {"class": "region-name"}).text.strip()
+        locationRegion = alert.find("span", class_=re.compile(r"region-name"))
 
         alerts.append(
             zoneKey=ZONE_KEY,


### PR DESCRIPTION
## Description

We missed out on some [really important Grid Alerts](https://www.linkedin.com/posts/grid-status_august-11th-2025-bge-eea-activity-7360756701031006208-NmRs/?utm_source=share&utm_medium=member_ios&rcm=ACoAAABGaasBZFQV41plA301CHT3sOEaoFcPNDU) because the selector for the region was too strict. 

### Double check

- [x] I have tested my parser changes locally with `poetry run test_parser "zone_key"`
- [ ] I have run `pnpx prettier@2 --write .` and `poetry run format` in the top level directory to format my changes.
