### PR TITLE
(fix) make PJM alerts even more robust

### DIFF
--- a/parsers/US_PJM.py
+++ b/parsers/US_PJM.py
@@ -469,7 +469,7 @@ def fetch_grid_alerts(
         alertType = extract_alert_type(alert, i)
         message = extract_message(alert, i)
         startTime, endTime = extract_start_and_end_time(alert, i)
-        locationRegion = alert.find("span", class_=re.compile(r"region-name"))
+        locationRegion = alert.find(class_=re.compile(r"region-name")).text.strip()
 
         alerts.append(
             zoneKey=ZONE_KEY,


### PR DESCRIPTION
## Description

A fix for this fix https://github.com/electricitymaps/electricitymaps-contrib/pull/8350. Turns out it can be a `span` or an `a` and I need to extract the text.

### Double check

- [x] I have tested my parser changes locally with `poetry run test_parser "zone_key"`
- [ ] I have run `pnpx prettier@2 --write .` and `poetry run format` in the top level directory to format my changes.
