### PR TITLE
fix(parsers):Change TR parser to replace with 0 for negative production

### DIFF
--- a/parsers/TR.py
+++ b/parsers/TR.py
@@ -144,7 +144,11 @@ def fetch_production(
         mix = ProductionMix()
         for key, value in item.items():
             if key in INVERT_PRODUCTION_MAPPPING:
-                mix.add_value(INVERT_PRODUCTION_MAPPPING[key], value)
+                mix.add_value(
+                    INVERT_PRODUCTION_MAPPPING[key],
+                    value,
+                    correct_negative_with_zero=True,
+                )
             elif key not in IGNORED_KEYS:
                 logger.warning("Unrecognized key '%s' in data skipped", key)
 


### PR DESCRIPTION
## Issue

Replace negative solar production with 0 instead of None.

## Description
Closes #7807 

When there is some negative production (some self consumption perhaps) as for ex solar, instead of replacing with None we replace with 0. This allow us to add solar for TR to expected modes. 

**A PR for adding solar to expected modes for TR will also be made.** 

### Double check

- [ ] I have tested my parser changes locally with `poetry run test_parser "zone_key"`
- [ ] I have run `pnpx prettier@2 --write .` and `poetry run format` in the top level directory to format my changes.
