### PR TITLE
use ENSTO-e Parser

### DIFF
--- a/config/zones/CY.yaml
+++ b/config/zones/CY.yaml
@@ -357,7 +357,8 @@ parsers:
   consumption: ENTSOE.fetch_consumption
   consumptionForecast: ENTSOE.fetch_consumption_forecast
   generationForecast: ENTSOE.fetch_generation_forecast
-  production: CY.fetch_production
+  # production: CY.fetch_production # Valid until end of February 2025
+  production: ENTSOE.fetch_production # Valid from 1st of March 2025
   productionCapacity: EMBER.fetch_production_capacity
   productionPerModeForecast: ENTSOE.fetch_wind_solar_forecasts
 region: Asia


### PR DESCRIPTION
## Issue
Our current CY parser is not working properly.
At the same time, the ENSTO-e parser for CY seems to work well. 

## Analysis: 
From the flowtracing pipeline, it seems that the CY parser is okay until 2025-March, after it is no longer correct.
<img width="671" height="750" alt="image" src="https://github.com/user-attachments/assets/ccdf4089-3aba-434c-bf30-7a809072b88e" />


From ENSTO-e, the data seems complete from 1st of March:
[Cyprus analysis ENSTO-e](https://docs.google.com/spreadsheets/d/19PQcZ75TL_0KsyDI8r3l03DwSaUNyD3zXkbKcT6ovDU/edit?gid=596322936#gid=596322936)
It is more or less in line with [EMBER monthly:](https://ember-energy.org/data/electricity-data-explorer/?entity=Cyprus) . 

## Actions:
- In lib -> Change the estimation time box
- Refetch Cyprus from 2025-03-01
- Re-rerun flowtracing.
