### PR TITLE
Add generation and consumption forecasts to MD

### DIFF
--- a/config/zones/MD.yaml
+++ b/config/zones/MD.yaml
@@ -281,6 +281,8 @@ fallbackZoneMixes:
         wind: 0.03416068856152983
 parsers:
   consumption: ENTSOE.fetch_consumption
+  consumptionForecast: ENTSOE.fetch_consumption_forecast
+  generationForecast: ENTSOE.fetch_generation_forecast
   price: MD.fetch_price
   production: ENTSOE.fetch_production
   productionCapacity: EMBER.fetch_production_capacity


### PR DESCRIPTION
This pull request adds support for fetching consumption and generation forecasts in the `MD.yaml` zone configuration. The main change is the addition of new forecast parser entries.

**Enhancements to forecast data support:**

* Added `consumptionForecast` and `generationForecast` parser entries using `ENTSOE.fetch_consumption_forecast` and `ENTSOE.fetch_generation_forecast` in `config/zones/MD.yaml` to enable forecast data fetching for the MD zone.