### PR TITLE
temp fix for AU-* data

### DIFF
--- a/parsers/OPENNEM.py
+++ b/parsers/OPENNEM.py
@@ -217,27 +217,27 @@ def process_production_datasets(
         logger=logger,
     )
 
-    if zone_key == ZoneKey("AU-TAS"):
-        # Tasmania sometimes only report solar for the latest data, remove the datapoint if it only has solar
-        # TODO: Remove this once the race condition between feeder-electricity and quality validation is fixed
-        corrected_breakdown = ProductionBreakdownList(logger=logger)
-        for event in merged_production:
-            for mode, value in event.production.__dict__.items():
-                if mode != "solar" and value is not None:
-                    dt = event.datetime
-                    production = event.production
-                    storage = event.storage
-                    source = event.source
-                    zoneKey = event.zoneKey
-                    corrected_breakdown.append(
-                        zoneKey=zoneKey,
-                        datetime=dt,
-                        production=production,
-                        storage=storage,
-                        source=source,
-                    )
-                    break
-        merged_production = corrected_breakdown
+
+    # OPENNEM sometimes only report solar for the latest data, remove the datapoint if it only has solar
+    # TODO: Remove this once the race condition between feeder-electricity and quality validation is fixed
+    corrected_breakdown = ProductionBreakdownList(logger=logger)
+    for event in merged_production:
+        for mode, value in event.production.__dict__.items():
+            if mode != "solar" and value is not None:
+                dt = event.datetime
+                production = event.production
+                storage = event.storage
+                source = event.source
+                zoneKey = event.zoneKey
+                corrected_breakdown.append(
+                    zoneKey=zoneKey,
+                    datetime=dt,
+                    production=production,
+                    storage=storage,
+                    source=source,
+                )
+                break
+    merged_production = corrected_breakdown
     return merged_production
 
 


### PR DESCRIPTION
This pull request makes a small but important change to the `process_production_datasets` function in `parsers/OPENNEM.py`. The logic for handling datapoints that only contain solar production has been generalized: it now applies to all regions, not just the AU-TAS zone.

- Generalized the removal of datapoints that only have solar production from being specific to the `AU-TAS` zone to all regions in the `process_production_datasets` function.
