### PR TITLE
fix(TR): fetch the last 2 days of data to avoid missing the last hours of the day

### DIFF
--- a/parsers/TR.py
+++ b/parsers/TR.py
@@ -79,15 +79,17 @@ def fetch_data(target_datetime: datetime, kind: str, session: Session) -> list:
     results = []
 
     target_datetime = target_datetime.replace(tzinfo=TR_TZ)
-
+    # Fetch for the last 2 days since start and end date are truncated to the day and to avoid missing last hours.
     while not is_last_page:
         payload = json.dumps(
             {
-                "startDate": (target_datetime).strftime("%Y-%m-%dT%H:%M:%S+03:00"),
+                "startDate": (target_datetime - timedelta(days=1)).strftime(
+                    "%Y-%m-%dT%H:%M:%S+03:00"
+                ),
                 "endDate": (target_datetime).strftime("%Y-%m-%dT%H:%M:%S+03:00"),
                 "page": {
                     "number": pagenum,
-                    "size": 24,
+                    "size": 48,
                     "sort": {"field": "date", "direction": "ASC"},
                 },
             }


### PR DESCRIPTION
## Issue
We miss the last hours of the day every day because we fetch the current day only. 

## Description
Fetch the last 2 days instead. 


### Double check

- [x] I have tested my parser changes locally with `poetry run test_parser "zone_key"`
- [x] I have run `pnpx prettier@2 --write .` and `poetry run format` in the top level directory to format my changes.
