### PR TITLE
Include static config in built package

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,11 +1,11 @@
 [tool.poetry]
 name = "electricitymap-contrib"
-version = "1.0.0"
+version = "1.0.1"
 description = ""
 license = "AGPL-3.0-or-later"
 authors = ["Electricity Maps <app@electricitymaps.com>"]
 packages = [{ include = "electricitymap" }]
-include = ["config/*.json", "config/*.yaml"]
+include = ["config/**/*.json", "config/**/*.yaml"]
 
 [tool.poetry.dependencies]
 python = '>= 3.10, < 3.11'


### PR DESCRIPTION
The `include` directive was limited to immediate children of the `config` directory. Update, so that we get all static config files in the built package.

#### Before
```
tar -tf dist/electricitymap_contrib-1.0.0.tar.gz | grep data_centers.json
# nothing! 😢 
```
#### After
```
poetry build
# build output
tar -tf dist/electricitymap_contrib-1.0.1.tar.gz | grep data_centers.json
electricitymap_contrib-1.0.1/config/data_centers/data_centers.json # 🥳 
```


