### PR TITLE
Package config separately

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,8 +4,7 @@ version = "1.0.1"
 description = ""
 license = "AGPL-3.0-or-later"
 authors = ["Electricity Maps <app@electricitymaps.com>"]
-packages = [{ include = "electricitymap" }]
-include = ["config/**/*.json", "config/**/*.yaml"]
+packages = [{ include = "electricitymap" }, { include = "config" }]
 
 [tool.poetry.dependencies]
 python = '>= 3.10, < 3.11'


### PR DESCRIPTION
We can ensure that the config folder is installed to consuming projects by adding an `__init__.py` file and adding it to the `packages` directive. This will mean that it will be installed simply as `config` in the `/.venv/lib/python/site-packages/` directory of the consuming project and can then be accessed using a relative path from the `electricitymap-config` package. This is a good deal simpler than other solutions proposed, but one disadvantage is that the new `config` package has a very undescriptive name. It could be possible to change this, but this would involve updating the callers which makes this a bigger change. As such, I suggest going with this solution as the other possibilities are more difficult.

How the files look when installed:

```
ls .venv/lib/python3.10/site-packages/config
__init__.py   data_centers  defaults.yaml Earthfile     exchanges     retired_zones zones
```

Verifying that the constants work:
```
poetry run python
Python 3.10.13 (main, May  1 2025, 13:41:41) [Clang 17.0.0 (clang-1700.0.13.3)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> from electricitymap.contrib.config import ZONES_CONFIG, EXCHANGES_CONFIG
>>> type(ZONES_CONFIG)
<class 'dict'>
```
