### PR TITLE
fix(price): remove IL and US_PJM price parsers since they don't work

### DIFF
--- a/config/zones/IL.yaml
+++ b/config/zones/IL.yaml
@@ -358,7 +358,6 @@ isRenewable:
     value: 0.056
 parsers:
   consumption: IL.fetch_consumption
-  price: IL.fetch_price
   productionCapacity: EMBER.fetch_production_capacity
 region: Asia
 timezone: Asia/Jerusalem

--- a/config/zones/US-MIDA-PJM.yaml
+++ b/config/zones/US-MIDA-PJM.yaml
@@ -1446,7 +1446,6 @@ parsers:
   consumption: EIA.fetch_consumption
   consumptionForecast: US_PJM.fetch_consumption_forecast
   gridAlerts: US_PJM.fetch_grid_alerts
-  price: US_PJM.fetch_price
   production: US_PJM.fetch_production
   productionCapacity: EIA.fetch_production_capacity
   productionPerModeForecast: US_PJM.fetch_wind_solar_forecasts

--- a/electricitymap/contrib/parsers/IL.py
+++ b/electricitymap/contrib/parsers/IL.py
@@ -33,7 +33,6 @@ IEC_URL = "www.iec.co.il"
 IEC_PRODUCTION = (
     "https://www.iec.co.il/_layouts/iec/applicationpages/lackmanagment.aspx"
 )
-IEC_PRICE = "https://www.iec.co.il/homeclients/pages/tariffs.aspx"
 TZ = ZoneInfo("Asia/Jerusalem")
 
 
@@ -65,45 +64,6 @@ def fetch_all() -> list:
         return flat_list
 
     return flatten_list(cleaned_list)
-
-
-def fetch_price(
-    zone_key: str = "IL",
-    session: Session | None = None,
-    target_datetime: datetime | None = None,
-    logger: Logger = getLogger(__name__),
-) -> dict:
-    """Fetch price from IEC table."""
-    if target_datetime is not None:
-        raise NotImplementedError("This parser is not yet able to parse past dates")
-
-    with get(IEC_PRICE) as response:
-        soup = BeautifulSoup(response.content, "lxml")
-
-    price = soup.find("td", class_="ms-rteTableEvenCol-6")
-
-    return {
-        "zoneKey": zone_key,
-        "currency": "NIS",
-        "datetime": extract_price_date(soup),
-        "price": float(price.p.text),
-        "source": IEC_URL,
-    }
-
-
-def extract_price_date(soup):
-    """Fetch updated price date."""
-    span_soup = soup.find("span", lang="HE")
-    if span_soup:
-        date_str = span_soup.text
-    else:
-        raise ValueError("Could not parse IEC price date")
-    date_str = date_str.split(sep=" - ")
-    date_str = date_str.pop(1)
-
-    date = datetime.strptime(date_str, "%d.%m.%Y")
-
-    return date
 
 
 def fetch_noga_iso_data(session: Session, logger: Logger):
@@ -199,5 +159,3 @@ if __name__ == "__main__":
     print(fetch_production())
     print("fetch_consumption() ->")
     print(fetch_consumption())
-    print("fetch_price() ->")
-    print(fetch_price())


### PR DESCRIPTION
## Description
IL and PJM price parsers haven't been working for ages. The websites they fetch data from changed. Let's remove them 

### Double check

- [x] I have tested my parser changes locally with `poetry run test_parser "zone_key"`
- [ ] I have run `pnpx prettier@2 --write .` and `poetry run format` in the top level directory to format my changes.
