### PR TITLE
feat(parsers): Add eSett parser and timebox SE subzone parsers

### DIFF
--- a/config/zones/SE-SE1.yaml
+++ b/config/zones/SE-SE1.yaml
@@ -291,7 +291,7 @@ parsers:
   consumptionForecast: ENTSOE.fetch_consumption_forecast
   generationForecast: ENTSOE.fetch_generation_forecast
   price: NORDPOOL.fetch_price
-  production: ENTSOE.fetch_production
+  production: SE.fetch_production
   productionPerModeForecast: ENTSOE.fetch_wind_solar_forecasts
 region: Europe
 sources:

--- a/config/zones/SE-SE2.yaml
+++ b/config/zones/SE-SE2.yaml
@@ -377,7 +377,7 @@ parsers:
   consumptionForecast: ENTSOE.fetch_consumption_forecast
   generationForecast: ENTSOE.fetch_generation_forecast
   price: NORDPOOL.fetch_price
-  production: ENTSOE.fetch_production
+  production: SE.fetch_production
   productionPerModeForecast: ENTSOE.fetch_wind_solar_forecasts
 region: Europe
 sources:

--- a/config/zones/SE-SE3.yaml
+++ b/config/zones/SE-SE3.yaml
@@ -377,7 +377,7 @@ parsers:
   consumptionForecast: ENTSOE.fetch_consumption_forecast
   generationForecast: ENTSOE.fetch_generation_forecast
   price: NORDPOOL.fetch_price
-  production: ENTSOE.fetch_production
+  production: SE.fetch_production
   productionPerModeForecast: ENTSOE.fetch_wind_solar_forecasts
 region: Europe
 sources:

--- a/config/zones/SE-SE4.yaml
+++ b/config/zones/SE-SE4.yaml
@@ -362,7 +362,7 @@ parsers:
   consumptionForecast: ENTSOE.fetch_consumption_forecast
   generationForecast: ENTSOE.fetch_generation_forecast
   price: NORDPOOL.fetch_price
-  production: ENTSOE.fetch_production
+  production: SE.fetch_production
   productionPerModeForecast: ENTSOE.fetch_wind_solar_forecasts
 region: Europe
 sources:

--- a/electricitymap/contrib/parsers/SE.py
+++ b/electricitymap/contrib/parsers/SE.py
@@ -30,7 +30,9 @@ def fetch_production(
         ZoneKey("SE-SE3"),
         ZoneKey("SE-SE4"),
     }, f"Zone {zone_key} is not supported by the SE parser."
-    target_datetime = (target_datetime or datetime.now(timezone.utc)).astimezone(timezone.utc)
+    target_datetime = (target_datetime or datetime.now(timezone.utc)).astimezone(
+        timezone.utc
+    )
 
     if target_datetime < datetime(2022, 1, 1, tzinfo=timezone.utc):
         return fetch_production_esett(zone_key, session, target_datetime, logger)

--- a/electricitymap/contrib/parsers/SE.py
+++ b/electricitymap/contrib/parsers/SE.py
@@ -1,0 +1,38 @@
+"""
+Poor mans parser timeboxing for Sweden subzones.
+"""
+
+from datetime import datetime, timedelta, timezone
+from logging import Logger, getLogger
+
+from requests import Session
+
+from electricitymap.contrib.lib.types import ZoneKey
+from electricitymap.contrib.parsers.ENTSOE import (
+    fetch_production as fetch_production_enstoe,
+)
+from electricitymap.contrib.parsers.eSett import (
+    fetch_production as fetch_production_esett,
+)
+from electricitymap.contrib.parsers.lib.config import refetch_frequency
+
+
+@refetch_frequency(timedelta(days=3))
+def fetch_production(
+    zone_key: ZoneKey,
+    session: Session | None = None,
+    target_datetime: datetime | None = None,
+    logger: Logger = getLogger(__name__),
+) -> list:
+    assert zone_key in {
+        ZoneKey("SE-SE1"),
+        ZoneKey("SE-SE2"),
+        ZoneKey("SE-SE3"),
+        ZoneKey("SE-SE4"),
+    }, f"Zone {zone_key} is not supported by the SE parser."
+    target_datetime = target_datetime or datetime.now(timezone.utc)
+
+    if target_datetime < datetime(2022, 1, 1, tzinfo=timezone.utc):
+        return fetch_production_esett(zone_key, session, target_datetime, logger)
+    else:
+        return fetch_production_enstoe(zone_key, session, target_datetime, logger)

--- a/electricitymap/contrib/parsers/SE.py
+++ b/electricitymap/contrib/parsers/SE.py
@@ -30,7 +30,7 @@ def fetch_production(
         ZoneKey("SE-SE3"),
         ZoneKey("SE-SE4"),
     }, f"Zone {zone_key} is not supported by the SE parser."
-    target_datetime = target_datetime or datetime.now(timezone.utc)
+    target_datetime = (target_datetime or datetime.now(timezone.utc)).astimezone(timezone.utc)
 
     if target_datetime < datetime(2022, 1, 1, tzinfo=timezone.utc):
         return fetch_production_esett(zone_key, session, target_datetime, logger)

--- a/electricitymap/contrib/parsers/eSett.py
+++ b/electricitymap/contrib/parsers/eSett.py
@@ -12,21 +12,19 @@ from electricitymap.contrib.parsers.lib.config import refetch_frequency
 BASE_URL = "https://api.opendata.esett.com"
 PRODUCTION_URL = f"{BASE_URL}/EXP16/Aggregate"
 
-IGNORED_PRODUCTION_KEYS = {'timestamp', 'timestampUTC', 'mba', 'total'}
+IGNORED_PRODUCTION_KEYS = {"timestamp", "timestampUTC", "mba", "total"}
 
 PRODUCTION_MAPPINGS = {
-  'hydro': 'hydro',
-  'wind': 'wind',
-  'windOffshore': 'wind',
-  'nuclear': 'nuclear',
-  'solar': 'solar',
-  'thermal': 'unknown',
-  'other': 'unknown',
+    "hydro": "hydro",
+    "wind": "wind",
+    "windOffshore": "wind",
+    "nuclear": "nuclear",
+    "solar": "solar",
+    "thermal": "unknown",
+    "other": "unknown",
 }
 
-STORAGE_MAPPINGS = {'energyStorage': 'battery'}
-
-
+STORAGE_MAPPINGS = {"energyStorage": "battery"}
 
 
 @refetch_frequency(timedelta(days=3))
@@ -60,14 +58,14 @@ def fetch_production(
     for entry in json or []:
         production_mix = ProductionMix()
         storage_mix = StorageMix()
-        timestamp = datetime.fromisoformat(entry['timestampUTC'].replace("Z", "+00:00"))
+        timestamp = datetime.fromisoformat(entry["timestampUTC"].replace("Z", "+00:00"))
         for key, value in entry.items():
             if key in IGNORED_PRODUCTION_KEYS:
                 continue
             elif key in PRODUCTION_MAPPINGS:
-              production_mix.add_value(PRODUCTION_MAPPINGS[key], value)
+                production_mix.add_value(PRODUCTION_MAPPINGS[key], value)
             elif key in STORAGE_MAPPINGS:
-              storage_mix.add_value(STORAGE_MAPPINGS[key], value)
+                storage_mix.add_value(STORAGE_MAPPINGS[key], value)
             else:
                 logger.warning(f"Unknown production key: {key}")
 

--- a/electricitymap/contrib/parsers/eSett.py
+++ b/electricitymap/contrib/parsers/eSett.py
@@ -1,0 +1,84 @@
+from datetime import datetime, timedelta, timezone
+from logging import Logger, getLogger
+
+from requests import Session
+
+from electricitymap.contrib.lib.models.event_lists import ProductionBreakdownList
+from electricitymap.contrib.lib.models.events import ProductionMix, StorageMix
+from electricitymap.contrib.lib.types import ZoneKey
+from electricitymap.contrib.parsers.ENTSOE import ENTSOE_DOMAIN_MAPPINGS
+from electricitymap.contrib.parsers.lib.config import refetch_frequency
+
+BASE_URL = "https://api.opendata.esett.com"
+PRODUCTION_URL = f"{BASE_URL}/EXP16/Aggregate"
+
+IGNORED_PRODUCTION_KEYS = {'timestamp', 'timestampUTC', 'mba', 'total'}
+
+PRODUCTION_MAPPINGS = {
+  'hydro': 'hydro',
+  'wind': 'wind',
+  'windOffshore': 'wind',
+  'nuclear': 'nuclear',
+  'solar': 'solar',
+  'thermal': 'unknown',
+  'other': 'unknown',
+}
+
+STORAGE_MAPPINGS = {'energyStorage': 'battery'}
+
+
+
+
+@refetch_frequency(timedelta(days=3))
+def fetch_production(
+    zone_key: ZoneKey,
+    session: Session | None = None,
+    target_datetime: datetime | None = None,
+    logger: Logger = getLogger(__name__),
+) -> list:
+    session = session or Session()
+    target_datetime = (target_datetime or datetime.now(timezone.utc)).astimezone(
+        timezone.utc
+    )
+
+    start_time = target_datetime - timedelta(days=3)
+
+    query_params = {
+        "start": start_time.isoformat(timespec="milliseconds").replace("+00:00", "Z"),
+        "end": target_datetime.isoformat(timespec="milliseconds").replace(
+            "+00:00", "Z"
+        ),
+        "resolution": "hour",
+        "mba": ENTSOE_DOMAIN_MAPPINGS[zone_key],
+    }
+
+    response = session.get(PRODUCTION_URL, params=query_params)
+    response.raise_for_status()
+
+    json: list = response.json()
+    production_breakdown_list = ProductionBreakdownList(logger)
+    for entry in json or []:
+        production_mix = ProductionMix()
+        storage_mix = StorageMix()
+        timestamp = datetime.fromisoformat(entry['timestampUTC'].replace("Z", "+00:00"))
+        for key, value in entry.items():
+            if key in IGNORED_PRODUCTION_KEYS:
+                continue
+            elif key in PRODUCTION_MAPPINGS:
+              production_mix.add_value(PRODUCTION_MAPPINGS[key], value)
+            elif key in STORAGE_MAPPINGS:
+              storage_mix.add_value(STORAGE_MAPPINGS[key], value)
+            else:
+                logger.warning(f"Unknown production key: {key}")
+
+        production_breakdown_list.append(
+            zoneKey=zone_key,
+            datetime=timestamp,
+            production=production_mix,
+            source="eSett",
+        )
+    return production_breakdown_list.to_list()
+
+
+if __name__ == "__main__":
+    print(fetch_production(ZoneKey("SE-SE4")))


### PR DESCRIPTION
## Issue

ENTSO-E only has production from 2021 and only wind production for 2021-01 to 2021-11 which is causing issues when trying to calculate the emission factor as the export is higher than import + production.
<img width="930" height="1384" alt="image" src="https://github.com/user-attachments/assets/24952b56-412f-46b7-a70e-151d1703dfaf" />


## Description

To fix this we had two alternatives:

- estimate all of this data instead.
- find an alternative source.

I opted for number 2 as we could get data from mid 2017 if we used eSett which is a company providing Nordic Imbalance Settlement. They also have a open data platform which has all of the data we need but thermal is mapped to unknown vs gas and unknown. But since the gas production in Sweden is really low I decided this was acceptable.

### Double check

- [x] I have tested my parser changes locally with `poetry run test_parser "zone_key"`
- [x] I have run `pnpx prettier@2 --write .` and `poetry run format` in the top level directory to format my changes.
