### PR TITLE
chore(parsers): Switch back to using ENTSO-E for the nordic exchanges

### DIFF
--- a/config/exchanges/DK-DK1_SE-SE3.yaml
+++ b/config/exchanges/DK-DK1_SE-SE3.yaml
@@ -5,6 +5,6 @@ lonlat:
   - 11.556268
   - 56.857802
 parsers:
-  exchange: NORDPOOL.fetch_exchange
+  exchange: ENTSOE.fetch_exchange
   exchangeForecast: ENTSOE.fetch_exchange_forecast
 rotation: 70

--- a/config/exchanges/DK-DK2_SE-SE4.yaml
+++ b/config/exchanges/DK-DK2_SE-SE4.yaml
@@ -5,6 +5,6 @@ lonlat:
   - 12.704418
   - 55.952282
 parsers:
-  exchange: NORDPOOL.fetch_exchange
+  exchange: ENTSOE.fetch_exchange
   exchangeForecast: ENTSOE.fetch_exchange_forecast
 rotation: 70

--- a/config/exchanges/FI_NO-NO4.yaml
+++ b/config/exchanges/FI_NO-NO4.yaml
@@ -5,6 +5,6 @@ lonlat:
   - 25.35158
   - 68.862684
 parsers:
-  exchange: NORDPOOL.fetch_exchange
+  exchange: ENTSOE.fetch_exchange
   exchangeForecast: ENTSOE.fetch_exchange_forecast
 rotation: -30

--- a/config/exchanges/FI_SE-SE1.yaml
+++ b/config/exchanges/FI_SE-SE1.yaml
@@ -5,6 +5,6 @@ lonlat:
   - 23.857
   - 66.921
 parsers:
-  exchange: NORDPOOL.fetch_exchange
+  exchange: ENTSOE.fetch_exchange
   exchangeForecast: ENTSOE.fetch_exchange_forecast
 rotation: -90

--- a/config/exchanges/FI_SE-SE3.yaml
+++ b/config/exchanges/FI_SE-SE3.yaml
@@ -5,6 +5,6 @@ lonlat:
   - 19.797
   - 60.628
 parsers:
-  exchange: NORDPOOL.fetch_exchange
+  exchange: ENTSOE.fetch_exchange
   exchangeForecast: ENTSOE.fetch_exchange_forecast
 rotation: -110

--- a/config/exchanges/NO-NO1_NO-NO2.yaml
+++ b/config/exchanges/NO-NO1_NO-NO2.yaml
@@ -5,6 +5,6 @@ lonlat:
   - 9.3
   - 59.844429
 parsers:
-  exchange: NORDPOOL.fetch_exchange
+  exchange: ENTSOE.fetch_exchange
   exchangeForecast: ENTSOE.fetch_exchange_forecast
 rotation: -110

--- a/config/exchanges/NO-NO1_NO-NO3.yaml
+++ b/config/exchanges/NO-NO1_NO-NO3.yaml
@@ -5,6 +5,6 @@ lonlat:
   - 9.533218
   - 61.731596
 parsers:
-  exchange: NORDPOOL.fetch_exchange
+  exchange: ENTSOE.fetch_exchange
   exchangeForecast: ENTSOE.fetch_exchange_forecast
 rotation: -45

--- a/config/exchanges/NO-NO1_NO-NO5.yaml
+++ b/config/exchanges/NO-NO1_NO-NO5.yaml
@@ -5,6 +5,6 @@ lonlat:
   - 8.3
   - 61.132896
 parsers:
-  exchange: NORDPOOL.fetch_exchange
+  exchange: ENTSOE.fetch_exchange
   exchangeForecast: ENTSOE.fetch_exchange_forecast
 rotation: -90

--- a/config/exchanges/NO-NO1_SE-SE3.yaml
+++ b/config/exchanges/NO-NO1_SE-SE3.yaml
@@ -5,6 +5,6 @@ lonlat:
   - 12.254138
   - 61.008235
 parsers:
-  exchange: NORDPOOL.fetch_exchange
+  exchange: ENTSOE.fetch_exchange
   exchangeForecast: ENTSOE.fetch_exchange_forecast
 rotation: 90

--- a/config/exchanges/NO-NO2_NO-NO5.yaml
+++ b/config/exchanges/NO-NO2_NO-NO5.yaml
@@ -5,6 +5,6 @@ lonlat:
   - 7.461
   - 60.0
 parsers:
-  exchange: NORDPOOL.fetch_exchange
+  exchange: ENTSOE.fetch_exchange
   exchangeForecast: ENTSOE.fetch_exchange_forecast
 rotation: -10

--- a/config/exchanges/NO-NO3_NO-NO4.yaml
+++ b/config/exchanges/NO-NO3_NO-NO4.yaml
@@ -5,6 +5,6 @@ lonlat:
   - 12.465132
   - 64.745638
 parsers:
-  exchange: NORDPOOL.fetch_exchange
+  exchange: ENTSOE.fetch_exchange
   exchangeForecast: ENTSOE.fetch_exchange_forecast
 rotation: 30

--- a/config/exchanges/NO-NO3_NO-NO5.yaml
+++ b/config/exchanges/NO-NO3_NO-NO5.yaml
@@ -6,6 +6,6 @@ lonlat:
   - 7.1
   - 61.194118
 parsers:
-  exchange: NORDPOOL.fetch_exchange
+  exchange: ENTSOE.fetch_exchange
   exchangeForecast: ENTSOE.fetch_exchange_forecast
 rotation: 140

--- a/config/exchanges/NO-NO3_SE-SE2.yaml
+++ b/config/exchanges/NO-NO3_SE-SE2.yaml
@@ -5,6 +5,6 @@ lonlat:
   - 12.24842
   - 63.462916
 parsers:
-  exchange: NORDPOOL.fetch_exchange
+  exchange: ENTSOE.fetch_exchange
   exchangeForecast: ENTSOE.fetch_exchange_forecast
 rotation: 90

--- a/config/exchanges/NO-NO4_SE-SE1.yaml
+++ b/config/exchanges/NO-NO4_SE-SE1.yaml
@@ -5,6 +5,6 @@ lonlat:
   - 15.656
   - 66.609
 parsers:
-  exchange: NORDPOOL.fetch_exchange
+  exchange: ENTSOE.fetch_exchange
   exchangeForecast: ENTSOE.fetch_exchange_forecast
 rotation: 130

--- a/config/exchanges/NO-NO4_SE-SE2.yaml
+++ b/config/exchanges/NO-NO4_SE-SE2.yaml
@@ -5,6 +5,6 @@ lonlat:
   - 14.051
   - 64.913
 parsers:
-  exchange: NORDPOOL.fetch_exchange
+  exchange: ENTSOE.fetch_exchange
   exchangeForecast: ENTSOE.fetch_exchange_forecast
 rotation: 130

--- a/config/exchanges/SE-SE1_SE-SE2.yaml
+++ b/config/exchanges/SE-SE1_SE-SE2.yaml
@@ -5,6 +5,6 @@ lonlat:
   - 17.869
   - 65.469
 parsers:
-  exchange: NORDPOOL.fetch_exchange
+  exchange: ENTSOE.fetch_exchange
   exchangeForecast: ENTSOE.fetch_exchange_forecast
 rotation: 205

--- a/config/exchanges/SE-SE2_SE-SE3.yaml
+++ b/config/exchanges/SE-SE2_SE-SE3.yaml
@@ -5,6 +5,6 @@ lonlat:
   - 14.804
   - 61.42
 parsers:
-  exchange: NORDPOOL.fetch_exchange
+  exchange: ENTSOE.fetch_exchange
   exchangeForecast: ENTSOE.fetch_exchange_forecast
 rotation: 180

--- a/config/exchanges/SE-SE3_SE-SE4.yaml
+++ b/config/exchanges/SE-SE3_SE-SE4.yaml
@@ -5,6 +5,6 @@ lonlat:
   - 14.5
   - 57.2
 parsers:
-  exchange: NORDPOOL.fetch_exchange
+  exchange: ENTSOE.fetch_exchange
   exchangeForecast: ENTSOE.fetch_exchange_forecast
 rotation: 180


### PR DESCRIPTION
## Issue

We found some 0 filled gaps from the NordPool API and ENTSO-E don't have this problem.

## Description

Switches back to using ENTSO-E for the nordic exchange data.
