### PR TITLE
chore(parsers): Use proxy for TR.py

### DIFF
--- a/electricitymap/contrib/parsers/TR.py
+++ b/electricitymap/contrib/parsers/TR.py
@@ -117,7 +117,6 @@ def fetch_data(target_datetime: datetime, kind: str, session: Session) -> list:
     return results
 
 
-
 @refetch_frequency(timedelta(days=1))
 @use_proxy("TR")
 def fetch_production(

--- a/electricitymap/contrib/parsers/TR.py
+++ b/electricitymap/contrib/parsers/TR.py
@@ -16,7 +16,7 @@ from electricitymap.contrib.lib.models.event_lists import (
     TotalConsumptionList,
 )
 from electricitymap.contrib.lib.models.events import ProductionMix
-from electricitymap.contrib.parsers.lib.config import refetch_frequency
+from electricitymap.contrib.parsers.lib.config import refetch_frequency, use_proxy
 from electricitymap.contrib.parsers.lib.exceptions import ParserException
 
 from .lib.utils import get_token
@@ -117,7 +117,9 @@ def fetch_data(target_datetime: datetime, kind: str, session: Session) -> list:
     return results
 
 
+
 @refetch_frequency(timedelta(days=1))
+@use_proxy("TR")
 def fetch_production(
     zone_key: ZoneKey = ZoneKey("TR"),
     session: Session | None = None,


### PR DESCRIPTION
## Issue

This parser is not working in production for some reason.

ref: CON-340
ref: GMM-1053

## Description

Uses the proxy we already have in place.

### Double check

- [x] I have tested my parser changes locally with `poetry run test_parser "zone_key"`
- [x] I have run `pnpx prettier@2 --write .` and `poetry run format` in the top level directory to format my changes.
