### PR TITLE
Fix for Module is imported with 'import' and 'import from'

### DIFF
--- a/electricitymap/contrib/parsers/IEMOP.py
+++ b/electricitymap/contrib/parsers/IEMOP.py
@@ -1,4 +1,3 @@
-import logging
 from datetime import datetime, timedelta
 from logging import Logger, getLogger
 from typing import NamedTuple


### PR DESCRIPTION
To resolve the issue flagged by CodeQL, we should standardize on one import style for the `logging` module. If only specific submodules or classes/functions from `logging` are used (such as `Logger` and `getLogger`), we should keep the `from logging import Logger, getLogger` statement and remove the `import logging` statement, unless there are references to the `logging` module object (such as `logging.info(...)`) elsewhere in the code.

Since the actual code that uses logging is not shown, and based solely on the imports, the minimal and safest fix is to remove the duplicate `import logging` line (line 1), maintaining clarity and consistency. If later code needs access to the `logging` module object, then `import logging` should be kept instead. Given only what's presented, remove the redundant module-level import.

Only line 1 in electricitymap/contrib/parsers/IEMOP.py needs to be deleted.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._