### PR TITLE
fix(entsoe-e): fix index out of range error

### DIFF
--- a/electricitymap/contrib/parsers/ENTSOE.py
+++ b/electricitymap/contrib/parsers/ENTSOE.py
@@ -813,10 +813,11 @@ def _reverse_A3_curve_compression_for_period(
     Reverses the A3 curve compression for a *single* Period object.
     Fills in missing points with the last known value.
     """
-    if not period.points:
-        return
 
     points_list = sorted(period.points, key=attrgetter("position"))
+
+    if not points_list:
+        return
 
     start_time = period.datetime_start
     end_time = period.datetime_end


### PR DESCRIPTION
## Issue
We had an issue on the NO zone, which surfaced a bug.

```
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/Users/bastienbigue/electricitymaps/electricitymaps-contrib/.venv/lib/python3.10/site-packages/click/core.py", line 1161, in __call__
    return self.main(*args, **kwargs)
  File "/Users/bastienbigue/electricitymaps/electricitymaps-contrib/.venv/lib/python3.10/site-packages/click/core.py", line 1082, in main
    rv = self.invoke(ctx)
  File "/Users/bastienbigue/electricitymaps/electricitymaps-contrib/.venv/lib/python3.10/site-packages/click/core.py", line 1443, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/Users/bastienbigue/electricitymaps/electricitymaps-contrib/.venv/lib/python3.10/site-packages/click/core.py", line 788, in invoke
    return __callback(*args, **kwargs)
  File "/Users/bastienbigue/electricitymaps/electricitymaps-contrib/test_parser.py", line 74, in test_parser
    res = parser(*args, target_datetime=parsed_target_datetime, logger=logger)
  File "/Users/bastienbigue/electricitymaps/electricitymaps-contrib/electricitymap/contrib/parsers/lib/config.py", line 77, in wrapped_f
    result = f(*args, **kwargs)
  File "/Users/bastienbigue/electricitymaps/electricitymaps-contrib/electricitymap/contrib/parsers/ENTSOE.py", line 955, in fetch_production
    non_aggregated_data.append(parse_production(raw_production, logger, zone_key))
  File "/Users/bastienbigue/electricitymaps/electricitymaps-contrib/electricitymap/contrib/parsers/ENTSOE.py", line 559, in parse_production
    list_of_raw_data = _get_raw_production_events(soup)
  File "/Users/bastienbigue/electricitymaps/electricitymaps-contrib/electricitymap/contrib/parsers/ENTSOE.py", line 601, in _get_raw_production_events
    for dt, quantity in points:
  File "/Users/bastienbigue/electricitymaps/electricitymaps-contrib/electricitymap/contrib/parsers/ENTSOE.py", line 804, in _get_datetime_value_from_timeseries
    yield from _reverse_A3_curve_compression_for_period(period)
  File "/Users/bastienbigue/electricitymaps/electricitymaps-contrib/electricitymap/contrib/parsers/ENTSOE.py", line 835, in _reverse_A3_curve_compression_for_period
    last_point = points_list[-1]
IndexError: list index out of range
```
Which happen because one of the period had no points : 
```
<period>
	<timeinterval>
		<start>2025-11-01T08:30Z</start>
		<end>2025-11-01T11:15Z</end>
	</timeinterval>
	<resolution>PT15M</resolution>
</period>
```
## Description
The check on the generator object did not have the expected effet (generators are truthy)

### Preview

<!-- Please add screenshots and/or gif that shows visual changes (if applicable) -->

### Double check

- [x] I have tested my parser changes locally with `poetry run test_parser "zone_key"`
- [x] I have run `pnpx prettier@2 --write .` and `poetry run format` in the top level directory to format my changes.
