### PR TITLE
fix(CY, emission factor): oil for 2022

### DIFF
--- a/config/zones/CY.yaml
+++ b/config/zones/CY.yaml
@@ -120,6 +120,9 @@ emissionFactors:
       - datetime: '2021-01-01'
         source: EU-ETS, TSOC 2021 Report
         value: 709.61
+      - datetime: '2022-01-01'
+        source: EU-ETS, TSOC 2022 Report
+        value: 730.32
       - datetime: '2023-01-01'
         source: EU-ETS, ENTSO-E 2023
         value: 641.08
@@ -219,6 +222,9 @@ emissionFactors:
       - datetime: '2021-01-01'
         source: EU-ETS, TSOC 2021 Report; IPCC 2014
         value: 953.61
+      - datetime: '2022-01-01'
+        source: EU-ETS, TSOC 2022 Report; IPCC 2014
+        value: 974.32
       - datetime: '2023-01-01'
         source: EU-ETS, ENTSO-E 2023; IPCC 2014
         value: 885.08
@@ -376,6 +382,8 @@ sources:
     link: https://colab.research.google.com/drive/1IkDXX4p1xQIuY3WicL94TUkRcZQnS9c7?usp=drive_link
   EU-ETS, TSOC 2021 Report:
     link: https://tsoc.org.cy/files/reports/annual-reports/TSOC_Annual_Report_2021.pdf#page=34
+  EU-ETS, TSOC 2022 Report:
+    link: https://tsoc.org.cy/files/reports/annual-reports/TSOC_Annual_Report_2022.pdf#page=32
   INCER ACV:
     link: https://docs.google.com/spreadsheets/d/1w5DJ7sPen6axIHU8TCVcuzNCjlct4I6JAbhUlw-ZXu8/edit?usp=sharing
   IPCC 2014:


### PR DESCRIPTION
Copied from GMM-1256:

We have a custom source for total yearly production for Cyprus, see this [PR](https://github.com/electricitymaps/electricitymaps-contrib/pull/6406) for details.

This calculation is manual and wasn't repeated for 2022, while for 2023 we had a Europe-wide update.

I've found the same report used in the original PR for 2022 [here](https://tsoc.org.cy/files/reports/annual-reports/TSOC_Annual_Report_2022.pdf#page=32) and it states 4243286 MWh from conventional sources, while ETS for 2022 states 3098942 [10^6 gCO2e] emissions for that year from the three power plants in Cyprus.

Using this we can calculate direct oil (3098942 * 10^6)/(4243286 * 10^3) = 730.3165518421337 ~ 730.32 [gCO2e/kWh]
For lifecycle we add 244 on top -> 974.32
