### PR TITLE
Add country-level zone aggregation for Chile (CL)

### DIFF
--- a/config/zones/CL-SEN.yaml
+++ b/config/zones/CL-SEN.yaml
@@ -4,11 +4,41 @@ bounding_box:
   - - -66.51396683799987
     - -17.006588197999946
 capacity:
-  geothermal: 95.0
-  hydro: 7514.0
-  solar: 9171.0
-  unknown: 12786.0
-  wind: 4710.0
+  geothermal:
+    - datetime: '2023-12-01'
+      source: coordinador.cl
+      value: 95.0
+    - datetime: '2022-12-01'
+      source: coordinador.cl
+      value: 82.0
+  hydro:
+    - datetime: '2023-12-01'
+      source: coordinador.cl
+      value: 7514.0
+    - datetime: '2022-12-01'
+      source: coordinador.cl
+      value: 7396.0
+  solar:
+    - datetime: '2023-12-01'
+      source: coordinador.cl
+      value: 9171.0
+    - datetime: '2022-12-01'
+      source: coordinador.cl
+      value: 8018.0
+  unknown:
+    - datetime: '2023-12-01'
+      source: coordinador.cl
+      value: 12786.0
+    - datetime: '2022-12-01'
+      source: coordinador.cl
+      value: 13394.0
+  wind:
+    - datetime: '2023-12-01'
+      source: coordinador.cl
+      value: 4710.0
+    - datetime: '2022-12-01'
+      source: coordinador.cl
+      value: 4328.0
 contributors:
   - systemcatch
   - alixunderplatz

--- a/config/zones/CL-SEN.yaml
+++ b/config/zones/CL-SEN.yaml
@@ -4,41 +4,11 @@ bounding_box:
   - - -66.51396683799987
     - -17.006588197999946
 capacity:
-  geothermal:
-    - datetime: '2023-12-01'
-      source: coordinador.cl
-      value: 95.0
-    - datetime: '2022-12-01'
-      source: coordinador.cl
-      value: 82.0
-  hydro:
-    - datetime: '2023-12-01'
-      source: coordinador.cl
-      value: 7514.0
-    - datetime: '2022-12-01'
-      source: coordinador.cl
-      value: 7396.0
-  solar:
-    - datetime: '2023-12-01'
-      source: coordinador.cl
-      value: 9171.0
-    - datetime: '2022-12-01'
-      source: coordinador.cl
-      value: 8018.0
-  unknown:
-    - datetime: '2023-12-01'
-      source: coordinador.cl
-      value: 12786.0
-    - datetime: '2022-12-01'
-      source: coordinador.cl
-      value: 13394.0
-  wind:
-    - datetime: '2023-12-01'
-      source: coordinador.cl
-      value: 4710.0
-    - datetime: '2022-12-01'
-      source: coordinador.cl
-      value: 4328.0
+  geothermal: 95.0
+  hydro: 7514.0
+  solar: 9171.0
+  unknown: 12786.0
+  wind: 4710.0
 contributors:
   - systemcatch
   - alixunderplatz

--- a/config/zones/CL.yaml
+++ b/config/zones/CL.yaml
@@ -1,0 +1,24 @@
+bypass_aggregation_checks: []
+capacity:
+  battery storage: 0
+  biomass: 0
+  coal: 0
+  gas: 97.3
+  geothermal: 95.0
+  hydro: 7539.9
+  hydro storage: 0
+  nuclear: 0
+  oil: 66.2
+  solar: 9174.1
+  unknown: 12786.0
+  wind: 4724.7
+contributors:
+- alixunderplatz
+- systemcatch
+- autipial
+subZoneNames:
+- CL-CHP
+- CL-SEA
+- CL-SEM
+- CL-SEN
+timezone: America/Santiago

--- a/config/zones/CL.yaml
+++ b/config/zones/CL.yaml
@@ -13,12 +13,12 @@ capacity:
   unknown: 12786.0
   wind: 4724.7
 contributors:
-- alixunderplatz
-- systemcatch
-- autipial
+  - alixunderplatz
+  - systemcatch
+  - autipial
 subZoneNames:
-- CL-CHP
-- CL-SEA
-- CL-SEM
-- CL-SEN
+  - CL-CHP
+  - CL-SEA
+  - CL-SEM
+  - CL-SEN
 timezone: America/Santiago


### PR DESCRIPTION
## Issue

May resolve #8220.

## Description

Countries that have subregions generally also have an aggregated country config file.

One imprecise and semi-manual but functional way to inspect for missing country-level aggregations is to run: `$ ls -l config/zones | grep -A 1 '[A-Z][A-Z][-]'`

Knowing that Chile was missing (partly from reporting #8220, but then also by guessing that it is due to a missing country-level config), I ran the script added in #4741 (`scripts/create_aggregated_zone_config.py`) to generate one.

Initially that failed, I think because the script does not support the multi-date entry format of the [`capacity` key for `CL-SEN.yaml`](https://github.com/electricitymaps/electricitymaps-contrib/blob/b5b70117ef891c7e42d2cdf712ad07378027d999/config/zones/CL-SEN.yaml#L6-L41):

```sh
$ PYTHONPATH=. python3 scripts/create_aggregated_zone_config.py CL America/Santiago
Creating CL
Traceback (most recent call last):
  File "<filtered>/electricitymaps-contrib/scripts/create_aggregated_zone_config.py", line 90, in <module>
    main()
    ~~~~^^
  File "<filtered>/electricitymaps-contrib/scripts/create_aggregated_zone_config.py", line 85, in main
    create_aggregated_config(zone, timezone)
    ~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^
  File "<filtered>/electricitymaps-contrib/scripts/create_aggregated_zone_config.py", line 51, in create_aggregated_config
    mapped_key, current_capacity + capacity
                ~~~~~~~~~~~~~~~~~^~~~~~~~~~
TypeError: unsupported operand type(s) for +: 'int' and 'list'
```

I worked around that by temporarily de-nesting the `capacity` keys (and then reverting that) in commit 208c988b17b53035be340526a6f12afb80383c97 (and revert 12f7a915f6f5bd98370fead0ea6c08c76d0259bb).

### Preview

N/A

### Double check

- [x] I have tested my parser changes locally with `poetry run test_parser "CL-SEN"`
- [x] I have run `npx prettier@2 --write .` and `poetry run format` in the top level directory to format my changes.

Edit: update double-checks after running `prettier`.