### PR TITLE
fix(IN): fallback on zone share over country when mode zone share is wrong

### DIFF
--- a/electricitymap/contrib/parsers/IN.py
+++ b/electricitymap/contrib/parsers/IN.py
@@ -771,7 +771,24 @@ def compute_zone_key_share_per_mode_out_of_total(
     zone_production_breakdown = get_production_breakdown(
         content=content, zone_key=zone_key
     )
-    return zone_production_breakdown["value"] / country_production_breakdown["value"]
+
+    total_production_zone_share_out_of_country = (
+        zone_production_breakdown.sum() / country_production_breakdown.sum()
+    )["value"]
+
+    zone_key_share_per_mode_out_of_country = (
+        zone_production_breakdown["value"] / country_production_breakdown["value"]
+    )
+
+    # We ensure that all share are between 0 and 1.
+    # If not, we replace the value by the share of the total production of the zone out of the total production of the country.
+    condition = (zone_key_share_per_mode_out_of_country >= 0) & (
+        zone_key_share_per_mode_out_of_country <= 1
+    )
+
+    return zone_key_share_per_mode_out_of_country.where(
+        condition, total_production_zone_share_out_of_country
+    )
 
 
 def scale_15min_production(content: bytes, scaling_factor: float) -> pd.DataFrame:


### PR DESCRIPTION
## Issue

In some cases, when we compute the share of a mode for a zone key out of the country-wide production of this mode, the share it out of the [0;1] bound because of the data being reported. 
This makes us report very high and incorrect values. 

## Description
This PR make the zone/mode share fallback on the zone share when the zone/mode value is incorrect.


### Preview

Before : 
<img width="799" height="679" alt="Screenshot 2025-11-24 at 13 24 22" src="https://github.com/user-attachments/assets/1bd8b28d-800b-43a4-bc53-7502a0a0003a" />


After : 
<img width="799" height="679" alt="Screenshot 2025-11-24 at 13 22 27" src="https://github.com/user-attachments/assets/ad87543c-e17b-4ec7-8172-efc805461dc2" />


### Double check

- [x] I have tested my parser changes locally with `poetry run test_parser "zone_key"`
- [x] I have run `pnpx prettier@2 --write .` and `poetry run format` in the top level directory to format my changes.
