### PR TITLE
fix(GB): fix GB capacity

### DIFF
--- a/config/zones/GB.yaml
+++ b/config/zones/GB.yaml
@@ -44,10 +44,13 @@ capacity:
       source: Ember, Yearly electricity data
       value: 4310
     - datetime: '2023-01-01'
-      source: Ember, Yearly electricity data
-      value: 1250
+      source: bmrs.elexon.co.uk
+      value: 1998
     - datetime: '2024-01-01'
-      source: Ember, Yearly electricity data
+      source: bmrs.elexon.co.uk
+      value: 1998
+    - datetime: '2025-01-01'
+      source: bmrs.elexon.co.uk
       value: 0
   gas:
     - datetime: '2017-01-01'
@@ -145,9 +148,6 @@ capacity:
     - datetime: '2023-01-01'
       source: bmreports.com
       value: 4775
-    - datetime: '2024-01-01'
-      source: bmreports.com
-      value: 745
     - datetime: '2025-01-01'
       source: bmreports.com
       value: 6238


### PR DESCRIPTION
## Issue
GB coal capacity from Ember is incorrect. Ember seems to be reporting the capacities at the end of the year instead of at the beginning ? 
In this case, the last coal power plant closed in 09/2024. 

## Description
Use capacity from elexon instead, with precise dates.

### Double check

- [x] I have tested my parser changes locally with `poetry run test_parser "zone_key"`
- [ ] I have run `pnpx prettier@2 --write .` and `poetry run format` in the top level directory to format my changes.
