### PR TITLE
fix(capacities): Fix SE-SE3 nuclear capacities

### DIFF
--- a/config/zones/SE-SE3.yaml
+++ b/config/zones/SE-SE3.yaml
@@ -4,12 +4,40 @@ bounding_box:
   - - 19.873529599638907
     - 62.50688674370767
 capacity:
-  biomass: 2561
-  gas: 950
-  hydro: 2593
-  nuclear: 9000
-  solar: 1130
-  wind: 3678
+  biomass:
+    - datetime: '2017-01-01'
+      value: 2561
+  gas:
+    - datetime: '2017-01-01'
+      value: 950
+  hydro:
+    - datetime: '2017-01-01'
+      value: 2593
+  nuclear:
+    - datetime: '2017-01-01'
+      value: 9076.00
+      source: entsoe.eu
+    - datetime: '2018-01-01'
+      value: 8603.00
+      source: entsoe.eu
+    - datetime: '2019-01-01'
+      value: 8586.00
+      source: entsoe.eu
+    - datetime: '2020-01-01'
+      value: 7710.00
+      source: entsoe.eu
+    - datetime: '2021-01-01'
+      value: 6871.00
+      source: entsoe.eu
+    - datetime: '2022-01-01'
+      value: 6900.00
+      source: entsoe.eu
+  solar:
+    - datetime: '2017-01-01'
+      value: 1130
+  wind:
+    - datetime: '2017-01-01'
+      value: 3678
 country: SE
 delays:
   production: 7

--- a/config/zones/SE.yaml
+++ b/config/zones/SE.yaml
@@ -3,16 +3,6 @@ bounding_box:
     - 55.379110448
   - - 21.2255859375
     - 69.0214140884
-capacity:
-  biomass: 4462
-  coal: 0
-  gas: 1535
-  geothermal: 0
-  hydro: 16334
-  nuclear: 6871
-  oil: 662
-  solar: 2385
-  wind: 14662
 contributors:
   - augustekman
   - RRyyas


### PR DESCRIPTION
## Issue
Fixes: GMM-1366

## Description
A little hacky as we don't know from when the others are supposed to be valid and for how long. Solar in 2017 was not this high for example but this way won't cause any problems while I hunt down better capacities for the other modes.

Also removes the top level capacity config for Sweden as it's not used, we use a sum of the subzones at compute time. This is to reduce confusion in the future.

### Double check

- [x] I have tested my parser changes locally with `poetry run test_parser "zone_key"`
- [x] I have run `pnpx prettier@2 --write .` and `poetry run format` in the top level directory to format my changes.
