### PR TITLE
fix(capacities): Fix SE wind capacities

### DIFF
--- a/config/zones/SE-SE1.yaml
+++ b/config/zones/SE-SE1.yaml
@@ -4,15 +4,55 @@ bounding_box:
   - - 24.663413534000114
     - 69.53635569300009
 capacity:
-  biomass: 271
-  coal: 0
-  gas: 1
-  geothermal: 0
-  hydro: 5271
-  nuclear: 0
-  oil: 0
-  solar: 19
-  wind: 2978
+  biomass:
+    - datetime: '2017-01-01'
+      value: 271
+  coal:
+    - datetime: '2017-01-01'
+      value: 0
+  gas:
+    - datetime: '2017-01-01'
+      value: 1
+  geothermal:
+    - datetime: '2017-01-01'
+      value: 0
+  hydro:
+    - datetime: '2017-01-01'
+      value: 5271
+  nuclear:
+    - datetime: '2017-01-01'
+      value: 0
+  oil:
+    - datetime: '2017-01-01'
+      value: 0
+  solar:
+    - datetime: '2017-01-01'
+      value: 19
+  wind:
+    - datetime: '2017-01-01'
+      value: 520.97
+      source: energimyndigheten.se
+    - datetime: '2018-01-01'
+      value: 830.22
+      source: energimyndigheten.se
+    - datetime: '2019-01-01'
+      value: 1254.37
+      source: energimyndigheten.se
+    - datetime: '2020-01-01'
+      value: 1648.07
+      source: energimyndigheten.se
+    - datetime: '2021-01-01'
+      value: 1947.37
+      source: energimyndigheten.se
+    - datetime: '2022-01-01'
+      value: 2872.00
+      source: energimyndigheten.se
+    - datetime: '2023-01-01'
+      value: 2999.87
+      source: energimyndigheten.se
+    - datetime: '2024-01-01'
+      value: 3066.87
+      source: energimyndigheten.se
 country: SE
 delays:
   production: 7

--- a/config/zones/SE-SE2.yaml
+++ b/config/zones/SE-SE2.yaml
@@ -4,15 +4,55 @@ bounding_box:
   - - 21.486074487958014
     - 66.78799631800014
 capacity:
-  biomass: 680
-  coal: 0
-  gas: 2
-  geothermal: 0
-  hydro: 8077
-  nuclear: 0
-  oil: 0
-  solar: 145
-  wind: 5908
+  biomass:
+    - datetime: '2017-01-01'
+      value: 680
+  coal:
+    - datetime: '2017-01-01'
+      value: 0
+  gas:
+    - datetime: '2017-01-01'
+      value: 2
+  geothermal:
+    - datetime: '2017-01-01'
+      value: 0
+  hydro:
+    - datetime: '2017-01-01'
+      value: 8077
+  nuclear:
+    - datetime: '2017-01-01'
+      value: 0
+  oil:
+    - datetime: '2017-01-01'
+      value: 0
+  solar:
+    - datetime: '2017-01-01'
+      value: 145
+  wind:
+    - datetime: '2017-01-01'
+      value: 2346.60
+      source: energimyndigheten.se
+    - datetime: '2018-01-01'
+      value: 2561.15
+      source: energimyndigheten.se
+    - datetime: '2019-01-01'
+      value: 3148.24
+      source: energimyndigheten.se
+    - datetime: '2020-01-01'
+      value: 3944.74
+      source: energimyndigheten.se
+    - datetime: '2021-01-01'
+      value: 5167.70
+      source: energimyndigheten.se
+    - datetime: '2022-01-01'
+      value: 5969.00
+      source: energimyndigheten.se
+    - datetime: '2023-01-01'
+      value: 6823.35
+      source: energimyndigheten.se
+    - datetime: '2024-01-01'
+      value: 7075.25
+      source: energimyndigheten.se
 country: SE
 delays:
   production: 7

--- a/config/zones/SE-SE3.yaml
+++ b/config/zones/SE-SE3.yaml
@@ -4,12 +4,40 @@ bounding_box:
   - - 19.873529599638907
     - 62.50688674370767
 capacity:
-  biomass: 2561
-  gas: 950
-  hydro: 2593
-  nuclear: 9000
-  solar: 1130
-  wind: 3678
+  biomass:
+    - datetime: '2017-01-01'
+      value: 2561
+  gas:
+    - datetime: '2017-01-01'
+      value: 950
+  hydro:
+    - datetime: '2017-01-01'
+      value: 2593
+  nuclear:
+    - datetime: '2017-01-01'
+      value: 9076.00
+      source: entsoe.eu
+    - datetime: '2018-01-01'
+      value: 8603.00
+      source: entsoe.eu
+    - datetime: '2019-01-01'
+      value: 8586.00
+      source: entsoe.eu
+    - datetime: '2020-01-01'
+      value: 7710.00
+      source: entsoe.eu
+    - datetime: '2021-01-01'
+      value: 6871.00
+      source: entsoe.eu
+    - datetime: '2022-01-01'
+      value: 6900.00
+      source: entsoe.eu
+  solar:
+    - datetime: '2017-01-01'
+      value: 1130
+  wind:
+    - datetime: '2017-01-01'
+      value: 3678
 country: SE
 delays:
   production: 7

--- a/config/zones/SE-SE3.yaml
+++ b/config/zones/SE-SE3.yaml
@@ -37,7 +37,29 @@ capacity:
       value: 1130
   wind:
     - datetime: '2017-01-01'
-      value: 3678
+      value: 2115.89
+      source: energimyndigheten.se
+    - datetime: '2018-01-01'
+      value: 2278.19
+      source: energimyndigheten.se
+    - datetime: '2019-01-01'
+      value: 2625.69
+      source: energimyndigheten.se
+    - datetime: '2020-01-01'
+      value: 2839.95
+      source: energimyndigheten.se
+    - datetime: '2021-01-01'
+      value: 3078.82
+      source: energimyndigheten.se
+    - datetime: '2022-01-01'
+      value: 3254.00
+      source: energimyndigheten.se
+    - datetime: '2023-01-01'
+      value: 3969.16
+      source: energimyndigheten.se
+    - datetime: '2024-01-01'
+      value: 4233.36
+      source: energimyndigheten.se
 country: SE
 delays:
   production: 7

--- a/config/zones/SE-SE4.yaml
+++ b/config/zones/SE-SE4.yaml
@@ -4,15 +4,55 @@ bounding_box:
   - - 17.699686739075773
     - 58.013078824484765
 capacity:
-  biomass: 883
-  coal: 0
-  gas: 582
-  geothermal: 0
-  hydro: 345
-  nuclear: 0
-  oil: 662
-  solar: 1091
-  wind: 2098
+  biomass:
+    - datetime: '2017-01-01'
+      value: 883
+  coal:
+    - datetime: '2017-01-01'
+      value: 0
+  gas:
+    - datetime: '2017-01-01'
+      value: 582
+  geothermal:
+    - datetime: '2017-01-01'
+      value: 0
+  hydro:
+    - datetime: '2017-01-01'
+      value: 345
+  nuclear:
+    - datetime: '2017-01-01'
+      value: 0
+  oil:
+    - datetime: '2017-01-01'
+      value: 662
+  solar:
+    - datetime: '2017-01-01'
+      value: 1091
+  wind:
+    - datetime: '2017-01-01'
+      value: 1627.49
+      source: energimyndigheten.se
+    - datetime: '2018-01-01'
+      value: 1630.66
+      source: energimyndigheten.se
+    - datetime: '2019-01-01'
+      value: 1652.93
+      source: energimyndigheten.se
+    - datetime: '2020-01-01'
+      value: 1649.20
+      source: energimyndigheten.se
+    - datetime: '2021-01-01'
+      value: 1921.89
+      source: energimyndigheten.se
+    - datetime: '2022-01-01'
+      value: 2183.00
+      source: energimyndigheten.se
+    - datetime: '2023-01-01'
+      value: 2431.34
+      source: energimyndigheten.se
+    - datetime: '2024-01-01'
+      value: 2443.88
+      source: energimyndigheten.se
 country: SE
 delays:
   production: 7

--- a/config/zones/SE.yaml
+++ b/config/zones/SE.yaml
@@ -3,16 +3,6 @@ bounding_box:
     - 55.379110448
   - - 21.2255859375
     - 69.0214140884
-capacity:
-  biomass: 4462
-  coal: 0
-  gas: 1535
-  geothermal: 0
-  hydro: 16334
-  nuclear: 6871
-  oil: 662
-  solar: 2385
-  wind: 14662
 contributors:
   - augustekman
   - RRyyas


### PR DESCRIPTION
## Issue

Closes: GMM-1366

## Description

Same as for #8525 but for wind and all the Swedish subzones using this source: https://pxexternal.energimyndigheten.se/pxweb/sv/Energimyndighetens_statistikdatabas/Energimyndighetens_statistikdatabas__Officiell_energistatistik__Vindkraftsstatistik/EN0105_2.px/table/tableViewLayout2/

This is the official statistical database but it don't have installed capacities for the other modes.

### Double check

- [x] I have tested my parser changes locally with `poetry run test_parser "zone_key"`
- [x] I have run `pnpx prettier@2 --write .` and `poetry run format` in the top level directory to format my changes.
