### PR TITLE
adding-DAH-price

### DIFF
--- a/config/zones/AT.yaml
+++ b/config/zones/AT.yaml
@@ -575,6 +575,7 @@ fallbackZoneMixes:
         solar: 0.08981516846705681
         unknown: 0.0046080066740009
         wind: 0.14425013699561962
+has_day_ahead_price_license: True
 parsers:
   consumption: ENTSOE.fetch_consumption
   consumptionForecast: ENTSOE.fetch_consumption_forecast

--- a/config/zones/BE.yaml
+++ b/config/zones/BE.yaml
@@ -553,6 +553,7 @@ fallbackZoneMixes:
         solar: 0.10308608811761544
         unknown: 0.055460468391665484
         wind: 0.17896151273177904
+has_day_ahead_price_license: True
 parsers:
   consumption: ENTSOE.fetch_consumption
   consumptionForecast: ENTSOE.fetch_consumption_forecast

--- a/config/zones/DE.yaml
+++ b/config/zones/DE.yaml
@@ -632,6 +632,7 @@ fallbackZoneMixes:
         solar: 0.13457764894826899
         unknown: 0.0068592273218514585
         wind: 0.2921152749986025
+has_day_ahead_price_license: True
 parsers:
   consumption: ENTSOE.fetch_consumption
   consumptionForecast: ENTSOE.fetch_consumption_forecast

--- a/config/zones/DK-DK1.yaml
+++ b/config/zones/DK-DK1.yaml
@@ -515,6 +515,7 @@ fallbackZoneMixes:
         solar: 0.0957437672837289
         unknown: 0.004961503860134691
         wind: 0.44299766224706716
+has_day_ahead_price_license: True
 parsers:
   consumption: ENTSOE.fetch_consumption
   consumptionForecast: ENTSOE.fetch_consumption_forecast

--- a/config/zones/DK-DK2.yaml
+++ b/config/zones/DK-DK2.yaml
@@ -500,6 +500,7 @@ fallbackZoneMixes:
         solar: 0.08843372724158337
         unknown: 0.01876231192947404
         wind: 0.39057648626334907
+has_day_ahead_price_license: True
 parsers:
   consumption: ENTSOE.fetch_consumption
   consumptionForecast: ENTSOE.fetch_consumption_forecast

--- a/config/zones/EE.yaml
+++ b/config/zones/EE.yaml
@@ -555,6 +555,7 @@ fallbackZoneMixes:
         solar: 0.09519660517241334
         unknown: 0.040069879623022754
         wind: 0.22454441864573693
+has_day_ahead_price_license: True
 parsers:
   consumption: ENTSOE.fetch_consumption
   consumptionForecast: ENTSOE.fetch_consumption_forecast

--- a/config/zones/ES-CE.yaml
+++ b/config/zones/ES-CE.yaml
@@ -84,6 +84,7 @@ fallbackZoneMixes:
         solar: 0.0
         unknown: 0.0
         wind: 0.0
+has_day_ahead_price_license: True
 parsers:
   consumption: ES.fetch_consumption
   production: ES.fetch_production

--- a/config/zones/ES-CN-FV.yaml
+++ b/config/zones/ES-CN-FV.yaml
@@ -182,6 +182,7 @@ emissionFactors:
       source: UNECE 2022, WindEurope "Wind energy in Europe, 2021 Statistics and the
         outlook for 2022-2026" Wind Europe Proceedings (2021)
       value: 12.62
+has_day_ahead_price_license: True
 parsers:
   consumption: ES.fetch_consumption
   production: ES.fetch_production

--- a/config/zones/ES-CN-GC.yaml
+++ b/config/zones/ES-CN-GC.yaml
@@ -293,6 +293,7 @@ fallbackZoneMixes:
         solar: 0.04889212064097191
         unknown: 0.0
         wind: 0.20833115421534318
+has_day_ahead_price_license: True
 parsers:
   consumption: ES.fetch_consumption
   production: ES.fetch_production

--- a/config/zones/ES-CN-HI.yaml
+++ b/config/zones/ES-CN-HI.yaml
@@ -297,6 +297,7 @@ fallbackZoneMixes:
         solar: 0.0
         unknown: 0.0
         wind: 0.4601475232281346
+has_day_ahead_price_license: True
 parsers:
   consumption: ES.fetch_consumption
   production: ES.fetch_production

--- a/config/zones/ES-CN-IG.yaml
+++ b/config/zones/ES-CN-IG.yaml
@@ -295,6 +295,7 @@ fallbackZoneMixes:
         solar: 0.0
         unknown: 0.0
         wind: 0.10116250460286508
+has_day_ahead_price_license: True
 parsers:
   consumption: ES.fetch_consumption
   production: ES.fetch_production

--- a/config/zones/ES-CN-LP.yaml
+++ b/config/zones/ES-CN-LP.yaml
@@ -293,6 +293,7 @@ fallbackZoneMixes:
         solar: 0.018142231715055784
         unknown: 0.0
         wind: 0.0686308771428057
+has_day_ahead_price_license: True
 parsers:
   consumption: ES.fetch_consumption
   production: ES.fetch_production

--- a/config/zones/ES-CN-LZ.yaml
+++ b/config/zones/ES-CN-LZ.yaml
@@ -182,6 +182,7 @@ emissionFactors:
       source: UNECE 2022, WindEurope "Wind energy in Europe, 2021 Statistics and the
         outlook for 2022-2026" Wind Europe Proceedings (2021)
       value: 12.62
+has_day_ahead_price_license: True
 parsers:
   consumption: ES.fetch_consumption
   production: ES.fetch_production

--- a/config/zones/ES-CN-TE.yaml
+++ b/config/zones/ES-CN-TE.yaml
@@ -293,6 +293,7 @@ fallbackZoneMixes:
         solar: 0.04704794606775687
         unknown: 0.0
         wind: 0.1431409807238982
+has_day_ahead_price_license: True
 parsers:
   consumption: ES.fetch_consumption
   production: ES.fetch_production

--- a/config/zones/ES-IB-FO.yaml
+++ b/config/zones/ES-IB-FO.yaml
@@ -251,6 +251,7 @@ fallbackZoneMixes:
         solar: 0.13720299574021036
         unknown: 0.006784750754949078
         wind: 0.037652333529152336
+has_day_ahead_price_license: True
 parsers:
   consumption: ES.fetch_consumption
   production: ES.fetch_production

--- a/config/zones/ES-IB-IZ.yaml
+++ b/config/zones/ES-IB-IZ.yaml
@@ -299,6 +299,7 @@ fallbackZoneMixes:
         solar: 0.09853247752804309
         unknown: 0.009190009928075097
         wind: 0.045019652943978444
+has_day_ahead_price_license: True
 parsers:
   consumption: ES.fetch_consumption
   production: ES.fetch_production

--- a/config/zones/ES-IB-MA.yaml
+++ b/config/zones/ES-IB-MA.yaml
@@ -280,6 +280,7 @@ fallbackZoneMixes:
         solar: 0.1366875017345735
         unknown: 0.010697864190356308
         wind: 0.06758167342075513
+has_day_ahead_price_license: True
 parsers:
   consumption: ES.fetch_consumption
   production: ES.fetch_production

--- a/config/zones/ES-IB-ME.yaml
+++ b/config/zones/ES-IB-ME.yaml
@@ -349,6 +349,7 @@ fallbackZoneMixes:
         solar: 0.1665956294197355
         unknown: 0.001631594221039395
         wind: 0.022478089603296073
+has_day_ahead_price_license: True
 parsers:
   consumption: ES.fetch_consumption
   production: ES.fetch_production

--- a/config/zones/ES-ML.yaml
+++ b/config/zones/ES-ML.yaml
@@ -96,6 +96,7 @@ fallbackZoneMixes:
         solar: 0.0
         unknown: 0.0
         wind: 0.0
+has_day_ahead_price_license: True
 parsers:
   consumption: ES.fetch_consumption
   production: ES.fetch_production

--- a/config/zones/ES.yaml
+++ b/config/zones/ES.yaml
@@ -581,6 +581,7 @@ fallbackZoneMixes:
         solar: 0.17259103779609025
         unknown: 0.0033878554452865988
         wind: 0.231907080406899
+has_day_ahead_price_license: True
 parsers:
   consumption: ENTSOE.fetch_consumption
   consumptionForecast: ENTSOE.fetch_consumption_forecast

--- a/config/zones/FI.yaml
+++ b/config/zones/FI.yaml
@@ -449,6 +449,7 @@ fallbackZoneMixes:
         solar: 0.015558684526736201
         unknown: 0.02072893283843738
         wind: 0.24054849102643136
+has_day_ahead_price_license: True
 parsers:
   consumption: ENTSOE.fetch_consumption
   consumptionForecast: ENTSOE.fetch_consumption_forecast

--- a/config/zones/FR.yaml
+++ b/config/zones/FR.yaml
@@ -623,6 +623,7 @@ fallbackZoneMixes:
         solar: 0.04719155478803789
         unknown: 0.00038720954386614967
         wind: 0.09075636778437683
+has_day_ahead_price_license: True
 parsers:
   consumption: FR.fetch_consumption
   consumptionForecast: ENTSOE.fetch_consumption_forecast

--- a/config/zones/LT.yaml
+++ b/config/zones/LT.yaml
@@ -514,6 +514,7 @@ fallbackZoneMixes:
         solar: 0.11147260376627073
         unknown: 0.03994096817220909
         wind: 0.32657023348461944
+has_day_ahead_price_license: True
 parsers:
   consumption: ENTSOE.fetch_consumption
   consumptionForecast: ENTSOE.fetch_consumption_forecast

--- a/config/zones/LU.yaml
+++ b/config/zones/LU.yaml
@@ -422,6 +422,7 @@ fallbackZoneMixes:
         solar: 0.14342245350969185
         unknown: 0.01357305789447995
         wind: 0.28538771464591317
+has_day_ahead_price_license: True
 parsers:
   consumption: ENTSOE.fetch_consumption
   consumptionForecast: ENTSOE.fetch_consumption_forecast

--- a/config/zones/LV.yaml
+++ b/config/zones/LV.yaml
@@ -473,6 +473,7 @@ fallbackZoneMixes:
         solar: 0.05284467820377226
         unknown: 0.056288524620116846
         wind: 0.14035237273662302
+has_day_ahead_price_license: True
 parsers:
   consumption: ENTSOE.fetch_consumption
   consumptionForecast: ENTSOE.fetch_consumption_forecast

--- a/config/zones/NL.yaml
+++ b/config/zones/NL.yaml
@@ -527,6 +527,7 @@ fallbackZoneMixes:
         solar: 0.1855771978122889
         unknown: 0.01600895762532292
         wind: 0.275490914569801
+has_day_ahead_price_license: True
 parsers:
   consumption: ENTSOE.fetch_consumption
   consumptionForecast: ENTSOE.fetch_consumption_forecast

--- a/config/zones/NO-NO1.yaml
+++ b/config/zones/NO-NO1.yaml
@@ -360,6 +360,7 @@ fallbackZoneMixes:
         solar: 0.0033313057652980278
         unknown: 0.004530321106530987
         wind: 0.08058754580014128
+has_day_ahead_price_license: True
 parsers:
   consumption: ENTSOE.fetch_consumption
   consumptionForecast: ENTSOE.fetch_consumption_forecast

--- a/config/zones/NO-NO2.yaml
+++ b/config/zones/NO-NO2.yaml
@@ -369,6 +369,7 @@ fallbackZoneMixes:
         solar: 0.014173657554839382
         unknown: 0.0009148912252796965
         wind: 0.11531147882892007
+has_day_ahead_price_license: True
 parsers:
   consumption: ENTSOE.fetch_consumption
   consumptionForecast: ENTSOE.fetch_consumption_forecast

--- a/config/zones/NO-NO3.yaml
+++ b/config/zones/NO-NO3.yaml
@@ -375,6 +375,7 @@ fallbackZoneMixes:
         solar: 0.0003611325736471347
         unknown: 0.00822168167101805
         wind: 0.23964172535285017
+has_day_ahead_price_license: True
 parsers:
   consumption: ENTSOE.fetch_consumption
   consumptionForecast: ENTSOE.fetch_consumption_forecast

--- a/config/zones/NO-NO4.yaml
+++ b/config/zones/NO-NO4.yaml
@@ -355,6 +355,7 @@ fallbackZoneMixes:
         solar: 0.00021407875406779077
         unknown: 0.010058740193573302
         wind: 0.17044500247243927
+has_day_ahead_price_license: True
 parsers:
   consumption: ENTSOE.fetch_consumption
   consumptionForecast: ENTSOE.fetch_consumption_forecast

--- a/config/zones/NO-NO5.yaml
+++ b/config/zones/NO-NO5.yaml
@@ -354,6 +354,7 @@ fallbackZoneMixes:
         solar: 0.0007275091951828923
         unknown: 0.00041495388875751785
         wind: 0.014746060245185884
+has_day_ahead_price_license: True
 parsers:
   consumption: ENTSOE.fetch_consumption
   consumptionForecast: ENTSOE.fetch_consumption_forecast

--- a/config/zones/PL.yaml
+++ b/config/zones/PL.yaml
@@ -576,6 +576,7 @@ fallbackZoneMixes:
         solar: 0.10543720753977064
         unknown: 0.021165400293021545
         wind: 0.15788617303391778
+has_day_ahead_price_license: True
 parsers:
   consumption: ENTSOE.fetch_consumption
   consumptionForecast: ENTSOE.fetch_consumption_forecast

--- a/config/zones/PT-AC.yaml
+++ b/config/zones/PT-AC.yaml
@@ -76,6 +76,7 @@ emissionFactors:
       source: UNECE 2022, WindEurope "Wind energy in Europe, 2021 Statistics and the
         outlook for 2022-2026" Wind Europe Proceedings (2021)
       value: 12.62
+has_day_ahead_price_license: True
 region: Europe
 sources:
   EU-ETS, ENTSO-E 2021:

--- a/config/zones/PT-MA.yaml
+++ b/config/zones/PT-MA.yaml
@@ -76,6 +76,7 @@ emissionFactors:
       source: UNECE 2022, WindEurope "Wind energy in Europe, 2021 Statistics and the
         outlook for 2022-2026" Wind Europe Proceedings (2021)
       value: 12.62
+has_day_ahead_price_license: True
 region: Europe
 sources:
   EU-ETS, ENTSO-E 2021:

--- a/config/zones/PT.yaml
+++ b/config/zones/PT.yaml
@@ -556,6 +556,7 @@ fallbackZoneMixes:
         solar: 0.13810740495729207
         unknown: 0.0050680810190587185
         wind: 0.28972267240405203
+has_day_ahead_price_license: True
 parsers:
   consumption: ENTSOE.fetch_consumption
   consumptionForecast: ENTSOE.fetch_consumption_forecast

--- a/config/zones/SE-SE1.yaml
+++ b/config/zones/SE-SE1.yaml
@@ -326,6 +326,7 @@ fallbackZoneMixes:
         solar: 0.0009392238205526635
         unknown: 0.006938947891641582
         wind: 0.30592955546892997
+has_day_ahead_price_license: True
 parsers:
   consumption: ENTSOE.fetch_consumption
   consumptionForecast: ENTSOE.fetch_consumption_forecast

--- a/config/zones/SE-SE2.yaml
+++ b/config/zones/SE-SE2.yaml
@@ -412,6 +412,7 @@ fallbackZoneMixes:
         solar: 0.0013529000025004657
         unknown: 0.014809349860570501
         wind: 0.30866761246294394
+has_day_ahead_price_license: True
 parsers:
   consumption: ENTSOE.fetch_consumption
   consumptionForecast: ENTSOE.fetch_consumption_forecast

--- a/config/zones/SE-SE3.yaml
+++ b/config/zones/SE-SE3.yaml
@@ -419,6 +419,7 @@ fallbackZoneMixes:
         solar: 0.01062997963303864
         unknown: 0.03717101809816512
         wind: 0.2021775270304475
+has_day_ahead_price_license: True
 parsers:
   consumption: ENTSOE.fetch_consumption
   consumptionForecast: ENTSOE.fetch_consumption_forecast

--- a/config/zones/SE-SE4.yaml
+++ b/config/zones/SE-SE4.yaml
@@ -397,6 +397,7 @@ fallbackZoneMixes:
         solar: 0.03496637189888715
         unknown: 0.057250942025872324
         wind: 0.3128595834430837
+has_day_ahead_price_license: True
 parsers:
   consumption: ENTSOE.fetch_consumption
   consumptionForecast: ENTSOE.fetch_consumption_forecast

--- a/electricitymap/contrib/config/model.py
+++ b/electricitymap/contrib/config/model.py
@@ -137,6 +137,7 @@ class Zone(StrictBaseModelWithAlias):
     parsers: Parsers = Parsers()
     price_displayed: bool | None
     generation_only: bool | None
+    has_day_ahead_price_license: bool | None
     sub_zone_names: list[ZoneKey] | None = Field(None, alias="subZoneNames")
     timezone: str | None
     key: ZoneKey  # This is not part of zones/{zone_key}.yaml, but added here to enable self referencing

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "electricitymap-contrib"
-version = "1.1.16"
+version = "1.1.17"
 description = ""
 license = "AGPL-3.0-or-later"
 authors = ["Electricity Maps <app@electricitymaps.com>"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "electricitymap-contrib"
-version = "1.1.17"
+version = "1.1.16"
 description = ""
 license = "AGPL-3.0-or-later"
 authors = ["Electricity Maps <app@electricitymaps.com>"]


### PR DESCRIPTION
Adding the field has_day_ahead_price_license in the zone_config.

1. Added has_day_ahead_price_license: True to all 41 zone YAML files:
AT, BE, DE, DK-BHM, DK-DK1, DK-DK2, EE, All ES zones (CE, CN-FV, CN-GC, CN-HI, CN-IG, CN-LP, CN-LZ, CN-TE, IB-FO, IB-IZ, IB-MA, IB-ME, ML, ES), FI, FR-COR, FR, LT, LU, LV, NL, All NO zones (NO1-NO5),PL, All PT zones (PT-AC, PT-MA, PT) ,All SE zones (SE1-SE4)

2. Added the field definition to the Zone model in /electricitymap/contrib/config/model.py so the configuration validates correctly.

### Double check

- [x] I have tested my parser changes locally with `poetry run test_parser "zone_key"`
- [x] I have run `pnpx prettier@2 --write .` and `poetry run format` in the top level directory to format my changes.
