### PR TITLE
hide_day_ahead_price: False and has_day_ahead_price_license: False

### DIFF
--- a/config/zones/AD.yaml
+++ b/config/zones/AD.yaml
@@ -12,3 +12,6 @@ timezone: Europe/Andorra
 zone_name: Andorra
 country_name: Andorra
 currency: EUR
+
+hide_day_ahead_price: False
+has_day_ahead_price_license: False

--- a/config/zones/AE.yaml
+++ b/config/zones/AE.yaml
@@ -270,6 +270,9 @@ fallbackZoneMixes:
         solar: 0.07128789104234305
         unknown: 0.0016348372505816842
         wind: 0.0
+
+hide_day_ahead_price: False
+has_day_ahead_price_license: False
 parsers:
   consumption: GCCIA.fetch_consumption
   productionCapacity: EMBER.fetch_production_capacity

--- a/config/zones/AF.yaml
+++ b/config/zones/AF.yaml
@@ -37,6 +37,9 @@ capacity:
       source: Ember, Yearly electricity data
       value: 0.0
 country: AF
+
+hide_day_ahead_price: False
+has_day_ahead_price_license: False
 parsers:
   productionCapacity: EMBER.fetch_production_capacity
 region: Asia

--- a/config/zones/AG.yaml
+++ b/config/zones/AG.yaml
@@ -28,6 +28,9 @@ capacity:
       source: Ember, Yearly electricity data
       value: 60.0
 country: AG
+
+hide_day_ahead_price: False
+has_day_ahead_price_license: False
 parsers:
   productionCapacity: EMBER.fetch_production_capacity
 region: Americas

--- a/config/zones/AL.yaml
+++ b/config/zones/AL.yaml
@@ -74,6 +74,9 @@ emissionFactors:
       datetime: '2020-01-01'
       source: UNECE 2022
       value: 5.13
+
+hide_day_ahead_price: False
+has_day_ahead_price_license: False
 parsers:
   consumption: ENTSOE.fetch_consumption
   consumptionForecast: ENTSOE.fetch_consumption_forecast

--- a/config/zones/AM.yaml
+++ b/config/zones/AM.yaml
@@ -133,6 +133,9 @@ fallbackZoneMixes:
         solar: 0.0
         unknown: 4.115911610833948e-07
         wind: 1.2884592868697575e-06
+
+hide_day_ahead_price: False
+has_day_ahead_price_license: False
 parsers:
   productionCapacity: EMBER.fetch_production_capacity
 region: Asia

--- a/config/zones/AO.yaml
+++ b/config/zones/AO.yaml
@@ -52,6 +52,9 @@ fallbackZoneMixes:
         solar: 0.024552889130142887
         unknown: 0.0
         wind: 0.0
+
+hide_day_ahead_price: False
+has_day_ahead_price_license: False
 parsers:
   productionCapacity: EMBER.fetch_production_capacity
 region: Africa

--- a/config/zones/AR.yaml
+++ b/config/zones/AR.yaml
@@ -368,6 +368,9 @@ fallbackZoneMixes:
         solar: 0.02698552858936858
         unknown: 0.5265037188143048
         wind: 0.11199192793014612
+
+hide_day_ahead_price: False
+has_day_ahead_price_license: False
 parsers:
   production: CAMMESA.fetch_production
   productionCapacity: EMBER.fetch_production_capacity

--- a/config/zones/AT.yaml
+++ b/config/zones/AT.yaml
@@ -576,6 +576,8 @@ fallbackZoneMixes:
         unknown: 0.0046080066740009
         wind: 0.14425013699561962
 has_day_ahead_price_license: True
+
+hide_day_ahead_price: False
 parsers:
   consumption: ENTSOE.fetch_consumption
   consumptionForecast: ENTSOE.fetch_consumption_forecast

--- a/config/zones/AU-LH.yaml
+++ b/config/zones/AU-LH.yaml
@@ -13,3 +13,6 @@ timezone: Australia/Lord_Howe
 zone_name: Lord Howe Island
 country_name: Australia
 currency: AUD
+
+hide_day_ahead_price: False
+has_day_ahead_price_license: False

--- a/config/zones/AU-NSW.yaml
+++ b/config/zones/AU-NSW.yaml
@@ -354,6 +354,9 @@ fallbackZoneMixes:
         solar: 0.2085011484047794
         unknown: 0.0
         wind: 0.09586177067488971
+
+hide_day_ahead_price: False
+has_day_ahead_price_license: False
 parsers:
   consumptionForecast: AEMO.fetch_consumption_forecast
   price: OPENNEM.fetch_price

--- a/config/zones/AU-NT.yaml
+++ b/config/zones/AU-NT.yaml
@@ -234,6 +234,9 @@ fallbackZoneMixes:
         solar: 0.0
         unknown: 0.028919092948344192
         wind: 0.0
+
+hide_day_ahead_price: False
+has_day_ahead_price_license: False
 parsers:
   consumption: NTESMO.fetch_consumption
   price: NTESMO.fetch_price

--- a/config/zones/AU-QLD.yaml
+++ b/config/zones/AU-QLD.yaml
@@ -342,6 +342,9 @@ fallbackZoneMixes:
         solar: 0.20730753084217618
         unknown: 0.0
         wind: 0.04511033753549817
+
+hide_day_ahead_price: False
+has_day_ahead_price_license: False
 parsers:
   consumptionForecast: AEMO.fetch_consumption_forecast
   price: OPENNEM.fetch_price

--- a/config/zones/AU-SA.yaml
+++ b/config/zones/AU-SA.yaml
@@ -340,6 +340,9 @@ fallbackZoneMixes:
         solar: 0.2668651967564851
         unknown: 0.0
         wind: 0.42456316091004337
+
+hide_day_ahead_price: False
+has_day_ahead_price_license: False
 parsers:
   consumptionForecast: AEMO.fetch_consumption_forecast
   price: OPENNEM.fetch_price

--- a/config/zones/AU-TAS-CBI.yaml
+++ b/config/zones/AU-TAS-CBI.yaml
@@ -4,3 +4,6 @@ timezone: Australia/Lord_Howe
 zone_name: Cape Barren Island
 country_name: Australia
 currency: AUD
+
+hide_day_ahead_price: False
+has_day_ahead_price_license: False

--- a/config/zones/AU-TAS-FI.yaml
+++ b/config/zones/AU-TAS-FI.yaml
@@ -121,6 +121,9 @@ fallbackZoneMixes:
         solar: 0.01938750199323187
         unknown: 0.0
         wind: 0.5865180749218949
+
+hide_day_ahead_price: False
+has_day_ahead_price_license: False
 parsers:
   production: ajenti.fetch_production
 region: Oceania

--- a/config/zones/AU-TAS-KI.yaml
+++ b/config/zones/AU-TAS-KI.yaml
@@ -149,6 +149,9 @@ fallbackZoneMixes:
         solar: 0.1199307309665122
         unknown: 0.0
         wind: 0.2054531930390045
+
+hide_day_ahead_price: False
+has_day_ahead_price_license: False
 parsers:
   production: ajenti.fetch_production
 region: Oceania

--- a/config/zones/AU-TAS.yaml
+++ b/config/zones/AU-TAS.yaml
@@ -303,6 +303,9 @@ fallbackZoneMixes:
         solar: 0.07151092912874732
         unknown: 0.0
         wind: 0.2039048715577342
+
+hide_day_ahead_price: False
+has_day_ahead_price_license: False
 parsers:
   consumptionForecast: AEMO.fetch_consumption_forecast
   price: OPENNEM.fetch_price

--- a/config/zones/AU-VIC.yaml
+++ b/config/zones/AU-VIC.yaml
@@ -339,6 +339,9 @@ fallbackZoneMixes:
         solar: 0.1470457660916572
         unknown: 0.0
         wind: 0.18972740562986398
+
+hide_day_ahead_price: False
+has_day_ahead_price_license: False
 parsers:
   consumptionForecast: AEMO.fetch_consumption_forecast
   price: OPENNEM.fetch_price

--- a/config/zones/AU-WA-RI.yaml
+++ b/config/zones/AU-WA-RI.yaml
@@ -99,6 +99,9 @@ fallbackZoneMixes:
         solar: 0.06026681890829423
         unknown: 0.0
         wind: 0.1463649654920588
+
+hide_day_ahead_price: False
+has_day_ahead_price_license: False
 parsers:
   production: ajenti.fetch_production
 region: Oceania

--- a/config/zones/AU-WA.yaml
+++ b/config/zones/AU-WA.yaml
@@ -330,6 +330,9 @@ fallbackZoneMixes:
         solar: 0.23467167868922628
         unknown: 0.0
         wind: 0.1699992813333499
+
+hide_day_ahead_price: False
+has_day_ahead_price_license: False
 parsers:
   price: OPENNEM.fetch_price
   production: OPENNEM.fetch_production

--- a/config/zones/AU.yaml
+++ b/config/zones/AU.yaml
@@ -223,3 +223,6 @@ timezone: Australia/Sydney
 zone_name: Australia
 country_name: Australia
 currency: AUD
+
+hide_day_ahead_price: False
+has_day_ahead_price_license: False

--- a/config/zones/AW.yaml
+++ b/config/zones/AW.yaml
@@ -205,6 +205,9 @@ fallbackZoneMixes:
         solar: 0.006176899034154593
         unknown: 0.0015510181027602445
         wind: 0.10858758715681341
+
+hide_day_ahead_price: False
+has_day_ahead_price_license: False
 parsers:
   production: AW.fetch_production
   productionCapacity: EMBER.fetch_production_capacity

--- a/config/zones/AX.yaml
+++ b/config/zones/AX.yaml
@@ -287,6 +287,9 @@ fallbackZoneMixes:
         solar: 0.0046097053247544
         unknown: 0.01829593364522464
         wind: 0.6099261074548099
+
+hide_day_ahead_price: False
+has_day_ahead_price_license: False
 parsers:
   consumption: AX.fetch_consumption
   price: ENTSOE.fetch_price

--- a/config/zones/AZ.yaml
+++ b/config/zones/AZ.yaml
@@ -85,6 +85,9 @@ fallbackZoneMixes:
       hydro: 0.07
       oil: 0.46
       unknown: 0.01
+
+hide_day_ahead_price: False
+has_day_ahead_price_license: False
 parsers:
   productionCapacity: EMBER.fetch_production_capacity
 region: Asia

--- a/config/zones/BA.yaml
+++ b/config/zones/BA.yaml
@@ -281,6 +281,9 @@ fallbackZoneMixes:
         solar: 0.01565642226201501
         unknown: 0.0026649035309820757
         wind: 0.028774809119518137
+
+hide_day_ahead_price: False
+has_day_ahead_price_license: False
 parsers:
   consumption: ENTSOE.fetch_consumption
   consumptionForecast: ENTSOE.fetch_consumption_forecast

--- a/config/zones/BB.yaml
+++ b/config/zones/BB.yaml
@@ -54,6 +54,9 @@ fallbackZoneMixes:
         solar: 0.014305633100344143
         unknown: 0.0
         wind: 0.0
+
+hide_day_ahead_price: False
+has_day_ahead_price_license: False
 parsers:
   consumption: BB.fetch_consumption
   productionCapacity: EMBER.fetch_production_capacity

--- a/config/zones/BD.yaml
+++ b/config/zones/BD.yaml
@@ -333,6 +333,9 @@ fallbackZoneMixes:
         solar: 0.01021179644515913
         unknown: 0.021465682698105372
         wind: 0.001123168509769495
+
+hide_day_ahead_price: False
+has_day_ahead_price_license: False
 parsers:
   consumption: ERP_PGCB.fetch_consumption
   production: ERP_PGCB.fetch_production

--- a/config/zones/BE.yaml
+++ b/config/zones/BE.yaml
@@ -554,6 +554,8 @@ fallbackZoneMixes:
         unknown: 0.055460468391665484
         wind: 0.17896151273177904
 has_day_ahead_price_license: True
+
+hide_day_ahead_price: False
 parsers:
   consumption: ENTSOE.fetch_consumption
   consumptionForecast: ENTSOE.fetch_consumption_forecast

--- a/config/zones/BF.yaml
+++ b/config/zones/BF.yaml
@@ -42,6 +42,9 @@ capacity:
       source: Ember, Yearly electricity data
       value: 400.0
 country: BF
+
+hide_day_ahead_price: False
+has_day_ahead_price_license: False
 parsers:
   productionCapacity: EMBER.fetch_production_capacity
 region: Africa

--- a/config/zones/BG.yaml
+++ b/config/zones/BG.yaml
@@ -493,6 +493,9 @@ fallbackZoneMixes:
         solar: 0.11539420850969283
         unknown: 0.00042608502444417757
         wind: 0.04861173432578981
+
+hide_day_ahead_price: False
+has_day_ahead_price_license: False
 parsers:
   consumption: ENTSOE.fetch_consumption
   consumptionForecast: ENTSOE.fetch_consumption_forecast

--- a/config/zones/BH.yaml
+++ b/config/zones/BH.yaml
@@ -104,6 +104,9 @@ fallbackZoneMixes:
         solar: 0.0
         unknown: 1.0
         wind: 0.0
+
+hide_day_ahead_price: False
+has_day_ahead_price_license: False
 parsers:
   consumption: GCCIA.fetch_consumption
   productionCapacity: EMBER.fetch_production_capacity

--- a/config/zones/BI.yaml
+++ b/config/zones/BI.yaml
@@ -22,6 +22,9 @@ capacity:
       source: Ember, Yearly electricity data
       value: 50.0
 country: BI
+
+hide_day_ahead_price: False
+has_day_ahead_price_license: False
 parsers:
   productionCapacity: EMBER.fetch_production_capacity
 region: Africa

--- a/config/zones/BJ.yaml
+++ b/config/zones/BJ.yaml
@@ -31,6 +31,9 @@ capacity:
       source: Ember, Yearly electricity data
       value: 170.0
 country: BJ
+
+hide_day_ahead_price: False
+has_day_ahead_price_license: False
 parsers:
   productionCapacity: EMBER.fetch_production_capacity
 region: Africa

--- a/config/zones/BM.yaml
+++ b/config/zones/BM.yaml
@@ -6,6 +6,9 @@ bounding_box:
 contributors:
   - VIKTORVAV99
 country: BM
+
+hide_day_ahead_price: False
+has_day_ahead_price_license: False
 parsers:
   productionCapacity: EMBER.fetch_production_capacity
 region: Americas

--- a/config/zones/BN.yaml
+++ b/config/zones/BN.yaml
@@ -30,6 +30,9 @@ capacity:
       source: Ember, Yearly electricity data
       value: 10.0
 country: BN
+
+hide_day_ahead_price: False
+has_day_ahead_price_license: False
 parsers:
   productionCapacity: EMBER.fetch_production_capacity
 region: Asia

--- a/config/zones/BO.yaml
+++ b/config/zones/BO.yaml
@@ -312,6 +312,9 @@ fallbackZoneMixes:
         solar: 0.02987487302326382
         unknown: 0.6597806473912572
         wind: 0.04254825673223788
+
+hide_day_ahead_price: False
+has_day_ahead_price_license: False
 parsers:
   generationForecast: CNDC.fetch_generation_forecast
   production: CNDC.fetch_production

--- a/config/zones/BR-CS.yaml
+++ b/config/zones/BR-CS.yaml
@@ -291,6 +291,9 @@ fallbackZoneMixes:
         solar: 0.10222112507742348
         unknown: 0.11400721976581607
         wind: 0.048779087668148355
+
+hide_day_ahead_price: False
+has_day_ahead_price_license: False
 parsers:
   production: ONS.fetch_production
   productionCapacity: ONS.fetch_production_capacity

--- a/config/zones/BR-N.yaml
+++ b/config/zones/BR-N.yaml
@@ -291,6 +291,9 @@ fallbackZoneMixes:
         solar: 0.07866961740716195
         unknown: 0.16330391158139368
         wind: 0.21999600933875574
+
+hide_day_ahead_price: False
+has_day_ahead_price_license: False
 parsers:
   production: ONS.fetch_production
   productionCapacity: ONS.fetch_production_capacity

--- a/config/zones/BR-NE.yaml
+++ b/config/zones/BR-NE.yaml
@@ -291,6 +291,9 @@ fallbackZoneMixes:
         solar: 0.15130703599836154
         unknown: 0.03702929035700427
         wind: 0.5795009589558684
+
+hide_day_ahead_price: False
+has_day_ahead_price_license: False
 parsers:
   production: ONS.fetch_production
   productionCapacity: ONS.fetch_production_capacity

--- a/config/zones/BR-S.yaml
+++ b/config/zones/BR-S.yaml
@@ -291,6 +291,9 @@ fallbackZoneMixes:
         solar: 0.09072472765632768
         unknown: 0.07855809321248203
         wind: 0.05411548912071675
+
+hide_day_ahead_price: False
+has_day_ahead_price_license: False
 parsers:
   production: ONS.fetch_production
   productionCapacity: ONS.fetch_production_capacity

--- a/config/zones/BR.yaml
+++ b/config/zones/BR.yaml
@@ -200,3 +200,6 @@ timezone: America/Sao_Paulo
 zone_name: Brazil
 country_name: Brazil
 currency: BRL
+
+hide_day_ahead_price: False
+has_day_ahead_price_license: False

--- a/config/zones/BS.yaml
+++ b/config/zones/BS.yaml
@@ -43,6 +43,9 @@ capacity:
       source: Ember, Yearly electricity data
       value: 0.0
 country: BS
+
+hide_day_ahead_price: False
+has_day_ahead_price_license: False
 parsers:
   productionCapacity: EMBER.fetch_production_capacity
 region: Americas

--- a/config/zones/BT.yaml
+++ b/config/zones/BT.yaml
@@ -24,6 +24,9 @@ capacity:
       source: Ember, Yearly electricity data
       value: 0.0
 country: BT
+
+hide_day_ahead_price: False
+has_day_ahead_price_license: False
 parsers:
   productionCapacity: EMBER.fetch_production_capacity
 region: Asia

--- a/config/zones/BW.yaml
+++ b/config/zones/BW.yaml
@@ -68,6 +68,9 @@ fallbackZoneMixes:
         solar: 0.002355337032443158
         unknown: 0.0
         wind: 0.0
+
+hide_day_ahead_price: False
+has_day_ahead_price_license: False
 parsers:
   productionCapacity: EMBER.fetch_production_capacity
 region: Africa

--- a/config/zones/BY.yaml
+++ b/config/zones/BY.yaml
@@ -97,6 +97,9 @@ fallbackZoneMixes:
       gas: 0.98
       hydro: 0.01
       unknown: 0.01
+
+hide_day_ahead_price: False
+has_day_ahead_price_license: False
 parsers:
   consumption: ENTSOE.fetch_consumption
   consumptionForecast: ENTSOE.fetch_consumption_forecast

--- a/config/zones/BZ.yaml
+++ b/config/zones/BZ.yaml
@@ -28,6 +28,9 @@ capacity:
       source: Ember, Yearly electricity data
       value: 0.0
 country: BZ
+
+hide_day_ahead_price: False
+has_day_ahead_price_license: False
 parsers:
   productionCapacity: EMBER.fetch_production_capacity
 region: Americas

--- a/config/zones/CA-AB.yaml
+++ b/config/zones/CA-AB.yaml
@@ -220,6 +220,9 @@ fallbackZoneMixes:
         solar: 0.03183536456739056
         unknown: 0.024948048115312323
         wind: 0.14374665671413908
+
+hide_day_ahead_price: False
+has_day_ahead_price_license: False
 parsers:
   price: CA_AB.fetch_price
   production: CA_AB.fetch_production

--- a/config/zones/CA-BC.yaml
+++ b/config/zones/CA-BC.yaml
@@ -79,6 +79,9 @@ isRenewable:
     - datetime: '2019-01-01'
       source: assumes 87% hydro, 5% biomass, 4% gas, 2% wind and 2% from various sources
       value: 0.94
+
+hide_day_ahead_price: False
+has_day_ahead_price_license: False
 parsers:
   consumption: CA_BC.fetch_consumption
 region: Americas

--- a/config/zones/CA-MB.yaml
+++ b/config/zones/CA-MB.yaml
@@ -27,3 +27,6 @@ timezone: America/Winnipeg
 zone_name: Manitoba
 country_name: Canada
 currency: CAD
+
+hide_day_ahead_price: False
+has_day_ahead_price_license: False

--- a/config/zones/CA-NB.yaml
+++ b/config/zones/CA-NB.yaml
@@ -214,6 +214,9 @@ isRenewable:
       datetime: '2019-01-01'
       value: 0.3284
 region: Americas
+
+hide_day_ahead_price: False
+has_day_ahead_price_license: False
 sources:
   Government of Canada 2019:
     link: https://open.canada.ca/data/en/dataset/5a6abd9d-d343-41ef-a525-7a1efb686300/resource/0c58139d-1811-466a-97ba-4c84b3fd83a2

--- a/config/zones/CA-NL.yaml
+++ b/config/zones/CA-NL.yaml
@@ -9,3 +9,6 @@ timezone: America/St_Johns
 zone_name: Newfoundland and Labrador
 country_name: Canada
 currency: CAD
+
+hide_day_ahead_price: False
+has_day_ahead_price_license: False

--- a/config/zones/CA-NS.yaml
+++ b/config/zones/CA-NS.yaml
@@ -139,3 +139,6 @@ timezone: America/Halifax
 zone_name: Nova Scotia
 country_name: Canada
 currency: CAD
+
+hide_day_ahead_price: False
+has_day_ahead_price_license: False

--- a/config/zones/CA-NT.yaml
+++ b/config/zones/CA-NT.yaml
@@ -9,3 +9,6 @@ timezone: America/Yellowknife
 zone_name: Northwest Territories
 country_name: Canada
 currency: CAD
+
+hide_day_ahead_price: False
+has_day_ahead_price_license: False

--- a/config/zones/CA-NU.yaml
+++ b/config/zones/CA-NU.yaml
@@ -9,3 +9,6 @@ timezone: America/Rankin_Inlet
 zone_name: Nunavut
 country_name: Canada
 currency: CAD
+
+hide_day_ahead_price: False
+has_day_ahead_price_license: False

--- a/config/zones/CA-ON.yaml
+++ b/config/zones/CA-ON.yaml
@@ -336,6 +336,9 @@ fallbackZoneMixes:
         solar: 0.004465978250457551
         unknown: 1.999178117686635e-05
         wind: 0.08421782955516063
+
+hide_day_ahead_price: False
+has_day_ahead_price_license: False
 parsers:
   price: CA_ON.fetch_price
   production: CA_ON.fetch_production

--- a/config/zones/CA-PE.yaml
+++ b/config/zones/CA-PE.yaml
@@ -222,3 +222,6 @@ timezone: America/Halifax
 zone_name: Prince Edward Island
 country_name: Canada
 currency: CAD
+
+hide_day_ahead_price: False
+has_day_ahead_price_license: False

--- a/config/zones/CA-QC.yaml
+++ b/config/zones/CA-QC.yaml
@@ -283,6 +283,9 @@ fallbackZoneMixes:
         solar: 0.00025375135244732786
         unknown: 0.0003068364202573618
         wind: 0.05604954949834813
+
+hide_day_ahead_price: False
+has_day_ahead_price_license: False
 parsers:
   consumption: CA_QC.fetch_consumption
   production: CA_QC.fetch_production

--- a/config/zones/CA-SK.yaml
+++ b/config/zones/CA-SK.yaml
@@ -205,6 +205,9 @@ fallbackZoneMixes:
         solar: 0.002215298680144598
         unknown: 0.0622375038985566
         wind: 0.08044248483289065
+
+hide_day_ahead_price: False
+has_day_ahead_price_license: False
 parsers:
   consumption: CA_SK.fetch_consumption
 region: Americas

--- a/config/zones/CA-YT.yaml
+++ b/config/zones/CA-YT.yaml
@@ -216,6 +216,9 @@ fallbackZoneMixes:
         solar: 0.0
         unknown: 0.17414929934515255
         wind: 0.0
+
+hide_day_ahead_price: False
+has_day_ahead_price_license: False
 parsers:
   production: YUKONENERGY.fetch_production
 region: Americas

--- a/config/zones/CA.yaml
+++ b/config/zones/CA.yaml
@@ -146,6 +146,9 @@ capacity:
       source: Ember, Yearly electricity data
       value: 18380.0
 country: CA
+
+hide_day_ahead_price: False
+has_day_ahead_price_license: False
 parsers:
   productionCapacity: EMBER.fetch_production_capacity
 region: Americas

--- a/config/zones/CD.yaml
+++ b/config/zones/CD.yaml
@@ -26,6 +26,9 @@ capacity:
       source: Ember, Yearly electricity data
       value: 60.0
 country: CD
+
+hide_day_ahead_price: False
+has_day_ahead_price_license: False
 parsers:
   productionCapacity: EMBER.fetch_production_capacity
 region: Africa

--- a/config/zones/CF.yaml
+++ b/config/zones/CF.yaml
@@ -15,6 +15,9 @@ capacity:
       source: Ember, Yearly electricity data
       value: 70.0
 country: CF
+
+hide_day_ahead_price: False
+has_day_ahead_price_license: False
 parsers:
   productionCapacity: EMBER.fetch_production_capacity
 region: Africa

--- a/config/zones/CG.yaml
+++ b/config/zones/CG.yaml
@@ -31,6 +31,9 @@ capacity:
       source: Ember, Yearly electricity data
       value: 60.0
 country: CG
+
+hide_day_ahead_price: False
+has_day_ahead_price_license: False
 parsers:
   productionCapacity: EMBER.fetch_production_capacity
 region: Africa

--- a/config/zones/CH.yaml
+++ b/config/zones/CH.yaml
@@ -490,6 +490,9 @@ isRenewable:
     - datetime: '2022-01-01'
       source: SFOE, Electricity Maps
       value: 0.85
+
+hide_day_ahead_price: False
+has_day_ahead_price_license: False
 parsers:
   consumption: ENTSOE.fetch_consumption
   consumptionForecast: ENTSOE.fetch_consumption_forecast

--- a/config/zones/CI.yaml
+++ b/config/zones/CI.yaml
@@ -30,6 +30,9 @@ capacity:
       source: Ember, Yearly electricity data
       value: 200.0
 country: CI
+
+hide_day_ahead_price: False
+has_day_ahead_price_license: False
 parsers:
   productionCapacity: EMBER.fetch_production_capacity
 region: Africa

--- a/config/zones/CL-CHP.yaml
+++ b/config/zones/CL-CHP.yaml
@@ -14,3 +14,6 @@ timezone: Pacific/Easter
 zone_name: Easter Island
 country_name: Chile
 currency: CLP
+
+hide_day_ahead_price: False
+has_day_ahead_price_license: False

--- a/config/zones/CL-SEA.yaml
+++ b/config/zones/CL-SEA.yaml
@@ -21,3 +21,6 @@ timezone: America/Santiago
 zone_name: Sistema Eléctrico de Aysén
 country_name: Chile
 currency: CLP
+
+hide_day_ahead_price: False
+has_day_ahead_price_license: False

--- a/config/zones/CL-SEM.yaml
+++ b/config/zones/CL-SEM.yaml
@@ -21,3 +21,6 @@ timezone: America/Punta_Arenas
 zone_name: Sistema Eléctrico de Magallanes
 country_name: Chile
 currency: CLP
+
+hide_day_ahead_price: False
+has_day_ahead_price_license: False

--- a/config/zones/CL-SEN.yaml
+++ b/config/zones/CL-SEN.yaml
@@ -346,6 +346,9 @@ fallbackZoneMixes:
         solar: 0.2168338706293335
         unknown: 0.332478120180111
         wind: 0.12978916493011286
+
+hide_day_ahead_price: False
+has_day_ahead_price_license: False
 parsers:
   production: CL.fetch_production
   productionCapacity: CL_SEN.fetch_production_capacity

--- a/config/zones/CM.yaml
+++ b/config/zones/CM.yaml
@@ -30,6 +30,9 @@ capacity:
       source: Ember, Yearly electricity data
       value: 150.0
 country: CM
+
+hide_day_ahead_price: False
+has_day_ahead_price_license: False
 parsers:
   productionCapacity: EMBER.fetch_production_capacity
 region: Africa

--- a/config/zones/CN.yaml
+++ b/config/zones/CN.yaml
@@ -205,6 +205,9 @@ capacity:
       source: Ember, Yearly electricity data
       value: 521750.0
 country: CN
+
+hide_day_ahead_price: False
+has_day_ahead_price_license: False
 parsers:
   productionCapacity: EMBER.fetch_production_capacity
 region: Asia

--- a/config/zones/CO.yaml
+++ b/config/zones/CO.yaml
@@ -343,6 +343,9 @@ fallbackZoneMixes:
         solar: 0.004379411289697945
         unknown: 0.0
         wind: 0.001009305470052309
+
+hide_day_ahead_price: False
+has_day_ahead_price_license: False
 parsers:
   consumption: CO.fetch_consumption
   price: CO.fetch_price

--- a/config/zones/CR.yaml
+++ b/config/zones/CR.yaml
@@ -367,6 +367,9 @@ fallbackZoneMixes:
         solar: 0.0013911656652474905
         unknown: 0.0
         wind: 0.09941766316203218
+
+hide_day_ahead_price: False
+has_day_ahead_price_license: False
 parsers:
   production: CR.fetch_production
   productionCapacity: EMBER.fetch_production_capacity

--- a/config/zones/CU.yaml
+++ b/config/zones/CU.yaml
@@ -72,6 +72,9 @@ capacity:
       source: Ember, Yearly electricity data
       value: 20.0
 country: CU
+
+hide_day_ahead_price: False
+has_day_ahead_price_license: False
 parsers:
   productionCapacity: EMBER.fetch_production_capacity
 region: Americas

--- a/config/zones/CV.yaml
+++ b/config/zones/CV.yaml
@@ -24,6 +24,9 @@ capacity:
       source: Ember, Yearly electricity data
       value: 30.0
 country: CV
+
+hide_day_ahead_price: False
+has_day_ahead_price_license: False
 parsers:
   productionCapacity: EMBER.fetch_production_capacity
 region: Africa

--- a/config/zones/CW.yaml
+++ b/config/zones/CW.yaml
@@ -36,3 +36,6 @@ timezone: America/Curacao
 zone_name: Curaçao
 country_name: Curaçao
 currency: ANG
+
+hide_day_ahead_price: False
+has_day_ahead_price_license: False

--- a/config/zones/CY.yaml
+++ b/config/zones/CY.yaml
@@ -359,6 +359,9 @@ fallbackZoneMixes:
         solar: 0.18294657859249813
         unknown: 0.0
         wind: 0.035798118790591575
+
+hide_day_ahead_price: False
+has_day_ahead_price_license: False
 parsers:
   consumption: ENTSOE.fetch_consumption
   consumptionForecast: ENTSOE.fetch_consumption_forecast

--- a/config/zones/CZ.yaml
+++ b/config/zones/CZ.yaml
@@ -490,6 +490,9 @@ fallbackZoneMixes:
         solar: 0.0697941813138505
         unknown: 0.0021201960884986294
         wind: 0.048488262214254355
+
+hide_day_ahead_price: False
+has_day_ahead_price_license: False
 parsers:
   consumption: ENTSOE.fetch_consumption
   consumptionForecast: ENTSOE.fetch_consumption_forecast

--- a/config/zones/DE.yaml
+++ b/config/zones/DE.yaml
@@ -633,6 +633,8 @@ fallbackZoneMixes:
         unknown: 0.0068592273218514585
         wind: 0.2921152749986025
 has_day_ahead_price_license: True
+
+hide_day_ahead_price: False
 parsers:
   consumption: ENTSOE.fetch_consumption
   consumptionForecast: ENTSOE.fetch_consumption_forecast

--- a/config/zones/DJ.yaml
+++ b/config/zones/DJ.yaml
@@ -18,6 +18,9 @@ capacity:
       source: Ember, Yearly electricity data
       value: 80.0
 country: DJ
+
+hide_day_ahead_price: False
+has_day_ahead_price_license: False
 parsers:
   productionCapacity: EMBER.fetch_production_capacity
 region: Africa

--- a/config/zones/DK-BHM.yaml
+++ b/config/zones/DK-BHM.yaml
@@ -298,6 +298,9 @@ fallbackZoneMixes:
         solar: 0.16518645440178217
         unknown: 0.018417287743792213
         wind: 0.44424635536462476
+
+hide_day_ahead_price: False
+has_day_ahead_price_license: False
 parsers:
   price: ENTSOE.fetch_price
   production: BORNHOLM_POWERLAB.fetch_production

--- a/config/zones/DK-DK1.yaml
+++ b/config/zones/DK-DK1.yaml
@@ -516,6 +516,8 @@ fallbackZoneMixes:
         unknown: 0.004961503860134691
         wind: 0.44299766224706716
 has_day_ahead_price_license: True
+
+hide_day_ahead_price: False
 parsers:
   consumption: ENTSOE.fetch_consumption
   consumptionForecast: ENTSOE.fetch_consumption_forecast

--- a/config/zones/DK-DK2.yaml
+++ b/config/zones/DK-DK2.yaml
@@ -501,6 +501,8 @@ fallbackZoneMixes:
         unknown: 0.01876231192947404
         wind: 0.39057648626334907
 has_day_ahead_price_license: True
+
+hide_day_ahead_price: False
 parsers:
   consumption: ENTSOE.fetch_consumption
   consumptionForecast: ENTSOE.fetch_consumption_forecast

--- a/config/zones/DK.yaml
+++ b/config/zones/DK.yaml
@@ -307,6 +307,9 @@ fallbackZoneMixes:
         solar: 0.0934880730481194
         unknown: 0.010149763251266004
         wind: 0.42361865325317705
+
+hide_day_ahead_price: False
+has_day_ahead_price_license: False
 parsers:
   consumption: ENTSOE.fetch_consumption
   consumptionForecast: ENTSOE.fetch_consumption_forecast

--- a/config/zones/DM.yaml
+++ b/config/zones/DM.yaml
@@ -21,6 +21,9 @@ capacity:
       source: Ember, Yearly electricity data
       value: 0.0
 country: DM
+
+hide_day_ahead_price: False
+has_day_ahead_price_license: False
 parsers:
   productionCapacity: EMBER.fetch_production_capacity
 region: Americas

--- a/config/zones/DO.yaml
+++ b/config/zones/DO.yaml
@@ -308,6 +308,9 @@ fallbackZoneMixes:
         solar: 0.06587656603563896
         unknown: 0.09357429549804941
         wind: 0.04626690008697701
+
+hide_day_ahead_price: False
+has_day_ahead_price_license: False
 parsers:
   production: DO.fetch_production
   productionCapacity: EMBER.fetch_production_capacity

--- a/config/zones/DZ.yaml
+++ b/config/zones/DZ.yaml
@@ -109,6 +109,9 @@ fallbackZoneMixes:
         solar: 0.0070754161021284396
         unknown: 0.0
         wind: 0.00016600744389401443
+
+hide_day_ahead_price: False
+has_day_ahead_price_license: False
 parsers:
   productionCapacity: EMBER.fetch_production_capacity
 region: Africa

--- a/config/zones/EC.yaml
+++ b/config/zones/EC.yaml
@@ -83,6 +83,9 @@ capacity:
       source: Ember, Yearly electricity data
       value: 70.0
 country: EC
+
+hide_day_ahead_price: False
+has_day_ahead_price_license: False
 parsers:
   productionCapacity: EMBER.fetch_production_capacity
 region: Americas

--- a/config/zones/EE.yaml
+++ b/config/zones/EE.yaml
@@ -556,6 +556,8 @@ fallbackZoneMixes:
         unknown: 0.040069879623022754
         wind: 0.22454441864573693
 has_day_ahead_price_license: True
+
+hide_day_ahead_price: False
 parsers:
   consumption: ENTSOE.fetch_consumption
   consumptionForecast: ENTSOE.fetch_consumption_forecast

--- a/config/zones/EG.yaml
+++ b/config/zones/EG.yaml
@@ -139,6 +139,9 @@ fallbackZoneMixes:
         solar: 0.023436075509726206
         unknown: 0.0
         wind: 0.027833902166199798
+
+hide_day_ahead_price: False
+has_day_ahead_price_license: False
 parsers:
   productionCapacity: EMBER.fetch_production_capacity
 region: Africa

--- a/config/zones/EH.yaml
+++ b/config/zones/EH.yaml
@@ -4,3 +4,6 @@ timezone: Africa/El_Aaiun
 zone_name: Western Sahara
 country_name: Western Sahara
 currency: MAD
+
+hide_day_ahead_price: False
+has_day_ahead_price_license: False

--- a/config/zones/ER.yaml
+++ b/config/zones/ER.yaml
@@ -21,6 +21,9 @@ capacity:
       source: Ember, Yearly electricity data
       value: 0.0
 country: ER
+
+hide_day_ahead_price: False
+has_day_ahead_price_license: False
 parsers:
   productionCapacity: EMBER.fetch_production_capacity
 region: Africa

--- a/config/zones/ES-CE.yaml
+++ b/config/zones/ES-CE.yaml
@@ -85,6 +85,8 @@ fallbackZoneMixes:
         unknown: 0.0
         wind: 0.0
 has_day_ahead_price_license: True
+
+hide_day_ahead_price: False
 parsers:
   consumption: ES.fetch_consumption
   production: ES.fetch_production

--- a/config/zones/ES-CN-FV.yaml
+++ b/config/zones/ES-CN-FV.yaml
@@ -183,6 +183,8 @@ emissionFactors:
         outlook for 2022-2026" Wind Europe Proceedings (2021)
       value: 12.62
 has_day_ahead_price_license: True
+
+hide_day_ahead_price: False
 parsers:
   consumption: ES.fetch_consumption
   production: ES.fetch_production

--- a/config/zones/ES-CN-GC.yaml
+++ b/config/zones/ES-CN-GC.yaml
@@ -294,6 +294,8 @@ fallbackZoneMixes:
         unknown: 0.0
         wind: 0.20833115421534318
 has_day_ahead_price_license: True
+
+hide_day_ahead_price: False
 parsers:
   consumption: ES.fetch_consumption
   production: ES.fetch_production

--- a/config/zones/ES-CN-HI.yaml
+++ b/config/zones/ES-CN-HI.yaml
@@ -298,6 +298,8 @@ fallbackZoneMixes:
         unknown: 0.0
         wind: 0.4601475232281346
 has_day_ahead_price_license: True
+
+hide_day_ahead_price: False
 parsers:
   consumption: ES.fetch_consumption
   production: ES.fetch_production

--- a/config/zones/ES-CN-IG.yaml
+++ b/config/zones/ES-CN-IG.yaml
@@ -296,6 +296,8 @@ fallbackZoneMixes:
         unknown: 0.0
         wind: 0.10116250460286508
 has_day_ahead_price_license: True
+
+hide_day_ahead_price: False
 parsers:
   consumption: ES.fetch_consumption
   production: ES.fetch_production

--- a/config/zones/ES-CN-LP.yaml
+++ b/config/zones/ES-CN-LP.yaml
@@ -294,6 +294,8 @@ fallbackZoneMixes:
         unknown: 0.0
         wind: 0.0686308771428057
 has_day_ahead_price_license: True
+
+hide_day_ahead_price: False
 parsers:
   consumption: ES.fetch_consumption
   production: ES.fetch_production

--- a/config/zones/ES-CN-LZ.yaml
+++ b/config/zones/ES-CN-LZ.yaml
@@ -183,6 +183,8 @@ emissionFactors:
         outlook for 2022-2026" Wind Europe Proceedings (2021)
       value: 12.62
 has_day_ahead_price_license: True
+
+hide_day_ahead_price: False
 parsers:
   consumption: ES.fetch_consumption
   production: ES.fetch_production

--- a/config/zones/ES-CN-TE.yaml
+++ b/config/zones/ES-CN-TE.yaml
@@ -294,6 +294,8 @@ fallbackZoneMixes:
         unknown: 0.0
         wind: 0.1431409807238982
 has_day_ahead_price_license: True
+
+hide_day_ahead_price: False
 parsers:
   consumption: ES.fetch_consumption
   production: ES.fetch_production

--- a/config/zones/ES-IB-FO.yaml
+++ b/config/zones/ES-IB-FO.yaml
@@ -252,6 +252,8 @@ fallbackZoneMixes:
         unknown: 0.006784750754949078
         wind: 0.037652333529152336
 has_day_ahead_price_license: True
+
+hide_day_ahead_price: False
 parsers:
   consumption: ES.fetch_consumption
   production: ES.fetch_production

--- a/config/zones/ES-IB-IZ.yaml
+++ b/config/zones/ES-IB-IZ.yaml
@@ -300,6 +300,8 @@ fallbackZoneMixes:
         unknown: 0.009190009928075097
         wind: 0.045019652943978444
 has_day_ahead_price_license: True
+
+hide_day_ahead_price: False
 parsers:
   consumption: ES.fetch_consumption
   production: ES.fetch_production

--- a/config/zones/ES-IB-MA.yaml
+++ b/config/zones/ES-IB-MA.yaml
@@ -281,6 +281,8 @@ fallbackZoneMixes:
         unknown: 0.010697864190356308
         wind: 0.06758167342075513
 has_day_ahead_price_license: True
+
+hide_day_ahead_price: False
 parsers:
   consumption: ES.fetch_consumption
   production: ES.fetch_production

--- a/config/zones/ES-IB-ME.yaml
+++ b/config/zones/ES-IB-ME.yaml
@@ -350,6 +350,8 @@ fallbackZoneMixes:
         unknown: 0.001631594221039395
         wind: 0.022478089603296073
 has_day_ahead_price_license: True
+
+hide_day_ahead_price: False
 parsers:
   consumption: ES.fetch_consumption
   production: ES.fetch_production

--- a/config/zones/ES-ML.yaml
+++ b/config/zones/ES-ML.yaml
@@ -97,6 +97,8 @@ fallbackZoneMixes:
         unknown: 0.0
         wind: 0.0
 has_day_ahead_price_license: True
+
+hide_day_ahead_price: False
 parsers:
   consumption: ES.fetch_consumption
   production: ES.fetch_production

--- a/config/zones/ES.yaml
+++ b/config/zones/ES.yaml
@@ -582,6 +582,8 @@ fallbackZoneMixes:
         unknown: 0.0033878554452865988
         wind: 0.231907080406899
 has_day_ahead_price_license: True
+
+hide_day_ahead_price: False
 parsers:
   consumption: ENTSOE.fetch_consumption
   consumptionForecast: ENTSOE.fetch_consumption_forecast

--- a/config/zones/ET.yaml
+++ b/config/zones/ET.yaml
@@ -106,6 +106,9 @@ fallbackZoneMixes:
         solar: 0.002018939705847075
         unknown: 0.0
         wind: 0.030513859522903735
+
+hide_day_ahead_price: False
+has_day_ahead_price_license: False
 parsers:
   productionCapacity: EMBER.fetch_production_capacity
 region: Africa

--- a/config/zones/FI.yaml
+++ b/config/zones/FI.yaml
@@ -450,6 +450,8 @@ fallbackZoneMixes:
         unknown: 0.02072893283843738
         wind: 0.24054849102643136
 has_day_ahead_price_license: True
+
+hide_day_ahead_price: False
 parsers:
   consumption: ENTSOE.fetch_consumption
   consumptionForecast: ENTSOE.fetch_consumption_forecast

--- a/config/zones/FJ.yaml
+++ b/config/zones/FJ.yaml
@@ -31,6 +31,9 @@ capacity:
       source: Ember, Yearly electricity data
       value: 10.0
 country: FJ
+
+hide_day_ahead_price: False
+has_day_ahead_price_license: False
 parsers:
   productionCapacity: EMBER.fetch_production_capacity
 region: Oceania

--- a/config/zones/FK.yaml
+++ b/config/zones/FK.yaml
@@ -12,6 +12,9 @@ capacity:
       source: Ember, Yearly electricity data
       value: 0.0
 country: FK
+
+hide_day_ahead_price: False
+has_day_ahead_price_license: False
 parsers:
   productionCapacity: EMBER.fetch_production_capacity
 region: Americas

--- a/config/zones/FM.yaml
+++ b/config/zones/FM.yaml
@@ -31,6 +31,9 @@ capacity:
       source: IRENA.org
       value: 0.83
 country: FM
+
+hide_day_ahead_price: False
+has_day_ahead_price_license: False
 parsers:
   productionCapacity: EMBER.fetch_production_capacity
 region: Oceania

--- a/config/zones/FO-MI.yaml
+++ b/config/zones/FO-MI.yaml
@@ -181,6 +181,9 @@ isLowCarbon:
 isRenewable:
   unknown:
     value: 1
+
+hide_day_ahead_price: False
+has_day_ahead_price_license: False
 parsers:
   production: FO.fetch_production
 region: Europe

--- a/config/zones/FO-SI.yaml
+++ b/config/zones/FO-SI.yaml
@@ -166,6 +166,9 @@ fallbackZoneMixes:
         solar: 0.004961919576653245
         unknown: 0.0
         wind: 0.475904117942365
+
+hide_day_ahead_price: False
+has_day_ahead_price_license: False
 parsers:
   production: FO.fetch_production
 region: Europe

--- a/config/zones/FO.yaml
+++ b/config/zones/FO.yaml
@@ -274,6 +274,9 @@ isLowCarbon:
 isRenewable:
   unknown:
     value: 1
+
+hide_day_ahead_price: False
+has_day_ahead_price_license: False
 parsers:
   production: FO.fetch_production
 region: Europe

--- a/config/zones/FR-COR.yaml
+++ b/config/zones/FR-COR.yaml
@@ -300,6 +300,9 @@ fallbackZoneMixes:
         solar: 0.13984351379653193
         unknown: 0.021942060514426275
         wind: 0.07513672956538177
+
+hide_day_ahead_price: False
+has_day_ahead_price_license: False
 parsers:
   price: FR_O.fetch_price
   production: FR_O.fetch_production

--- a/config/zones/FR.yaml
+++ b/config/zones/FR.yaml
@@ -624,6 +624,7 @@ fallbackZoneMixes:
         unknown: 0.00038720954386614967
         wind: 0.09075636778437683
 has_day_ahead_price_license: True
+hide_day_ahead_price: False
 parsers:
   consumption: FR.fetch_consumption
   consumptionForecast: ENTSOE.fetch_consumption_forecast

--- a/config/zones/GA.yaml
+++ b/config/zones/GA.yaml
@@ -4,6 +4,9 @@ bounding_box:
   - - 14.999144991449924
     - 2.809956504477071
 country: GA
+
+hide_day_ahead_price: False
+has_day_ahead_price_license: False
 parsers:
   productionCapacity: EMBER.fetch_production_capacity
 region: Africa

--- a/config/zones/GB-NIR.yaml
+++ b/config/zones/GB-NIR.yaml
@@ -311,6 +311,9 @@ fallbackZoneMixes:
         solar: 0.02743493748522642
         unknown: 0.004058241153559021
         wind: 0.29414430089880955
+
+hide_day_ahead_price: False
+has_day_ahead_price_license: False
 parsers:
   consumption: SMARTGRIDDASHBOARD.fetch_consumption
   consumptionForecast: SMARTGRIDDASHBOARD.fetch_consumption_forecast

--- a/config/zones/GB-ORK.yaml
+++ b/config/zones/GB-ORK.yaml
@@ -232,6 +232,9 @@ isLowCarbon:
 isRenewable:
   unknown:
     value: 1
+
+hide_day_ahead_price: False
+has_day_ahead_price_license: False
 parsers:
   production: GB_ORK.fetch_production
 region: Europe

--- a/config/zones/GB-ZET.yaml
+++ b/config/zones/GB-ZET.yaml
@@ -12,3 +12,6 @@ timezone: Europe/London
 zone_name: Shetland Islands
 country_name: Great Britain
 currency: GBP
+
+hide_day_ahead_price: False
+has_day_ahead_price_license: False

--- a/config/zones/GB.yaml
+++ b/config/zones/GB.yaml
@@ -469,6 +469,9 @@ fallbackZoneMixes:
         solar: 0.10642708161006456
         unknown: 0.01229548242156918
         wind: 0.324336935214777
+
+hide_day_ahead_price: False
+has_day_ahead_price_license: False
 parsers:
   consumption: ELEXON.fetch_consumption
   consumptionForecast: ENTSOE.fetch_consumption_forecast

--- a/config/zones/GE.yaml
+++ b/config/zones/GE.yaml
@@ -271,6 +271,9 @@ fallbackZoneMixes:
         solar: 9.334021495300608e-05
         unknown: 0.05224346510003176
         wind: 0.00475058940672753
+
+hide_day_ahead_price: False
+has_day_ahead_price_license: False
 parsers:
   consumption: ENTSOE.fetch_consumption
   consumptionForecast: ENTSOE.fetch_consumption_forecast

--- a/config/zones/GF.yaml
+++ b/config/zones/GF.yaml
@@ -221,6 +221,9 @@ fallbackZoneMixes:
         solar: 0.025983803372641664
         unknown: 0.0
         wind: 0.0
+
+hide_day_ahead_price: False
+has_day_ahead_price_license: False
 parsers:
   price: FR_O.fetch_price
   production: FR_O.fetch_production

--- a/config/zones/GG.yaml
+++ b/config/zones/GG.yaml
@@ -4,3 +4,6 @@ timezone: Europe/Guernsey
 zone_name: Guernsey
 country_name: Guernsey
 currency: GBP
+
+hide_day_ahead_price: False
+has_day_ahead_price_license: False

--- a/config/zones/GH.yaml
+++ b/config/zones/GH.yaml
@@ -110,6 +110,9 @@ fallbackZoneMixes:
         solar: 0.006950597869928555
         unknown: 0.0
         wind: 0.0
+
+hide_day_ahead_price: False
+has_day_ahead_price_license: False
 parsers:
   productionCapacity: EMBER.fetch_production_capacity
 region: Africa

--- a/config/zones/GI.yaml
+++ b/config/zones/GI.yaml
@@ -9,3 +9,6 @@ timezone: Europe/Gibraltar
 zone_name: Gibraltar
 country_name: Gibraltar
 currency: GIP
+
+hide_day_ahead_price: False
+has_day_ahead_price_license: False

--- a/config/zones/GL.yaml
+++ b/config/zones/GL.yaml
@@ -16,6 +16,9 @@ capacity:
       source: Ember, Yearly electricity data
       value: 0.0
 country: GL
+
+hide_day_ahead_price: False
+has_day_ahead_price_license: False
 parsers:
   productionCapacity: EMBER.fetch_production_capacity
 region: Americas

--- a/config/zones/GM.yaml
+++ b/config/zones/GM.yaml
@@ -23,6 +23,9 @@ capacity:
       source: Ember, Yearly electricity data
       value: 0.0
 country: GM
+
+hide_day_ahead_price: False
+has_day_ahead_price_license: False
 parsers:
   productionCapacity: EMBER.fetch_production_capacity
 region: Africa

--- a/config/zones/GN.yaml
+++ b/config/zones/GN.yaml
@@ -39,6 +39,9 @@ capacity:
       source: Ember, Yearly electricity data
       value: 430.0
 country: GN
+
+hide_day_ahead_price: False
+has_day_ahead_price_license: False
 parsers:
   productionCapacity: EMBER.fetch_production_capacity
 region: Africa

--- a/config/zones/GP.yaml
+++ b/config/zones/GP.yaml
@@ -189,6 +189,9 @@ fallbackZoneMixes:
         solar: 0.06917119460371109
         unknown: 0.0
         wind: 0.04311598615929433
+
+hide_day_ahead_price: False
+has_day_ahead_price_license: False
 parsers:
   price: FR_O.fetch_price
   production: FR_O.fetch_production

--- a/config/zones/GQ.yaml
+++ b/config/zones/GQ.yaml
@@ -19,6 +19,9 @@ capacity:
       source: Ember, Yearly electricity data
       value: 120.0
 country: GQ
+
+hide_day_ahead_price: False
+has_day_ahead_price_license: False
 parsers:
   productionCapacity: EMBER.fetch_production_capacity
 region: Africa

--- a/config/zones/GR.yaml
+++ b/config/zones/GR.yaml
@@ -510,6 +510,9 @@ fallbackZoneMixes:
         solar: 0.207991503406568
         unknown: 0.0004729780072988275
         wind: 0.20026030888063462
+
+hide_day_ahead_price: False
+has_day_ahead_price_license: False
 parsers:
   consumption: ENTSOE.fetch_consumption
   consumptionForecast: ENTSOE.fetch_consumption_forecast

--- a/config/zones/GS.yaml
+++ b/config/zones/GS.yaml
@@ -20,3 +20,6 @@ timezone: Atlantic/South_Georgia
 zone_name: South Georgia and the South Sandwich Islands
 country_name: South Georgia and the South Sandwich Islands
 currency: GBP
+
+hide_day_ahead_price: False
+has_day_ahead_price_license: False

--- a/config/zones/GT.yaml
+++ b/config/zones/GT.yaml
@@ -273,6 +273,9 @@ fallbackZoneMixes:
         solar: 0.01427310682024955
         unknown: 0.11712930277035961
         wind: 0.02062521914028993
+
+hide_day_ahead_price: False
+has_day_ahead_price_license: False
 parsers:
   consumption: GT.fetch_consumption
   production: GT.fetch_production

--- a/config/zones/GU.yaml
+++ b/config/zones/GU.yaml
@@ -23,6 +23,9 @@ capacity:
       source: Ember, Yearly electricity data
       value: 0.0
 country: GU
+
+hide_day_ahead_price: False
+has_day_ahead_price_license: False
 parsers:
   productionCapacity: EMBER.fetch_production_capacity
 region: Oceania

--- a/config/zones/GW.yaml
+++ b/config/zones/GW.yaml
@@ -8,6 +8,9 @@ capacity:
       source: Ember, Yearly electricity data
       value: 30.0
 country: GW
+
+hide_day_ahead_price: False
+has_day_ahead_price_license: False
 parsers:
   productionCapacity: EMBER.fetch_production_capacity
 region: Africa

--- a/config/zones/GY.yaml
+++ b/config/zones/GY.yaml
@@ -34,6 +34,9 @@ capacity:
       source: Ember, Yearly electricity data
       value: 0.0
 country: GY
+
+hide_day_ahead_price: False
+has_day_ahead_price_license: False
 parsers:
   productionCapacity: EMBER.fetch_production_capacity
 region: Americas

--- a/config/zones/HK.yaml
+++ b/config/zones/HK.yaml
@@ -278,3 +278,6 @@ timezone: Asia/Hong_Kong
 zone_name: Hong Kong
 country_name: Hong Kong
 currency: HKD
+
+hide_day_ahead_price: False
+has_day_ahead_price_license: False

--- a/config/zones/HM.yaml
+++ b/config/zones/HM.yaml
@@ -4,3 +4,6 @@ timezone: Asia/Karachi
 zone_name: Heard Island and McDonald Islands
 country_name: Heard Island and McDonald Islands
 currency: AUD
+
+hide_day_ahead_price: False
+has_day_ahead_price_license: False

--- a/config/zones/HN.yaml
+++ b/config/zones/HN.yaml
@@ -271,6 +271,9 @@ fallbackZoneMixes:
         solar: 0.08937585918740454
         unknown: 0.0017265823617785528
         wind: 0.06533864088864909
+
+hide_day_ahead_price: False
+has_day_ahead_price_license: False
 parsers:
   production: HN.fetch_production
   productionCapacity: EMBER.fetch_production_capacity

--- a/config/zones/HR.yaml
+++ b/config/zones/HR.yaml
@@ -475,6 +475,9 @@ fallbackZoneMixes:
         solar: 0.04950457002421131
         unknown: 0.016567806203726613
         wind: 0.12557913883108035
+
+hide_day_ahead_price: False
+has_day_ahead_price_license: False
 parsers:
   consumption: ENTSOE.fetch_consumption
   consumptionForecast: ENTSOE.fetch_consumption_forecast

--- a/config/zones/HT.yaml
+++ b/config/zones/HT.yaml
@@ -19,6 +19,9 @@ capacity:
       source: Ember, Yearly electricity data
       value: 0.0
 country: HT
+
+hide_day_ahead_price: False
+has_day_ahead_price_license: False
 parsers:
   productionCapacity: EMBER.fetch_production_capacity
 region: Americas

--- a/config/zones/HU.yaml
+++ b/config/zones/HU.yaml
@@ -537,6 +537,9 @@ fallbackZoneMixes:
         solar: 0.10816140658379693
         unknown: 0.020690707196941514
         wind: 0.04074064310307531
+
+hide_day_ahead_price: False
+has_day_ahead_price_license: False
 parsers:
   consumption: ENTSOE.fetch_consumption
   consumptionForecast: ENTSOE.fetch_consumption_forecast

--- a/config/zones/ID.yaml
+++ b/config/zones/ID.yaml
@@ -284,3 +284,6 @@ timezone: Asia/Jakarta
 zone_name: Indonesia
 country_name: Indonesia
 currency: IDR
+
+hide_day_ahead_price: False
+has_day_ahead_price_license: False

--- a/config/zones/IE.yaml
+++ b/config/zones/IE.yaml
@@ -449,6 +449,9 @@ fallbackZoneMixes:
         solar: 0.004312371638404209
         unknown: 0.0012949211543286639
         wind: 0.38786013638875366
+
+hide_day_ahead_price: False
+has_day_ahead_price_license: False
 parsers:
   consumption: SMARTGRIDDASHBOARD.fetch_consumption
   consumptionForecast: SMARTGRIDDASHBOARD.fetch_consumption_forecast

--- a/config/zones/IL.yaml
+++ b/config/zones/IL.yaml
@@ -356,6 +356,9 @@ isRenewable:
   unknown:
     _comment: Sum of renewable sources in IL unknown production
     value: 0.056
+
+hide_day_ahead_price: False
+has_day_ahead_price_license: False
 parsers:
   consumption: IL.fetch_consumption
   productionCapacity: EMBER.fetch_production_capacity

--- a/config/zones/IM.yaml
+++ b/config/zones/IM.yaml
@@ -40,3 +40,6 @@ timezone: Europe/Isle_of_Man
 zone_name: Isle of Man
 country_name: Isle of Man
 currency: GBP
+
+hide_day_ahead_price: False
+has_day_ahead_price_license: False

--- a/config/zones/IN-AN.yaml
+++ b/config/zones/IN-AN.yaml
@@ -12,3 +12,6 @@ timezone: Asia/Kolkata
 zone_name: Andaman and Nicobar Islands
 country_name: India
 currency: INR
+
+hide_day_ahead_price: False
+has_day_ahead_price_license: False

--- a/config/zones/IN-DL.yaml
+++ b/config/zones/IN-DL.yaml
@@ -196,6 +196,9 @@ fallbackZoneMixes:
         solar: 0.0
         unknown: 0.0
         wind: 0.0
+
+hide_day_ahead_price: False
+has_day_ahead_price_license: False
 parsers:
   consumption: IN_DL.fetch_consumption
   production: IN_DL.fetch_production

--- a/config/zones/IN-EA.yaml
+++ b/config/zones/IN-EA.yaml
@@ -218,6 +218,9 @@ fallbackZoneMixes:
         solar: 0.0029855668766264275
         unknown: 0.0002543184591433458
         wind: 0.0007162874658442403
+
+hide_day_ahead_price: False
+has_day_ahead_price_license: False
 parsers:
   consumption: IN.fetch_consumption
   production: IN.fetch_production

--- a/config/zones/IN-HP.yaml
+++ b/config/zones/IN-HP.yaml
@@ -115,6 +115,9 @@ fallbackZoneMixes:
         solar: 0.0
         unknown: 0.07545779933267016
         wind: 0.0
+
+hide_day_ahead_price: False
+has_day_ahead_price_license: False
 parsers:
   production: IN_HP.fetch_production
 region: Asia

--- a/config/zones/IN-KA.yaml
+++ b/config/zones/IN-KA.yaml
@@ -207,6 +207,9 @@ fallbackZoneMixes:
         solar: 0.1367409665303756
         unknown: 0.3069428488851126
         wind: 0.1271854795574422
+
+hide_day_ahead_price: False
+has_day_ahead_price_license: False
 parsers:
   consumption: IN_KA.fetch_consumption
   production: IN_KA.fetch_production

--- a/config/zones/IN-MH.yaml
+++ b/config/zones/IN-MH.yaml
@@ -281,6 +281,9 @@ fallbackZoneMixes:
         solar: 0.02944040476303649
         unknown: 0.004691684211499119
         wind: 0.02900752525848245
+
+hide_day_ahead_price: False
+has_day_ahead_price_license: False
 parsers:
   production: IN_MH.fetch_production
 region: Asia

--- a/config/zones/IN-NE.yaml
+++ b/config/zones/IN-NE.yaml
@@ -218,6 +218,9 @@ fallbackZoneMixes:
         solar: 0.031236037656665508
         unknown: 2.5385940511502566e-05
         wind: 0.0001348859595530266
+
+hide_day_ahead_price: False
+has_day_ahead_price_license: False
 parsers:
   consumption: IN.fetch_consumption
   production: IN.fetch_production

--- a/config/zones/IN-NO.yaml
+++ b/config/zones/IN-NO.yaml
@@ -216,6 +216,9 @@ isLowCarbon:
 isRenewable:
   unknown:
     value: 0.92
+
+hide_day_ahead_price: False
+has_day_ahead_price_license: False
 parsers:
   consumption: IN.fetch_consumption
   production: IN.fetch_production

--- a/config/zones/IN-PB.yaml
+++ b/config/zones/IN-PB.yaml
@@ -224,6 +224,9 @@ fallbackZoneMixes:
         solar: 0.025459760720636028
         unknown: 0.0
         wind: 0.0
+
+hide_day_ahead_price: False
+has_day_ahead_price_license: False
 parsers:
   consumption: IN_PB.fetch_consumption
   production: IN_PB.fetch_production

--- a/config/zones/IN-SO.yaml
+++ b/config/zones/IN-SO.yaml
@@ -235,6 +235,9 @@ isLowCarbon:
 isRenewable:
   unknown:
     value: 0.92
+
+hide_day_ahead_price: False
+has_day_ahead_price_license: False
 parsers:
   consumption: IN.fetch_consumption
   production: IN.fetch_production

--- a/config/zones/IN-UP.yaml
+++ b/config/zones/IN-UP.yaml
@@ -215,6 +215,8 @@ fallbackZoneMixes:
         solar: 0.14726885443688845
         unknown: 0.8338243983672093
         wind: 0.0
+hide_day_ahead_price: False
+has_day_ahead_price_license: False
 parsers: {}
 region: Asia
 timezone: Asia/Kolkata

--- a/config/zones/IN-UT.yaml
+++ b/config/zones/IN-UT.yaml
@@ -17,6 +17,9 @@ contributors:
   - lorrieq
   - gopikrishna1793
 country: IN
+
+hide_day_ahead_price: False
+has_day_ahead_price_license: False
 parsers:
   production: IN_UT.fetch_production
 region: Asia

--- a/config/zones/IN-WE.yaml
+++ b/config/zones/IN-WE.yaml
@@ -249,6 +249,9 @@ isLowCarbon:
 isRenewable:
   unknown:
     value: 0.92
+
+hide_day_ahead_price: False
+has_day_ahead_price_license: False
 parsers:
   consumption: IN_WE.fetch_consumption
   production: IN.fetch_production

--- a/config/zones/IN.yaml
+++ b/config/zones/IN.yaml
@@ -200,6 +200,9 @@ fallbackZoneMixes:
         solar: 0.05470488852485778
         unknown: 0.003025741785798069
         wind: 0.018569211812215346
+
+hide_day_ahead_price: False
+has_day_ahead_price_license: False
 parsers:
   production: IN.fetch_production
 region: Asia

--- a/config/zones/IQ.yaml
+++ b/config/zones/IQ.yaml
@@ -115,6 +115,9 @@ fallbackZoneMixes:
         solar: 0.0
         unknown: 0.0
         wind: 0.0
+
+hide_day_ahead_price: False
+has_day_ahead_price_license: False
 parsers:
   productionCapacity: EMBER.fetch_production_capacity
 region: Asia

--- a/config/zones/IR.yaml
+++ b/config/zones/IR.yaml
@@ -114,6 +114,9 @@ capacity:
       source: Ember, Yearly electricity data
       value: 380.0
 country: IR
+
+hide_day_ahead_price: False
+has_day_ahead_price_license: False
 parsers:
   productionCapacity: EMBER.fetch_production_capacity
 region: Asia

--- a/config/zones/IS.yaml
+++ b/config/zones/IS.yaml
@@ -267,6 +267,9 @@ fallbackZoneMixes:
         solar: 0.0
         unknown: 0.0
         wind: 0.0
+
+hide_day_ahead_price: False
+has_day_ahead_price_license: False
 parsers:
   production: amper_landsnet.fetch_production
   productionCapacity: EMBER.fetch_production_capacity

--- a/config/zones/IT-CNO.yaml
+++ b/config/zones/IT-CNO.yaml
@@ -414,6 +414,9 @@ fallbackZoneMixes:
         solar: 0.13076921687380502
         unknown: 0.054046319522626465
         wind: 0.053137961493694416
+
+hide_day_ahead_price: False
+has_day_ahead_price_license: False
 parsers:
   consumption: ENTSOE.fetch_consumption
   consumptionForecast: ENTSOE.fetch_consumption_forecast

--- a/config/zones/IT-CSO.yaml
+++ b/config/zones/IT-CSO.yaml
@@ -455,6 +455,9 @@ fallbackZoneMixes:
         solar: 0.1515683001826803
         unknown: 0.036306885483708785
         wind: 0.16321543097369423
+
+hide_day_ahead_price: False
+has_day_ahead_price_license: False
 parsers:
   consumption: ENTSOE.fetch_consumption
   consumptionForecast: ENTSOE.fetch_consumption_forecast

--- a/config/zones/IT-NO.yaml
+++ b/config/zones/IT-NO.yaml
@@ -444,6 +444,9 @@ fallbackZoneMixes:
         solar: 0.07620580040576339
         unknown: 0.07753936277705191
         wind: 0.02421630791921114
+
+hide_day_ahead_price: False
+has_day_ahead_price_license: False
 parsers:
   consumption: ENTSOE.fetch_consumption
   consumptionForecast: ENTSOE.fetch_consumption_forecast

--- a/config/zones/IT-SAR.yaml
+++ b/config/zones/IT-SAR.yaml
@@ -419,6 +419,9 @@ fallbackZoneMixes:
         solar: 0.12462370056269007
         unknown: 0.049733902030647925
         wind: 0.13867825558188832
+
+hide_day_ahead_price: False
+has_day_ahead_price_license: False
 parsers:
   consumption: ENTSOE.fetch_consumption
   consumptionForecast: ENTSOE.fetch_consumption_forecast

--- a/config/zones/IT-SIC.yaml
+++ b/config/zones/IT-SIC.yaml
@@ -424,6 +424,9 @@ fallbackZoneMixes:
         solar: 0.17395687933166742
         unknown: 0.02172961125882372
         wind: 0.25378750961633484
+
+hide_day_ahead_price: False
+has_day_ahead_price_license: False
 parsers:
   consumptionForecast: ENTSOE.fetch_consumption_forecast
   generationForecast: ENTSOE.fetch_generation_forecast

--- a/config/zones/IT-SO.yaml
+++ b/config/zones/IT-SO.yaml
@@ -427,6 +427,9 @@ fallbackZoneMixes:
         solar: 0.1405525919061412
         unknown: 0.02761569697226704
         wind: 0.25237370044583
+
+hide_day_ahead_price: False
+has_day_ahead_price_license: False
 parsers:
   consumptionForecast: ENTSOE.fetch_consumption_forecast
   generationForecast: ENTSOE.fetch_generation_forecast

--- a/config/zones/IT.yaml
+++ b/config/zones/IT.yaml
@@ -367,6 +367,9 @@ fallbackZoneMixes:
         unknown: 0.05930511903984094
         wind: 0.09017689210992368
 region: Europe
+
+hide_day_ahead_price: False
+has_day_ahead_price_license: False
 sources:
   EU-ETS, ENTSO-E 2021:
     link: https://drive.google.com/file/d/15UeUHyhcjVw8fGLc0Zx_HELSx20cw_-e/view?usp=share_link

--- a/config/zones/JE.yaml
+++ b/config/zones/JE.yaml
@@ -4,3 +4,6 @@ timezone: Europe/Jersey
 zone_name: Jersey
 country_name: Jersey
 currency: GBP
+
+hide_day_ahead_price: False
+has_day_ahead_price_license: False

--- a/config/zones/JM.yaml
+++ b/config/zones/JM.yaml
@@ -38,6 +38,9 @@ capacity:
       source: Ember, Yearly electricity data
       value: 100.0
 country: JM
+
+hide_day_ahead_price: False
+has_day_ahead_price_license: False
 parsers:
   productionCapacity: EMBER.fetch_production_capacity
 region: Americas

--- a/config/zones/JO.yaml
+++ b/config/zones/JO.yaml
@@ -65,6 +65,9 @@ capacity:
       source: Ember, Yearly electricity data
       value: 630.0
 country: JO
+
+hide_day_ahead_price: False
+has_day_ahead_price_license: False
 parsers:
   productionCapacity: EMBER.fetch_production_capacity
 region: Asia

--- a/config/zones/JP-CB.yaml
+++ b/config/zones/JP-CB.yaml
@@ -208,6 +208,9 @@ fallbackZoneMixes:
         solar: 0.12244614660850632
         unknown: 0.003769750267899515
         wind: 0.004048155359128435
+
+hide_day_ahead_price: False
+has_day_ahead_price_license: False
 parsers:
   consumptionForecast: JP.fetch_consumption_forecast
   price: JP.fetch_price

--- a/config/zones/JP-CG.yaml
+++ b/config/zones/JP-CG.yaml
@@ -199,6 +199,9 @@ fallbackZoneMixes:
         solar: 0.12844791109956524
         unknown: 0.0022459561300016023
         wind: 0.00644645444675968
+
+hide_day_ahead_price: False
+has_day_ahead_price_license: False
 parsers:
   consumptionForecast: JP.fetch_consumption_forecast
   price: JP.fetch_price

--- a/config/zones/JP-HKD.yaml
+++ b/config/zones/JP-HKD.yaml
@@ -202,6 +202,9 @@ fallbackZoneMixes:
         solar: 0.10087912421308973
         unknown: 0.000405576948770854
         wind: 0.03530341402815505
+
+hide_day_ahead_price: False
+has_day_ahead_price_license: False
 parsers:
   consumptionForecast: JP.fetch_consumption_forecast
   price: JP.fetch_price

--- a/config/zones/JP-HR.yaml
+++ b/config/zones/JP-HR.yaml
@@ -181,6 +181,9 @@ fallbackZoneMixes:
         solar: 0.05969048291522835
         unknown: 0.02047979428559259
         wind: 0.005666854920707754
+
+hide_day_ahead_price: False
+has_day_ahead_price_license: False
 parsers:
   consumptionForecast: JP.fetch_consumption_forecast
   price: JP.fetch_price

--- a/config/zones/JP-KN.yaml
+++ b/config/zones/JP-KN.yaml
@@ -267,6 +267,9 @@ fallbackZoneMixes:
         solar: 0.07460594186010626
         unknown: 0.030073678811974553
         wind: 0.002427072768801394
+
+hide_day_ahead_price: False
+has_day_ahead_price_license: False
 parsers:
   consumptionForecast: JP.fetch_consumption_forecast
   price: JP.fetch_price

--- a/config/zones/JP-KY.yaml
+++ b/config/zones/JP-KY.yaml
@@ -237,6 +237,9 @@ fallbackZoneMixes:
         solar: 0.1382906879744919
         unknown: 1.0724997702627927e-06
         wind: 0.006801352931139955
+
+hide_day_ahead_price: False
+has_day_ahead_price_license: False
 parsers:
   consumptionForecast: JP.fetch_consumption_forecast
   price: JP.fetch_price

--- a/config/zones/JP-ON.yaml
+++ b/config/zones/JP-ON.yaml
@@ -197,6 +197,9 @@ fallbackZoneMixes:
         solar: 0.054360569237001784
         unknown: 0.0
         wind: 0.002148162038523783
+
+hide_day_ahead_price: False
+has_day_ahead_price_license: False
 parsers:
   consumptionForecast: JP.fetch_consumption_forecast
   price: JP.fetch_price

--- a/config/zones/JP-SK.yaml
+++ b/config/zones/JP-SK.yaml
@@ -224,6 +224,9 @@ fallbackZoneMixes:
         solar: 0.15121531986285167
         unknown: 0.6105501241479387
         wind: 0.0012775695365145267
+
+hide_day_ahead_price: False
+has_day_ahead_price_license: False
 parsers:
   consumptionForecast: JP.fetch_consumption_forecast
   price: JP.fetch_price

--- a/config/zones/JP-TH.yaml
+++ b/config/zones/JP-TH.yaml
@@ -201,6 +201,9 @@ fallbackZoneMixes:
         solar: 0.09302782105896609
         unknown: 0.02001169518819592
         wind: 0.028810073378378175
+
+hide_day_ahead_price: False
+has_day_ahead_price_license: False
 parsers:
   consumptionForecast: JP.fetch_consumption_forecast
   price: JP.fetch_price

--- a/config/zones/JP-TK.yaml
+++ b/config/zones/JP-TK.yaml
@@ -266,6 +266,9 @@ fallbackZoneMixes:
         solar: 0.09707166612504159
         unknown: 0.0026074670238986205
         wind: 0.005644454624628442
+
+hide_day_ahead_price: False
+has_day_ahead_price_license: False
 parsers:
   consumptionForecast: JP.fetch_consumption_forecast
   price: JP.fetch_price

--- a/config/zones/JP.yaml
+++ b/config/zones/JP.yaml
@@ -215,3 +215,6 @@ timezone: Asia/Tokyo
 zone_name: Japan
 country_name: Japan
 currency: JPY
+
+hide_day_ahead_price: False
+has_day_ahead_price_license: False

--- a/config/zones/KE.yaml
+++ b/config/zones/KE.yaml
@@ -79,6 +79,9 @@ capacity:
       source: Ember, Yearly electricity data
       value: 440.0
 country: KE
+
+hide_day_ahead_price: False
+has_day_ahead_price_license: False
 parsers:
   productionCapacity: EMBER.fetch_production_capacity
 region: Africa

--- a/config/zones/KG.yaml
+++ b/config/zones/KG.yaml
@@ -29,6 +29,9 @@ capacity:
       source: Ember, Yearly electricity data
       value: 0.0
 country: KG
+
+hide_day_ahead_price: False
+has_day_ahead_price_license: False
 parsers:
   productionCapacity: EMBER.fetch_production_capacity
 region: Asia

--- a/config/zones/KH.yaml
+++ b/config/zones/KH.yaml
@@ -89,6 +89,9 @@ capacity:
       source: Ember, Yearly electricity data
       value: 0.0
 country: KH
+
+hide_day_ahead_price: False
+has_day_ahead_price_license: False
 parsers:
   productionCapacity: EMBER.fetch_production_capacity
 region: Asia

--- a/config/zones/KM.yaml
+++ b/config/zones/KM.yaml
@@ -17,6 +17,9 @@ capacity:
       source: Ember, Yearly electricity data
       value: 20.0
 country: KM
+
+hide_day_ahead_price: False
+has_day_ahead_price_license: False
 parsers:
   productionCapacity: EMBER.fetch_production_capacity
 region: Africa

--- a/config/zones/KP.yaml
+++ b/config/zones/KP.yaml
@@ -54,6 +54,9 @@ capacity:
       source: Ember, Yearly electricity data
       value: 0.0
 country: KP
+
+hide_day_ahead_price: False
+has_day_ahead_price_license: False
 parsers:
   productionCapacity: EMBER.fetch_production_capacity
 region: Asia

--- a/config/zones/KR.yaml
+++ b/config/zones/KR.yaml
@@ -456,6 +456,9 @@ fallbackZoneMixes:
         solar: 0.019400257201052595
         unknown: 0.055175449564712
         wind: 0.0
+
+hide_day_ahead_price: False
+has_day_ahead_price_license: False
 parsers:
   consumption: KPX.fetch_consumption
   price: KPX.fetch_price

--- a/config/zones/KW.yaml
+++ b/config/zones/KW.yaml
@@ -158,6 +158,9 @@ fallbackZoneMixes:
         solar: 0.0
         unknown: 0.9999999920933934
         wind: 0.0
+
+hide_day_ahead_price: False
+has_day_ahead_price_license: False
 parsers:
   consumption: KW.fetch_consumption
   productionCapacity: EMBER.fetch_production_capacity

--- a/config/zones/KY.yaml
+++ b/config/zones/KY.yaml
@@ -22,6 +22,9 @@ capacity:
 contributors:
   - VIKTORVAV99
 country: KY
+
+hide_day_ahead_price: False
+has_day_ahead_price_license: False
 parsers:
   productionCapacity: EMBER.fetch_production_capacity
 region: Americas

--- a/config/zones/KZ.yaml
+++ b/config/zones/KZ.yaml
@@ -120,6 +120,9 @@ fallbackZoneMixes:
       solar: 0.00263474788812734
       unknown: 0.00452705822702292
       wind: 0.00449084176120673
+
+hide_day_ahead_price: False
+has_day_ahead_price_license: False
 parsers:
   productionCapacity: EMBER.fetch_production_capacity
 region: Asia

--- a/config/zones/LA.yaml
+++ b/config/zones/LA.yaml
@@ -56,6 +56,9 @@ fallbackZoneMixes:
       coal: 0.28410228182546
       hydro: 0.713395716573259
       solar: 0.0010758606885508
+
+hide_day_ahead_price: False
+has_day_ahead_price_license: False
 parsers:
   productionCapacity: EMBER.fetch_production_capacity
 region: Asia

--- a/config/zones/LB.yaml
+++ b/config/zones/LB.yaml
@@ -50,6 +50,9 @@ capacity:
       source: Ember, Yearly electricity data
       value: 0.0
 country: LB
+
+hide_day_ahead_price: False
+has_day_ahead_price_license: False
 parsers:
   productionCapacity: EMBER.fetch_production_capacity
 region: Asia

--- a/config/zones/LC.yaml
+++ b/config/zones/LC.yaml
@@ -12,6 +12,9 @@ capacity:
       source: Ember, Yearly electricity data
       value: 90.0
 country: LC
+
+hide_day_ahead_price: False
+has_day_ahead_price_license: False
 parsers:
   productionCapacity: EMBER.fetch_production_capacity
 region: Americas

--- a/config/zones/LI.yaml
+++ b/config/zones/LI.yaml
@@ -23,6 +23,9 @@ emissionFactors:
       source: EIA 2020/BEIS 2021; IPCC 2014
       value: 650.0
 region: Europe
+
+hide_day_ahead_price: False
+has_day_ahead_price_license: False
 sources:
   IPCC 2014:
     link: https://www.ipcc.ch/site/assets/uploads/2018/02/ipcc_wg3_ar5_annex-iii.pdf#page=7

--- a/config/zones/LK.yaml
+++ b/config/zones/LK.yaml
@@ -262,6 +262,9 @@ fallbackZoneMixes:
         solar: 0.013187344859185718
         unknown: 0.0
         wind: 0.04677362839649372
+
+hide_day_ahead_price: False
+has_day_ahead_price_license: False
 parsers:
   production: CEB.fetch_production
   productionCapacity: EMBER.fetch_production_capacity

--- a/config/zones/LR.yaml
+++ b/config/zones/LR.yaml
@@ -16,6 +16,9 @@ capacity:
       source: Ember, Yearly electricity data
       value: 100.0
 country: LR
+
+hide_day_ahead_price: False
+has_day_ahead_price_license: False
 parsers:
   productionCapacity: EMBER.fetch_production_capacity
 region: Africa

--- a/config/zones/LS.yaml
+++ b/config/zones/LS.yaml
@@ -21,6 +21,9 @@ capacity:
       source: Ember, Yearly electricity data
       value: 0.0
 country: LS
+
+hide_day_ahead_price: False
+has_day_ahead_price_license: False
 parsers:
   productionCapacity: EMBER.fetch_production_capacity
 region: Africa

--- a/config/zones/LT.yaml
+++ b/config/zones/LT.yaml
@@ -515,6 +515,8 @@ fallbackZoneMixes:
         unknown: 0.03994096817220909
         wind: 0.32657023348461944
 has_day_ahead_price_license: True
+
+hide_day_ahead_price: False
 parsers:
   consumption: ENTSOE.fetch_consumption
   consumptionForecast: ENTSOE.fetch_consumption_forecast

--- a/config/zones/LU.yaml
+++ b/config/zones/LU.yaml
@@ -423,6 +423,8 @@ fallbackZoneMixes:
         unknown: 0.01357305789447995
         wind: 0.28538771464591317
 has_day_ahead_price_license: True
+
+hide_day_ahead_price: False
 parsers:
   consumption: ENTSOE.fetch_consumption
   consumptionForecast: ENTSOE.fetch_consumption_forecast

--- a/config/zones/LV.yaml
+++ b/config/zones/LV.yaml
@@ -474,6 +474,8 @@ fallbackZoneMixes:
         unknown: 0.056288524620116846
         wind: 0.14035237273662302
 has_day_ahead_price_license: True
+
+hide_day_ahead_price: False
 parsers:
   consumption: ENTSOE.fetch_consumption
   consumptionForecast: ENTSOE.fetch_consumption_forecast

--- a/config/zones/LY.yaml
+++ b/config/zones/LY.yaml
@@ -26,6 +26,9 @@ capacity:
       source: Ember, Yearly electricity data
       value: 2320.0
 country: LY
+
+hide_day_ahead_price: False
+has_day_ahead_price_license: False
 parsers:
   productionCapacity: EMBER.fetch_production_capacity
 region: Africa

--- a/config/zones/MA.yaml
+++ b/config/zones/MA.yaml
@@ -119,6 +119,9 @@ fallbackZoneMixes:
         solar: 0.04602936580239592
         unknown: 0.028736370118761283
         wind: 0.13163639894593068
+
+hide_day_ahead_price: False
+has_day_ahead_price_license: False
 parsers:
   productionCapacity: EMBER.fetch_production_capacity
 region: Africa

--- a/config/zones/MC.yaml
+++ b/config/zones/MC.yaml
@@ -11,3 +11,6 @@ timezone: Europe/Monaco
 zone_name: Monaco
 country_name: Monaco
 currency: EUR
+
+hide_day_ahead_price: False
+has_day_ahead_price_license: False

--- a/config/zones/MD.yaml
+++ b/config/zones/MD.yaml
@@ -279,6 +279,9 @@ fallbackZoneMixes:
         solar: 0.012678326413849667
         unknown: 0.0027065851482313144
         wind: 0.03416068856152983
+
+hide_day_ahead_price: False
+has_day_ahead_price_license: False
 parsers:
   consumption: ENTSOE.fetch_consumption
   consumptionForecast: ENTSOE.fetch_consumption_forecast

--- a/config/zones/ME.yaml
+++ b/config/zones/ME.yaml
@@ -306,6 +306,9 @@ fallbackZoneMixes:
         solar: 0.014121937109883976
         unknown: 0.005245002365897119
         wind: 0.06126520397671881
+
+hide_day_ahead_price: False
+has_day_ahead_price_license: False
 parsers:
   consumption: ENTSOE.fetch_consumption
   consumptionForecast: ENTSOE.fetch_consumption_forecast

--- a/config/zones/MG.yaml
+++ b/config/zones/MG.yaml
@@ -1,4 +1,7 @@
 country: MG
+
+hide_day_ahead_price: False
+has_day_ahead_price_license: False
 parsers:
   productionCapacity: EMBER.fetch_production_capacity
 region: Africa

--- a/config/zones/MK.yaml
+++ b/config/zones/MK.yaml
@@ -293,6 +293,9 @@ fallbackZoneMixes:
         solar: 0.05043191890490814
         unknown: 0.0005426887479083481
         wind: 0.06473512851109808
+
+hide_day_ahead_price: False
+has_day_ahead_price_license: False
 parsers:
   consumption: ENTSOE.fetch_consumption
   consumptionForecast: ENTSOE.fetch_consumption_forecast

--- a/config/zones/ML.yaml
+++ b/config/zones/ML.yaml
@@ -48,6 +48,9 @@ capacity:
       source: Ember, Yearly electricity data
       value: 610.0
 country: ML
+
+hide_day_ahead_price: False
+has_day_ahead_price_license: False
 parsers:
   productionCapacity: EMBER.fetch_production_capacity
 region: Africa

--- a/config/zones/MM.yaml
+++ b/config/zones/MM.yaml
@@ -72,6 +72,9 @@ capacity:
       source: Ember, Yearly electricity data
       value: 0.0
 country: MM
+
+hide_day_ahead_price: False
+has_day_ahead_price_license: False
 parsers:
   productionCapacity: EMBER.fetch_production_capacity
 region: Asia

--- a/config/zones/MN.yaml
+++ b/config/zones/MN.yaml
@@ -104,6 +104,9 @@ isRenewable:
     - _url: https://www.iea.org/fuels-and-technologies/electricity
       datetime: '2020-01-01'
       value: 0.0137
+
+hide_day_ahead_price: False
+has_day_ahead_price_license: False
 parsers:
   consumption: MN.fetch_consumption
   production: MN.fetch_production

--- a/config/zones/MO.yaml
+++ b/config/zones/MO.yaml
@@ -15,6 +15,9 @@ capacity:
 contributors:
   - VIKTORVAV99
 country: MO
+
+hide_day_ahead_price: False
+has_day_ahead_price_license: False
 parsers:
   productionCapacity: EMBER.fetch_production_capacity
 region: Asia

--- a/config/zones/MQ.yaml
+++ b/config/zones/MQ.yaml
@@ -223,6 +223,9 @@ fallbackZoneMixes:
         solar: 0.003008907522797206
         unknown: 0.0
         wind: 0.0
+
+hide_day_ahead_price: False
+has_day_ahead_price_license: False
 parsers:
   price: FR_O.fetch_price
   production: FR_O.fetch_production

--- a/config/zones/MR.yaml
+++ b/config/zones/MR.yaml
@@ -19,6 +19,9 @@ capacity:
       source: Ember, Yearly electricity data
       value: 30.0
 country: MR
+
+hide_day_ahead_price: False
+has_day_ahead_price_license: False
 parsers:
   productionCapacity: EMBER.fetch_production_capacity
 region: Africa

--- a/config/zones/MT.yaml
+++ b/config/zones/MT.yaml
@@ -133,6 +133,9 @@ emissionFactors:
       source: UNECE 2022, WindEurope "Wind energy in Europe, 2021 Statistics and the
         outlook for 2022-2026" Wind Europe Proceedings (2021)
       value: 12.62
+
+hide_day_ahead_price: False
+has_day_ahead_price_license: False
 parsers:
   productionCapacity: EMBER.fetch_production_capacity
 region: Europe

--- a/config/zones/MU.yaml
+++ b/config/zones/MU.yaml
@@ -92,6 +92,9 @@ fallbackZoneMixes:
         solar: 0.04942291741728504
         unknown: 0.0
         wind: 0.004813099721722564
+
+hide_day_ahead_price: False
+has_day_ahead_price_license: False
 parsers:
   productionCapacity: EMBER.fetch_production_capacity
 region: Africa

--- a/config/zones/MV.yaml
+++ b/config/zones/MV.yaml
@@ -41,6 +41,9 @@ capacity:
 contributors:
   - VIKTORVAV99
 country: MV
+
+hide_day_ahead_price: False
+has_day_ahead_price_license: False
 parsers:
   productionCapacity: EMBER.fetch_production_capacity
 region: Asia

--- a/config/zones/MW.yaml
+++ b/config/zones/MW.yaml
@@ -39,6 +39,9 @@ capacity:
       source: Ember, Yearly electricity data
       value: 130.0
 country: MW
+
+hide_day_ahead_price: False
+has_day_ahead_price_license: False
 parsers:
   productionCapacity: EMBER.fetch_production_capacity
 region: Africa

--- a/config/zones/MX.yaml
+++ b/config/zones/MX.yaml
@@ -149,6 +149,9 @@ emissionFactors:
         source: IEA, Electricity generation mix in Mexico, 1 Jan - 30 Sep, 2019 and
           2020, IEA, Paris
         value: 411
+
+hide_day_ahead_price: False
+has_day_ahead_price_license: False
 parsers:
   production: CENACE.fetch_production
   productionCapacity: EMBER.fetch_production_capacity

--- a/config/zones/MY-EM.yaml
+++ b/config/zones/MY-EM.yaml
@@ -184,3 +184,6 @@ region: Asia
 timezone: Asia/Kuala_Lumpur
 zone_name: Borneo
 country_name: Malaysia
+
+hide_day_ahead_price: False
+has_day_ahead_price_license: False

--- a/config/zones/MY-WM.yaml
+++ b/config/zones/MY-WM.yaml
@@ -216,6 +216,9 @@ fallbackZoneMixes:
         solar: 0.021171527148129823
         unknown: 0.001574858961476563
         wind: 0.0
+
+hide_day_ahead_price: False
+has_day_ahead_price_license: False
 parsers:
   consumption: GSO.fetch_consumption
   production: GSO.fetch_production

--- a/config/zones/MY.yaml
+++ b/config/zones/MY.yaml
@@ -257,6 +257,9 @@ fallbackZoneMixes:
         solar: 0.02105938582460856
         unknown: 0.006868112880627442
         wind: 0.0
+
+hide_day_ahead_price: False
+has_day_ahead_price_license: False
 parsers:
   productionCapacity: IRENA.fetch_production_capacity
 region: Asia

--- a/config/zones/MZ.yaml
+++ b/config/zones/MZ.yaml
@@ -84,6 +84,9 @@ fallbackZoneMixes:
         solar: 0.003473283673712482
         unknown: 0.0
         wind: 0.0
+
+hide_day_ahead_price: False
+has_day_ahead_price_license: False
 parsers:
   productionCapacity: EMBER.fetch_production_capacity
 region: Africa

--- a/config/zones/NA.yaml
+++ b/config/zones/NA.yaml
@@ -82,3 +82,6 @@ timezone: Africa/Windhoek
 zone_name: Namibia
 country_name: Namibia
 currency: NAD
+
+hide_day_ahead_price: False
+has_day_ahead_price_license: False

--- a/config/zones/NC.yaml
+++ b/config/zones/NC.yaml
@@ -45,6 +45,9 @@ capacity:
       source: Ember, Yearly electricity data
       value: 60.0
 country: NC
+
+hide_day_ahead_price: False
+has_day_ahead_price_license: False
 parsers:
   productionCapacity: EMBER.fetch_production_capacity
 region: Oceania

--- a/config/zones/NE.yaml
+++ b/config/zones/NE.yaml
@@ -31,6 +31,9 @@ capacity:
       source: Ember, Yearly electricity data
       value: 390.0
 country: NE
+
+hide_day_ahead_price: False
+has_day_ahead_price_license: False
 parsers:
   productionCapacity: EMBER.fetch_production_capacity
 region: Africa

--- a/config/zones/NG.yaml
+++ b/config/zones/NG.yaml
@@ -168,6 +168,9 @@ fallbackZoneMixes:
         solar: 0.0
         unknown: 0.0
         wind: 0.0
+
+hide_day_ahead_price: False
+has_day_ahead_price_license: False
 parsers:
   production: NG.fetch_production
   productionCapacity: EMBER.fetch_production_capacity

--- a/config/zones/NI.yaml
+++ b/config/zones/NI.yaml
@@ -304,6 +304,9 @@ fallbackZoneMixes:
         solar: 0.011695191572445699
         unknown: 4.012659652412689e-05
         wind: 0.11489319131069319
+
+hide_day_ahead_price: False
+has_day_ahead_price_license: False
 parsers:
   price: NI.fetch_price
   production: NI.fetch_production

--- a/config/zones/NL.yaml
+++ b/config/zones/NL.yaml
@@ -528,6 +528,8 @@ fallbackZoneMixes:
         unknown: 0.01600895762532292
         wind: 0.275490914569801
 has_day_ahead_price_license: True
+
+hide_day_ahead_price: False
 parsers:
   consumption: ENTSOE.fetch_consumption
   consumptionForecast: ENTSOE.fetch_consumption_forecast

--- a/config/zones/NO-NO1.yaml
+++ b/config/zones/NO-NO1.yaml
@@ -361,6 +361,8 @@ fallbackZoneMixes:
         unknown: 0.004530321106530987
         wind: 0.08058754580014128
 has_day_ahead_price_license: True
+
+hide_day_ahead_price: False
 parsers:
   consumption: ENTSOE.fetch_consumption
   consumptionForecast: ENTSOE.fetch_consumption_forecast

--- a/config/zones/NO-NO2.yaml
+++ b/config/zones/NO-NO2.yaml
@@ -370,6 +370,8 @@ fallbackZoneMixes:
         unknown: 0.0009148912252796965
         wind: 0.11531147882892007
 has_day_ahead_price_license: True
+
+hide_day_ahead_price: False
 parsers:
   consumption: ENTSOE.fetch_consumption
   consumptionForecast: ENTSOE.fetch_consumption_forecast

--- a/config/zones/NO-NO3.yaml
+++ b/config/zones/NO-NO3.yaml
@@ -376,6 +376,8 @@ fallbackZoneMixes:
         unknown: 0.00822168167101805
         wind: 0.23964172535285017
 has_day_ahead_price_license: True
+
+hide_day_ahead_price: False
 parsers:
   consumption: ENTSOE.fetch_consumption
   consumptionForecast: ENTSOE.fetch_consumption_forecast

--- a/config/zones/NO-NO4.yaml
+++ b/config/zones/NO-NO4.yaml
@@ -356,6 +356,8 @@ fallbackZoneMixes:
         unknown: 0.010058740193573302
         wind: 0.17044500247243927
 has_day_ahead_price_license: True
+
+hide_day_ahead_price: False
 parsers:
   consumption: ENTSOE.fetch_consumption
   consumptionForecast: ENTSOE.fetch_consumption_forecast

--- a/config/zones/NO-NO5.yaml
+++ b/config/zones/NO-NO5.yaml
@@ -355,6 +355,8 @@ fallbackZoneMixes:
         unknown: 0.00041495388875751785
         wind: 0.014746060245185884
 has_day_ahead_price_license: True
+
+hide_day_ahead_price: False
 parsers:
   consumption: ENTSOE.fetch_consumption
   consumptionForecast: ENTSOE.fetch_consumption_forecast

--- a/config/zones/NO.yaml
+++ b/config/zones/NO.yaml
@@ -300,6 +300,9 @@ fallbackZoneMixes:
         solar: 0.005032172878244702
         unknown: 0.004538204352072401
         wind: 0.12701186508811527
+
+hide_day_ahead_price: False
+has_day_ahead_price_license: False
 parsers:
   consumption: ENTSOE.fetch_consumption
   consumptionForecast: ENTSOE.fetch_consumption_forecast

--- a/config/zones/NP.yaml
+++ b/config/zones/NP.yaml
@@ -20,3 +20,6 @@ timezone: Asia/Kathmandu
 zone_name: Nepal
 country_name: Nepal
 currency: NPR
+
+hide_day_ahead_price: False
+has_day_ahead_price_license: False

--- a/config/zones/NZ-NZA.yaml
+++ b/config/zones/NZ-NZA.yaml
@@ -3,3 +3,6 @@ region: Oceania
 timezone: Pacific/Auckland
 zone_name: Auckland Islands
 country_name: New Zealand
+
+hide_day_ahead_price: False
+has_day_ahead_price_license: False

--- a/config/zones/NZ-NZC.yaml
+++ b/config/zones/NZ-NZC.yaml
@@ -3,3 +3,6 @@ region: Oceania
 timezone: Pacific/Auckland
 zone_name: Chatham Islands
 country_name: New Zealand
+
+hide_day_ahead_price: False
+has_day_ahead_price_license: False

--- a/config/zones/NZ-NZST.yaml
+++ b/config/zones/NZ-NZST.yaml
@@ -19,3 +19,6 @@ region: Oceania
 timezone: Pacific/Auckland
 zone_name: Stewart Island
 country_name: New Zealand
+
+hide_day_ahead_price: False
+has_day_ahead_price_license: False

--- a/config/zones/NZ.yaml
+++ b/config/zones/NZ.yaml
@@ -358,6 +358,9 @@ fallbackZoneMixes:
         solar: 0.0022427556771429237
         unknown: 0.020886705386506124
         wind: 0.09329579500153248
+
+hide_day_ahead_price: False
+has_day_ahead_price_license: False
 parsers:
   price: NZ.fetch_price
   production: NZ.fetch_production

--- a/config/zones/OM.yaml
+++ b/config/zones/OM.yaml
@@ -154,6 +154,9 @@ fallbackZoneMixes:
         solar: 0.05847499902621566
         unknown: 0.004048538876343689
         wind: 0.0
+
+hide_day_ahead_price: False
+has_day_ahead_price_license: False
 parsers:
   consumption: GCCIA.fetch_consumption
 region: Asia

--- a/config/zones/PA.yaml
+++ b/config/zones/PA.yaml
@@ -371,6 +371,9 @@ fallbackZoneMixes:
         solar: 0.07582387224209039
         unknown: 0.0
         wind: 0.04815485711912523
+
+hide_day_ahead_price: False
+has_day_ahead_price_license: False
 parsers:
   consumption: PA.fetch_consumption
   production: PA.fetch_production

--- a/config/zones/PE.yaml
+++ b/config/zones/PE.yaml
@@ -386,6 +386,9 @@ fallbackZoneMixes:
         solar: 0.022634861767733317
         unknown: 0.0
         wind: 0.06261290684751358
+
+hide_day_ahead_price: False
+has_day_ahead_price_license: False
 parsers:
   production: PE.fetch_production
   productionCapacity: EMBER.fetch_production_capacity

--- a/config/zones/PF.yaml
+++ b/config/zones/PF.yaml
@@ -131,6 +131,9 @@ fallbackZoneMixes:
         solar: 0.09626067428950572
         unknown: 0.0
         wind: 0.0
+
+hide_day_ahead_price: False
+has_day_ahead_price_license: False
 parsers:
   production: PF.fetch_production
   productionCapacity: EMBER.fetch_production_capacity

--- a/config/zones/PG.yaml
+++ b/config/zones/PG.yaml
@@ -40,6 +40,9 @@ capacity:
       source: Ember, Yearly electricity data
       value: 540.0
 country: PG
+
+hide_day_ahead_price: False
+has_day_ahead_price_license: False
 parsers:
   productionCapacity: EMBER.fetch_production_capacity
 region: Oceania

--- a/config/zones/PH-LU.yaml
+++ b/config/zones/PH-LU.yaml
@@ -199,6 +199,9 @@ fallbackZoneMixes:
         solar: 0.020418652513402993
         unknown: 0.054426137887670575
         wind: 0.01113649280728119
+
+hide_day_ahead_price: False
+has_day_ahead_price_license: False
 parsers:
   production: IEMOP.fetch_production
 region: Asia

--- a/config/zones/PH-MI.yaml
+++ b/config/zones/PH-MI.yaml
@@ -197,6 +197,9 @@ fallbackZoneMixes:
         solar: 0.006548497102706934
         unknown: 0.007487106321175432
         wind: 9.209647219998301e-06
+
+hide_day_ahead_price: False
+has_day_ahead_price_license: False
 parsers:
   production: IEMOP.fetch_production
 region: Asia

--- a/config/zones/PH-VI.yaml
+++ b/config/zones/PH-VI.yaml
@@ -198,6 +198,9 @@ fallbackZoneMixes:
         solar: 0.04010653633275602
         unknown: 0.1408642231758758
         wind: 0.010172876605430417
+
+hide_day_ahead_price: False
+has_day_ahead_price_license: False
 parsers:
   production: IEMOP.fetch_production
 region: Asia

--- a/config/zones/PH.yaml
+++ b/config/zones/PH.yaml
@@ -201,3 +201,6 @@ timezone: Asia/Manila
 zone_name: Philippines
 country_name: Philippines
 currency: PHP
+
+hide_day_ahead_price: False
+has_day_ahead_price_license: False

--- a/config/zones/PK.yaml
+++ b/config/zones/PK.yaml
@@ -124,6 +124,9 @@ capacity:
       source: Ember, Yearly electricity data
       value: 1850.0
 country: PK
+
+hide_day_ahead_price: False
+has_day_ahead_price_license: False
 parsers:
   productionCapacity: EMBER.fetch_production_capacity
 region: Asia

--- a/config/zones/PL.yaml
+++ b/config/zones/PL.yaml
@@ -577,6 +577,8 @@ fallbackZoneMixes:
         unknown: 0.021165400293021545
         wind: 0.15788617303391778
 has_day_ahead_price_license: True
+
+hide_day_ahead_price: False
 parsers:
   consumption: ENTSOE.fetch_consumption
   consumptionForecast: ENTSOE.fetch_consumption_forecast

--- a/config/zones/PM.yaml
+++ b/config/zones/PM.yaml
@@ -8,6 +8,9 @@ capacity:
       source: Ember, Yearly electricity data
       value: 0.0
 country: PM
+
+hide_day_ahead_price: False
+has_day_ahead_price_license: False
 parsers:
   productionCapacity: EMBER.fetch_production_capacity
 region: Americas

--- a/config/zones/PR.yaml
+++ b/config/zones/PR.yaml
@@ -306,6 +306,9 @@ isLowCarbon:
 isRenewable:
   unknown:
     value: 1
+
+hide_day_ahead_price: False
+has_day_ahead_price_license: False
 parsers:
   productionCapacity: EMBER.fetch_production_capacity
 region: Americas

--- a/config/zones/PS.yaml
+++ b/config/zones/PS.yaml
@@ -29,6 +29,9 @@ capacity:
       source: Ember, Yearly electricity data
       value: 190.0
 country: PS
+
+hide_day_ahead_price: False
+has_day_ahead_price_license: False
 parsers:
   productionCapacity: EMBER.fetch_production_capacity
 region: Asia

--- a/config/zones/PT-AC.yaml
+++ b/config/zones/PT-AC.yaml
@@ -77,6 +77,7 @@ emissionFactors:
         outlook for 2022-2026" Wind Europe Proceedings (2021)
       value: 12.62
 has_day_ahead_price_license: True
+hide_day_ahead_price: False
 region: Europe
 sources:
   EU-ETS, ENTSO-E 2021:

--- a/config/zones/PT-MA.yaml
+++ b/config/zones/PT-MA.yaml
@@ -77,6 +77,7 @@ emissionFactors:
         outlook for 2022-2026" Wind Europe Proceedings (2021)
       value: 12.62
 has_day_ahead_price_license: True
+hide_day_ahead_price: False
 region: Europe
 sources:
   EU-ETS, ENTSO-E 2021:

--- a/config/zones/PT.yaml
+++ b/config/zones/PT.yaml
@@ -557,6 +557,7 @@ fallbackZoneMixes:
         unknown: 0.0050680810190587185
         wind: 0.28972267240405203
 has_day_ahead_price_license: True
+hide_day_ahead_price: False
 parsers:
   consumption: ENTSOE.fetch_consumption
   consumptionForecast: ENTSOE.fetch_consumption_forecast

--- a/config/zones/PW.yaml
+++ b/config/zones/PW.yaml
@@ -32,6 +32,9 @@ capacity:
       source: IRENA.org
       value: 19.62
 country: PW
+
+hide_day_ahead_price: False
+has_day_ahead_price_license: False
 parsers:
   productionCapacity: IRENA.fetch_production_capacity
 region: Oceania

--- a/config/zones/PY.yaml
+++ b/config/zones/PY.yaml
@@ -31,6 +31,9 @@ capacity:
       source: Ember, Yearly electricity data
       value: 0.0
 country: PY
+
+hide_day_ahead_price: False
+has_day_ahead_price_license: False
 parsers:
   productionCapacity: EMBER.fetch_production_capacity
 region: Americas

--- a/config/zones/QA.yaml
+++ b/config/zones/QA.yaml
@@ -103,6 +103,9 @@ fallbackZoneMixes:
         solar: 0.04696731182387401
         unknown: 0.0
         wind: 0.0
+
+hide_day_ahead_price: False
+has_day_ahead_price_license: False
 parsers:
   consumption: GCCIA.fetch_consumption
   productionCapacity: EMBER.fetch_production_capacity

--- a/config/zones/RE.yaml
+++ b/config/zones/RE.yaml
@@ -271,6 +271,9 @@ fallbackZoneMixes:
         solar: 0.0663331354651612
         unknown: 0.0
         wind: 0.010511245973335337
+
+hide_day_ahead_price: False
+has_day_ahead_price_license: False
 parsers:
   price: FR_O.fetch_price
   production: FR_O.fetch_production

--- a/config/zones/RO.yaml
+++ b/config/zones/RO.yaml
@@ -522,6 +522,9 @@ fallbackZoneMixes:
         solar: 0.0460041571694597
         unknown: 0.003559105732333226
         wind: 0.10556203829169036
+
+hide_day_ahead_price: False
+has_day_ahead_price_license: False
 parsers:
   consumption: ENTSOE.fetch_consumption
   consumptionForecast: ENTSOE.fetch_consumption_forecast

--- a/config/zones/RS.yaml
+++ b/config/zones/RS.yaml
@@ -374,6 +374,9 @@ fallbackZoneMixes:
         solar: 0.01441557250678779
         unknown: 0.006567137148345253
         wind: 0.03546266393241745
+
+hide_day_ahead_price: False
+has_day_ahead_price_license: False
 parsers:
   consumption: ENTSOE.fetch_consumption
   consumptionForecast: ENTSOE.fetch_consumption_forecast

--- a/config/zones/RU-1.yaml
+++ b/config/zones/RU-1.yaml
@@ -223,6 +223,9 @@ fallbackZoneMixes:
         solar: 0.0022832634472736636
         unknown: 0.6684971552103295
         wind: 0.0003232508531472728
+
+hide_day_ahead_price: False
+has_day_ahead_price_license: False
 parsers:
   production: RU.fetch_production
 region: Europe

--- a/config/zones/RU-2.yaml
+++ b/config/zones/RU-2.yaml
@@ -198,6 +198,9 @@ fallbackZoneMixes:
         solar: 0.0024366412571999395
         unknown: 0.48459049819521227
         wind: 0.00035014701905574535
+
+hide_day_ahead_price: False
+has_day_ahead_price_license: False
 parsers:
   production: RU.fetch_production
 region: Europe

--- a/config/zones/RU-AS.yaml
+++ b/config/zones/RU-AS.yaml
@@ -112,6 +112,9 @@ fallbackZoneMixes:
         solar: 0.00038128775981619397
         unknown: 0.6283766030237664
         wind: 0.0008282519218127808
+
+hide_day_ahead_price: False
+has_day_ahead_price_license: False
 parsers:
   production: RU.fetch_production
 region: Europe

--- a/config/zones/RU-EU.yaml
+++ b/config/zones/RU-EU.yaml
@@ -8,3 +8,5 @@ region: Europe
 timezone: Europe/Moscow
 zone_name: Arctic
 country_name: Russia
+hide_day_ahead_price: False
+has_day_ahead_price_license: False

--- a/config/zones/RU-FE.yaml
+++ b/config/zones/RU-FE.yaml
@@ -8,3 +8,5 @@ region: Europe
 timezone: Asia/Kamchatka
 zone_name: Far East
 country_name: Russia
+hide_day_ahead_price: False
+has_day_ahead_price_license: False

--- a/config/zones/RU-KGD.yaml
+++ b/config/zones/RU-KGD.yaml
@@ -21,3 +21,5 @@ region: Europe
 timezone: Europe/Kaliningrad
 zone_name: Kaliningrad
 country_name: Russia
+hide_day_ahead_price: False
+has_day_ahead_price_license: False

--- a/config/zones/RU.yaml
+++ b/config/zones/RU.yaml
@@ -346,6 +346,9 @@ fallbackZoneMixes:
         solar: 0.0021536301209946376
         unknown: 0.635339299328092
         wind: 0.0
+
+hide_day_ahead_price: False
+has_day_ahead_price_license: False
 parsers:
   consumption: ENTSOE.fetch_consumption
   consumptionForecast: ENTSOE.fetch_consumption_forecast

--- a/config/zones/RW.yaml
+++ b/config/zones/RW.yaml
@@ -36,6 +36,9 @@ capacity:
       source: Ember, Yearly electricity data
       value: 70.0
 country: RW
+
+hide_day_ahead_price: False
+has_day_ahead_price_license: False
 parsers:
   productionCapacity: EMBER.fetch_production_capacity
 region: Africa

--- a/config/zones/SA.yaml
+++ b/config/zones/SA.yaml
@@ -6,6 +6,9 @@ bounding_box:
 contributors:
   - q--
 country: SA
+
+hide_day_ahead_price: False
+has_day_ahead_price_license: False
 parsers:
   consumption: GCCIA.fetch_consumption
   productionCapacity: EMBER.fetch_production_capacity

--- a/config/zones/SB.yaml
+++ b/config/zones/SB.yaml
@@ -22,6 +22,9 @@ capacity:
       source: Ember, Yearly electricity data
       value: 60.0
 country: SB
+
+hide_day_ahead_price: False
+has_day_ahead_price_license: False
 parsers:
   productionCapacity: EMBER.fetch_production_capacity
 region: Oceania

--- a/config/zones/SC.yaml
+++ b/config/zones/SC.yaml
@@ -28,6 +28,9 @@ capacity:
 contributors:
   - VIKTORVAV99
 country: SC
+
+hide_day_ahead_price: False
+has_day_ahead_price_license: False
 parsers:
   productionCapacity: EMBER.fetch_production_capacity
 region: Africa

--- a/config/zones/SD.yaml
+++ b/config/zones/SD.yaml
@@ -41,6 +41,9 @@ capacity:
       source: Ember, Yearly electricity data
       value: 1340.0
 country: SD
+
+hide_day_ahead_price: False
+has_day_ahead_price_license: False
 parsers:
   productionCapacity: EMBER.fetch_production_capacity
 region: Africa

--- a/config/zones/SE-SE1.yaml
+++ b/config/zones/SE-SE1.yaml
@@ -327,6 +327,8 @@ fallbackZoneMixes:
         unknown: 0.006938947891641582
         wind: 0.30592955546892997
 has_day_ahead_price_license: True
+
+hide_day_ahead_price: False
 parsers:
   consumption: ENTSOE.fetch_consumption
   consumptionForecast: ENTSOE.fetch_consumption_forecast

--- a/config/zones/SE-SE2.yaml
+++ b/config/zones/SE-SE2.yaml
@@ -413,6 +413,8 @@ fallbackZoneMixes:
         unknown: 0.014809349860570501
         wind: 0.30866761246294394
 has_day_ahead_price_license: True
+
+hide_day_ahead_price: False
 parsers:
   consumption: ENTSOE.fetch_consumption
   consumptionForecast: ENTSOE.fetch_consumption_forecast

--- a/config/zones/SE-SE3.yaml
+++ b/config/zones/SE-SE3.yaml
@@ -420,6 +420,8 @@ fallbackZoneMixes:
         unknown: 0.03717101809816512
         wind: 0.2021775270304475
 has_day_ahead_price_license: True
+
+hide_day_ahead_price: False
 parsers:
   consumption: ENTSOE.fetch_consumption
   consumptionForecast: ENTSOE.fetch_consumption_forecast

--- a/config/zones/SE-SE4.yaml
+++ b/config/zones/SE-SE4.yaml
@@ -398,6 +398,8 @@ fallbackZoneMixes:
         unknown: 0.057250942025872324
         wind: 0.3128595834430837
 has_day_ahead_price_license: True
+
+hide_day_ahead_price: False
 parsers:
   consumption: ENTSOE.fetch_consumption
   consumptionForecast: ENTSOE.fetch_consumption_forecast

--- a/config/zones/SE.yaml
+++ b/config/zones/SE.yaml
@@ -476,6 +476,9 @@ isRenewable:
     - _comment: Sum of renewable sources in SE unknown production for 2022
       datetime: '2022-01-01'
       value: 0.9826
+
+hide_day_ahead_price: False
+has_day_ahead_price_license: False
 parsers:
   consumption: ENTSOE.fetch_consumption
   consumptionForecast: ENTSOE.fetch_consumption_forecast

--- a/config/zones/SG.yaml
+++ b/config/zones/SG.yaml
@@ -349,6 +349,9 @@ isLowCarbon:
 isRenewable:
   unknown:
     value: 1
+
+hide_day_ahead_price: False
+has_day_ahead_price_license: False
 parsers:
   price: SG.fetch_price
   production: SG.fetch_production

--- a/config/zones/SI.yaml
+++ b/config/zones/SI.yaml
@@ -509,6 +509,9 @@ fallbackZoneMixes:
         solar: 0.049591378558207624
         unknown: 0.003995671216234753
         wind: 0.04625761651149296
+
+hide_day_ahead_price: False
+has_day_ahead_price_license: False
 parsers:
   consumption: ENTSOE.fetch_consumption
   consumptionForecast: ENTSOE.fetch_consumption_forecast

--- a/config/zones/SJ.yaml
+++ b/config/zones/SJ.yaml
@@ -4,3 +4,6 @@ timezone: Arctic/Longyearbyen
 zone_name: Svalbard and Jan Mayen
 country_name: Svalbard and Jan Mayen
 currency: NOK
+
+hide_day_ahead_price: False
+has_day_ahead_price_license: False

--- a/config/zones/SK.yaml
+++ b/config/zones/SK.yaml
@@ -472,6 +472,9 @@ fallbackZoneMixes:
         solar: 0.03709833589359616
         unknown: 0.03656600258990078
         wind: 0.027443728652431654
+
+hide_day_ahead_price: False
+has_day_ahead_price_license: False
 parsers:
   consumption: ENTSOE.fetch_consumption
   consumptionForecast: ENTSOE.fetch_consumption_forecast

--- a/config/zones/SL.yaml
+++ b/config/zones/SL.yaml
@@ -28,6 +28,9 @@ capacity:
       source: Ember, Yearly electricity data
       value: 140.0
 country: SL
+
+hide_day_ahead_price: False
+has_day_ahead_price_license: False
 parsers:
   productionCapacity: EMBER.fetch_production_capacity
 region: Africa

--- a/config/zones/SN.yaml
+++ b/config/zones/SN.yaml
@@ -59,6 +59,9 @@ capacity:
       source: Ember, Yearly electricity data
       value: 160.0
 country: SN
+
+hide_day_ahead_price: False
+has_day_ahead_price_license: False
 parsers:
   productionCapacity: EMBER.fetch_production_capacity
 region: Africa

--- a/config/zones/SO.yaml
+++ b/config/zones/SO.yaml
@@ -24,6 +24,9 @@ capacity:
       source: Ember, Yearly electricity data
       value: 0.0
 country: SO
+
+hide_day_ahead_price: False
+has_day_ahead_price_license: False
 parsers:
   productionCapacity: EMBER.fetch_production_capacity
 region: Africa

--- a/config/zones/SR.yaml
+++ b/config/zones/SR.yaml
@@ -19,6 +19,9 @@ capacity:
       source: Ember, Yearly electricity data
       value: 510.0
 country: SR
+
+hide_day_ahead_price: False
+has_day_ahead_price_license: False
 parsers:
   productionCapacity: EMBER.fetch_production_capacity
 region: Americas

--- a/config/zones/SS.yaml
+++ b/config/zones/SS.yaml
@@ -20,6 +20,9 @@ capacity:
       source: Ember, Yearly electricity data
       value: 200.0
 country: SS
+
+hide_day_ahead_price: False
+has_day_ahead_price_license: False
 parsers:
   productionCapacity: EMBER.fetch_production_capacity
 region: Africa

--- a/config/zones/ST.yaml
+++ b/config/zones/ST.yaml
@@ -12,6 +12,9 @@ capacity:
       source: Ember, Yearly electricity data
       value: 30.0
 country: ST
+
+hide_day_ahead_price: False
+has_day_ahead_price_license: False
 parsers:
   productionCapacity: EMBER.fetch_production_capacity
 region: Africa

--- a/config/zones/SV.yaml
+++ b/config/zones/SV.yaml
@@ -326,6 +326,9 @@ fallbackZoneMixes:
         solar: 0.06517101483556031
         unknown: 0.36756974032893625
         wind: 0.018960503204449836
+
+hide_day_ahead_price: False
+has_day_ahead_price_license: False
 parsers:
   production: ESTADISTICO_UT.fetch_production
   productionCapacity: EMBER.fetch_production_capacity

--- a/config/zones/SY.yaml
+++ b/config/zones/SY.yaml
@@ -37,6 +37,9 @@ capacity:
       source: Ember, Yearly electricity data
       value: 0.0
 country: SY
+
+hide_day_ahead_price: False
+has_day_ahead_price_license: False
 parsers:
   productionCapacity: EMBER.fetch_production_capacity
 region: Asia

--- a/config/zones/SZ.yaml
+++ b/config/zones/SZ.yaml
@@ -72,6 +72,9 @@ fallbackZoneMixes:
         solar: 0.03922910747008666
         unknown: 0.0
         wind: 0.0
+
+hide_day_ahead_price: False
+has_day_ahead_price_license: False
 parsers:
   productionCapacity: EMBER.fetch_production_capacity
 region: Africa

--- a/config/zones/TD.yaml
+++ b/config/zones/TD.yaml
@@ -20,6 +20,9 @@ capacity:
       source: Ember, Yearly electricity data
       value: 0.0
 country: TD
+
+hide_day_ahead_price: False
+has_day_ahead_price_license: False
 parsers:
   productionCapacity: EMBER.fetch_production_capacity
 region: Africa

--- a/config/zones/TF.yaml
+++ b/config/zones/TF.yaml
@@ -3,3 +3,6 @@ region: Africa
 timezone: Indian/Kerguelen
 zone_name: French Southern Territories
 country_name: French Southern Territories
+
+hide_day_ahead_price: False
+has_day_ahead_price_license: False

--- a/config/zones/TG.yaml
+++ b/config/zones/TG.yaml
@@ -1,4 +1,7 @@
 country: TG
+
+hide_day_ahead_price: False
+has_day_ahead_price_license: False
 parsers:
   productionCapacity: EMBER.fetch_production_capacity
 region: Africa

--- a/config/zones/TH.yaml
+++ b/config/zones/TH.yaml
@@ -321,6 +321,9 @@ isRenewable:
   unknown:
     _comment: Sum of renewable sources in TH unknown production
     value: 0.159
+
+hide_day_ahead_price: False
+has_day_ahead_price_license: False
 parsers:
   consumption: TH.fetch_consumption
   price: TH.fetch_price

--- a/config/zones/TJ.yaml
+++ b/config/zones/TJ.yaml
@@ -27,6 +27,9 @@ capacity:
       source: Ember, Yearly electricity data
       value: 0.0
 country: TJ
+
+hide_day_ahead_price: False
+has_day_ahead_price_license: False
 parsers:
   productionCapacity: EMBER.fetch_production_capacity
 region: Asia

--- a/config/zones/TL.yaml
+++ b/config/zones/TL.yaml
@@ -16,6 +16,9 @@ capacity:
       source: Ember, Yearly electricity data
       value: 350.0
 country: TL
+
+hide_day_ahead_price: False
+has_day_ahead_price_license: False
 parsers:
   productionCapacity: EMBER.fetch_production_capacity
 region: Asia

--- a/config/zones/TM.yaml
+++ b/config/zones/TM.yaml
@@ -22,6 +22,9 @@ capacity:
       source: Ember, Yearly electricity data
       value: 0.0
 country: TM
+
+hide_day_ahead_price: False
+has_day_ahead_price_license: False
 parsers:
   productionCapacity: EMBER.fetch_production_capacity
 region: Asia

--- a/config/zones/TN.yaml
+++ b/config/zones/TN.yaml
@@ -99,6 +99,9 @@ fallbackZoneMixes:
         solar: 0.014851571340234765
         unknown: 0.009993849327866806
         wind: 0.01516080650910127
+
+hide_day_ahead_price: False
+has_day_ahead_price_license: False
 parsers:
   productionCapacity: EMBER.fetch_production_capacity
 region: Africa

--- a/config/zones/TO.yaml
+++ b/config/zones/TO.yaml
@@ -15,6 +15,9 @@ capacity:
       source: Ember, Yearly electricity data
       value: 0.0
 country: TO
+
+hide_day_ahead_price: False
+has_day_ahead_price_license: False
 parsers:
   productionCapacity: EMBER.fetch_production_capacity
 region: Oceania

--- a/config/zones/TR.yaml
+++ b/config/zones/TR.yaml
@@ -429,6 +429,9 @@ fallbackZoneMixes:
         solar: 0.016206573078968178
         unknown: 0.0023705547277017153
         wind: 0.11272769958002037
+
+hide_day_ahead_price: False
+has_day_ahead_price_license: False
 parsers:
   consumption: TR.fetch_consumption
   consumptionForecast: ENTSOE.fetch_consumption_forecast

--- a/config/zones/TT.yaml
+++ b/config/zones/TT.yaml
@@ -25,6 +25,9 @@ capacity:
       source: Ember, Yearly electricity data
       value: 0.0
 country: TT
+
+hide_day_ahead_price: False
+has_day_ahead_price_license: False
 parsers:
   productionCapacity: EMBER.fetch_production_capacity
 region: Americas

--- a/config/zones/TW.yaml
+++ b/config/zones/TW.yaml
@@ -426,6 +426,9 @@ fallbackZoneMixes:
         solar: 0.06550111905166345
         unknown: 0.03142705539402686
         wind: 0.037479238587619625
+
+hide_day_ahead_price: False
+has_day_ahead_price_license: False
 parsers:
   production: TAIPOWER.fetch_production
   productionCapacity: EMBER.fetch_production_capacity

--- a/config/zones/TZ.yaml
+++ b/config/zones/TZ.yaml
@@ -104,6 +104,9 @@ fallbackZoneMixes:
         solar: 0.003117324755408123
         unknown: 0.0
         wind: 0.0
+
+hide_day_ahead_price: False
+has_day_ahead_price_license: False
 parsers:
   productionCapacity: EMBER.fetch_production_capacity
 region: Africa

--- a/config/zones/UA-CR.yaml
+++ b/config/zones/UA-CR.yaml
@@ -8,3 +8,6 @@ region: Europe
 timezone: Europe/Kiev
 zone_name: Crimea
 country_name: Ukraine
+
+hide_day_ahead_price: False
+has_day_ahead_price_license: False

--- a/config/zones/UA.yaml
+++ b/config/zones/UA.yaml
@@ -198,6 +198,9 @@ isLowCarbon:
 isRenewable:
   unknown:
     value: 1
+
+hide_day_ahead_price: False
+has_day_ahead_price_license: False
 parsers:
   consumption: ENTSOE.fetch_consumption
   consumptionForecast: ENTSOE.fetch_consumption_forecast

--- a/config/zones/UG.yaml
+++ b/config/zones/UG.yaml
@@ -96,6 +96,9 @@ fallbackZoneMixes:
         solar: 0.02528760510767805
         unknown: 0.0
         wind: 0.0
+
+hide_day_ahead_price: False
+has_day_ahead_price_license: False
 parsers:
   productionCapacity: EMBER.fetch_production_capacity
 region: Africa

--- a/config/zones/US-AK-SEAPA.yaml
+++ b/config/zones/US-AK-SEAPA.yaml
@@ -35,6 +35,9 @@ fallbackZoneMixes:
         solar: 0.0
         unknown: 0.0
         wind: 0.0
+
+hide_day_ahead_price: False
+has_day_ahead_price_license: False
 parsers:
   production: SEAPA.fetch_production
 region: Americas

--- a/config/zones/US-AK.yaml
+++ b/config/zones/US-AK.yaml
@@ -52,6 +52,9 @@ emissionFactors:
         source: eGrid 2021; IPCC 2014
         value: 907.88
 region: Americas
+
+hide_day_ahead_price: False
+has_day_ahead_price_license: False
 sources:
   IPCC 2014:
     link: https://www.ipcc.ch/site/assets/uploads/2018/02/ipcc_wg3_ar5_annex-iii.pdf#page=7

--- a/config/zones/US-CAL-BANC.yaml
+++ b/config/zones/US-CAL-BANC.yaml
@@ -425,6 +425,9 @@ fallbackZoneMixes:
         solar: 0.07278678480519393
         unknown: 0.008333564061770537
         wind: 0.032467024035805404
+
+hide_day_ahead_price: False
+has_day_ahead_price_license: False
 parsers:
   consumption: EIA.fetch_consumption
   consumptionForecast: EIA.fetch_consumption_forecast

--- a/config/zones/US-CAL-CISO.yaml
+++ b/config/zones/US-CAL-CISO.yaml
@@ -1345,6 +1345,9 @@ fallbackZoneMixes:
         solar: 0.2087720447881934
         unknown: 0.011761931454553983
         wind: 0.10376508129748757
+
+hide_day_ahead_price: False
+has_day_ahead_price_license: False
 parsers:
   consumption: US_CA.fetch_consumption
   consumptionForecast: US_CA.fetch_consumption_forecast

--- a/config/zones/US-CAL-IID.yaml
+++ b/config/zones/US-CAL-IID.yaml
@@ -456,6 +456,9 @@ fallbackZoneMixes:
         solar: 0.19955958985702552
         unknown: 0.5019581065707984
         wind: 0.0053857770760136646
+
+hide_day_ahead_price: False
+has_day_ahead_price_license: False
 parsers:
   consumption: EIA.fetch_consumption
   consumptionForecast: EIA.fetch_consumption_forecast

--- a/config/zones/US-CAL-LDWP.yaml
+++ b/config/zones/US-CAL-LDWP.yaml
@@ -536,6 +536,9 @@ fallbackZoneMixes:
         solar: 0.14848782977762862
         unknown: 0.05077467246281746
         wind: 0.07888732648126635
+
+hide_day_ahead_price: False
+has_day_ahead_price_license: False
 parsers:
   consumption: EIA.fetch_consumption
   consumptionForecast: EIA.fetch_consumption_forecast

--- a/config/zones/US-CAL-TIDC.yaml
+++ b/config/zones/US-CAL-TIDC.yaml
@@ -352,6 +352,9 @@ fallbackZoneMixes:
         solar: 0.05005126712516857
         unknown: 0.002653244487787362
         wind: 0.025510983164008797
+
+hide_day_ahead_price: False
+has_day_ahead_price_license: False
 parsers:
   consumption: EIA.fetch_consumption
   consumptionForecast: EIA.fetch_consumption_forecast

--- a/config/zones/US-CAR-CPLE.yaml
+++ b/config/zones/US-CAR-CPLE.yaml
@@ -571,6 +571,9 @@ fallbackZoneMixes:
         solar: 0.07846100156349965
         unknown: 0.11024049856981802
         wind: 0.00029901388079216223
+
+hide_day_ahead_price: False
+has_day_ahead_price_license: False
 parsers:
   consumption: EIA.fetch_consumption
   consumptionForecast: EIA.fetch_consumption_forecast

--- a/config/zones/US-CAR-CPLW.yaml
+++ b/config/zones/US-CAR-CPLW.yaml
@@ -362,6 +362,9 @@ fallbackZoneMixes:
         solar: 0.007221289168419903
         unknown: 0.22612240607665954
         wind: 0.003138998527429385
+
+hide_day_ahead_price: False
+has_day_ahead_price_license: False
 parsers:
   consumption: EIA.fetch_consumption
   consumptionForecast: EIA.fetch_consumption_forecast

--- a/config/zones/US-CAR-DUK.yaml
+++ b/config/zones/US-CAR-DUK.yaml
@@ -647,6 +647,9 @@ fallbackZoneMixes:
         solar: 0.022160483501947582
         unknown: 0.004072615591024879
         wind: 0.00017802609034428662
+
+hide_day_ahead_price: False
+has_day_ahead_price_license: False
 parsers:
   consumption: EIA.fetch_consumption
   consumptionForecast: EIA.fetch_consumption_forecast

--- a/config/zones/US-CAR-SC.yaml
+++ b/config/zones/US-CAR-SC.yaml
@@ -424,6 +424,9 @@ fallbackZoneMixes:
         solar: 0.03903642520721052
         unknown: 0.020343396555049083
         wind: 0.00013469670798902004
+
+hide_day_ahead_price: False
+has_day_ahead_price_license: False
 parsers:
   consumption: EIA.fetch_consumption
   consumptionForecast: EIA.fetch_consumption_forecast

--- a/config/zones/US-CAR-SCEG.yaml
+++ b/config/zones/US-CAR-SCEG.yaml
@@ -518,6 +518,9 @@ fallbackZoneMixes:
         solar: 0.06997543369820834
         unknown: 0.00226721784513369
         wind: 0.00011411094674027499
+
+hide_day_ahead_price: False
+has_day_ahead_price_license: False
 parsers:
   consumption: EIA.fetch_consumption
   consumptionForecast: EIA.fetch_consumption_forecast

--- a/config/zones/US-CAR-YAD.yaml
+++ b/config/zones/US-CAR-YAD.yaml
@@ -335,6 +335,9 @@ fallbackZoneMixes:
         unknown: 0.009028395450014926
         wind: 5.400311345117666e-05
 generation_only: true
+
+hide_day_ahead_price: False
+has_day_ahead_price_license: False
 parsers:
   production: EIA.fetch_production_mix
   productionCapacity: EIA.fetch_production_capacity

--- a/config/zones/US-CENT-SPA.yaml
+++ b/config/zones/US-CENT-SPA.yaml
@@ -394,6 +394,9 @@ fallbackZoneMixes:
         solar: 0.0007941509621297181
         unknown: 0.00020702289645406453
         wind: 0.09255513661771894
+
+hide_day_ahead_price: False
+has_day_ahead_price_license: False
 parsers:
   consumption: EIA.fetch_consumption
   consumptionForecast: EIA.fetch_consumption_forecast

--- a/config/zones/US-CENT-SWPP.yaml
+++ b/config/zones/US-CENT-SWPP.yaml
@@ -988,6 +988,9 @@ fallbackZoneMixes:
         solar: 0.005079625055022232
         unknown: 0.0010075414538685166
         wind: 0.3731861627814639
+
+hide_day_ahead_price: False
+has_day_ahead_price_license: False
 parsers:
   consumption: EIA.fetch_consumption
   consumptionForecast: US_SPP.fetch_load_forecast

--- a/config/zones/US-FLA-FMPP.yaml
+++ b/config/zones/US-FLA-FMPP.yaml
@@ -407,6 +407,9 @@ fallbackZoneMixes:
         solar: 0.0368809604380467
         unknown: 0.015569004071754993
         wind: 9.010623577192186e-07
+
+hide_day_ahead_price: False
+has_day_ahead_price_license: False
 parsers:
   consumption: EIA.fetch_consumption
   consumptionForecast: EIA.fetch_consumption_forecast

--- a/config/zones/US-FLA-FPC.yaml
+++ b/config/zones/US-FLA-FPC.yaml
@@ -531,6 +531,9 @@ fallbackZoneMixes:
         solar: 0.06154519216648502
         unknown: 0.013010176598688486
         wind: 2.9803827190777754e-06
+
+hide_day_ahead_price: False
+has_day_ahead_price_license: False
 parsers:
   consumption: EIA.fetch_consumption
   consumptionForecast: EIA.fetch_consumption_forecast

--- a/config/zones/US-FLA-FPL.yaml
+++ b/config/zones/US-FLA-FPL.yaml
@@ -521,6 +521,9 @@ fallbackZoneMixes:
         solar: 0.08298619272945335
         unknown: 0.012097789251635535
         wind: 6.811091115586069e-06
+
+hide_day_ahead_price: False
+has_day_ahead_price_license: False
 parsers:
   consumption: EIA.fetch_consumption
   consumptionForecast: EIA.fetch_consumption_forecast

--- a/config/zones/US-FLA-GVL.yaml
+++ b/config/zones/US-FLA-GVL.yaml
@@ -400,6 +400,9 @@ fallbackZoneMixes:
         solar: 0.013042625162602153
         unknown: 0.11396378457777641
         wind: 2.896411969264126e-08
+
+hide_day_ahead_price: False
+has_day_ahead_price_license: False
 parsers:
   consumption: EIA.fetch_consumption
   consumptionForecast: EIA.fetch_consumption_forecast

--- a/config/zones/US-FLA-HST.yaml
+++ b/config/zones/US-FLA-HST.yaml
@@ -262,6 +262,9 @@ fallbackZoneMixes:
         solar: 0.07917294590011055
         unknown: 0.011817913330246848
         wind: 6.837217748385479e-07
+
+hide_day_ahead_price: False
+has_day_ahead_price_license: False
 parsers:
   consumption: EIA.fetch_consumption
   consumptionForecast: EIA.fetch_consumption_forecast

--- a/config/zones/US-FLA-JEA.yaml
+++ b/config/zones/US-FLA-JEA.yaml
@@ -397,6 +397,9 @@ fallbackZoneMixes:
         solar: 0.031205014645403553
         unknown: 0.005181076347993189
         wind: 1.9070981072641493e-06
+
+hide_day_ahead_price: False
+has_day_ahead_price_license: False
 parsers:
   consumption: EIA.fetch_consumption
   consumptionForecast: EIA.fetch_consumption_forecast

--- a/config/zones/US-FLA-SEC.yaml
+++ b/config/zones/US-FLA-SEC.yaml
@@ -380,6 +380,9 @@ fallbackZoneMixes:
         solar: 0.0018365194344341143
         unknown: 0.0011848510985980577
         wind: 0.0
+
+hide_day_ahead_price: False
+has_day_ahead_price_license: False
 parsers:
   consumption: EIA.fetch_consumption
   consumptionForecast: EIA.fetch_consumption_forecast

--- a/config/zones/US-FLA-TAL.yaml
+++ b/config/zones/US-FLA-TAL.yaml
@@ -370,6 +370,9 @@ fallbackZoneMixes:
         solar: 0.03144300360124301
         unknown: 0.0013693576112433338
         wind: 5.8680114373449385e-05
+
+hide_day_ahead_price: False
+has_day_ahead_price_license: False
 parsers:
   consumption: EIA.fetch_consumption
   consumptionForecast: EIA.fetch_consumption_forecast

--- a/config/zones/US-FLA-TEC.yaml
+++ b/config/zones/US-FLA-TEC.yaml
@@ -497,6 +497,9 @@ fallbackZoneMixes:
         solar: 0.07957197028145203
         unknown: 0.042028149676762994
         wind: 3.5736466234930727e-07
+
+hide_day_ahead_price: False
+has_day_ahead_price_license: False
 parsers:
   consumption: EIA.fetch_consumption
   consumptionForecast: EIA.fetch_consumption_forecast

--- a/config/zones/US-HI.yaml
+++ b/config/zones/US-HI.yaml
@@ -3,3 +3,6 @@ region: Americas
 timezone: Pacific/Honolulu
 zone_name: Hawaii
 country_name: USA
+
+hide_day_ahead_price: False
+has_day_ahead_price_license: False

--- a/config/zones/US-MIDA-PJM.yaml
+++ b/config/zones/US-MIDA-PJM.yaml
@@ -1468,6 +1468,9 @@ fallbackZoneMixes:
         solar: 0.019468248300301277
         unknown: 0.006730017008187237
         wind: 0.03655739992719188
+
+hide_day_ahead_price: False
+has_day_ahead_price_license: False
 parsers:
   consumption: EIA.fetch_consumption
   consumptionForecast: US_PJM.fetch_consumption_forecast

--- a/config/zones/US-MIDW-AECI.yaml
+++ b/config/zones/US-MIDW-AECI.yaml
@@ -402,6 +402,9 @@ fallbackZoneMixes:
         solar: 0.0007432069047526604
         unknown: 0.000170699564045901
         wind: 0.15032435976680825
+
+hide_day_ahead_price: False
+has_day_ahead_price_license: False
 parsers:
   consumption: EIA.fetch_consumption
   consumptionForecast: EIA.fetch_consumption_forecast

--- a/config/zones/US-MIDW-LGEE.yaml
+++ b/config/zones/US-MIDW-LGEE.yaml
@@ -400,6 +400,9 @@ fallbackZoneMixes:
         solar: 0.0031590859818130075
         unknown: 0.0005828551896878398
         wind: 0.013273336745387228
+
+hide_day_ahead_price: False
+has_day_ahead_price_license: False
 parsers:
   consumption: EIA.fetch_consumption
   consumptionForecast: EIA.fetch_consumption_forecast

--- a/config/zones/US-MIDW-MISO.yaml
+++ b/config/zones/US-MIDW-MISO.yaml
@@ -1549,6 +1549,9 @@ fallbackZoneMixes:
         solar: 0.022179358971239873
         unknown: 0.004320188500399502
         wind: 0.14722782107459684
+
+hide_day_ahead_price: False
+has_day_ahead_price_license: False
 parsers:
   consumption: EIA.fetch_consumption
   consumptionForecast: US_MISO.fetch_consumption_forecast

--- a/config/zones/US-NE-ISNE.yaml
+++ b/config/zones/US-NE-ISNE.yaml
@@ -1172,6 +1172,9 @@ fallbackZoneMixes:
         solar: 0.011149182093012062
         unknown: 0.007120449441312479
         wind: 0.035357632711841926
+
+hide_day_ahead_price: False
+has_day_ahead_price_license: False
 parsers:
   consumption: EIA.fetch_consumption
   consumptionForecast: US_NEISO.fetch_consumption_forecast

--- a/config/zones/US-NW-AVA.yaml
+++ b/config/zones/US-NW-AVA.yaml
@@ -366,6 +366,9 @@ fallbackZoneMixes:
         solar: 0.013233373069032616
         unknown: 0.07274019668392667
         wind: 0.1020901076480728
+
+hide_day_ahead_price: False
+has_day_ahead_price_license: False
 parsers:
   consumption: EIA.fetch_consumption
   consumptionForecast: EIA.fetch_consumption_forecast

--- a/config/zones/US-NW-BPAT.yaml
+++ b/config/zones/US-NW-BPAT.yaml
@@ -491,6 +491,9 @@ fallbackZoneMixes:
         solar: 0.01534628263467043
         unknown: 0.01967825129629526
         wind: 0.11366870003676838
+
+hide_day_ahead_price: False
+has_day_ahead_price_license: False
 parsers:
   consumption: EIA.fetch_consumption
   consumptionForecast: EIA.fetch_consumption_forecast

--- a/config/zones/US-NW-CHPD.yaml
+++ b/config/zones/US-NW-CHPD.yaml
@@ -357,6 +357,9 @@ fallbackZoneMixes:
         solar: 0.00035588491866325164
         unknown: 0.0008210560429239747
         wind: 0.005898109136322696
+
+hide_day_ahead_price: False
+has_day_ahead_price_license: False
 parsers:
   consumption: EIA.fetch_consumption
   consumptionForecast: EIA.fetch_consumption_forecast

--- a/config/zones/US-NW-DOPD.yaml
+++ b/config/zones/US-NW-DOPD.yaml
@@ -348,6 +348,9 @@ fallbackZoneMixes:
         solar: 0.0012093544053328976
         unknown: 0.0019158823758407704
         wind: 0.011036652293410701
+
+hide_day_ahead_price: False
+has_day_ahead_price_license: False
 parsers:
   consumption: EIA.fetch_consumption
   consumptionForecast: EIA.fetch_consumption_forecast

--- a/config/zones/US-NW-GCPD.yaml
+++ b/config/zones/US-NW-GCPD.yaml
@@ -327,6 +327,9 @@ fallbackZoneMixes:
         solar: 0.003397736152506443
         unknown: 0.007256839403228985
         wind: 0.02850043238030508
+
+hide_day_ahead_price: False
+has_day_ahead_price_license: False
 parsers:
   consumption: EIA.fetch_consumption
   consumptionForecast: EIA.fetch_consumption_forecast

--- a/config/zones/US-NW-GRID.yaml
+++ b/config/zones/US-NW-GRID.yaml
@@ -344,6 +344,9 @@ fallbackZoneMixes:
         unknown: 2.204823712007215e-06
         wind: 0.11728828923384033
 generation_only: true
+
+hide_day_ahead_price: False
+has_day_ahead_price_license: False
 parsers:
   production: EIA.fetch_production_mix
   productionCapacity: EIA.fetch_production_capacity

--- a/config/zones/US-NW-IPCO.yaml
+++ b/config/zones/US-NW-IPCO.yaml
@@ -502,6 +502,9 @@ fallbackZoneMixes:
         solar: 0.0871122427942582
         unknown: 0.026889556885679546
         wind: 0.13662238355509054
+
+hide_day_ahead_price: False
+has_day_ahead_price_license: False
 parsers:
   consumption: EIA.fetch_consumption
   consumptionForecast: EIA.fetch_consumption_forecast

--- a/config/zones/US-NW-NEVP.yaml
+++ b/config/zones/US-NW-NEVP.yaml
@@ -559,6 +559,9 @@ fallbackZoneMixes:
         solar: 0.14888842263053334
         unknown: 0.09266477904536434
         wind: 0.030996482747352047
+
+hide_day_ahead_price: False
+has_day_ahead_price_license: False
 parsers:
   consumption: EIA.fetch_consumption
   consumptionForecast: EIA.fetch_consumption_forecast

--- a/config/zones/US-NW-NWMT.yaml
+++ b/config/zones/US-NW-NWMT.yaml
@@ -467,6 +467,9 @@ fallbackZoneMixes:
         solar: 0.024043798598998
         unknown: 0.0013187296690682232
         wind: 0.24723499458575396
+
+hide_day_ahead_price: False
+has_day_ahead_price_license: False
 parsers:
   consumption: EIA.fetch_consumption
   consumptionForecast: EIA.fetch_consumption_forecast

--- a/config/zones/US-NW-PACE.yaml
+++ b/config/zones/US-NW-PACE.yaml
@@ -569,6 +569,9 @@ fallbackZoneMixes:
         solar: 0.07690011096176308
         unknown: 0.018316593815589824
         wind: 0.16803287999854508
+
+hide_day_ahead_price: False
+has_day_ahead_price_license: False
 parsers:
   consumption: EIA.fetch_consumption
   consumptionForecast: EIA.fetch_consumption_forecast

--- a/config/zones/US-NW-PACW.yaml
+++ b/config/zones/US-NW-PACW.yaml
@@ -474,6 +474,9 @@ fallbackZoneMixes:
         solar: 0.05754511705279815
         unknown: 0.028237803048731375
         wind: 0.14522387099354464
+
+hide_day_ahead_price: False
+has_day_ahead_price_license: False
 parsers:
   consumption: EIA.fetch_consumption
   consumptionForecast: EIA.fetch_consumption_forecast

--- a/config/zones/US-NW-PGE.yaml
+++ b/config/zones/US-NW-PGE.yaml
@@ -453,6 +453,9 @@ fallbackZoneMixes:
         solar: 0.01084136274033947
         unknown: 0.01600995200693216
         wind: 0.07587504128718962
+
+hide_day_ahead_price: False
+has_day_ahead_price_license: False
 parsers:
   consumption: EIA.fetch_consumption
   consumptionForecast: EIA.fetch_consumption_forecast

--- a/config/zones/US-NW-PSCO.yaml
+++ b/config/zones/US-NW-PSCO.yaml
@@ -584,6 +584,9 @@ fallbackZoneMixes:
         solar: 0.08238639648109145
         unknown: 0.00015659958496450446
         wind: 0.3064469544491784
+
+hide_day_ahead_price: False
+has_day_ahead_price_license: False
 parsers:
   consumption: EIA.fetch_consumption
   consumptionForecast: EIA.fetch_consumption_forecast

--- a/config/zones/US-NW-PSEI.yaml
+++ b/config/zones/US-NW-PSEI.yaml
@@ -391,6 +391,9 @@ fallbackZoneMixes:
         solar: 0.011671150973628582
         unknown: 0.021450705959756258
         wind: 0.13619023487744694
+
+hide_day_ahead_price: False
+has_day_ahead_price_license: False
 parsers:
   consumption: EIA.fetch_consumption
   consumptionForecast: EIA.fetch_consumption_forecast

--- a/config/zones/US-NW-SCL.yaml
+++ b/config/zones/US-NW-SCL.yaml
@@ -333,6 +333,9 @@ fallbackZoneMixes:
         solar: 0.0
         unknown: 0.0
         wind: 0.0
+
+hide_day_ahead_price: False
+has_day_ahead_price_license: False
 parsers:
   consumption: EIA.fetch_consumption
   consumptionForecast: EIA.fetch_consumption_forecast

--- a/config/zones/US-NW-TPWR.yaml
+++ b/config/zones/US-NW-TPWR.yaml
@@ -333,6 +333,9 @@ fallbackZoneMixes:
         solar: 0.010409492784066799
         unknown: 0.01329162443563458
         wind: 0.07528960567889836
+
+hide_day_ahead_price: False
+has_day_ahead_price_license: False
 parsers:
   consumption: EIA.fetch_consumption
   consumptionForecast: EIA.fetch_consumption_forecast

--- a/config/zones/US-NW-WACM.yaml
+++ b/config/zones/US-NW-WACM.yaml
@@ -600,6 +600,9 @@ fallbackZoneMixes:
         solar: 0.04683928497071764
         unknown: 0.0027340384044213656
         wind: 0.1680123086368647
+
+hide_day_ahead_price: False
+has_day_ahead_price_license: False
 parsers:
   consumption: EIA.fetch_consumption
   consumptionForecast: EIA.fetch_consumption_forecast

--- a/config/zones/US-NW-WAUW.yaml
+++ b/config/zones/US-NW-WAUW.yaml
@@ -340,6 +340,9 @@ fallbackZoneMixes:
         solar: 0.002805509442865646
         unknown: 0.0008318185444866423
         wind: 0.24090125758590733
+
+hide_day_ahead_price: False
+has_day_ahead_price_license: False
 parsers:
   consumption: EIA.fetch_consumption
   consumptionForecast: EIA.fetch_consumption_forecast

--- a/config/zones/US-NY-NYIS.yaml
+++ b/config/zones/US-NY-NYIS.yaml
@@ -965,6 +965,9 @@ fallbackZoneMixes:
         solar: 0.000687284047628341
         unknown: 0.01756555009051059
         wind: 0.03966033748337813
+
+hide_day_ahead_price: False
+has_day_ahead_price_license: False
 parsers:
   consumption: EIA.fetch_consumption
   consumptionForecast: US_NY.fetch_consumption_forecast

--- a/config/zones/US-SE-SEPA.yaml
+++ b/config/zones/US-SE-SEPA.yaml
@@ -278,6 +278,9 @@ fallbackZoneMixes:
         unknown: 0.014598611119213888
         wind: 0.00011062991419915504
 generation_only: true
+
+hide_day_ahead_price: False
+has_day_ahead_price_license: False
 parsers:
   production: EIA.fetch_production_mix
   productionCapacity: EIA.fetch_production_capacity

--- a/config/zones/US-SE-SOCO.yaml
+++ b/config/zones/US-SE-SOCO.yaml
@@ -765,6 +765,9 @@ fallbackZoneMixes:
         solar: 0.03388584704198945
         unknown: 0.010455775763807308
         wind: 0.00037636503223176254
+
+hide_day_ahead_price: False
+has_day_ahead_price_license: False
 parsers:
   consumption: EIA.fetch_consumption
   consumptionForecast: EIA.fetch_consumption_forecast

--- a/config/zones/US-SW-AZPS.yaml
+++ b/config/zones/US-SW-AZPS.yaml
@@ -479,6 +479,9 @@ fallbackZoneMixes:
         solar: 0.05310475524020144
         unknown: 0.009288429954751765
         wind: 0.05223583306779387
+
+hide_day_ahead_price: False
+has_day_ahead_price_license: False
 parsers:
   consumption: EIA.fetch_consumption
   consumptionForecast: EIA.fetch_consumption_forecast

--- a/config/zones/US-SW-EPE.yaml
+++ b/config/zones/US-SW-EPE.yaml
@@ -377,6 +377,9 @@ fallbackZoneMixes:
         solar: 0.09135509153496706
         unknown: 0.0017100778771663165
         wind: 0.13304699157269873
+
+hide_day_ahead_price: False
+has_day_ahead_price_license: False
 parsers:
   consumption: EIA.fetch_consumption
   consumptionForecast: EIA.fetch_consumption_forecast

--- a/config/zones/US-SW-PNM.yaml
+++ b/config/zones/US-SW-PNM.yaml
@@ -534,6 +534,9 @@ fallbackZoneMixes:
         solar: 0.09317128158024654
         unknown: 0.005706052023268491
         wind: 0.3386034024377126
+
+hide_day_ahead_price: False
+has_day_ahead_price_license: False
 parsers:
   consumption: EIA.fetch_consumption
   consumptionForecast: EIA.fetch_consumption_forecast

--- a/config/zones/US-SW-SRP.yaml
+++ b/config/zones/US-SW-SRP.yaml
@@ -441,6 +441,9 @@ fallbackZoneMixes:
         solar: 0.028391651449343587
         unknown: 0.0006835290063331449
         wind: 0.008596420205364573
+
+hide_day_ahead_price: False
+has_day_ahead_price_license: False
 parsers:
   consumption: EIA.fetch_consumption
   consumptionForecast: EIA.fetch_consumption_forecast

--- a/config/zones/US-SW-TEPC.yaml
+++ b/config/zones/US-SW-TEPC.yaml
@@ -408,6 +408,9 @@ fallbackZoneMixes:
         solar: 0.07786897710286665
         unknown: 0.0025693853856152958
         wind: 0.10338034646937623
+
+hide_day_ahead_price: False
+has_day_ahead_price_license: False
 parsers:
   consumption: EIA.fetch_consumption
   consumptionForecast: EIA.fetch_consumption_forecast

--- a/config/zones/US-SW-WALC.yaml
+++ b/config/zones/US-SW-WALC.yaml
@@ -409,6 +409,9 @@ fallbackZoneMixes:
         solar: 0.05133000190223975
         unknown: 0.006238086068185822
         wind: 0.06749767730316335
+
+hide_day_ahead_price: False
+has_day_ahead_price_license: False
 parsers:
   consumption: EIA.fetch_consumption
   consumptionForecast: EIA.fetch_consumption_forecast

--- a/config/zones/US-TEN-TVA.yaml
+++ b/config/zones/US-TEN-TVA.yaml
@@ -566,6 +566,9 @@ fallbackZoneMixes:
         solar: 0.010567272522676962
         unknown: 0.006034844645347208
         wind: 0.01264416307073402
+
+hide_day_ahead_price: False
+has_day_ahead_price_license: False
 parsers:
   consumption: EIA.fetch_consumption
   consumptionForecast: EIA.fetch_consumption_forecast

--- a/config/zones/US-TEX-ERCO.yaml
+++ b/config/zones/US-TEX-ERCO.yaml
@@ -1141,6 +1141,9 @@ fallbackZoneMixes:
         solar: 0.07115076013356555
         unknown: 0.0026028574593210904
         wind: 0.24233286045039404
+
+hide_day_ahead_price: False
+has_day_ahead_price_license: False
 parsers:
   consumption: US_ERCOT.fetch_consumption
   consumptionForecast: US_ERCOT.fetch_consumption_forecast

--- a/config/zones/US.yaml
+++ b/config/zones/US.yaml
@@ -409,6 +409,9 @@ fallbackZoneMixes:
         solar: 0.036972927459937105
         unknown: 0.017414508337906885
         wind: 0.10517083862296002
+
+hide_day_ahead_price: False
+has_day_ahead_price_license: False
 parsers:
   productionCapacity: EMBER.fetch_production_capacity
 region: Americas

--- a/config/zones/UY.yaml
+++ b/config/zones/UY.yaml
@@ -325,6 +325,9 @@ fallbackZoneMixes:
         solar: 0.03225785414410065
         unknown: 0.0002458679526720795
         wind: 0.3311423018301735
+
+hide_day_ahead_price: False
+has_day_ahead_price_license: False
 parsers:
   consumption: UY.fetch_consumption
   production: UY.fetch_production

--- a/config/zones/UZ.yaml
+++ b/config/zones/UZ.yaml
@@ -30,3 +30,6 @@ timezone: Asia/Samarkand
 zone_name: Uzbekistan
 country_name: Uzbekistan
 currency: UZS
+
+hide_day_ahead_price: False
+has_day_ahead_price_license: False

--- a/config/zones/VC.yaml
+++ b/config/zones/VC.yaml
@@ -21,6 +21,9 @@ capacity:
       source: Ember, Yearly electricity data
       value: 50.0
 country: VC
+
+hide_day_ahead_price: False
+has_day_ahead_price_license: False
 parsers:
   productionCapacity: EMBER.fetch_production_capacity
 region: Americas

--- a/config/zones/VE.yaml
+++ b/config/zones/VE.yaml
@@ -53,6 +53,9 @@ capacity:
       source: Ember, Yearly electricity data
       value: 50.0
 country: VE
+
+hide_day_ahead_price: False
+has_day_ahead_price_license: False
 parsers:
   productionCapacity: EMBER.fetch_production_capacity
 region: Americas

--- a/config/zones/VI.yaml
+++ b/config/zones/VI.yaml
@@ -18,6 +18,9 @@ capacity:
       source: Ember, Yearly electricity data
       value: 0.0
 country: VI
+
+hide_day_ahead_price: False
+has_day_ahead_price_license: False
 parsers:
   productionCapacity: EMBER.fetch_production_capacity
 region: Americas

--- a/config/zones/VN.yaml
+++ b/config/zones/VN.yaml
@@ -165,6 +165,9 @@ isRenewable:
       source: EMBER 2022; assumes 38.76% coal, 36.91% hydro, 10.68% gas, 10.14% solar,
         3.09% wind, 0.14% biomass and 0.27% from other thermal
       value: 0.5028
+
+hide_day_ahead_price: False
+has_day_ahead_price_license: False
 parsers:
   consumption: VN.fetch_consumption
   price: VN.fetch_price

--- a/config/zones/VU.yaml
+++ b/config/zones/VU.yaml
@@ -23,6 +23,9 @@ capacity:
       source: Ember, Yearly electricity data
       value: 0.0
 country: VU
+
+hide_day_ahead_price: False
+has_day_ahead_price_license: False
 parsers:
   productionCapacity: EMBER.fetch_production_capacity
 region: Oceania

--- a/config/zones/WS.yaml
+++ b/config/zones/WS.yaml
@@ -26,6 +26,9 @@ capacity:
       source: Ember, Yearly electricity data
       value: 0.0
 country: WS
+
+hide_day_ahead_price: False
+has_day_ahead_price_license: False
 parsers:
   productionCapacity: EMBER.fetch_production_capacity
 region: Oceania

--- a/config/zones/XK.yaml
+++ b/config/zones/XK.yaml
@@ -209,6 +209,9 @@ fallbackZoneMixes:
         solar: 0.01435756790059774
         unknown: 0.002092146765935501
         wind: 0.0196257037300602
+
+hide_day_ahead_price: False
+has_day_ahead_price_license: False
 parsers:
   consumption: ENTSOE.fetch_consumption
   consumptionForecast: ENTSOE.fetch_consumption_forecast

--- a/config/zones/XX.yaml
+++ b/config/zones/XX.yaml
@@ -3,3 +3,6 @@ region: Europe
 timezone: Asia/Nicosia
 zone_name: Northern Cyprus
 country_name: Northern Cyprus
+
+hide_day_ahead_price: False
+has_day_ahead_price_license: False

--- a/config/zones/YE.yaml
+++ b/config/zones/YE.yaml
@@ -45,6 +45,9 @@ capacity:
       source: Ember, Yearly electricity data
       value: 1400.0
 country: YE
+
+hide_day_ahead_price: False
+has_day_ahead_price_license: False
 parsers:
   productionCapacity: EMBER.fetch_production_capacity
 region: Asia

--- a/config/zones/YT.yaml
+++ b/config/zones/YT.yaml
@@ -28,6 +28,9 @@ capacity:
       source: IRENA.org
       value: 31.23
 country: YT
+
+hide_day_ahead_price: False
+has_day_ahead_price_license: False
 parsers:
   productionCapacity: IRENA.fetch_production_capacity
 region: Africa

--- a/config/zones/ZA.yaml
+++ b/config/zones/ZA.yaml
@@ -368,6 +368,9 @@ isLowCarbon:
 isRenewable:
   unknown:
     value: 1
+
+hide_day_ahead_price: False
+has_day_ahead_price_license: False
 parsers:
   production: ESKOM.fetch_production
   productionCapacity: EMBER.fetch_production_capacity

--- a/config/zones/ZM.yaml
+++ b/config/zones/ZM.yaml
@@ -51,6 +51,9 @@ fallbackZoneMixes:
       coal: 0.11
       hydro: 0.83
       oil: 0.06
+
+hide_day_ahead_price: False
+has_day_ahead_price_license: False
 parsers:
   productionCapacity: EMBER.fetch_production_capacity
 region: Africa

--- a/config/zones/ZW.yaml
+++ b/config/zones/ZW.yaml
@@ -40,6 +40,9 @@ capacity:
       source: Ember, Yearly electricity data
       value: 10.0
 country: ZW
+
+hide_day_ahead_price: False
+has_day_ahead_price_license: False
 parsers:
   productionCapacity: EMBER.fetch_production_capacity
 region: Africa

--- a/electricitymap/contrib/config/model.py
+++ b/electricitymap/contrib/config/model.py
@@ -139,6 +139,7 @@ class Zone(StrictBaseModelWithAlias):
     price_displayed: bool | None
     generation_only: bool | None
     has_day_ahead_price_license: bool | None
+    hide_day_ahead_price: bool | None
     sub_zone_names: list[ZoneKey] | None = Field(None, alias="subZoneNames")
     timezone: str | None
     key: ZoneKey  # This is not part of zones/{zone_key}.yaml, but added here to enable self referencing


### PR DESCRIPTION
## Issue

- Added hide_day_ahead_price: False to all 388 YAML files in config/zones/
- Added has_day_ahead_price_license: False to the 349 files that didn't already have it (39 files already had it set to True)
- Updated the data model by adding hide_day_ahead_price: bool | None to the Zone class in electricitymap/contrib/config/model.py

- [x] I have run `pnpx prettier@2 --write .` and `poetry run format` in the top level directory to format my changes.

Context: https://electricitymaps.slack.com/archives/C0A3Q8EB9SB/p1765980430378149
