### PR TITLE
fix(emission-factors): remove 2014 ipcc entry for lifecycle coal and oil

### DIFF
--- a/config/zones/US-CAL-BANC.yaml
+++ b/config/zones/US-CAL-BANC.yaml
@@ -311,9 +311,6 @@ emissionFactors:
       source: eGrid 2023
       value: 282.7016835752059
     coal:
-    - datetime: '2014-01-01'
-      source: IPCC 2014
-      value: 820.0
     - _comment: Mean of all US zones
       datetime: '2020-01-01'
       source: eGrid 2020; IPCC 2014
@@ -392,9 +389,6 @@ emissionFactors:
       source: Electricity Maps, 2024 average
       value: 272.14
     oil:
-    - datetime: '2014-01-01'
-      source: IPCC 2014; EIA 2020/BEIS 2021
-      value: 650.0
     - _comment: Mean of all US zones
       datetime: '2020-01-01'
       source: eGrid 2020; IPCC 2014

--- a/config/zones/US-CAL-IID.yaml
+++ b/config/zones/US-CAL-IID.yaml
@@ -310,9 +310,6 @@ emissionFactors:
       source: eGrid 2023
       value: 282.7016835752059
     coal:
-    - datetime: '2014-01-01'
-      source: IPCC 2014
-      value: 820.0
     - _comment: Mean of all US zones
       datetime: '2020-01-01'
       source: eGrid 2020; IPCC 2014
@@ -387,9 +384,6 @@ emissionFactors:
       source: Electricity Maps, 2024 average
       value: 368.76
     oil:
-    - datetime: '2014-01-01'
-      source: IPCC 2014; EIA 2020/BEIS 2021
-      value: 650.0
     - _comment: Mean of all US zones
       datetime: '2020-01-01'
       source: eGrid 2020; IPCC 2014

--- a/config/zones/US-CAL-LDWP.yaml
+++ b/config/zones/US-CAL-LDWP.yaml
@@ -468,9 +468,6 @@ emissionFactors:
       source: Electricity Maps, 2024 average
       value: 375.4
     oil:
-    - datetime: '2014-01-01'
-      source: IPCC 2014; EIA 2020/BEIS 2021
-      value: 650.0
     - _comment: Mean of all US zones
       datetime: '2020-01-01'
       source: eGrid 2020; IPCC 2014

--- a/config/zones/US-CAL-TIDC.yaml
+++ b/config/zones/US-CAL-TIDC.yaml
@@ -242,9 +242,6 @@ emissionFactors:
       source: eGrid 2023
       value: 282.7016835752059
     coal:
-    - datetime: '2014-01-01'
-      source: IPCC 2014
-      value: 820.0
     - _comment: Mean of all US zones
       datetime: '2020-01-01'
       source: eGrid 2020; IPCC 2014
@@ -323,9 +320,6 @@ emissionFactors:
       source: Electricity Maps, 2024 average
       value: 395.13
     oil:
-    - datetime: '2014-01-01'
-      source: IPCC 2014; EIA 2020/BEIS 2021
-      value: 650.0
     - _comment: Mean of all US zones
       datetime: '2020-01-01'
       source: eGrid 2020; IPCC 2014

--- a/config/zones/US-CAR-CPLE.yaml
+++ b/config/zones/US-CAR-CPLE.yaml
@@ -501,9 +501,6 @@ emissionFactors:
       source: Electricity Maps, 2024 average
       value: 347.02
     oil:
-    - datetime: '2014-01-01'
-      source: IPCC 2014; EIA 2020/BEIS 2021
-      value: 650.0
     - _comment: Mean of all US zones
       datetime: '2020-01-01'
       source: eGrid 2020; IPCC 2014

--- a/config/zones/US-CAR-CPLW.yaml
+++ b/config/zones/US-CAR-CPLW.yaml
@@ -350,9 +350,6 @@ emissionFactors:
       source: Electricity Maps, 2024 average
       value: 518.03
     oil:
-    - datetime: '2014-01-01'
-      source: IPCC 2014; EIA 2020/BEIS 2021
-      value: 650.0
     - _comment: Mean of all US zones
       datetime: '2020-01-01'
       source: eGrid 2020; IPCC 2014

--- a/config/zones/US-CAR-DUK.yaml
+++ b/config/zones/US-CAR-DUK.yaml
@@ -592,9 +592,6 @@ emissionFactors:
       source: Electricity Maps, 2024 average
       value: 304.15
     oil:
-    - datetime: '2014-01-01'
-      source: IPCC 2014; EIA 2020/BEIS 2021
-      value: 650.0
     - _comment: Mean of all US zones
       datetime: '2020-01-01'
       source: eGrid 2020; IPCC 2014

--- a/config/zones/US-CAR-SC.yaml
+++ b/config/zones/US-CAR-SC.yaml
@@ -353,9 +353,6 @@ emissionFactors:
       source: Electricity Maps, 2024 average
       value: 667.22
     oil:
-    - datetime: '2014-01-01'
-      source: IPCC 2014; EIA 2020/BEIS 2021
-      value: 650.0
     - _comment: Mean of all US zones
       datetime: '2020-01-01'
       source: eGrid 2020; IPCC 2014

--- a/config/zones/US-CAR-SCEG.yaml
+++ b/config/zones/US-CAR-SCEG.yaml
@@ -447,9 +447,6 @@ emissionFactors:
       source: Electricity Maps, 2024 average
       value: 459.98
     oil:
-    - datetime: '2014-01-01'
-      source: IPCC 2014; EIA 2020/BEIS 2021
-      value: 650.0
     - _comment: Mean of all US zones
       datetime: '2020-01-01'
       source: eGrid 2020; IPCC 2014

--- a/config/zones/US-CAR-YAD.yaml
+++ b/config/zones/US-CAR-YAD.yaml
@@ -238,9 +238,6 @@ emissionFactors:
       source: eGrid 2023
       value: 282.7016835752059
     coal:
-    - datetime: '2014-01-01'
-      source: IPCC 2014
-      value: 820.0
     - _comment: Mean of all US zones
       datetime: '2020-01-01'
       source: eGrid 2020; IPCC 2014
@@ -326,9 +323,6 @@ emissionFactors:
       source: Electricity Maps, 2024 average
       value: 54.06
     oil:
-    - datetime: '2014-01-01'
-      source: IPCC 2014; EIA 2020/BEIS 2021
-      value: 650.0
     - _comment: Mean of all US zones
       datetime: '2020-01-01'
       source: eGrid 2020; IPCC 2014

--- a/config/zones/US-CENT-SPA.yaml
+++ b/config/zones/US-CENT-SPA.yaml
@@ -365,9 +365,6 @@ emissionFactors:
       source: Electricity Maps, 2024 average
       value: 124.83
     oil:
-    - datetime: '2014-01-01'
-      source: IPCC 2014; EIA 2020/BEIS 2021
-      value: 650.0
     - _comment: Mean of all US zones
       datetime: '2020-01-01'
       source: eGrid 2020; IPCC 2014

--- a/config/zones/US-FLA-FMPP.yaml
+++ b/config/zones/US-FLA-FMPP.yaml
@@ -345,9 +345,6 @@ emissionFactors:
       source: Electricity Maps, 2024 average
       value: 537.85
     oil:
-    - datetime: '2014-01-01'
-      source: IPCC 2014; EIA 2020/BEIS 2021
-      value: 650.0
     - _comment: Mean of all US zones
       datetime: '2020-01-01'
       source: eGrid 2020; IPCC 2014

--- a/config/zones/US-FLA-FPL.yaml
+++ b/config/zones/US-FLA-FPL.yaml
@@ -379,9 +379,6 @@ emissionFactors:
       source: eGrid 2023
       value: 282.7016835752059
     coal:
-    - datetime: '2014-01-01'
-      source: IPCC 2014
-      value: 820.0
     - _comment: Mean of all US zones
       datetime: '2020-01-01'
       source: eGrid 2020; IPCC 2014

--- a/config/zones/US-FLA-GVL.yaml
+++ b/config/zones/US-FLA-GVL.yaml
@@ -334,9 +334,6 @@ emissionFactors:
       source: Electricity Maps, 2024 average
       value: 573.1
     oil:
-    - datetime: '2014-01-01'
-      source: IPCC 2014; EIA 2020/BEIS 2021
-      value: 650.0
     - _comment: Mean of all US zones
       datetime: '2020-01-01'
       source: eGrid 2020; IPCC 2014

--- a/config/zones/US-FLA-HST.yaml
+++ b/config/zones/US-FLA-HST.yaml
@@ -202,9 +202,6 @@ emissionFactors:
       source: eGrid 2023
       value: 282.7016835752059
     coal:
-    - datetime: '2014-01-01'
-      source: IPCC 2014
-      value: 820.0
     - _comment: Mean of all US zones
       datetime: '2020-01-01'
       source: eGrid 2020; IPCC 2014
@@ -284,9 +281,6 @@ emissionFactors:
       source: Electricity Maps, 2024 average
       value: 370.79
     oil:
-    - datetime: '2014-01-01'
-      source: IPCC 2014; EIA 2020/BEIS 2021
-      value: 650.0
     - _comment: Mean of all US zones
       datetime: '2020-01-01'
       source: eGrid 2020; IPCC 2014

--- a/config/zones/US-FLA-JEA.yaml
+++ b/config/zones/US-FLA-JEA.yaml
@@ -350,9 +350,6 @@ emissionFactors:
       source: Electricity Maps, 2024 average
       value: 613.07
     oil:
-    - datetime: '2014-01-01'
-      source: IPCC 2014; EIA 2020/BEIS 2021
-      value: 650.0
     - _comment: Mean of all US zones
       datetime: '2020-01-01'
       source: eGrid 2020; IPCC 2014

--- a/config/zones/US-FLA-SEC.yaml
+++ b/config/zones/US-FLA-SEC.yaml
@@ -324,9 +324,6 @@ emissionFactors:
       source: Electricity Maps, 2024 average
       value: 592.15
     oil:
-    - datetime: '2014-01-01'
-      source: IPCC 2014; EIA 2020/BEIS 2021
-      value: 650.0
     - _comment: Mean of all US zones
       datetime: '2020-01-01'
       source: eGrid 2020; IPCC 2014

--- a/config/zones/US-FLA-TAL.yaml
+++ b/config/zones/US-FLA-TAL.yaml
@@ -260,9 +260,6 @@ emissionFactors:
       source: eGrid 2023
       value: 282.7016835752059
     coal:
-    - datetime: '2014-01-01'
-      source: IPCC 2014
-      value: 820.0
     - _comment: Mean of all US zones
       datetime: '2020-01-01'
       source: eGrid 2020; IPCC 2014
@@ -341,9 +338,6 @@ emissionFactors:
       source: Electricity Maps, 2024 average
       value: 462.47
     oil:
-    - datetime: '2014-01-01'
-      source: IPCC 2014; EIA 2020/BEIS 2021
-      value: 650.0
     - _comment: Mean of all US zones
       datetime: '2020-01-01'
       source: eGrid 2020; IPCC 2014

--- a/config/zones/US-FLA-TEC.yaml
+++ b/config/zones/US-FLA-TEC.yaml
@@ -438,9 +438,6 @@ emissionFactors:
       source: Electricity Maps, 2024 average
       value: 472.26
     oil:
-    - datetime: '2014-01-01'
-      source: IPCC 2014; EIA 2020/BEIS 2021
-      value: 650.0
     - _comment: Mean of all US zones
       datetime: '2020-01-01'
       source: eGrid 2020; IPCC 2014

--- a/config/zones/US-MIDW-AECI.yaml
+++ b/config/zones/US-MIDW-AECI.yaml
@@ -338,9 +338,6 @@ emissionFactors:
       source: Electricity Maps, 2024 average
       value: 615.16
     oil:
-    - datetime: '2014-01-01'
-      source: IPCC 2014; EIA 2020/BEIS 2021
-      value: 650.0
     - _comment: Mean of all US zones
       datetime: '2020-01-01'
       source: eGrid 2020; IPCC 2014

--- a/config/zones/US-MIDW-LGEE.yaml
+++ b/config/zones/US-MIDW-LGEE.yaml
@@ -348,9 +348,6 @@ emissionFactors:
       source: Electricity Maps, 2024 average
       value: 854.24
     oil:
-    - datetime: '2014-01-01'
-      source: IPCC 2014; EIA 2020/BEIS 2021
-      value: 650.0
     - _comment: Mean of all US zones
       datetime: '2020-01-01'
       source: eGrid 2020; IPCC 2014

--- a/config/zones/US-NW-AVA.yaml
+++ b/config/zones/US-NW-AVA.yaml
@@ -260,9 +260,6 @@ emissionFactors:
       source: eGrid 2023
       value: 282.7016835752059
     coal:
-    - datetime: '2014-01-01'
-      source: IPCC 2014
-      value: 820.0
     - _comment: Mean of all US zones
       datetime: '2020-01-01'
       source: eGrid 2020; IPCC 2014
@@ -338,9 +335,6 @@ emissionFactors:
       source: Electricity Maps, 2023 average
       value: 240.3
     oil:
-    - datetime: '2014-01-01'
-      source: IPCC 2014; EIA 2020/BEIS 2021
-      value: 650.0
     - _comment: Mean of all US zones
       datetime: '2020-01-01'
       source: eGrid 2020; IPCC 2014

--- a/config/zones/US-NW-BPAT.yaml
+++ b/config/zones/US-NW-BPAT.yaml
@@ -427,9 +427,6 @@ emissionFactors:
       source: Electricity Maps, 2023 average
       value: 122.8
     oil:
-    - datetime: '2014-01-01'
-      source: IPCC 2014; EIA 2020/BEIS 2021
-      value: 650.0
     - _comment: Mean of all US zones
       datetime: '2020-01-01'
       source: eGrid 2020; IPCC 2014

--- a/config/zones/US-NW-CHPD.yaml
+++ b/config/zones/US-NW-CHPD.yaml
@@ -261,9 +261,6 @@ emissionFactors:
       source: eGrid 2023
       value: 282.7016835752059
     coal:
-    - datetime: '2014-01-01'
-      source: IPCC 2014
-      value: 820.0
     - _comment: Mean of all US zones
       datetime: '2020-01-01'
       source: eGrid 2020; IPCC 2014
@@ -349,9 +346,6 @@ emissionFactors:
       source: Electricity Maps, 2024 average
       value: 27.21
     oil:
-    - datetime: '2014-01-01'
-      source: IPCC 2014; EIA 2020/BEIS 2021
-      value: 650.0
     - _comment: Mean of all US zones
       datetime: '2020-01-01'
       source: eGrid 2020; IPCC 2014

--- a/config/zones/US-NW-DOPD.yaml
+++ b/config/zones/US-NW-DOPD.yaml
@@ -252,9 +252,6 @@ emissionFactors:
       source: eGrid 2023
       value: 282.7016835752059
     coal:
-    - datetime: '2014-01-01'
-      source: IPCC 2014
-      value: 820.0
     - _comment: Mean of all US zones
       datetime: '2020-01-01'
       source: eGrid 2020; IPCC 2014
@@ -340,9 +337,6 @@ emissionFactors:
       source: Electricity Maps, 2024 average
       value: 33.8
     oil:
-    - datetime: '2014-01-01'
-      source: IPCC 2014; EIA 2020/BEIS 2021
-      value: 650.0
     - _comment: Mean of all US zones
       datetime: '2020-01-01'
       source: eGrid 2020; IPCC 2014

--- a/config/zones/US-NW-GCPD.yaml
+++ b/config/zones/US-NW-GCPD.yaml
@@ -249,9 +249,6 @@ emissionFactors:
       source: eGrid 2023
       value: 282.7016835752059
     coal:
-    - datetime: '2014-01-01'
-      source: IPCC 2014
-      value: 820.0
     - _comment: Mean of all US zones
       datetime: '2020-01-01'
       source: eGrid 2020; IPCC 2014
@@ -334,9 +331,6 @@ emissionFactors:
       source: Electricity Maps, 2023 average
       value: 57.8
     oil:
-    - datetime: '2014-01-01'
-      source: IPCC 2014; EIA 2020/BEIS 2021
-      value: 650.0
     - _comment: Mean of all US zones
       datetime: '2020-01-01'
       source: eGrid 2020; IPCC 2014

--- a/config/zones/US-NW-GRID.yaml
+++ b/config/zones/US-NW-GRID.yaml
@@ -234,9 +234,6 @@ emissionFactors:
       source: eGrid 2023
       value: 282.7016835752059
     coal:
-    - datetime: '2014-01-01'
-      source: IPCC 2014
-      value: 820.0
     - _comment: Mean of all US zones
       datetime: '2020-01-01'
       source: eGrid 2020; IPCC 2014
@@ -316,9 +313,6 @@ emissionFactors:
       source: Electricity Maps, 2024 average
       value: 490.66
     oil:
-    - datetime: '2014-01-01'
-      source: IPCC 2014; EIA 2020/BEIS 2021
-      value: 650.0
     - _comment: Mean of all US zones
       datetime: '2020-01-01'
       source: eGrid 2020; IPCC 2014

--- a/config/zones/US-NW-IPCO.yaml
+++ b/config/zones/US-NW-IPCO.yaml
@@ -370,9 +370,6 @@ emissionFactors:
       source: eGrid 2023
       value: 282.7016835752059
     coal:
-    - datetime: '2014-01-01'
-      source: IPCC 2014
-      value: 820.0
     - _comment: Mean of all US zones
       datetime: '2020-01-01'
       source: eGrid 2020; IPCC 2014
@@ -447,9 +444,6 @@ emissionFactors:
       source: Electricity Maps, 2024 average
       value: 306.23
     oil:
-    - datetime: '2014-01-01'
-      source: IPCC 2014; EIA 2020/BEIS 2021
-      value: 650.0
     - _comment: Mean of all US zones
       datetime: '2020-01-01'
       source: eGrid 2020; IPCC 2014

--- a/config/zones/US-NW-NEVP.yaml
+++ b/config/zones/US-NW-NEVP.yaml
@@ -496,9 +496,6 @@ emissionFactors:
       source: Electricity Maps, 2023 average
       value: 456.18
     oil:
-    - datetime: '2014-01-01'
-      source: IPCC 2014; EIA 2020/BEIS 2021
-      value: 650.0
     - _comment: Mean of all US zones
       datetime: '2020-01-01'
       source: eGrid 2020; IPCC 2014

--- a/config/zones/US-NW-PACE.yaml
+++ b/config/zones/US-NW-PACE.yaml
@@ -505,9 +505,6 @@ emissionFactors:
       source: Electricity Maps, 2023 average
       value: 741.42
     oil:
-    - datetime: '2014-01-01'
-      source: IPCC 2014; EIA 2020/BEIS 2021
-      value: 650.0
     - _comment: Mean of all US zones
       datetime: '2020-01-01'
       source: eGrid 2020; IPCC 2014

--- a/config/zones/US-NW-PACW.yaml
+++ b/config/zones/US-NW-PACW.yaml
@@ -442,9 +442,6 @@ emissionFactors:
       source: Electricity Maps, 2023 average
       value: 269.51
     oil:
-    - datetime: '2014-01-01'
-      source: IPCC 2014; EIA 2020/BEIS 2021
-      value: 650.0
     - _comment: Mean of all US zones
       datetime: '2020-01-01'
       source: eGrid 2020; IPCC 2014

--- a/config/zones/US-NW-PGE.yaml
+++ b/config/zones/US-NW-PGE.yaml
@@ -426,9 +426,6 @@ emissionFactors:
       source: Electricity Maps, 2023 average
       value: 239.12
     oil:
-    - datetime: '2014-01-01'
-      source: IPCC 2014; EIA 2020/BEIS 2021
-      value: 650.0
     - _comment: Mean of all US zones
       datetime: '2020-01-01'
       source: eGrid 2020; IPCC 2014

--- a/config/zones/US-NW-PSCO.yaml
+++ b/config/zones/US-NW-PSCO.yaml
@@ -543,9 +543,6 @@ emissionFactors:
       source: Electricity Maps, 2023 average
       value: 511.43
     oil:
-    - datetime: '2014-01-01'
-      source: IPCC 2014; EIA 2020/BEIS 2021
-      value: 650.0
     - _comment: Mean of all US zones
       datetime: '2020-01-01'
       source: eGrid 2020; IPCC 2014

--- a/config/zones/US-NW-PSEI.yaml
+++ b/config/zones/US-NW-PSEI.yaml
@@ -267,9 +267,6 @@ emissionFactors:
       source: eGrid 2023
       value: 282.7016835752059
     coal:
-    - datetime: '2014-01-01'
-      source: IPCC 2014
-      value: 820.0
     - _comment: Mean of all US zones
       datetime: '2020-01-01'
       source: eGrid 2020; IPCC 2014
@@ -348,9 +345,6 @@ emissionFactors:
       source: Electricity Maps, 2024 average
       value: 177.24
     oil:
-    - datetime: '2014-01-01'
-      source: IPCC 2014; EIA 2020/BEIS 2021
-      value: 650.0
     - _comment: Mean of all US zones
       datetime: '2020-01-01'
       source: eGrid 2020; IPCC 2014

--- a/config/zones/US-NW-SCL.yaml
+++ b/config/zones/US-NW-SCL.yaml
@@ -255,9 +255,6 @@ emissionFactors:
       source: eGrid 2023
       value: 282.7016835752059
     coal:
-    - datetime: '2014-01-01'
-      source: IPCC 2014
-      value: 820.0
     - _comment: Mean of all US zones
       datetime: '2020-01-01'
       source: eGrid 2020; IPCC 2014
@@ -340,9 +337,6 @@ emissionFactors:
       source: Electricity Maps, 2023 average
       value: 24.0
     oil:
-    - datetime: '2014-01-01'
-      source: IPCC 2014; EIA 2020/BEIS 2021
-      value: 650.0
     - _comment: Mean of all US zones
       datetime: '2020-01-01'
       source: eGrid 2020; IPCC 2014

--- a/config/zones/US-NW-TPWR.yaml
+++ b/config/zones/US-NW-TPWR.yaml
@@ -326,9 +326,6 @@ emissionFactors:
       source: Electricity Maps, 2023 average
       value: 95.71
     oil:
-    - datetime: '2014-01-01'
-      source: IPCC 2014; EIA 2020/BEIS 2021
-      value: 650.0
     - _comment: Mean of all US zones
       datetime: '2020-01-01'
       source: eGrid 2020; IPCC 2014

--- a/config/zones/US-NW-WAUW.yaml
+++ b/config/zones/US-NW-WAUW.yaml
@@ -347,9 +347,6 @@ emissionFactors:
       source: Electricity Maps, 2023 average
       value: 271.22
     oil:
-    - datetime: '2014-01-01'
-      source: IPCC 2014; EIA 2020/BEIS 2021
-      value: 650.0
     - _comment: Mean of all US zones
       datetime: '2020-01-01'
       source: eGrid 2020; IPCC 2014

--- a/config/zones/US-SE-SEPA.yaml
+++ b/config/zones/US-SE-SEPA.yaml
@@ -235,9 +235,6 @@ emissionFactors:
       source: eGrid 2023
       value: 282.7016835752059
     coal:
-    - datetime: '2014-01-01'
-      source: IPCC 2014
-      value: 820.0
     - _comment: Mean of all US zones
       datetime: '2020-01-01'
       source: eGrid 2020; IPCC 2014
@@ -314,9 +311,6 @@ emissionFactors:
       source: Electricity Maps, 2023 average
       value: 153.72
     oil:
-    - datetime: '2014-01-01'
-      source: IPCC 2014; EIA 2020/BEIS 2021
-      value: 650.0
     - _comment: Mean of all US zones
       datetime: '2020-01-01'
       source: eGrid 2020; IPCC 2014

--- a/config/zones/US-SW-AZPS.yaml
+++ b/config/zones/US-SW-AZPS.yaml
@@ -424,9 +424,6 @@ emissionFactors:
       source: Electricity Maps, 2023 average
       value: 430.05
     oil:
-    - datetime: '2014-01-01'
-      source: IPCC 2014; EIA 2020/BEIS 2021
-      value: 650.0
     - _comment: Mean of all US zones
       datetime: '2020-01-01'
       source: eGrid 2020; IPCC 2014

--- a/config/zones/US-SW-EPE.yaml
+++ b/config/zones/US-SW-EPE.yaml
@@ -281,9 +281,6 @@ emissionFactors:
       source: eGrid 2023
       value: 282.7016835752059
     coal:
-    - datetime: '2014-01-01'
-      source: IPCC 2014
-      value: 820
     - _comment: Mean of all US zones
       datetime: '2020-01-01'
       source: eGrid 2020; IPCC 2014
@@ -359,9 +356,6 @@ emissionFactors:
       source: Electricity Maps, 2023 average
       value: 545.8
     oil:
-    - datetime: '2014-01-01'
-      source: IPCC 2014; EIA 2020/BEIS 2021
-      value: 650
     - _comment: Mean of all US zones
       datetime: '2020-01-01'
       source: eGrid 2020; IPCC 2014

--- a/config/zones/US-SW-PNM.yaml
+++ b/config/zones/US-SW-PNM.yaml
@@ -495,9 +495,6 @@ emissionFactors:
       source: Electricity Maps, 2023 average
       value: 247.54
     oil:
-    - datetime: '2014-01-01'
-      source: IPCC 2014; EIA 2020/BEIS 2021
-      value: 650
     - _comment: Mean of all US zones
       datetime: '2020-01-01'
       source: eGrid 2020; IPCC 2014

--- a/config/zones/US-SW-SRP.yaml
+++ b/config/zones/US-SW-SRP.yaml
@@ -402,9 +402,6 @@ emissionFactors:
       source: Electricity Maps, 2023 average
       value: 304.7
     oil:
-    - datetime: '2014-01-01'
-      source: IPCC 2014; EIA 2020/BEIS 2021
-      value: 650.0
     - _comment: Mean of all US zones
       datetime: '2020-01-01'
       source: eGrid 2020; IPCC 2014

--- a/config/zones/US-SW-TEPC.yaml
+++ b/config/zones/US-SW-TEPC.yaml
@@ -369,9 +369,6 @@ emissionFactors:
       source: Electricity Maps, 2023 average
       value: 593.21
     oil:
-    - datetime: '2014-01-01'
-      source: IPCC 2014; EIA 2020/BEIS 2021
-      value: 650.0
     - _comment: Mean of all US zones
       datetime: '2020-01-01'
       source: eGrid 2020; IPCC 2014

--- a/config/zones/US-SW-WALC.yaml
+++ b/config/zones/US-SW-WALC.yaml
@@ -381,9 +381,6 @@ emissionFactors:
       source: Electricity Maps, 2023 average
       value: 511.56
     oil:
-    - datetime: '2014-01-01'
-      source: IPCC 2014; EIA 2020/BEIS 2021
-      value: 650.0
     - _comment: Mean of all US zones
       datetime: '2020-01-01'
       source: eGrid 2020; IPCC 2014


### PR DESCRIPTION
this is already in defaults.yaml and due to the way emission factor lookup code works, these entries are causing errors because the zone's direct value is higher than the ipcc lifecycle value.

with this remove, the emission factors for this zone will default to the oldest entry i.e. egrid 2020, which is considered more accurate and has a correct addition for upstream emission