### PR TITLE
fix(emission-factors): remove zone specific unknown factors with no source

### DIFF
--- a/config/zones/HR.yaml
+++ b/config/zones/HR.yaml
@@ -363,9 +363,6 @@ emissionFactors:
       datetime: '2021-01-01'
       source: INCER ACV
       value: 29.03333333
-    unknown:
-      source: HOPS 2018; HOPS 2018 derived calculation
-      value: 240
     wind:
       datetime: '2021-01-01'
       source: UNECE 2022, WindEurope "Wind energy in Europe, 2021 Statistics and the
@@ -510,10 +507,6 @@ sources:
     link: https://drive.google.com/file/d/15UeUHyhcjVw8fGLc0Zx_HELSx20cw_-e/view?usp=share_link
   EU-ETS, ENTSO-E 2023:
     link: https://colab.research.google.com/drive/1IkDXX4p1xQIuY3WicL94TUkRcZQnS9c7?usp=drive_link
-  HOPS 2018:
-    link: https://www.hops.hr/page-file/oEvvKj779KAhmQg10Gezt2/temeljni-podaci/Temeljni%20podaci%202018.pdf
-  HOPS 2018 derived calculation:
-    link: https://github.com/electricitymaps/electricitymaps-contrib/pull/1965
   INCER ACV:
     link: https://docs.google.com/spreadsheets/d/1w5DJ7sPen6axIHU8TCVcuzNCjlct4I6JAbhUlw-ZXu8/edit?usp=sharing
   IPCC 2014:

--- a/config/zones/JP-CG.yaml
+++ b/config/zones/JP-CG.yaml
@@ -74,9 +74,6 @@ emissionFactors:
       - datetime: '2024-01-01'
         source: Electricity Maps, 2024 average
         value: 471.4
-    unknown:
-      source: Enerdata 2022 Japanese National Average
-      value: 462
 fallbackZoneMixes:
   powerOriginRatios:
     - _source: Electricity Maps, 2017 average
@@ -206,8 +203,6 @@ parsers:
   generationForecast: JP.fetch_generation_forecast
 region: Asia
 sources:
-  Enerdata 2022 Japanese National Average:
-    link: https://www.climate-transparency.org/wp-content/uploads/2022/10/CT2022-Japan-Web.pdf
 timezone: Asia/Tokyo
 zone_name: Chūgoku
 country_name: Japan

--- a/config/zones/JP-HKD.yaml
+++ b/config/zones/JP-HKD.yaml
@@ -77,9 +77,6 @@ emissionFactors:
       - datetime: '2024-01-01'
         source: Electricity Maps, 2024 average
         value: 464.86
-    unknown:
-      source: Enerdata 2022 Japanese National Average
-      value: 462
 fallbackZoneMixes:
   powerOriginRatios:
     - _source: Electricity Maps, 2017 average
@@ -209,8 +206,6 @@ parsers:
   generationForecast: JP.fetch_generation_forecast
 region: Asia
 sources:
-  Enerdata 2022 Japanese National Average:
-    link: https://www.climate-transparency.org/wp-content/uploads/2022/10/CT2022-Japan-Web.pdf
 timezone: Asia/Tokyo
 zone_name: Hokkaidō
 country_name: Japan

--- a/config/zones/JP-HR.yaml
+++ b/config/zones/JP-HR.yaml
@@ -71,9 +71,6 @@ emissionFactors:
       - datetime: '2023-01-01'
         source: Electricity Maps, 2023 average
         value: 454.8
-    unknown:
-      source: Enerdata 2022 Japanese National Average
-      value: 462
 fallbackZoneMixes:
   powerOriginRatios:
     - _source: Electricity Maps, 2017 average
@@ -188,8 +185,6 @@ parsers:
   generationForecast: JP.fetch_generation_forecast
 region: Asia
 sources:
-  Enerdata 2022 Japanese National Average:
-    link: https://www.climate-transparency.org/wp-content/uploads/2022/10/CT2022-Japan-Web.pdf
 timezone: Asia/Tokyo
 zone_name: Hokuriku
 country_name: Japan

--- a/config/zones/JP-ON.yaml
+++ b/config/zones/JP-ON.yaml
@@ -72,9 +72,7 @@ emissionFactors:
       - datetime: '2024-01-01'
         source: Electricity Maps, 2024 average
         value: 593.34
-    unknown:
-      source: Enerdata 2022 Japanese National Average
-      value: 462
+
 fallbackZoneMixes:
   powerOriginRatios:
     - _source: Electricity Maps, 2017 average
@@ -204,8 +202,6 @@ parsers:
   generationForecast: JP.fetch_generation_forecast
 region: Asia
 sources:
-  Enerdata 2022 Japanese National Average:
-    link: https://www.climate-transparency.org/wp-content/uploads/2022/10/CT2022-Japan-Web.pdf
 timezone: Asia/Tokyo
 zone_name: Okinawa
 country_name: Japan

--- a/config/zones/JP-SK.yaml
+++ b/config/zones/JP-SK.yaml
@@ -84,9 +84,6 @@ emissionFactors:
       - datetime: '2024-01-01'
         source: Electricity Maps, 2024 average
         value: 369.26
-    unknown:
-      source: Enerdata 2022 Japanese National Average
-      value: 462
 fallbackZoneMixes:
   powerOriginRatios:
     - _source: Electricity Maps, 2016 average
@@ -231,8 +228,6 @@ parsers:
   generationForecast: JP.fetch_generation_forecast
 region: Asia
 sources:
-  Enerdata 2022 Japanese National Average:
-    link: https://www.climate-transparency.org/wp-content/uploads/2022/10/CT2022-Japan-Web.pdf
 timezone: Asia/Tokyo
 zone_name: Shikoku
 country_name: Japan

--- a/config/zones/JP-TH.yaml
+++ b/config/zones/JP-TH.yaml
@@ -76,9 +76,6 @@ emissionFactors:
       - datetime: '2024-01-01'
         source: Electricity Maps, 2024 average
         value: 480.58
-    unknown:
-      source: Enerdata 2022 Japanese National Average
-      value: 462
 fallbackZoneMixes:
   powerOriginRatios:
     - _source: Electricity Maps, 2017 average
@@ -208,8 +205,6 @@ parsers:
   generationForecast: JP.fetch_generation_forecast
 region: Asia
 sources:
-  Enerdata 2022 Japanese National Average:
-    link: https://www.climate-transparency.org/wp-content/uploads/2022/10/CT2022-Japan-Web.pdf
 timezone: Asia/Tokyo
 zone_name: Tōhoku
 country_name: Japan

--- a/config/zones/NL.yaml
+++ b/config/zones/NL.yaml
@@ -374,10 +374,6 @@ emissionFactors:
       datetime: '2021-01-01'
       source: INCER ACV
       value: 36.5
-    unknown:
-      _url: https://github.com/electricitymaps/electricitymaps-contrib/issues/3015#issuecomment-888154930
-      source: Electricity Maps, 2020 average. See disclaimer
-      value: 342
     wind:
       datetime: '2021-01-01'
       source: UNECE 2022, WindEurope "Wind energy in Europe, 2021 Statistics and the


### PR DESCRIPTION

<img width="544" height="250" alt="image" src="https://github.com/user-attachments/assets/0a4ebacb-767c-4779-990c-e9645219008f" />

removing NL specific unknown factor because I can't justify it. also unknown percetange is low in recent years, impact should be small.
