### PR TITLE
add functionality to retain scroll position on zone details on zone/t…

### DIFF
--- a/web/src/utils/state/atoms.ts
+++ b/web/src/utils/state/atoms.ts
@@ -121,3 +121,5 @@ export const futurePriceCollapsedAtom = atom<boolean>(true);
 export const isRedirectedToLatestDatetimeAtom = atom<boolean>(false);
 
 export const openTooltipIdAtom = atom<string | null>(null);
+
+export const zoneDetailsScrollHashAtom = atom<string | undefined>(undefined);


### PR DESCRIPTION
…ime switch

## Issue 
https://github.com/electricitymaps/electricitymaps-contrib/issues/7618
Add functionality to retain scroll position on zone details when selecting another zone/country or timeframe

<!-- If you want to close an issue automatically when your PR is merged, write "Closes X" where X is the issue number. For example: Closes #000 -->

## Description
useScrollHashIntoView, the function responsible for scrolling the zone details panel, depended on useLocation() variables (hash,pathname,search). However, they were not changing as the user scrolled. The function saw that hash/anchor was blank and would scroll to the top every time the zone or time was switched.

Modifications:
- Added a function responsible for setting the scroll position by element id when the user scrolls (useUpdateHashOnScroll)
- That function sets a new state variable (zoneDetailsScrollHashAtom) when it does
- Modified useUpdateHashOnScroll to look at this state variable when determining scroll position. It currently resets this variable and scrolls to the top if the current zone doesn't have the desired section
- Added a getSectionIds function to get the section ids the current zone has, since some zones may not have all of them

It's possible that using useLocation() may still work if we set the hash onto the url when the user scrolls (change useUpdateHashOnScroll to do this) and move useLocation() inside the useEffect instead

<!-- Explains the goal of this PR -->

### Preview
![ElectricityMaps Issue 7618](https://github.com/user-attachments/assets/49f5a5a1-93e1-46a9-ac40-ed32a4829fe6)

<!-- Please add screenshots and/or gif that shows visual changes (if applicable) -->

### Double check

- [ ] I have tested my parser changes locally with `poetry run test_parser "zone_key"`
- [ ] I have run `pnpx prettier@2 --write .` and `poetry run format` in the top level directory to format my changes.
