### PR TITLE
feat(emission-factors): new battery and hydro numbers

### DIFF
--- a/config/zones/AT.yaml
+++ b/config/zones/AT.yaml
@@ -259,6 +259,11 @@ emissionFactors:
     - datetime: '2024-01-01'
       source: EU-ETS, ENTSO-E 2024
       value: 345.23
+    hydro discharge:
+    - _comment: used storage values greater than zero.
+      datetime: '2024-01-01'
+      source: Electricity Maps, 2024 zone average
+      value: 79.99
     oil:
     - datetime: '2021-01-01'
       source: EU-ETS, ENTSO-E 2021
@@ -303,6 +308,11 @@ emissionFactors:
       datetime: '2020-01-01'
       source: UNECE 2022
       value: 10.7
+    hydro discharge:
+    - _comment: used storage values greater than zero.
+      datetime: '2024-01-01'
+      source: Electricity Maps, 2024 zone average
+      value: 117.77
     nuclear:
       datetime: '2020-01-01'
       source: UNECE 2022

--- a/config/zones/AU-NSW.yaml
+++ b/config/zones/AU-NSW.yaml
@@ -95,6 +95,29 @@ country_name: Australia
 currency: AUD
 delays:
   production: 96
+emissionFactors:
+  direct:
+    battery discharge:
+    - _comment: used storage values greater than zero.
+      datetime: '2024-01-01'
+      source: Electricity Maps, 2024 zone average
+      value: 469.91
+    hydro discharge:
+    - _comment: used storage values greater than zero.
+      datetime: '2024-01-01'
+      source: Electricity Maps, 2024 zone average
+      value: 387.6
+  lifecycle:
+    battery discharge:
+    - _comment: used storage values greater than zero.
+      datetime: '2024-01-01'
+      source: Electricity Maps, 2024 zone average
+      value: 521.82
+    hydro discharge:
+    - _comment: used storage values greater than zero.
+      datetime: '2024-01-01'
+      source: Electricity Maps, 2024 zone average
+      value: 437.87
 fallbackZoneMixes:
   powerOriginRatios:
   - _source: Electricity Maps, 2015 average

--- a/config/zones/AU-QLD.yaml
+++ b/config/zones/AU-QLD.yaml
@@ -83,6 +83,29 @@ country_name: Australia
 currency: AUD
 delays:
   production: 96
+emissionFactors:
+  direct:
+    battery discharge:
+    - _comment: used storage values greater than zero.
+      datetime: '2024-01-01'
+      source: Electricity Maps, 2024 zone average
+      value: 493.02
+    hydro discharge:
+    - _comment: used storage values greater than zero.
+      datetime: '2024-01-01'
+      source: Electricity Maps, 2024 zone average
+      value: 369.22
+  lifecycle:
+    battery discharge:
+    - _comment: used storage values greater than zero.
+      datetime: '2024-01-01'
+      source: Electricity Maps, 2024 zone average
+      value: 549.1
+    hydro discharge:
+    - _comment: used storage values greater than zero.
+      datetime: '2024-01-01'
+      source: Electricity Maps, 2024 zone average
+      value: 422.51
 fallbackZoneMixes:
   powerOriginRatios:
   - _source: Electricity Maps, 2015 average

--- a/config/zones/AU-SA.yaml
+++ b/config/zones/AU-SA.yaml
@@ -81,6 +81,19 @@ country_name: Australia
 currency: AUD
 delays:
   production: 96
+emissionFactors:
+  direct:
+    battery discharge:
+    - _comment: used storage values greater than zero.
+      datetime: '2024-01-01'
+      source: Electricity Maps, 2024 zone average
+      value: 115.71
+  lifecycle:
+    battery discharge:
+    - _comment: used storage values greater than zero.
+      datetime: '2024-01-01'
+      source: Electricity Maps, 2024 zone average
+      value: 161.96
 fallbackZoneMixes:
   powerOriginRatios:
   - _source: Electricity Maps, 2015 average

--- a/config/zones/AU-TAS-FI.yaml
+++ b/config/zones/AU-TAS-FI.yaml
@@ -24,6 +24,19 @@ contributors:
 country: AU
 country_name: Australia
 currency: AUD
+emissionFactors:
+  direct:
+    battery discharge:
+    - _comment: used storage values greater than zero.
+      datetime: '2024-01-01'
+      source: Electricity Maps, 2024 zone average
+      value: 159.21
+  lifecycle:
+    battery discharge:
+    - _comment: used storage values greater than zero.
+      datetime: '2024-01-01'
+      source: Electricity Maps, 2024 zone average
+      value: 262.21
 fallbackZoneMixes:
   powerOriginRatios:
   - _source: Electricity Maps, 2021 average

--- a/config/zones/AU-TAS-KI.yaml
+++ b/config/zones/AU-TAS-KI.yaml
@@ -24,6 +24,19 @@ contributors:
 country: AU
 country_name: Australia
 currency: AUD
+emissionFactors:
+  direct:
+    battery discharge:
+    - _comment: used storage values greater than zero.
+      datetime: '2024-01-01'
+      source: Electricity Maps, 2024 zone average
+      value: 279.07
+  lifecycle:
+    battery discharge:
+    - _comment: used storage values greater than zero.
+      datetime: '2024-01-01'
+      source: Electricity Maps, 2024 zone average
+      value: 453.94
 fallbackZoneMixes:
   powerOriginRatios:
   - _source: Electricity Maps, 2020 average

--- a/config/zones/AU-VIC.yaml
+++ b/config/zones/AU-VIC.yaml
@@ -80,6 +80,19 @@ country_name: Australia
 currency: AUD
 delays:
   production: 96
+emissionFactors:
+  direct:
+    battery discharge:
+    - _comment: used storage values greater than zero.
+      datetime: '2024-01-01'
+      source: Electricity Maps, 2024 zone average
+      value: 441.88
+  lifecycle:
+    battery discharge:
+    - _comment: used storage values greater than zero.
+      datetime: '2024-01-01'
+      source: Electricity Maps, 2024 zone average
+      value: 489.79
 fallbackZoneMixes:
   powerOriginRatios:
   - _source: Electricity Maps, 2015 average

--- a/config/zones/AU-WA-RI.yaml
+++ b/config/zones/AU-WA-RI.yaml
@@ -23,6 +23,19 @@ contributors:
 country: AU
 country_name: Australia
 currency: AUD
+emissionFactors:
+  direct:
+    battery discharge:
+    - _comment: used storage values equal to zero.
+      datetime: '2024-01-01'
+      source: Electricity Maps, 2024 zone average
+      value: 322.04
+  lifecycle:
+    battery discharge:
+    - _comment: used storage values equal to zero.
+      datetime: '2024-01-01'
+      source: Electricity Maps, 2024 zone average
+      value: 519.91
 fallbackZoneMixes:
   powerOriginRatios:
   - _source: Electricity Maps, 2021 average

--- a/config/zones/AU-WA.yaml
+++ b/config/zones/AU-WA.yaml
@@ -71,6 +71,19 @@ delays:
   production: 96
 disclaimer: Western Australia's power grid is not connected to the (Australian) National
   Electricity Market or the Northern Territory grid.
+emissionFactors:
+  direct:
+    battery discharge:
+    - _comment: used storage values greater than zero.
+      datetime: '2024-01-01'
+      source: Electricity Maps, 2024 zone average
+      value: 303.78
+  lifecycle:
+    battery discharge:
+    - _comment: used storage values greater than zero.
+      datetime: '2024-01-01'
+      source: Electricity Maps, 2024 zone average
+      value: 368.61
 fallbackZoneMixes:
   powerOriginRatios:
   - _source: Electricity Maps, 2015 average

--- a/config/zones/AU.yaml
+++ b/config/zones/AU.yaml
@@ -34,7 +34,28 @@ country: AU
 country_name: Australia
 currency: AUD
 emissionFactors:
-  lifecycle: {}
+  direct:
+    battery discharge:
+    - _comment: used storage values greater than zero.
+      datetime: '2024-01-01'
+      source: Electricity Maps, 2024 zone average
+      value: 406.52
+    hydro discharge:
+    - _comment: used storage values greater than zero.
+      datetime: '2024-01-01'
+      source: Electricity Maps, 2024 zone average
+      value: 363.29
+  lifecycle:
+    battery discharge:
+    - _comment: used storage values greater than zero.
+      datetime: '2024-01-01'
+      source: Electricity Maps, 2024 zone average
+      value: 458.74
+    hydro discharge:
+    - _comment: used storage values greater than zero.
+      datetime: '2024-01-01'
+      source: Electricity Maps, 2024 zone average
+      value: 414.5
 fallbackZoneMixes:
   powerOriginRatios:
   - _source: Electricity Maps, 2017 average

--- a/config/zones/BA.yaml
+++ b/config/zones/BA.yaml
@@ -63,12 +63,22 @@ currency: BAM
 delays:
   production: 72
 emissionFactors:
-  direct: {}
+  direct:
+    hydro discharge:
+    - _comment: used storage values greater than zero.
+      datetime: '2024-01-01'
+      source: Electricity Maps, 2024 zone average
+      value: 314.09
   lifecycle:
     hydro:
       datetime: '2020-01-01'
       source: UNECE 2022
       value: 10.7
+    hydro discharge:
+    - _comment: used storage values greater than zero.
+      datetime: '2024-01-01'
+      source: Electricity Maps, 2024 zone average
+      value: 354.55
     nuclear:
       datetime: '2020-01-01'
       source: UNECE 2022

--- a/config/zones/BE.yaml
+++ b/config/zones/BE.yaml
@@ -237,6 +237,11 @@ emissionFactors:
     - datetime: '2024-01-01'
       source: EU-ETS, ENTSO-E 2024
       value: 408.56
+    hydro discharge:
+    - _comment: used storage values greater than zero.
+      datetime: '2024-01-01'
+      source: Electricity Maps, 2024 zone average
+      value: 98.82
     oil:
     - datetime: '2021-01-01'
       source: EU-ETS, ENTSO-E 2021
@@ -287,6 +292,11 @@ emissionFactors:
       datetime: '2020-01-01'
       source: UNECE 2022
       value: 10.7
+    hydro discharge:
+    - _comment: used storage values greater than zero.
+      datetime: '2024-01-01'
+      source: Electricity Maps, 2024 zone average
+      value: 141.5
     nuclear:
       datetime: '2020-01-01'
       source: UNECE 2022

--- a/config/zones/CA-AB.yaml
+++ b/config/zones/CA-AB.yaml
@@ -12,8 +12,18 @@ currency: CAD
 delays:
   production: 5
 emissionFactors:
-  direct: {}
+  direct:
+    battery discharge:
+    - _comment: used storage values greater than zero.
+      datetime: '2024-01-01'
+      source: Electricity Maps, 2024 zone average
+      value: 313.76
   lifecycle:
+    battery discharge:
+    - _comment: used storage values greater than zero.
+      datetime: '2024-01-01'
+      source: Electricity Maps, 2024 zone average
+      value: 418.35
     unknown:
       source: assumes 50% coal and 50% natural gas from Battle River dual fuel power
         plant

--- a/config/zones/CA.yaml
+++ b/config/zones/CA.yaml
@@ -1,169 +1,182 @@
 capacity:
   biomass:
-    - datetime: '2017-01-01'
-      source: Ember, Yearly electricity data
-      value: 2740.0
-    - datetime: '2018-01-01'
-      source: Ember, Yearly electricity data
-      value: 2750.0
-    - datetime: '2019-01-01'
-      source: Ember, Yearly electricity data
-      value: 2650.0
-    - datetime: '2022-01-01'
-      source: Ember, Yearly electricity data
-      value: 2660.0
+  - datetime: '2017-01-01'
+    source: Ember, Yearly electricity data
+    value: 2740.0
+  - datetime: '2018-01-01'
+    source: Ember, Yearly electricity data
+    value: 2750.0
+  - datetime: '2019-01-01'
+    source: Ember, Yearly electricity data
+    value: 2650.0
+  - datetime: '2022-01-01'
+    source: Ember, Yearly electricity data
+    value: 2660.0
   coal:
-    - datetime: '2017-01-01'
-      source: Ember, Yearly electricity data
-      value: 9980.0
-    - datetime: '2018-01-01'
-      source: Ember, Yearly electricity data
-      value: 9320.0
-    - datetime: '2019-01-01'
-      source: Ember, Yearly electricity data
-      value: 9170.0
-    - datetime: '2020-01-01'
-      source: Ember, Yearly electricity data
-      value: 8790.0
-    - datetime: '2021-01-01'
-      source: Ember, Yearly electricity data
-      value: 5310.0
-    - datetime: '2022-01-01'
-      source: Ember, Yearly electricity data
-      value: 4880.0
-    - datetime: '2023-01-01'
-      source: Ember, Yearly electricity data
-      value: 4260.0
-    - datetime: '2024-01-01'
-      source: Ember, Yearly electricity data
-      value: 3380.0
+  - datetime: '2017-01-01'
+    source: Ember, Yearly electricity data
+    value: 9980.0
+  - datetime: '2018-01-01'
+    source: Ember, Yearly electricity data
+    value: 9320.0
+  - datetime: '2019-01-01'
+    source: Ember, Yearly electricity data
+    value: 9170.0
+  - datetime: '2020-01-01'
+    source: Ember, Yearly electricity data
+    value: 8790.0
+  - datetime: '2021-01-01'
+    source: Ember, Yearly electricity data
+    value: 5310.0
+  - datetime: '2022-01-01'
+    source: Ember, Yearly electricity data
+    value: 4880.0
+  - datetime: '2023-01-01'
+    source: Ember, Yearly electricity data
+    value: 4260.0
+  - datetime: '2024-01-01'
+    source: Ember, Yearly electricity data
+    value: 3380.0
   gas:
-    - datetime: '2017-01-01'
-      source: Ember, Yearly electricity data
-      value: 18780.0
-    - datetime: '2019-01-01'
-      source: Ember, Yearly electricity data
-      value: 19130.0
-    - datetime: '2020-01-01'
-      source: Ember, Yearly electricity data
-      value: 20240.0
-    - datetime: '2021-01-01'
-      source: Ember, Yearly electricity data
-      value: 22950.0
-    - datetime: '2022-01-01'
-      source: Ember, Yearly electricity data
-      value: 23060.0
-    - datetime: '2023-01-01'
-      source: Ember, Yearly electricity data
-      value: 23620.0
-    - datetime: '2024-01-01'
-      source: Ember, Yearly electricity data
-      value: 25640.0
+  - datetime: '2017-01-01'
+    source: Ember, Yearly electricity data
+    value: 18780.0
+  - datetime: '2019-01-01'
+    source: Ember, Yearly electricity data
+    value: 19130.0
+  - datetime: '2020-01-01'
+    source: Ember, Yearly electricity data
+    value: 20240.0
+  - datetime: '2021-01-01'
+    source: Ember, Yearly electricity data
+    value: 22950.0
+  - datetime: '2022-01-01'
+    source: Ember, Yearly electricity data
+    value: 23060.0
+  - datetime: '2023-01-01'
+    source: Ember, Yearly electricity data
+    value: 23620.0
+  - datetime: '2024-01-01'
+    source: Ember, Yearly electricity data
+    value: 25640.0
   hydro:
-    - datetime: '2017-01-01'
-      source: Ember, Yearly electricity data
-      value: 80660.0
-    - datetime: '2018-01-01'
-      source: Ember, Yearly electricity data
-      value: 81400.0
-    - datetime: '2020-01-01'
-      source: Ember, Yearly electricity data
-      value: 81210.0
-    - datetime: '2021-01-01'
-      source: Ember, Yearly electricity data
-      value: 82130.0
-    - datetime: '2022-01-01'
-      source: Ember, Yearly electricity data
-      value: 83140.0
-    - datetime: '2023-01-01'
-      source: Ember, Yearly electricity data
-      value: 83280.0
+  - datetime: '2017-01-01'
+    source: Ember, Yearly electricity data
+    value: 80660.0
+  - datetime: '2018-01-01'
+    source: Ember, Yearly electricity data
+    value: 81400.0
+  - datetime: '2020-01-01'
+    source: Ember, Yearly electricity data
+    value: 81210.0
+  - datetime: '2021-01-01'
+    source: Ember, Yearly electricity data
+    value: 82130.0
+  - datetime: '2022-01-01'
+    source: Ember, Yearly electricity data
+    value: 83140.0
+  - datetime: '2023-01-01'
+    source: Ember, Yearly electricity data
+    value: 83280.0
   nuclear:
-    - datetime: '2017-01-01'
-      source: Ember, Yearly electricity data
-      value: 14030.0
-    - datetime: '2018-01-01'
-      source: Ember, Yearly electricity data
-      value: 13340.0
-    - datetime: '2020-01-01'
-      source: Ember, Yearly electricity data
-      value: 12510.0
-    - datetime: '2022-01-01'
-      source: Ember, Yearly electricity data
-      value: 11580.0
+  - datetime: '2017-01-01'
+    source: Ember, Yearly electricity data
+    value: 14030.0
+  - datetime: '2018-01-01'
+    source: Ember, Yearly electricity data
+    value: 13340.0
+  - datetime: '2020-01-01'
+    source: Ember, Yearly electricity data
+    value: 12510.0
+  - datetime: '2022-01-01'
+    source: Ember, Yearly electricity data
+    value: 11580.0
   solar:
-    - datetime: '2017-01-01'
-      source: Ember, Yearly electricity data
-      value: 3420.0
-    - datetime: '2018-01-01'
-      source: Ember, Yearly electricity data
-      value: 3720.0
-    - datetime: '2019-01-01'
-      source: Ember, Yearly electricity data
-      value: 4010.0
-    - datetime: '2020-01-01'
-      source: Ember, Yearly electricity data
-      value: 4380.0
-    - datetime: '2021-01-01'
-      source: Ember, Yearly electricity data
-      value: 5260.0
-    - datetime: '2022-01-01'
-      source: Ember, Yearly electricity data
-      value: 5440.0
-    - datetime: '2023-01-01'
-      source: Ember, Yearly electricity data
-      value: 5880.0
-    - datetime: '2024-01-01'
-      source: Ember, Yearly electricity data
-      value: 6110.0
+  - datetime: '2017-01-01'
+    source: Ember, Yearly electricity data
+    value: 3420.0
+  - datetime: '2018-01-01'
+    source: Ember, Yearly electricity data
+    value: 3720.0
+  - datetime: '2019-01-01'
+    source: Ember, Yearly electricity data
+    value: 4010.0
+  - datetime: '2020-01-01'
+    source: Ember, Yearly electricity data
+    value: 4380.0
+  - datetime: '2021-01-01'
+    source: Ember, Yearly electricity data
+    value: 5260.0
+  - datetime: '2022-01-01'
+    source: Ember, Yearly electricity data
+    value: 5440.0
+  - datetime: '2023-01-01'
+    source: Ember, Yearly electricity data
+    value: 5880.0
+  - datetime: '2024-01-01'
+    source: Ember, Yearly electricity data
+    value: 6110.0
   unknown:
-    - datetime: '2017-01-01'
-      source: Ember, Yearly electricity data
-      value: 2280.0
+  - datetime: '2017-01-01'
+    source: Ember, Yearly electricity data
+    value: 2280.0
   wind:
-    - datetime: '2017-01-01'
-      source: Ember, Yearly electricity data
-      value: 12250.0
-    - datetime: '2018-01-01'
-      source: Ember, Yearly electricity data
-      value: 12820.0
-    - datetime: '2019-01-01'
-      source: Ember, Yearly electricity data
-      value: 13220.0
-    - datetime: '2020-01-01'
-      source: Ember, Yearly electricity data
-      value: 13530.0
-    - datetime: '2021-01-01'
-      source: Ember, Yearly electricity data
-      value: 13720.0
-    - datetime: '2022-01-01'
-      source: Ember, Yearly electricity data
-      value: 15080.0
-    - datetime: '2023-01-01'
-      source: Ember, Yearly electricity data
-      value: 16990.0
-    - datetime: '2024-01-01'
-      source: Ember, Yearly electricity data
-      value: 18380.0
+  - datetime: '2017-01-01'
+    source: Ember, Yearly electricity data
+    value: 12250.0
+  - datetime: '2018-01-01'
+    source: Ember, Yearly electricity data
+    value: 12820.0
+  - datetime: '2019-01-01'
+    source: Ember, Yearly electricity data
+    value: 13220.0
+  - datetime: '2020-01-01'
+    source: Ember, Yearly electricity data
+    value: 13530.0
+  - datetime: '2021-01-01'
+    source: Ember, Yearly electricity data
+    value: 13720.0
+  - datetime: '2022-01-01'
+    source: Ember, Yearly electricity data
+    value: 15080.0
+  - datetime: '2023-01-01'
+    source: Ember, Yearly electricity data
+    value: 16990.0
+  - datetime: '2024-01-01'
+    source: Ember, Yearly electricity data
+    value: 18380.0
 country: CA
+country_name: Canada
+currency: CAD
+emissionFactors:
+  direct:
+    battery discharge:
+    - _comment: used storage values greater than zero.
+      datetime: '2024-01-01'
+      source: Electricity Maps, 2024 zone average
+      value: 89.07
+  lifecycle:
+    battery discharge:
+    - _comment: used storage values greater than zero.
+      datetime: '2024-01-01'
+      source: Electricity Maps, 2024 zone average
+      value: 134.78
 parsers:
   productionCapacity: EMBER.fetch_production_capacity
 region: Americas
 subZoneNames:
-  - CA-AB
-  - CA-BC
-  - CA-MB
-  - CA-NB
-  - CA-NL
-  - CA-NS
-  - CA-NT
-  - CA-NU
-  - CA-ON
-  - CA-PE
-  - CA-QC
-  - CA-SK
-  - CA-YT
+- CA-AB
+- CA-BC
+- CA-MB
+- CA-NB
+- CA-NL
+- CA-NS
+- CA-NT
+- CA-NU
+- CA-ON
+- CA-PE
+- CA-QC
+- CA-SK
+- CA-YT
 timezone: America/Toronto
 zone_name: Canada
-country_name: Canada
-currency: CAD

--- a/config/zones/CZ.yaml
+++ b/config/zones/CZ.yaml
@@ -180,6 +180,11 @@ emissionFactors:
     - datetime: '2024-01-01'
       source: EU-ETS, ENTSO-E 2024
       value: 370.68
+    hydro discharge:
+    - _comment: used storage values equal to zero.
+      datetime: '2024-01-01'
+      source: Electricity Maps, 2024 zone average
+      value: 416.44
     oil:
     - datetime: '2021-01-01'
       source: EU-ETS, ENTSO-E 2021
@@ -224,6 +229,11 @@ emissionFactors:
       datetime: '2020-01-01'
       source: UNECE 2022
       value: 10.7
+    hydro discharge:
+    - _comment: used storage values equal to zero.
+      datetime: '2024-01-01'
+      source: Electricity Maps, 2024 zone average
+      value: 457.52
     nuclear:
       datetime: '2020-01-01'
       source: UNECE 2022

--- a/config/zones/DE.yaml
+++ b/config/zones/DE.yaml
@@ -318,6 +318,11 @@ emissionFactors:
     - datetime: '2024-01-01'
       source: EU-ETS, ENTSO-E 2024
       value: 409.44
+    hydro discharge:
+    - _comment: used storage values greater than zero.
+      datetime: '2024-01-01'
+      source: Electricity Maps, 2024 zone average
+      value: 233.11
     oil:
     - datetime: '2021-01-01'
       source: EU-ETS, ENTSO-E 2021
@@ -368,6 +373,11 @@ emissionFactors:
       datetime: '2020-01-01'
       source: UNECE 2022
       value: 10.7
+    hydro discharge:
+    - _comment: used storage values greater than zero.
+      datetime: '2024-01-01'
+      source: Electricity Maps, 2024 zone average
+      value: 290.89
     nuclear:
       datetime: '2020-01-01'
       source: UNECE 2022

--- a/config/zones/ES-CE.yaml
+++ b/config/zones/ES-CE.yaml
@@ -18,7 +18,18 @@ country: ES
 country_name: Spain
 currency: EUR
 emissionFactors:
-  lifecycle: {}
+  direct:
+    battery discharge:
+    - _comment: used storage values equal to zero.
+      datetime: '2024-01-01'
+      source: Electricity Maps, 2024 zone average
+      value: 405.82
+  lifecycle:
+    battery discharge:
+    - _comment: used storage values equal to zero.
+      datetime: '2024-01-01'
+      source: Electricity Maps, 2024 zone average
+      value: 649.2
 fallbackZoneMixes:
   powerOriginRatios:
   - _source: Electricity Maps, 2022 average

--- a/config/zones/ES-CN-FV.yaml
+++ b/config/zones/ES-CN-FV.yaml
@@ -32,6 +32,11 @@ emissionFactors:
     - datetime: '2022-01-01'
       source: EU-ETS, ENTSO-E 2022
       value: 426.61
+    hydro discharge:
+    - _comment: used storage values equal to zero.
+      datetime: '2024-01-01'
+      source: Electricity Maps, 2024 zone average
+      value: 566.14
     oil:
     - datetime: '2017-01-01'
       source: EU-ETS, REE
@@ -82,6 +87,11 @@ emissionFactors:
       datetime: '2020-01-01'
       source: UNECE 2022
       value: 10.7
+    hydro discharge:
+    - _comment: used storage values equal to zero.
+      datetime: '2024-01-01'
+      source: Electricity Maps, 2024 zone average
+      value: 756.24
     nuclear:
       datetime: '2020-01-01'
       source: UNECE 2022

--- a/config/zones/ES-CN-GC.yaml
+++ b/config/zones/ES-CN-GC.yaml
@@ -30,6 +30,11 @@ emissionFactors:
     - datetime: '2022-01-01'
       source: EU-ETS, ENTSO-E 2022
       value: 426.61
+    hydro discharge:
+    - _comment: used storage values equal to zero.
+      datetime: '2024-01-01'
+      source: Electricity Maps, 2024 zone average
+      value: 512.88
     oil:
     - datetime: '2017-01-01'
       source: EU-ETS, REE
@@ -80,6 +85,11 @@ emissionFactors:
       datetime: '2020-01-01'
       source: UNECE 2022
       value: 10.7
+    hydro discharge:
+    - _comment: used storage values equal to zero.
+      datetime: '2024-01-01'
+      source: Electricity Maps, 2024 zone average
+      value: 698.04
     nuclear:
       datetime: '2020-01-01'
       source: UNECE 2022

--- a/config/zones/ES-CN-HI.yaml
+++ b/config/zones/ES-CN-HI.yaml
@@ -34,6 +34,11 @@ emissionFactors:
     - datetime: '2022-01-01'
       source: EU-ETS, ENTSO-E 2022
       value: 426.61
+    hydro discharge:
+    - _comment: used storage values greater than zero.
+      datetime: '2024-01-01'
+      source: Electricity Maps, 2024 zone average
+      value: 195.08
     oil:
     - datetime: '2017-01-01'
       source: EU-ETS, REE
@@ -84,6 +89,11 @@ emissionFactors:
       datetime: '2020-01-01'
       source: UNECE 2022
       value: 10.7
+    hydro discharge:
+    - _comment: used storage values greater than zero.
+      datetime: '2024-01-01'
+      source: Electricity Maps, 2024 zone average
+      value: 271.09
     nuclear:
       datetime: '2020-01-01'
       source: UNECE 2022

--- a/config/zones/ES-CN-IG.yaml
+++ b/config/zones/ES-CN-IG.yaml
@@ -32,6 +32,11 @@ emissionFactors:
     - datetime: '2022-01-01'
       source: EU-ETS, ENTSO-E 2022
       value: 426.61
+    hydro discharge:
+    - _comment: used storage values equal to zero.
+      datetime: '2024-01-01'
+      source: Electricity Maps, 2024 zone average
+      value: 615.07
     oil:
     - datetime: '2017-01-01'
       source: EU-ETS, REE
@@ -82,6 +87,11 @@ emissionFactors:
       datetime: '2020-01-01'
       source: UNECE 2022
       value: 10.7
+    hydro discharge:
+    - _comment: used storage values equal to zero.
+      datetime: '2024-01-01'
+      source: Electricity Maps, 2024 zone average
+      value: 835.66
     nuclear:
       datetime: '2020-01-01'
       source: UNECE 2022

--- a/config/zones/ES-CN-LP.yaml
+++ b/config/zones/ES-CN-LP.yaml
@@ -30,6 +30,11 @@ emissionFactors:
     - datetime: '2022-01-01'
       source: EU-ETS, ENTSO-E 2022
       value: 426.61
+    hydro discharge:
+    - _comment: used storage values equal to zero.
+      datetime: '2024-01-01'
+      source: Electricity Maps, 2024 zone average
+      value: 611.76
     oil:
     - datetime: '2017-01-01'
       source: EU-ETS, REE
@@ -80,6 +85,11 @@ emissionFactors:
       datetime: '2020-01-01'
       source: UNECE 2022
       value: 10.7
+    hydro discharge:
+    - _comment: used storage values equal to zero.
+      datetime: '2024-01-01'
+      source: Electricity Maps, 2024 zone average
+      value: 835.94
     nuclear:
       datetime: '2020-01-01'
       source: UNECE 2022

--- a/config/zones/ES-CN-LZ.yaml
+++ b/config/zones/ES-CN-LZ.yaml
@@ -32,6 +32,11 @@ emissionFactors:
     - datetime: '2022-01-01'
       source: EU-ETS, ENTSO-E 2022
       value: 426.61
+    hydro discharge:
+    - _comment: used storage values equal to zero.
+      datetime: '2024-01-01'
+      source: Electricity Maps, 2024 zone average
+      value: 590.11
     oil:
     - datetime: '2017-01-01'
       source: EU-ETS, REE
@@ -82,6 +87,11 @@ emissionFactors:
       datetime: '2020-01-01'
       source: UNECE 2022
       value: 10.7
+    hydro discharge:
+    - _comment: used storage values equal to zero.
+      datetime: '2024-01-01'
+      source: Electricity Maps, 2024 zone average
+      value: 812.75
     nuclear:
       datetime: '2020-01-01'
       source: UNECE 2022

--- a/config/zones/ES-CN-TE.yaml
+++ b/config/zones/ES-CN-TE.yaml
@@ -30,6 +30,11 @@ emissionFactors:
     - datetime: '2022-01-01'
       source: EU-ETS, ENTSO-E 2022
       value: 426.61
+    hydro discharge:
+    - _comment: used storage values equal to zero.
+      datetime: '2024-01-01'
+      source: Electricity Maps, 2024 zone average
+      value: 560.55
     oil:
     - datetime: '2017-01-01'
       source: EU-ETS, REE
@@ -80,6 +85,11 @@ emissionFactors:
       datetime: '2020-01-01'
       source: UNECE 2022
       value: 10.7
+    hydro discharge:
+    - _comment: used storage values equal to zero.
+      datetime: '2024-01-01'
+      source: Electricity Maps, 2024 zone average
+      value: 761.18
     nuclear:
       datetime: '2020-01-01'
       source: UNECE 2022

--- a/config/zones/ES-ML.yaml
+++ b/config/zones/ES-ML.yaml
@@ -30,7 +30,18 @@ country: ES
 country_name: Spain
 currency: EUR
 emissionFactors:
-  lifecycle: {}
+  direct:
+    battery discharge:
+    - _comment: used storage values equal to zero.
+      datetime: '2024-01-01'
+      source: Electricity Maps, 2024 zone average
+      value: 376.11
+  lifecycle:
+    battery discharge:
+    - _comment: used storage values equal to zero.
+      datetime: '2024-01-01'
+      source: Electricity Maps, 2024 zone average
+      value: 618.92
 fallbackZoneMixes:
   powerOriginRatios:
   - _source: Electricity Maps, 2022 average

--- a/config/zones/ES.yaml
+++ b/config/zones/ES.yaml
@@ -265,6 +265,11 @@ emissionFactors:
     - datetime: '2024-01-01'
       source: EU-ETS, ENTSO-E 2024
       value: 417.47
+    hydro discharge:
+    - _comment: used storage values greater than zero.
+      datetime: '2024-01-01'
+      source: Electricity Maps, 2024 zone average
+      value: 62.29
     oil:
     - datetime: '2021-01-01'
       source: EU-ETS, ENTSO-E 2021
@@ -315,6 +320,11 @@ emissionFactors:
       datetime: '2020-01-01'
       source: UNECE 2022
       value: 10.7
+    hydro discharge:
+    - _comment: used storage values greater than zero.
+      datetime: '2024-01-01'
+      source: Electricity Maps, 2024 zone average
+      value: 94.8
     nuclear:
       datetime: '2020-01-01'
       source: UNECE 2022

--- a/config/zones/FR-COR.yaml
+++ b/config/zones/FR-COR.yaml
@@ -21,6 +21,11 @@ delays:
   production: 6
 emissionFactors:
   direct:
+    battery discharge:
+    - _comment: used storage values greater than zero.
+      datetime: '2024-01-01'
+      source: Electricity Maps, 2024 zone average
+      value: 370.72
     biomass:
       datetime: '2021-01-01'
       source: BEIS 2021
@@ -65,6 +70,11 @@ emissionFactors:
       source: EU-ETS, ENTSO-E 2024
       value: 889.87
   lifecycle:
+    battery discharge:
+    - _comment: used storage values greater than zero.
+      datetime: '2024-01-01'
+      source: Electricity Maps, 2024 zone average
+      value: 480.4
     biomass:
       datetime: '2014-01-01'
       source: BEIS 2021; IPCC 2014

--- a/config/zones/FR.yaml
+++ b/config/zones/FR.yaml
@@ -277,6 +277,11 @@ delays:
   production: 6
 emissionFactors:
   direct:
+    battery discharge:
+    - _comment: used storage values greater than zero.
+      datetime: '2024-01-01'
+      source: Electricity Maps, 2024 zone average
+      value: 18.33
     biomass:
       datetime: '2021-01-01'
       source: BEIS 2021
@@ -307,6 +312,11 @@ emissionFactors:
     - datetime: '2024-01-01'
       source: EU-ETS, ENTSO-E 2024
       value: 415.47
+    hydro discharge:
+    - _comment: used storage values greater than zero.
+      datetime: '2024-01-01'
+      source: Electricity Maps, 2024 zone average
+      value: 12.96
     oil:
     - datetime: '2021-01-01'
       source: EU-ETS, ENTSO-E 2021
@@ -321,6 +331,11 @@ emissionFactors:
       source: EU-ETS, ENTSO-E 2024
       value: 889.95
   lifecycle:
+    battery discharge:
+    - _comment: used storage values greater than zero.
+      datetime: '2024-01-01'
+      source: Electricity Maps, 2024 zone average
+      value: 34.06
     biomass:
       datetime: '2014-01-01'
       source: BEIS 2021; IPCC 2014
@@ -357,6 +372,11 @@ emissionFactors:
       datetime: '2020-01-01'
       source: UNECE 2022
       value: 10.7
+    hydro discharge:
+    - _comment: used storage values greater than zero.
+      datetime: '2024-01-01'
+      source: Electricity Maps, 2024 zone average
+      value: 28.16
     nuclear:
       datetime: '2020-01-01'
       source: UNECE 2022

--- a/config/zones/GB.yaml
+++ b/config/zones/GB.yaml
@@ -194,12 +194,22 @@ currency: GBP
 delays:
   production: 5
 emissionFactors:
-  direct: {}
+  direct:
+    hydro discharge:
+    - _comment: used storage values greater than zero.
+      datetime: '2024-01-01'
+      source: Electricity Maps, 2024 zone average
+      value: 114.28
   lifecycle:
     hydro:
       datetime: '2020-01-01'
       source: UNECE 2022
       value: 10.7
+    hydro discharge:
+    - _comment: used storage values greater than zero.
+      datetime: '2024-01-01'
+      source: Electricity Maps, 2024 zone average
+      value: 173.62
     nuclear:
       datetime: '2020-01-01'
       source: UNECE 2022

--- a/config/zones/GR.yaml
+++ b/config/zones/GR.yaml
@@ -200,6 +200,11 @@ emissionFactors:
     - datetime: '2024-01-01'
       source: EU-ETS, ENTSO-E 2024
       value: 391.85
+    hydro discharge:
+    - _comment: used storage values equal to zero.
+      datetime: '2024-01-01'
+      source: Electricity Maps, 2024 zone average
+      value: 248.12
     oil:
     - datetime: '2021-01-01'
       source: EU-ETS, ENTSO-E 2021
@@ -244,6 +249,11 @@ emissionFactors:
       datetime: '2020-01-01'
       source: UNECE 2022
       value: 10.7
+    hydro discharge:
+    - _comment: used storage values equal to zero.
+      datetime: '2024-01-01'
+      source: Electricity Maps, 2024 zone average
+      value: 305.08
     nuclear:
       datetime: '2020-01-01'
       source: UNECE 2022

--- a/config/zones/HR.yaml
+++ b/config/zones/HR.yaml
@@ -222,6 +222,11 @@ emissionFactors:
     - datetime: '2024-01-01'
       source: EU-ETS, ENTSO-E 2024
       value: 415.69
+    hydro discharge:
+    - _comment: used storage values greater than zero.
+      datetime: '2024-01-01'
+      source: Electricity Maps, 2024 zone average
+      value: 186.81
     oil:
     - datetime: '2021-01-01'
       source: EU-ETS, ENTSO-E 2021
@@ -272,6 +277,11 @@ emissionFactors:
       datetime: '2020-01-01'
       source: UNECE 2022
       value: 10.7
+    hydro discharge:
+    - _comment: used storage values greater than zero.
+      datetime: '2024-01-01'
+      source: Electricity Maps, 2024 zone average
+      value: 223.96
     nuclear:
       datetime: '2020-01-01'
       source: UNECE 2022

--- a/config/zones/IT-CNO.yaml
+++ b/config/zones/IT-CNO.yaml
@@ -69,6 +69,11 @@ delays:
   production: 7
 emissionFactors:
   direct:
+    battery discharge:
+    - _comment: used storage values greater than zero.
+      datetime: '2024-01-01'
+      source: Electricity Maps, 2024 zone average
+      value: 261.9
     biomass:
       datetime: '2021-01-01'
       source: BEIS 2021
@@ -99,6 +104,11 @@ emissionFactors:
     - datetime: '2024-01-01'
       source: EU-ETS, ENTSO-E 2024
       value: 434.62
+    hydro discharge:
+    - _comment: used storage values greater than zero.
+      datetime: '2024-01-01'
+      source: Electricity Maps, 2024 zone average
+      value: 263.48
     oil:
     - datetime: '2021-01-01'
       source: EU-ETS, ENTSO-E 2021
@@ -113,6 +123,11 @@ emissionFactors:
       source: EU-ETS, ENTSO-E 2024
       value: 905.42
   lifecycle:
+    battery discharge:
+    - _comment: used storage values greater than zero.
+      datetime: '2024-01-01'
+      source: Electricity Maps, 2024 zone average
+      value: 343.91
     biomass:
       datetime: '2014-01-01'
       source: BEIS 2021; IPCC 2014
@@ -149,6 +164,11 @@ emissionFactors:
       datetime: '2020-01-01'
       source: UNECE 2022
       value: 10.7
+    hydro discharge:
+    - _comment: used storage values greater than zero.
+      datetime: '2024-01-01'
+      source: Electricity Maps, 2024 zone average
+      value: 346.09
     nuclear:
       datetime: '2020-01-01'
       source: UNECE 2022

--- a/config/zones/IT-CSO.yaml
+++ b/config/zones/IT-CSO.yaml
@@ -140,6 +140,11 @@ emissionFactors:
     - datetime: '2024-01-01'
       source: EU-ETS, ENTSO-E 2024
       value: 434.62
+    hydro discharge:
+    - _comment: used storage values greater than zero.
+      datetime: '2024-01-01'
+      source: Electricity Maps, 2024 zone average
+      value: 225.24
     oil:
     - datetime: '2021-01-01'
       source: EU-ETS, ENTSO-E 2021
@@ -190,6 +195,11 @@ emissionFactors:
       datetime: '2020-01-01'
       source: UNECE 2022
       value: 10.7
+    hydro discharge:
+    - _comment: used storage values greater than zero.
+      datetime: '2024-01-01'
+      source: Electricity Maps, 2024 zone average
+      value: 296.67
     nuclear:
       datetime: '2020-01-01'
       source: UNECE 2022

--- a/config/zones/IT-NO.yaml
+++ b/config/zones/IT-NO.yaml
@@ -129,6 +129,11 @@ emissionFactors:
     - datetime: '2024-01-01'
       source: EU-ETS, ENTSO-E 2024
       value: 434.62
+    hydro discharge:
+    - _comment: used storage values greater than zero.
+      datetime: '2024-01-01'
+      source: Electricity Maps, 2024 zone average
+      value: 180.62
     oil:
     - datetime: '2021-01-01'
       source: EU-ETS, ENTSO-E 2021
@@ -179,6 +184,11 @@ emissionFactors:
       datetime: '2020-01-01'
       source: UNECE 2022
       value: 10.7
+    hydro discharge:
+    - _comment: used storage values greater than zero.
+      datetime: '2024-01-01'
+      source: Electricity Maps, 2024 zone average
+      value: 241.02
     nuclear:
       datetime: '2020-01-01'
       source: UNECE 2022

--- a/config/zones/IT-SAR.yaml
+++ b/config/zones/IT-SAR.yaml
@@ -74,6 +74,11 @@ delays:
   production: 7
 emissionFactors:
   direct:
+    battery discharge:
+    - _comment: used storage values equal to zero.
+      datetime: '2024-01-01'
+      source: Electricity Maps, 2024 zone average
+      value: 417.03
     biomass:
       datetime: '2021-01-01'
       source: BEIS 2021
@@ -104,6 +109,11 @@ emissionFactors:
     - datetime: '2024-01-01'
       source: EU-ETS, ENTSO-E 2024
       value: 434.62
+    hydro discharge:
+    - _comment: used storage values greater than zero.
+      datetime: '2024-01-01'
+      source: Electricity Maps, 2024 zone average
+      value: 429.01
     oil:
     - datetime: '2021-01-01'
       source: EU-ETS, ENTSO-E 2021
@@ -118,6 +128,11 @@ emissionFactors:
       source: EU-ETS, ENTSO-E 2024
       value: 905.42
   lifecycle:
+    battery discharge:
+    - _comment: used storage values equal to zero.
+      datetime: '2024-01-01'
+      source: Electricity Maps, 2024 zone average
+      value: 548.55
     biomass:
       datetime: '2014-01-01'
       source: BEIS 2021; IPCC 2014
@@ -154,6 +169,11 @@ emissionFactors:
       datetime: '2020-01-01'
       source: UNECE 2022
       value: 10.7
+    hydro discharge:
+    - _comment: used storage values greater than zero.
+      datetime: '2024-01-01'
+      source: Electricity Maps, 2024 zone average
+      value: 506.25
     nuclear:
       datetime: '2020-01-01'
       source: UNECE 2022

--- a/config/zones/IT-SIC.yaml
+++ b/config/zones/IT-SIC.yaml
@@ -79,6 +79,11 @@ delays:
   production: 7
 emissionFactors:
   direct:
+    battery discharge:
+    - _comment: used storage values equal to zero.
+      datetime: '2024-01-01'
+      source: Electricity Maps, 2024 zone average
+      value: 249.91
     biomass:
       datetime: '2021-01-01'
       source: BEIS 2021
@@ -109,6 +114,11 @@ emissionFactors:
     - datetime: '2024-01-01'
       source: EU-ETS, ENTSO-E 2024
       value: 434.62
+    hydro discharge:
+    - _comment: used storage values greater than zero.
+      datetime: '2024-01-01'
+      source: Electricity Maps, 2024 zone average
+      value: 179.15
     oil:
     - datetime: '2021-01-01'
       source: EU-ETS, ENTSO-E 2021
@@ -123,6 +133,11 @@ emissionFactors:
       source: EU-ETS, ENTSO-E 2024
       value: 905.42
   lifecycle:
+    battery discharge:
+    - _comment: used storage values equal to zero.
+      datetime: '2024-01-01'
+      source: Electricity Maps, 2024 zone average
+      value: 388.18
     biomass:
       datetime: '2014-01-01'
       source: BEIS 2021; IPCC 2014
@@ -159,6 +174,11 @@ emissionFactors:
       datetime: '2020-01-01'
       source: UNECE 2022
       value: 10.7
+    hydro discharge:
+    - _comment: used storage values greater than zero.
+      datetime: '2024-01-01'
+      source: Electricity Maps, 2024 zone average
+      value: 245.99
     nuclear:
       datetime: '2020-01-01'
       source: UNECE 2022

--- a/config/zones/IT.yaml
+++ b/config/zones/IT.yaml
@@ -21,6 +21,11 @@ country_name: Italy
 currency: EUR
 emissionFactors:
   direct:
+    battery discharge:
+    - _comment: used storage values greater than zero.
+      datetime: '2024-01-01'
+      source: Electricity Maps, 2024 zone average
+      value: 273.1
     biomass:
       datetime: '2021-01-01'
       source: BEIS 2021
@@ -51,6 +56,11 @@ emissionFactors:
     - datetime: '2024-01-01'
       source: EU-ETS, ENTSO-E 2024
       value: 434.62
+    hydro discharge:
+    - _comment: used storage values greater than zero.
+      datetime: '2024-01-01'
+      source: Electricity Maps, 2024 zone average
+      value: 188.14
     oil:
     - datetime: '2021-01-01'
       source: EU-ETS, ENTSO-E 2021
@@ -65,6 +75,11 @@ emissionFactors:
       source: EU-ETS, ENTSO-E 2024
       value: 905.42
   lifecycle:
+    battery discharge:
+    - _comment: used storage values greater than zero.
+      datetime: '2024-01-01'
+      source: Electricity Maps, 2024 zone average
+      value: 357.51
     biomass:
       datetime: '2014-01-01'
       source: BEIS 2021; IPCC 2014
@@ -101,6 +116,11 @@ emissionFactors:
       datetime: '2020-01-01'
       source: UNECE 2022
       value: 10.7
+    hydro discharge:
+    - _comment: used storage values greater than zero.
+      datetime: '2024-01-01'
+      source: Electricity Maps, 2024 zone average
+      value: 251.05
     nuclear:
       datetime: '2020-01-01'
       source: UNECE 2022

--- a/config/zones/KR.yaml
+++ b/config/zones/KR.yaml
@@ -192,8 +192,18 @@ currency: KRW
 delays:
   production: 5
 emissionFactors:
-  direct: {}
+  direct:
+    hydro discharge:
+    - _comment: used storage values greater than zero.
+      datetime: '2024-01-01'
+      source: Electricity Maps, 2024 zone average
+      value: 351.5
   lifecycle:
+    hydro discharge:
+    - _comment: used storage values greater than zero.
+      datetime: '2024-01-01'
+      source: Electricity Maps, 2024 zone average
+      value: 412.05
     unknown:
       _comment: 'Source: 2020 annual electricity production by IEA'
       _url: https://www.iea.org/fuels-and-technologies/electricity

--- a/config/zones/LT.yaml
+++ b/config/zones/LT.yaml
@@ -206,6 +206,11 @@ emissionFactors:
     - datetime: '2024-01-01'
       source: EU-ETS, ENTSO-E 2024
       value: 370.92
+    hydro discharge:
+    - _comment: used storage values greater than zero.
+      datetime: '2024-01-01'
+      source: Electricity Maps, 2024 zone average
+      value: 112.96
     oil:
     - datetime: '2021-01-01'
       source: EU-ETS, ENTSO-E 2021
@@ -248,6 +253,11 @@ emissionFactors:
       datetime: '2020-01-01'
       source: UNECE 2022
       value: 10.7
+    hydro discharge:
+    - _comment: used storage values greater than zero.
+      datetime: '2024-01-01'
+      source: Electricity Maps, 2024 zone average
+      value: 158.58
     nuclear:
       datetime: '2020-01-01'
       source: UNECE 2022

--- a/config/zones/NO-NO2.yaml
+++ b/config/zones/NO-NO2.yaml
@@ -93,6 +93,11 @@ emissionFactors:
       datetime: '2021-01-01'
       source: EU-ETS 2021
       value: 0.0
+    hydro discharge:
+    - _comment: used storage values equal to zero.
+      datetime: '2024-01-01'
+      source: Electricity Maps, 2024 zone average
+      value: 10.23
   lifecycle:
     biomass:
       datetime: '2014-01-01'
@@ -102,6 +107,11 @@ emissionFactors:
       datetime: '2014-01-01'
       source: IPCC 2014
       value: 490.0
+    hydro discharge:
+    - _comment: used storage values equal to zero.
+      datetime: '2024-01-01'
+      source: Electricity Maps, 2024 zone average
+      value: 36.45
     oil:
       datetime: '2014-01-01'
       source: EIA 2020/BEIS 2021; IPCC 2014

--- a/config/zones/NO-NO3.yaml
+++ b/config/zones/NO-NO3.yaml
@@ -99,6 +99,11 @@ emissionFactors:
       datetime: '2021-01-01'
       source: EU-ETS 2021
       value: 0.0
+    hydro discharge:
+    - _comment: used storage values equal to zero.
+      datetime: '2024-01-01'
+      source: Electricity Maps, 2024 zone average
+      value: 7.53
   lifecycle:
     biomass:
       datetime: '2014-01-01'
@@ -108,6 +113,11 @@ emissionFactors:
       datetime: '2014-01-01'
       source: IPCC 2014
       value: 490.0
+    hydro discharge:
+    - _comment: used storage values equal to zero.
+      datetime: '2024-01-01'
+      source: Electricity Maps, 2024 zone average
+      value: 29.85
     oil:
       datetime: '2014-01-01'
       source: EIA 2020/BEIS 2021; IPCC 2014

--- a/config/zones/NO-NO5.yaml
+++ b/config/zones/NO-NO5.yaml
@@ -78,6 +78,11 @@ emissionFactors:
       datetime: '2021-01-01'
       source: EU-ETS 2021
       value: 0.0
+    hydro discharge:
+    - _comment: used storage values equal to zero.
+      datetime: '2024-01-01'
+      source: Electricity Maps, 2024 zone average
+      value: 0.82
   lifecycle:
     biomass:
       datetime: '2014-01-01'
@@ -87,6 +92,11 @@ emissionFactors:
       datetime: '2014-01-01'
       source: IPCC 2014
       value: 490.0
+    hydro discharge:
+    - _comment: used storage values equal to zero.
+      datetime: '2024-01-01'
+      source: Electricity Maps, 2024 zone average
+      value: 25.98
     oil:
       datetime: '2014-01-01'
       source: EIA 2020/BEIS 2021; IPCC 2014

--- a/config/zones/NO.yaml
+++ b/config/zones/NO.yaml
@@ -26,6 +26,11 @@ emissionFactors:
       datetime: '2021-01-01'
       source: EU-ETS 2021
       value: 0
+    hydro discharge:
+    - _comment: used storage values equal to zero.
+      datetime: '2024-01-01'
+      source: Electricity Maps, 2024 zone average
+      value: 10.95
   lifecycle:
     biomass:
       datetime: '2014-01-01'
@@ -35,6 +40,11 @@ emissionFactors:
       datetime: '2014-01-01'
       source: IPCC 2014
       value: 490
+    hydro discharge:
+    - _comment: used storage values equal to zero.
+      datetime: '2024-01-01'
+      source: Electricity Maps, 2024 zone average
+      value: 36.9
     oil:
       datetime: '2014-01-01'
       source: EIA 2020/BEIS 2021; IPCC 2014

--- a/config/zones/NZ.yaml
+++ b/config/zones/NZ.yaml
@@ -99,6 +99,19 @@ country_name: New Zealand
 currency: NZD
 delays:
   production: 6
+emissionFactors:
+  direct:
+    battery discharge:
+    - _comment: used storage values greater than zero.
+      datetime: '2024-01-01'
+      source: Electricity Maps, 2024 zone average
+      value: 82.49
+  lifecycle:
+    battery discharge:
+    - _comment: used storage values greater than zero.
+      datetime: '2024-01-01'
+      source: Electricity Maps, 2024 zone average
+      value: 120.96
 fallbackZoneMixes:
   powerOriginRatios:
   - _source: Electricity Maps, 2015 average

--- a/config/zones/PH-LU.yaml
+++ b/config/zones/PH-LU.yaml
@@ -27,7 +27,28 @@ country_name: Philippines
 delays:
   production: 25
 emissionFactors:
-  lifecycle: {}
+  direct:
+    battery discharge:
+    - _comment: used storage values greater than zero.
+      datetime: '2024-01-01'
+      source: Electricity Maps, 2024 zone average
+      value: 548.1
+    hydro discharge:
+    - _comment: used storage values greater than zero.
+      datetime: '2024-01-01'
+      source: Electricity Maps, 2024 zone average
+      value: 579.61
+  lifecycle:
+    battery discharge:
+    - _comment: used storage values greater than zero.
+      datetime: '2024-01-01'
+      source: Electricity Maps, 2024 zone average
+      value: 620.93
+    hydro discharge:
+    - _comment: used storage values greater than zero.
+      datetime: '2024-01-01'
+      source: Electricity Maps, 2024 zone average
+      value: 653.54
 fallbackZoneMixes:
   powerOriginRatios:
   - _source: Electricity Maps, 2017 average

--- a/config/zones/PH-MI.yaml
+++ b/config/zones/PH-MI.yaml
@@ -25,7 +25,18 @@ country_name: Philippines
 delays:
   production: 25
 emissionFactors:
-  lifecycle: {}
+  direct:
+    battery discharge:
+    - _comment: used storage values greater than zero.
+      datetime: '2024-01-01'
+      source: Electricity Maps, 2024 zone average
+      value: 489.77
+  lifecycle:
+    battery discharge:
+    - _comment: used storage values greater than zero.
+      datetime: '2024-01-01'
+      source: Electricity Maps, 2024 zone average
+      value: 549.42
 fallbackZoneMixes:
   powerOriginRatios:
   - _source: Electricity Maps, 2017 average

--- a/config/zones/PH-VI.yaml
+++ b/config/zones/PH-VI.yaml
@@ -26,7 +26,18 @@ country_name: Philippines
 delays:
   production: 25
 emissionFactors:
-  lifecycle: {}
+  direct:
+    battery discharge:
+    - _comment: used storage values greater than zero.
+      datetime: '2024-01-01'
+      source: Electricity Maps, 2024 zone average
+      value: 516.32
+  lifecycle:
+    battery discharge:
+    - _comment: used storage values greater than zero.
+      datetime: '2024-01-01'
+      source: Electricity Maps, 2024 zone average
+      value: 590.91
 fallbackZoneMixes:
   powerOriginRatios:
   - _source: Electricity Maps, 2017 average

--- a/config/zones/PH.yaml
+++ b/config/zones/PH.yaml
@@ -21,7 +21,28 @@ country: PH
 country_name: Philippines
 currency: PHP
 emissionFactors:
-  lifecycle: {}
+  direct:
+    battery discharge:
+    - _comment: used storage values greater than zero.
+      datetime: '2024-01-01'
+      source: Electricity Maps, 2024 zone average
+      value: 537.05
+    hydro discharge:
+    - _comment: used storage values greater than zero.
+      datetime: '2024-01-01'
+      source: Electricity Maps, 2024 zone average
+      value: 559.47
+  lifecycle:
+    battery discharge:
+    - _comment: used storage values greater than zero.
+      datetime: '2024-01-01'
+      source: Electricity Maps, 2024 zone average
+      value: 607.67
+    hydro discharge:
+    - _comment: used storage values greater than zero.
+      datetime: '2024-01-01'
+      source: Electricity Maps, 2024 zone average
+      value: 630.74
 fallbackZoneMixes:
   powerOriginRatios:
   - _source: Electricity Maps, 2017 average

--- a/config/zones/PL.yaml
+++ b/config/zones/PL.yaml
@@ -260,6 +260,11 @@ emissionFactors:
     - datetime: '2024-01-01'
       source: EU-ETS, ENTSO-E 2024
       value: 415.69
+    hydro discharge:
+    - _comment: used storage values greater than zero.
+      datetime: '2024-01-01'
+      source: Electricity Maps, 2024 zone average
+      value: 488.93
     oil:
     - datetime: '2021-01-01'
       source: EU-ETS, ENTSO-E 2021
@@ -310,6 +315,11 @@ emissionFactors:
       datetime: '2020-01-01'
       source: UNECE 2022
       value: 10.7
+    hydro discharge:
+    - _comment: used storage values greater than zero.
+      datetime: '2024-01-01'
+      source: Electricity Maps, 2024 zone average
+      value: 543.57
     nuclear:
       datetime: '2020-01-01'
       source: UNECE 2022

--- a/config/zones/PT.yaml
+++ b/config/zones/PT.yaml
@@ -246,6 +246,11 @@ emissionFactors:
     - datetime: '2024-01-01'
       source: EU-ETS, ENTSO-E 2024
       value: 387.05
+    hydro discharge:
+    - _comment: used storage values greater than zero.
+      datetime: '2024-01-01'
+      source: Electricity Maps, 2024 zone average
+      value: 51.4
     oil:
     - datetime: '2021-01-01'
       source: EU-ETS, ENTSO-E 2021
@@ -284,6 +289,11 @@ emissionFactors:
       datetime: '2020-01-01'
       source: UNECE 2022
       value: 10.7
+    hydro discharge:
+    - _comment: used storage values greater than zero.
+      datetime: '2024-01-01'
+      source: Electricity Maps, 2024 zone average
+      value: 93.1
     nuclear:
       datetime: '2020-01-01'
       source: UNECE 2022

--- a/config/zones/RE.yaml
+++ b/config/zones/RE.yaml
@@ -57,6 +57,19 @@ contributors:
 country: RE
 country_name: "R\xE9union"
 currency: EUR
+emissionFactors:
+  direct:
+    battery discharge:
+    - _comment: used storage values greater than zero.
+      datetime: '2024-01-01'
+      source: Electricity Maps, 2024 zone average
+      value: 316.62
+  lifecycle:
+    battery discharge:
+    - _comment: used storage values greater than zero.
+      datetime: '2024-01-01'
+      source: Electricity Maps, 2024 zone average
+      value: 468.03
 fallbackZoneMixes:
   powerOriginRatios:
   - _source: Electricity Maps, 2016 average

--- a/config/zones/RS.yaml
+++ b/config/zones/RS.yaml
@@ -156,12 +156,22 @@ currency: EUR
 delays:
   production: 9
 emissionFactors:
-  direct: {}
+  direct:
+    hydro discharge:
+    - _comment: used storage values greater than zero.
+      datetime: '2024-01-01'
+      source: Electricity Maps, 2024 zone average
+      value: 453.93
   lifecycle:
     hydro:
       datetime: '2020-01-01'
       source: UNECE 2022
       value: 10.7
+    hydro discharge:
+    - _comment: used storage values greater than zero.
+      datetime: '2024-01-01'
+      source: Electricity Maps, 2024 zone average
+      value: 501.46
     nuclear:
       datetime: '2020-01-01'
       source: UNECE 2022

--- a/config/zones/SI.yaml
+++ b/config/zones/SI.yaml
@@ -193,6 +193,11 @@ emissionFactors:
     - datetime: '2024-01-01'
       source: EU-ETS, ENTSO-E 2024
       value: 415.69
+    hydro discharge:
+    - _comment: used storage values equal to zero.
+      datetime: '2024-01-01'
+      source: Electricity Maps, 2024 zone average
+      value: 197.69
     oil:
     - datetime: '2021-01-01'
       source: EU-ETS, ENTSO-E 2021
@@ -243,6 +248,11 @@ emissionFactors:
       datetime: '2020-01-01'
       source: UNECE 2022
       value: 10.7
+    hydro discharge:
+    - _comment: used storage values equal to zero.
+      datetime: '2024-01-01'
+      source: Electricity Maps, 2024 zone average
+      value: 227.9
     nuclear:
       datetime: '2020-01-01'
       source: UNECE 2022

--- a/config/zones/SK.yaml
+++ b/config/zones/SK.yaml
@@ -156,6 +156,11 @@ emissionFactors:
     - datetime: '2024-01-01'
       source: EU-ETS, ENTSO-E 2024
       value: 362.01
+    hydro discharge:
+    - _comment: used storage values greater than zero.
+      datetime: '2024-01-01'
+      source: Electricity Maps, 2024 zone average
+      value: 152.87
     oil:
     - datetime: '2021-01-01'
       source: EU-ETS, ENTSO-E 2021
@@ -206,6 +211,11 @@ emissionFactors:
       datetime: '2020-01-01'
       source: UNECE 2022
       value: 10.7
+    hydro discharge:
+    - _comment: used storage values greater than zero.
+      datetime: '2024-01-01'
+      source: Electricity Maps, 2024 zone average
+      value: 188.49
     nuclear:
       datetime: '2020-01-01'
       source: UNECE 2022

--- a/config/zones/TW.yaml
+++ b/config/zones/TW.yaml
@@ -167,6 +167,29 @@ country_name: Taiwan
 currency: TWD
 delays:
   production: 5
+emissionFactors:
+  direct:
+    battery discharge:
+    - _comment: used storage values greater than zero.
+      datetime: '2024-01-01'
+      source: Electricity Maps, 2024 zone average
+      value: 388.71
+    hydro discharge:
+    - _comment: used storage values greater than zero.
+      datetime: '2024-01-01'
+      source: Electricity Maps, 2024 zone average
+      value: 400.95
+  lifecycle:
+    battery discharge:
+    - _comment: used storage values greater than zero.
+      datetime: '2024-01-01'
+      source: Electricity Maps, 2024 zone average
+      value: 476.41
+    hydro discharge:
+    - _comment: used storage values greater than zero.
+      datetime: '2024-01-01'
+      source: Electricity Maps, 2024 zone average
+      value: 484.65
 fallbackZoneMixes:
   powerOriginRatios:
   - _source: Electricity Maps, 2015 average

--- a/config/zones/US-CAL-CISO.yaml
+++ b/config/zones/US-CAL-CISO.yaml
@@ -1010,6 +1010,11 @@ delays:
   production: 5
 emissionFactors:
   direct:
+    battery discharge:
+    - _comment: used storage values greater than zero.
+      datetime: '2024-01-01'
+      source: Electricity Maps, 2024 zone average
+      value: 129.21
     biomass:
     - datetime: '2020-01-01'
       source: BEIS 2021
@@ -1062,6 +1067,11 @@ emissionFactors:
     - datetime: '2023-01-01'
       source: eGrid 2023
       value: 38.89697026267566
+    hydro discharge:
+    - _comment: used storage values greater than zero.
+      datetime: '2024-01-01'
+      source: Electricity Maps, 2024 zone average
+      value: 75.64
     oil:
     - datetime: '2020-01-01'
       source: eGrid 2020
@@ -1076,6 +1086,11 @@ emissionFactors:
       source: eGrid 2023
       value: 945.4848707544354
   lifecycle:
+    battery discharge:
+    - _comment: used storage values greater than zero.
+      datetime: '2024-01-01'
+      source: Electricity Maps, 2024 zone average
+      value: 185.27
     biomass:
     - _comment: Mean of all US zones
       datetime: '2020-01-01'
@@ -1132,6 +1147,11 @@ emissionFactors:
     - datetime: '2023-01-01'
       source: eGrid 2023; IPCC 2014
       value: 76.89697026267567
+    hydro discharge:
+    - _comment: used storage values greater than zero.
+      datetime: '2024-01-01'
+      source: Electricity Maps, 2024 zone average
+      value: 119.73
     oil:
     - datetime: '2020-01-01'
       source: eGrid 2020; IPCC 2014

--- a/config/zones/US-CAL-IID.yaml
+++ b/config/zones/US-CAL-IID.yaml
@@ -199,6 +199,11 @@ emissionFactors:
     - datetime: '2023-01-01'
       source: eGrid 2023
       value: 33.30793611464112
+    hydro discharge:
+    - _comment: used storage values greater than zero.
+      datetime: '2024-01-01'
+      source: Electricity Maps, 2024 zone average
+      value: 292.25
     oil:
     - _comment: Mean of all US zones
       datetime: '2020-01-01'
@@ -277,6 +282,11 @@ emissionFactors:
     - datetime: '2023-01-01'
       source: eGrid 2023; IPCC 2014
       value: 71.30793611464112
+    hydro discharge:
+    - _comment: used storage values greater than zero.
+      datetime: '2024-01-01'
+      source: Electricity Maps, 2024 zone average
+      value: 368.76
     oil:
     - _comment: Mean of all US zones
       datetime: '2020-01-01'

--- a/config/zones/US-CAR-CPLW.yaml
+++ b/config/zones/US-CAR-CPLW.yaml
@@ -150,6 +150,11 @@ emissionFactors:
       datetime: '2023-01-01'
       source: eGrid 2023
       value: 28.739435464835893
+    hydro discharge:
+    - _comment: used storage values greater than zero.
+      datetime: '2024-01-01'
+      source: Electricity Maps, 2024 zone average
+      value: 403.28
     oil:
     - _comment: Mean of all US zones
       datetime: '2020-01-01'
@@ -239,6 +244,11 @@ emissionFactors:
       datetime: '2023-01-01'
       source: eGrid 2023; IPCC 2014
       value: 66.73943546483589
+    hydro discharge:
+    - _comment: used storage values greater than zero.
+      datetime: '2024-01-01'
+      source: Electricity Maps, 2024 zone average
+      value: 475.1
     oil:
     - _comment: Mean of all US zones
       datetime: '2020-01-01'

--- a/config/zones/US-CAR-SC.yaml
+++ b/config/zones/US-CAR-SC.yaml
@@ -169,6 +169,11 @@ emissionFactors:
       datetime: '2023-01-01'
       source: eGrid 2023
       value: 28.739435464835893
+    hydro discharge:
+    - _comment: used storage values greater than zero.
+      datetime: '2024-01-01'
+      source: Electricity Maps, 2024 zone average
+      value: 596.74
     oil:
     - _comment: Mean of all US zones
       datetime: '2020-01-01'
@@ -246,6 +251,11 @@ emissionFactors:
       datetime: '2023-01-01'
       source: eGrid 2023; IPCC 2014
       value: 66.73943546483589
+    hydro discharge:
+    - _comment: used storage values greater than zero.
+      datetime: '2024-01-01'
+      source: Electricity Maps, 2024 zone average
+      value: 680.24
     oil:
     - _comment: Mean of all US zones
       datetime: '2020-01-01'

--- a/config/zones/US-MIDA-PJM.yaml
+++ b/config/zones/US-MIDA-PJM.yaml
@@ -1147,6 +1147,11 @@ delays:
   production: 7
 emissionFactors:
   direct:
+    battery discharge:
+    - _comment: used storage values greater than zero.
+      datetime: '2024-01-01'
+      source: Electricity Maps, 2024 zone average
+      value: 334.17
     biomass:
     - datetime: '2020-01-01'
       source: BEIS 2021
@@ -1217,6 +1222,11 @@ emissionFactors:
       source: eGrid 2023
       value: 860.2336465682306
   lifecycle:
+    battery discharge:
+    - _comment: used storage values greater than zero.
+      datetime: '2024-01-01'
+      source: Electricity Maps, 2024 zone average
+      value: 407.77
     biomass:
     - _comment: Mean of all US zones
       datetime: '2020-01-01'

--- a/config/zones/US-NE-ISNE.yaml
+++ b/config/zones/US-NE-ISNE.yaml
@@ -851,6 +851,11 @@ delays:
   production: 5
 emissionFactors:
   direct:
+    battery discharge:
+    - _comment: used storage values equal to zero.
+      datetime: '2024-01-01'
+      source: Electricity Maps, 2024 zone average
+      value: 205.92
     biomass:
     - datetime: '2020-01-01'
       source: BEIS 2021
@@ -921,6 +926,11 @@ emissionFactors:
       source: eGrid 2023
       value: 976.0253449225385
   lifecycle:
+    battery discharge:
+    - _comment: used storage values equal to zero.
+      datetime: '2024-01-01'
+      source: Electricity Maps, 2024 zone average
+      value: 288.26
     biomass:
     - _comment: Mean of all US zones
       datetime: '2020-01-01'

--- a/config/zones/US-NW-NWMT.yaml
+++ b/config/zones/US-NW-NWMT.yaml
@@ -220,6 +220,11 @@ emissionFactors:
       datetime: '2023-01-01'
       source: eGrid 2023
       value: 28.739435464835893
+    hydro discharge:
+    - _comment: used storage values greater than zero.
+      datetime: '2024-01-01'
+      source: Electricity Maps, 2024 zone average
+      value: 860.24
     oil:
     - datetime: '2020-01-01'
       source: eGrid 2020
@@ -294,6 +299,11 @@ emissionFactors:
       datetime: '2023-01-01'
       source: eGrid 2023; IPCC 2014
       value: 66.73943546483589
+    hydro discharge:
+    - _comment: used storage values greater than zero.
+      datetime: '2024-01-01'
+      source: Electricity Maps, 2024 zone average
+      value: 878.4
     oil:
     - datetime: '2020-01-01'
       source: eGrid 2020; IPCC 2014

--- a/config/zones/US-SW-PNM.yaml
+++ b/config/zones/US-SW-PNM.yaml
@@ -258,6 +258,11 @@ delays:
   production: 48
 emissionFactors:
   direct:
+    battery discharge:
+    - _comment: used storage values greater than zero.
+      datetime: '2024-01-01'
+      source: Electricity Maps, 2024 zone average
+      value: 298.46
     biomass:
     - datetime: '2020-01-01'
       source: BEIS 2021
@@ -315,6 +320,11 @@ emissionFactors:
       datetime: '2023-01-01'
       source: eGrid 2023
       value: 28.739435464835893
+    hydro discharge:
+    - _comment: used storage values greater than zero.
+      datetime: '2024-01-01'
+      source: Electricity Maps, 2024 zone average
+      value: 179.13
     oil:
     - _comment: Mean of all US zones
       datetime: '2020-01-01'
@@ -333,6 +343,11 @@ emissionFactors:
       source: eGrid 2023
       value: 692.2365799135232
   lifecycle:
+    battery discharge:
+    - _comment: used storage values greater than zero.
+      datetime: '2024-01-01'
+      source: Electricity Maps, 2024 zone average
+      value: 352.53
     biomass:
     - _comment: Mean of all US zones
       datetime: '2020-01-01'
@@ -394,6 +409,11 @@ emissionFactors:
       datetime: '2023-01-01'
       source: eGrid 2023; IPCC 2014
       value: 66.73943546483589
+    hydro discharge:
+    - _comment: used storage values greater than zero.
+      datetime: '2024-01-01'
+      source: Electricity Maps, 2024 zone average
+      value: 213.14
     oil:
     - _comment: Mean of all US zones
       datetime: '2020-01-01'

--- a/config/zones/US-SW-SRP.yaml
+++ b/config/zones/US-SW-SRP.yaml
@@ -167,6 +167,11 @@ disclaimer: This zone includes all electricity production from the generation-on
   Company, LLC - HGBA. Read more on the wiki page.
 emissionFactors:
   direct:
+    battery discharge:
+    - _comment: used storage values greater than zero.
+      datetime: '2024-01-01'
+      source: Electricity Maps, 2024 zone average
+      value: 230.77
     biomass:
     - datetime: '2020-01-01'
       source: BEIS 2021
@@ -223,6 +228,11 @@ emissionFactors:
       datetime: '2023-01-01'
       source: eGrid 2023
       value: 28.739435464835893
+    hydro discharge:
+    - _comment: used storage values greater than zero.
+      datetime: '2024-01-01'
+      source: Electricity Maps, 2024 zone average
+      value: 222.23
     oil:
     - _comment: Mean of all US zones
       datetime: '2020-01-01'
@@ -241,6 +251,11 @@ emissionFactors:
       source: eGrid 2023
       value: 692.2365799135232
   lifecycle:
+    battery discharge:
+    - _comment: used storage values greater than zero.
+      datetime: '2024-01-01'
+      source: Electricity Maps, 2024 zone average
+      value: 281.29
     biomass:
     - _comment: Mean of all US zones
       datetime: '2020-01-01'
@@ -301,6 +316,11 @@ emissionFactors:
       datetime: '2023-01-01'
       source: eGrid 2023; IPCC 2014
       value: 66.73943546483589
+    hydro discharge:
+    - _comment: used storage values greater than zero.
+      datetime: '2024-01-01'
+      source: Electricity Maps, 2024 zone average
+      value: 273.76
     oil:
     - _comment: Mean of all US zones
       datetime: '2020-01-01'

--- a/config/zones/US-SW-WALC.yaml
+++ b/config/zones/US-SW-WALC.yaml
@@ -197,6 +197,11 @@ emissionFactors:
       datetime: '2023-01-01'
       source: eGrid 2023
       value: 28.739435464835893
+    hydro discharge:
+    - _comment: used storage values greater than zero.
+      datetime: '2024-01-01'
+      source: Electricity Maps, 2024 zone average
+      value: 262.83
     oil:
     - _comment: Mean of all US zones
       datetime: '2020-01-01'
@@ -276,6 +281,11 @@ emissionFactors:
       datetime: '2023-01-01'
       source: eGrid 2023; IPCC 2014
       value: 66.73943546483589
+    hydro discharge:
+    - _comment: used storage values greater than zero.
+      datetime: '2024-01-01'
+      source: Electricity Maps, 2024 zone average
+      value: 333.56
     oil:
     - _comment: Mean of all US zones
       datetime: '2020-01-01'

--- a/config/zones/US-TEN-TVA.yaml
+++ b/config/zones/US-TEN-TVA.yaml
@@ -272,6 +272,11 @@ delays:
   production: 48
 emissionFactors:
   direct:
+    battery discharge:
+    - _comment: used storage values equal to zero.
+      datetime: '2024-01-01'
+      source: Electricity Maps, 2024 zone average
+      value: 359.56
     biomass:
     - datetime: '2020-01-01'
       source: BEIS 2021
@@ -328,6 +333,11 @@ emissionFactors:
       datetime: '2023-01-01'
       source: eGrid 2023
       value: 28.739435464835893
+    hydro discharge:
+    - _comment: used storage values greater than zero.
+      datetime: '2024-01-01'
+      source: Electricity Maps, 2024 zone average
+      value: 358.39
     oil:
     - datetime: '2020-01-01'
       source: eGrid 2020
@@ -345,6 +355,11 @@ emissionFactors:
       source: eGrid 2023
       value: 692.2365799135232
   lifecycle:
+    battery discharge:
+    - _comment: used storage values equal to zero.
+      datetime: '2024-01-01'
+      source: Electricity Maps, 2024 zone average
+      value: 430.72
     biomass:
     - _comment: Mean of all US zones
       datetime: '2020-01-01'
@@ -405,6 +420,11 @@ emissionFactors:
       datetime: '2023-01-01'
       source: eGrid 2023; IPCC 2014
       value: 66.73943546483589
+    hydro discharge:
+    - _comment: used storage values greater than zero.
+      datetime: '2024-01-01'
+      source: Electricity Maps, 2024 zone average
+      value: 428.8
     oil:
     - datetime: '2020-01-01'
       source: eGrid 2020; IPCC 2014

--- a/config/zones/US.yaml
+++ b/config/zones/US.yaml
@@ -222,6 +222,11 @@ country_name: United States
 currency: USD
 emissionFactors:
   direct:
+    battery discharge:
+    - _comment: used storage values greater than zero.
+      datetime: '2024-01-01'
+      source: Electricity Maps, 2024 zone average
+      value: 329.4
     biomass:
       datetime: '2020-01-01'
       source: eGrid 2020
@@ -238,11 +243,21 @@ emissionFactors:
       datetime: '2021-01-01'
       source: eGrid 2020
       value: 70.87985131
+    hydro discharge:
+    - _comment: used storage values greater than zero.
+      datetime: '2024-01-01'
+      source: Electricity Maps, 2024 zone average
+      value: 332.02
     oil:
       datetime: '2021-01-01'
       source: eGrid 2020
       value: 803.8986689
   lifecycle:
+    battery discharge:
+    - _comment: used storage values greater than zero.
+      datetime: '2024-01-01'
+      source: Electricity Maps, 2024 zone average
+      value: 396.95
     biomass:
       datetime: '2020-01-01'
       source: eGrid 2020
@@ -259,6 +274,11 @@ emissionFactors:
       datetime: '2021-01-01'
       source: eGrid 2020; IPCC 2014
       value: 108.87985131
+    hydro discharge:
+    - _comment: used storage values greater than zero.
+      datetime: '2024-01-01'
+      source: Electricity Maps, 2024 zone average
+      value: 399.08
     oil:
       datetime: '2021-01-01'
       source: eGrid 2020; IPCC 2014

--- a/config/zones/ZA.yaml
+++ b/config/zones/ZA.yaml
@@ -103,6 +103,19 @@ country_name: South Africa
 currency: ZAR
 delays:
   production: 96
+emissionFactors:
+  direct:
+    hydro discharge:
+    - _comment: used storage values greater than zero.
+      datetime: '2024-01-01'
+      source: Electricity Maps, 2024 zone average
+      value: 658.28
+  lifecycle:
+    hydro discharge:
+    - _comment: used storage values greater than zero.
+      datetime: '2024-01-01'
+      source: Electricity Maps, 2024 zone average
+      value: 715.53
 fallbackZoneMixes:
   powerOriginRatios:
   - _source: Electricity Maps, 2015 average


### PR DESCRIPTION
New methodology for calculating hydro and battery numbers. Previous methodology had circular dependency on carbon intensity. Crucially, the new method ensures that lifecycle discharge is always higher than direct discharge.

New method assumes that at the time the battery is charging, the electricity flowing into it matches the flowtraced consumption mix of all the modes in the zone except hydro and battery storage. Using this we calculate a weighted average emission factor summing `flowtraced_consumption_<mode>/total_consumption * emission_factor_<mode>` across all non-storage modes i.e. biomass, coal, gas, geothermal, hydro, nuclear, oil, solar, unknown, wind. We can do this calculating on a yearly level because we currently use yearly emission factors.

Note that the percentages do not add up to 100% necessary  because we are excluding battery discharge when calculating hydro and vice versa, but in practice these contribute a very small percentage on a yearly level and greatly simplify the calculation.

Example for 2024, SI, hydro (method is year, zone, storage independent):
1. take all hourly values where production_breakdown.hydro_storage > 0
2. sum up values for all modes and total_consumption for the year and calculate the percentages above
3. look up emission factors (direct and lifecycle) for the modes above and multiply with percentages
4. sum up across all modes to get the direct and lifecycle hydro emission factor

The above might not produce a number because step 1. can remove all data. To calculate a fallback, we then repeat the process for values where production_breakdown.hydro_storage = 0. Some zones only have non-negative storage numbers, but we still might want a zone specific factor. If this step also fails, then the zone does not get a hydro and/or battery emission factor and uses the global default instead.