### PR TITLE
fix(emission-factors): rerun battery and hydro discharge

### DIFF
--- a/config/zones/AT.yaml
+++ b/config/zones/AT.yaml
@@ -279,11 +279,11 @@ emissionFactors:
     - _comment: used storage values greater than zero.
       datetime: '2024-01-01'
       source: Electricity Maps, 2024 zone average
-      value: 79.99
+      value: 77.79
     - _comment: used storage values greater than zero.
       datetime: '2025-01-01'
       source: Electricity Maps, 2025 zone average
-      value: 112.37
+      value: 109.33
     oil:
     - datetime: '2021-01-01'
       source: EU-ETS, ENTSO-E 2021
@@ -348,11 +348,11 @@ emissionFactors:
     - _comment: used storage values greater than zero.
       datetime: '2024-01-01'
       source: Electricity Maps, 2024 zone average
-      value: 117.77
+      value: 115.57
     - _comment: used storage values greater than zero.
       datetime: '2025-01-01'
       source: Electricity Maps, 2025 zone average
-      value: 156.57
+      value: 153.54
     nuclear:
       datetime: '2020-01-01'
       source: UNECE 2022

--- a/config/zones/BE.yaml
+++ b/config/zones/BE.yaml
@@ -211,7 +211,7 @@ emissionFactors:
     - _comment: used storage values equal to zero.
       datetime: '2025-01-01'
       source: Electricity Maps, 2025 zone average
-      value: 141.07
+      value: 144.46
     biomass:
       datetime: '2021-01-01'
       source: BEIS 2021
@@ -258,15 +258,15 @@ emissionFactors:
     - _comment: used storage values greater than zero.
       datetime: '2023-01-01'
       source: Electricity Maps, 2023 zone average
-      value: 118.69
+      value: 118.82
     - _comment: used storage values greater than zero.
       datetime: '2024-01-01'
       source: Electricity Maps, 2024 zone average
-      value: 98.82
+      value: 101.06
     - _comment: used storage values greater than zero.
       datetime: '2025-01-01'
       source: Electricity Maps, 2025 zone average
-      value: 117.17
+      value: 119.72
     oil:
     - datetime: '2021-01-01'
       source: EU-ETS, ENTSO-E 2021
@@ -285,7 +285,7 @@ emissionFactors:
     - _comment: used storage values equal to zero.
       datetime: '2025-01-01'
       source: Electricity Maps, 2025 zone average
-      value: 194.85
+      value: 198.24
     biomass:
       datetime: '2014-01-01'
       source: BEIS 2021; IPCC 2014
@@ -338,15 +338,15 @@ emissionFactors:
     - _comment: used storage values greater than zero.
       datetime: '2023-01-01'
       source: Electricity Maps, 2023 zone average
-      value: 166.63
+      value: 166.77
     - _comment: used storage values greater than zero.
       datetime: '2024-01-01'
       source: Electricity Maps, 2024 zone average
-      value: 141.5
+      value: 143.74
     - _comment: used storage values greater than zero.
       datetime: '2025-01-01'
       source: Electricity Maps, 2025 zone average
-      value: 166.75
+      value: 169.3
     nuclear:
       datetime: '2020-01-01'
       source: UNECE 2022

--- a/config/zones/CZ.yaml
+++ b/config/zones/CZ.yaml
@@ -200,11 +200,11 @@ emissionFactors:
     - _comment: used storage values equal to zero.
       datetime: '2024-01-01'
       source: Electricity Maps, 2024 zone average
-      value: 416.44
+      value: 424.39
     - _comment: used storage values greater than zero.
       datetime: '2025-01-01'
       source: Electricity Maps, 2025 zone average
-      value: 458.32
+      value: 467.02
     oil:
     - datetime: '2021-01-01'
       source: EU-ETS, ENTSO-E 2021
@@ -269,11 +269,11 @@ emissionFactors:
     - _comment: used storage values equal to zero.
       datetime: '2024-01-01'
       source: Electricity Maps, 2024 zone average
-      value: 457.52
+      value: 465.47
     - _comment: used storage values greater than zero.
       datetime: '2025-01-01'
       source: Electricity Maps, 2025 zone average
-      value: 500.85
+      value: 509.56
     nuclear:
       datetime: '2020-01-01'
       source: UNECE 2022

--- a/config/zones/DE.yaml
+++ b/config/zones/DE.yaml
@@ -334,15 +334,15 @@ emissionFactors:
     - _comment: used storage values greater than zero.
       datetime: '2023-01-01'
       source: Electricity Maps, 2023 zone average
-      value: 269.54
+      value: 274.62
     - _comment: used storage values greater than zero.
       datetime: '2024-01-01'
       source: Electricity Maps, 2024 zone average
-      value: 233.11
+      value: 241.63
     - _comment: used storage values greater than zero.
       datetime: '2025-01-01'
       source: Electricity Maps, 2025 zone average
-      value: 228.45
+      value: 236.44
     oil:
     - datetime: '2021-01-01'
       source: EU-ETS, ENTSO-E 2021
@@ -409,15 +409,15 @@ emissionFactors:
     - _comment: used storage values greater than zero.
       datetime: '2023-01-01'
       source: Electricity Maps, 2023 zone average
-      value: 328.59
+      value: 333.67
     - _comment: used storage values greater than zero.
       datetime: '2024-01-01'
       source: Electricity Maps, 2024 zone average
-      value: 290.89
+      value: 299.41
     - _comment: used storage values greater than zero.
       datetime: '2025-01-01'
       source: Electricity Maps, 2025 zone average
-      value: 286.75
+      value: 294.74
     nuclear:
       datetime: '2020-01-01'
       source: UNECE 2022

--- a/config/zones/ES-CN-GC.yaml
+++ b/config/zones/ES-CN-GC.yaml
@@ -117,7 +117,7 @@ emissionFactors:
     - _comment: used storage values equal to zero.
       datetime: '2022-01-01'
       source: Electricity Maps, 2022 zone average
-      value: 709.35
+      value: 709.36
     - _comment: used storage values equal to zero.
       datetime: '2023-01-01'
       source: Electricity Maps, 2023 zone average

--- a/config/zones/ES.yaml
+++ b/config/zones/ES.yaml
@@ -239,7 +239,7 @@ emissionFactors:
     - _comment: used storage values equal to zero.
       datetime: '2025-01-01'
       source: Electricity Maps, 2025 zone average
-      value: 95.05
+      value: 99.49
     biomass:
       datetime: '2021-01-01'
       source: BEIS 2021
@@ -290,11 +290,11 @@ emissionFactors:
     - _comment: used storage values greater than zero.
       datetime: '2024-01-01'
       source: Electricity Maps, 2024 zone average
-      value: 62.29
+      value: 65.89
     - _comment: used storage values greater than zero.
       datetime: '2025-01-01'
       source: Electricity Maps, 2025 zone average
-      value: 63.32
+      value: 66.52
     oil:
     - datetime: '2021-01-01'
       source: EU-ETS, ENTSO-E 2021
@@ -313,7 +313,7 @@ emissionFactors:
     - _comment: used storage values equal to zero.
       datetime: '2025-01-01'
       source: Electricity Maps, 2025 zone average
-      value: 137.11
+      value: 141.55
     biomass:
       datetime: '2014-01-01'
       source: BEIS 2021; IPCC 2014
@@ -370,11 +370,11 @@ emissionFactors:
     - _comment: used storage values greater than zero.
       datetime: '2024-01-01'
       source: Electricity Maps, 2024 zone average
-      value: 94.8
+      value: 98.4
     - _comment: used storage values greater than zero.
       datetime: '2025-01-01'
       source: Electricity Maps, 2025 zone average
-      value: 98.79
+      value: 102.0
     nuclear:
       datetime: '2020-01-01'
       source: UNECE 2022

--- a/config/zones/FR-COR.yaml
+++ b/config/zones/FR-COR.yaml
@@ -25,15 +25,15 @@ emissionFactors:
     - _comment: used storage values greater than zero.
       datetime: '2023-01-01'
       source: Electricity Maps, 2023 zone average
-      value: 320.8
+      value: 321.52
     - _comment: used storage values greater than zero.
       datetime: '2024-01-01'
       source: Electricity Maps, 2024 zone average
-      value: 370.72
+      value: 444.58
     - _comment: used storage values greater than zero.
       datetime: '2025-01-01'
       source: Electricity Maps, 2025 zone average
-      value: 384.06
+      value: 497.36
     biomass:
       datetime: '2021-01-01'
       source: BEIS 2021
@@ -82,15 +82,15 @@ emissionFactors:
     - _comment: used storage values greater than zero.
       datetime: '2023-01-01'
       source: Electricity Maps, 2023 zone average
-      value: 424.88
+      value: 425.6
     - _comment: used storage values greater than zero.
       datetime: '2024-01-01'
       source: Electricity Maps, 2024 zone average
-      value: 480.4
+      value: 554.25
     - _comment: used storage values greater than zero.
       datetime: '2025-01-01'
       source: Electricity Maps, 2025 zone average
-      value: 519.63
+      value: 632.93
     biomass:
       datetime: '2014-01-01'
       source: BEIS 2021; IPCC 2014

--- a/config/zones/FR.yaml
+++ b/config/zones/FR.yaml
@@ -281,15 +281,15 @@ emissionFactors:
     - _comment: used storage values greater than zero.
       datetime: '2023-01-01'
       source: Electricity Maps, 2023 zone average
-      value: 23.08
+      value: 23.09
     - _comment: used storage values greater than zero.
       datetime: '2024-01-01'
       source: Electricity Maps, 2024 zone average
-      value: 18.33
+      value: 19.72
     - _comment: used storage values greater than zero.
       datetime: '2025-01-01'
       source: Electricity Maps, 2025 zone average
-      value: 15.69
+      value: 16.81
     biomass:
       datetime: '2021-01-01'
       source: BEIS 2021
@@ -336,15 +336,15 @@ emissionFactors:
     - _comment: used storage values greater than zero.
       datetime: '2023-01-01'
       source: Electricity Maps, 2023 zone average
-      value: 27.71
+      value: 27.72
     - _comment: used storage values greater than zero.
       datetime: '2024-01-01'
       source: Electricity Maps, 2024 zone average
-      value: 12.96
+      value: 14.01
     - _comment: used storage values greater than zero.
       datetime: '2025-01-01'
       source: Electricity Maps, 2025 zone average
-      value: 10.8
+      value: 11.6
     oil:
     - datetime: '2021-01-01'
       source: EU-ETS, ENTSO-E 2021
@@ -363,15 +363,15 @@ emissionFactors:
     - _comment: used storage values greater than zero.
       datetime: '2023-01-01'
       source: Electricity Maps, 2023 zone average
-      value: 40.18
+      value: 40.19
     - _comment: used storage values greater than zero.
       datetime: '2024-01-01'
       source: Electricity Maps, 2024 zone average
-      value: 34.06
+      value: 35.45
     - _comment: used storage values greater than zero.
       datetime: '2025-01-01'
       source: Electricity Maps, 2025 zone average
-      value: 31.43
+      value: 32.55
     biomass:
       datetime: '2014-01-01'
       source: BEIS 2021; IPCC 2014
@@ -424,15 +424,15 @@ emissionFactors:
     - _comment: used storage values greater than zero.
       datetime: '2023-01-01'
       source: Electricity Maps, 2023 zone average
-      value: 46.44
+      value: 46.45
     - _comment: used storage values greater than zero.
       datetime: '2024-01-01'
       source: Electricity Maps, 2024 zone average
-      value: 28.16
+      value: 29.21
     - _comment: used storage values greater than zero.
       datetime: '2025-01-01'
       source: Electricity Maps, 2025 zone average
-      value: 26.35
+      value: 27.14
     nuclear:
       datetime: '2020-01-01'
       source: UNECE 2022

--- a/config/zones/GR.yaml
+++ b/config/zones/GR.yaml
@@ -220,11 +220,11 @@ emissionFactors:
     - _comment: used storage values equal to zero.
       datetime: '2024-01-01'
       source: Electricity Maps, 2024 zone average
-      value: 248.12
+      value: 239.34
     - _comment: used storage values equal to zero.
       datetime: '2025-01-01'
       source: Electricity Maps, 2025 zone average
-      value: 223.3
+      value: 216.33
     oil:
     - datetime: '2021-01-01'
       source: EU-ETS, ENTSO-E 2021
@@ -289,11 +289,11 @@ emissionFactors:
     - _comment: used storage values equal to zero.
       datetime: '2024-01-01'
       source: Electricity Maps, 2024 zone average
-      value: 305.08
+      value: 296.3
     - _comment: used storage values equal to zero.
       datetime: '2025-01-01'
       source: Electricity Maps, 2025 zone average
-      value: 281.01
+      value: 274.04
     nuclear:
       datetime: '2020-01-01'
       source: UNECE 2022

--- a/config/zones/HR.yaml
+++ b/config/zones/HR.yaml
@@ -238,15 +238,15 @@ emissionFactors:
     - _comment: used storage values greater than zero.
       datetime: '2023-01-01'
       source: Electricity Maps, 2023 zone average
-      value: 255.81
+      value: 257.6
     - _comment: used storage values greater than zero.
       datetime: '2024-01-01'
       source: Electricity Maps, 2024 zone average
-      value: 186.81
+      value: 188.25
     - _comment: used storage values greater than zero.
       datetime: '2025-01-01'
       source: Electricity Maps, 2025 zone average
-      value: 203.72
+      value: 205.24
     oil:
     - datetime: '2021-01-01'
       source: EU-ETS, ENTSO-E 2021
@@ -301,27 +301,27 @@ emissionFactors:
     - _comment: used storage values greater than zero.
       datetime: '2020-01-01'
       source: Electricity Maps, 2020 zone average
-      value: 309.64
+      value: 321.78
     - _comment: used storage values greater than zero.
       datetime: '2021-01-01'
       source: Electricity Maps, 2021 zone average
-      value: 339.5
+      value: 351.85
     - _comment: used storage values greater than zero.
       datetime: '2022-01-01'
       source: Electricity Maps, 2022 zone average
-      value: 380.73
+      value: 391.84
     - _comment: used storage values greater than zero.
       datetime: '2023-01-01'
       source: Electricity Maps, 2023 zone average
-      value: 299.15
+      value: 308.24
     - _comment: used storage values greater than zero.
       datetime: '2024-01-01'
       source: Electricity Maps, 2024 zone average
-      value: 223.96
+      value: 233.77
     - _comment: used storage values greater than zero.
       datetime: '2025-01-01'
       source: Electricity Maps, 2025 zone average
-      value: 241.78
+      value: 252.35
     nuclear:
       datetime: '2020-01-01'
       source: UNECE 2022

--- a/config/zones/IT-CNO.yaml
+++ b/config/zones/IT-CNO.yaml
@@ -73,11 +73,11 @@ emissionFactors:
     - _comment: used storage values greater than zero.
       datetime: '2024-01-01'
       source: Electricity Maps, 2024 zone average
-      value: 261.9
+      value: 271.19
     - _comment: used storage values greater than zero.
       datetime: '2025-01-01'
       source: Electricity Maps, 2025 zone average
-      value: 169.5
+      value: 175.24
     biomass:
       datetime: '2021-01-01'
       source: BEIS 2021
@@ -112,7 +112,7 @@ emissionFactors:
     - _comment: used storage values greater than zero.
       datetime: '2024-01-01'
       source: Electricity Maps, 2024 zone average
-      value: 263.48
+      value: 272.82
     oil:
     - datetime: '2021-01-01'
       source: EU-ETS, ENTSO-E 2021
@@ -131,11 +131,11 @@ emissionFactors:
     - _comment: used storage values greater than zero.
       datetime: '2024-01-01'
       source: Electricity Maps, 2024 zone average
-      value: 343.91
+      value: 353.19
     - _comment: used storage values greater than zero.
       datetime: '2025-01-01'
       source: Electricity Maps, 2025 zone average
-      value: 232.81
+      value: 238.55
     biomass:
       datetime: '2014-01-01'
       source: BEIS 2021; IPCC 2014
@@ -176,7 +176,7 @@ emissionFactors:
     - _comment: used storage values greater than zero.
       datetime: '2024-01-01'
       source: Electricity Maps, 2024 zone average
-      value: 346.09
+      value: 355.42
     nuclear:
       datetime: '2020-01-01'
       source: UNECE 2022

--- a/config/zones/IT-CSO.yaml
+++ b/config/zones/IT-CSO.yaml
@@ -114,7 +114,7 @@ emissionFactors:
     - _comment: used storage values greater than zero.
       datetime: '2025-01-01'
       source: Electricity Maps, 2025 zone average
-      value: 207.38
+      value: 213.62
     biomass:
       datetime: '2021-01-01'
       source: BEIS 2021
@@ -165,11 +165,11 @@ emissionFactors:
     - _comment: used storage values greater than zero.
       datetime: '2024-01-01'
       source: Electricity Maps, 2024 zone average
-      value: 225.24
+      value: 230.84
     - _comment: used storage values greater than zero.
       datetime: '2025-01-01'
       source: Electricity Maps, 2025 zone average
-      value: 198.34
+      value: 204.25
     oil:
     - datetime: '2021-01-01'
       source: EU-ETS, ENTSO-E 2021
@@ -188,7 +188,7 @@ emissionFactors:
     - _comment: used storage values greater than zero.
       datetime: '2025-01-01'
       source: Electricity Maps, 2025 zone average
-      value: 277.07
+      value: 283.3
     biomass:
       datetime: '2014-01-01'
       source: BEIS 2021; IPCC 2014
@@ -245,11 +245,11 @@ emissionFactors:
     - _comment: used storage values greater than zero.
       datetime: '2024-01-01'
       source: Electricity Maps, 2024 zone average
-      value: 296.67
+      value: 302.26
     - _comment: used storage values greater than zero.
       datetime: '2025-01-01'
       source: Electricity Maps, 2025 zone average
-      value: 266.81
+      value: 272.72
     nuclear:
       datetime: '2020-01-01'
       source: UNECE 2022

--- a/config/zones/IT-NO.yaml
+++ b/config/zones/IT-NO.yaml
@@ -103,7 +103,7 @@ emissionFactors:
     - _comment: used storage values greater than zero.
       datetime: '2025-01-01'
       source: Electricity Maps, 2025 zone average
-      value: 204.81
+      value: 211.36
     biomass:
       datetime: '2021-01-01'
       source: BEIS 2021
@@ -154,11 +154,11 @@ emissionFactors:
     - _comment: used storage values greater than zero.
       datetime: '2024-01-01'
       source: Electricity Maps, 2024 zone average
-      value: 180.62
+      value: 185.87
     - _comment: used storage values greater than zero.
       datetime: '2025-01-01'
       source: Electricity Maps, 2025 zone average
-      value: 202.13
+      value: 208.53
     oil:
     - datetime: '2021-01-01'
       source: EU-ETS, ENTSO-E 2021
@@ -177,7 +177,7 @@ emissionFactors:
     - _comment: used storage values greater than zero.
       datetime: '2025-01-01'
       source: Electricity Maps, 2025 zone average
-      value: 270.05
+      value: 276.6
     biomass:
       datetime: '2014-01-01'
       source: BEIS 2021; IPCC 2014
@@ -234,11 +234,11 @@ emissionFactors:
     - _comment: used storage values greater than zero.
       datetime: '2024-01-01'
       source: Electricity Maps, 2024 zone average
-      value: 241.02
+      value: 246.27
     - _comment: used storage values greater than zero.
       datetime: '2025-01-01'
       source: Electricity Maps, 2025 zone average
-      value: 268.09
+      value: 274.48
     nuclear:
       datetime: '2020-01-01'
       source: UNECE 2022

--- a/config/zones/IT-SAR.yaml
+++ b/config/zones/IT-SAR.yaml
@@ -78,11 +78,11 @@ emissionFactors:
     - _comment: used storage values equal to zero.
       datetime: '2024-01-01'
       source: Electricity Maps, 2024 zone average
-      value: 417.03
+      value: 425.68
     - _comment: used storage values greater than zero.
       datetime: '2025-01-01'
       source: Electricity Maps, 2025 zone average
-      value: 389.64
+      value: 390.31
     biomass:
       datetime: '2021-01-01'
       source: BEIS 2021
@@ -133,11 +133,11 @@ emissionFactors:
     - _comment: used storage values greater than zero.
       datetime: '2024-01-01'
       source: Electricity Maps, 2024 zone average
-      value: 429.01
+      value: 428.5
     - _comment: used storage values greater than zero.
       datetime: '2025-01-01'
       source: Electricity Maps, 2025 zone average
-      value: 385.87
+      value: 387.44
     oil:
     - datetime: '2021-01-01'
       source: EU-ETS, ENTSO-E 2021
@@ -156,11 +156,11 @@ emissionFactors:
     - _comment: used storage values equal to zero.
       datetime: '2024-01-01'
       source: Electricity Maps, 2024 zone average
-      value: 548.55
+      value: 557.2
     - _comment: used storage values greater than zero.
       datetime: '2025-01-01'
       source: Electricity Maps, 2025 zone average
-      value: 468.09
+      value: 468.76
     biomass:
       datetime: '2014-01-01'
       source: BEIS 2021; IPCC 2014
@@ -217,11 +217,11 @@ emissionFactors:
     - _comment: used storage values greater than zero.
       datetime: '2024-01-01'
       source: Electricity Maps, 2024 zone average
-      value: 506.25
+      value: 505.74
     - _comment: used storage values greater than zero.
       datetime: '2025-01-01'
       source: Electricity Maps, 2025 zone average
-      value: 469.84
+      value: 471.41
     nuclear:
       datetime: '2020-01-01'
       source: UNECE 2022

--- a/config/zones/IT-SIC.yaml
+++ b/config/zones/IT-SIC.yaml
@@ -83,11 +83,11 @@ emissionFactors:
     - _comment: used storage values equal to zero.
       datetime: '2024-01-01'
       source: Electricity Maps, 2024 zone average
-      value: 249.91
+      value: 260.95
     - _comment: used storage values greater than zero.
       datetime: '2025-01-01'
       source: Electricity Maps, 2025 zone average
-      value: 203.12
+      value: 212.05
     biomass:
       datetime: '2021-01-01'
       source: BEIS 2021
@@ -138,11 +138,11 @@ emissionFactors:
     - _comment: used storage values greater than zero.
       datetime: '2024-01-01'
       source: Electricity Maps, 2024 zone average
-      value: 179.15
+      value: 186.76
     - _comment: used storage values greater than zero.
       datetime: '2025-01-01'
       source: Electricity Maps, 2025 zone average
-      value: 194.64
+      value: 203.2
     oil:
     - datetime: '2021-01-01'
       source: EU-ETS, ENTSO-E 2021
@@ -161,11 +161,11 @@ emissionFactors:
     - _comment: used storage values equal to zero.
       datetime: '2024-01-01'
       source: Electricity Maps, 2024 zone average
-      value: 388.18
+      value: 399.22
     - _comment: used storage values greater than zero.
       datetime: '2025-01-01'
       source: Electricity Maps, 2025 zone average
-      value: 275.86
+      value: 284.79
     biomass:
       datetime: '2014-01-01'
       source: BEIS 2021; IPCC 2014
@@ -222,11 +222,11 @@ emissionFactors:
     - _comment: used storage values greater than zero.
       datetime: '2024-01-01'
       source: Electricity Maps, 2024 zone average
-      value: 245.99
+      value: 253.6
     - _comment: used storage values greater than zero.
       datetime: '2025-01-01'
       source: Electricity Maps, 2025 zone average
-      value: 265.67
+      value: 274.23
     nuclear:
       datetime: '2020-01-01'
       source: UNECE 2022

--- a/config/zones/IT.yaml
+++ b/config/zones/IT.yaml
@@ -25,11 +25,11 @@ emissionFactors:
     - _comment: used storage values greater than zero.
       datetime: '2024-01-01'
       source: Electricity Maps, 2024 zone average
-      value: 273.1
+      value: 281.73
     - _comment: used storage values greater than zero.
       datetime: '2025-01-01'
       source: Electricity Maps, 2025 zone average
-      value: 204.44
+      value: 210.83
     biomass:
       datetime: '2021-01-01'
       source: BEIS 2021
@@ -80,11 +80,11 @@ emissionFactors:
     - _comment: used storage values greater than zero.
       datetime: '2024-01-01'
       source: Electricity Maps, 2024 zone average
-      value: 188.14
+      value: 193.24
     - _comment: used storage values greater than zero.
       datetime: '2025-01-01'
       source: Electricity Maps, 2025 zone average
-      value: 199.63
+      value: 205.81
     oil:
     - datetime: '2021-01-01'
       source: EU-ETS, ENTSO-E 2021
@@ -103,11 +103,11 @@ emissionFactors:
     - _comment: used storage values greater than zero.
       datetime: '2024-01-01'
       source: Electricity Maps, 2024 zone average
-      value: 357.51
+      value: 366.15
     - _comment: used storage values greater than zero.
       datetime: '2025-01-01'
       source: Electricity Maps, 2025 zone average
-      value: 271.98
+      value: 278.37
     biomass:
       datetime: '2014-01-01'
       source: BEIS 2021; IPCC 2014
@@ -164,11 +164,11 @@ emissionFactors:
     - _comment: used storage values greater than zero.
       datetime: '2024-01-01'
       source: Electricity Maps, 2024 zone average
-      value: 251.05
+      value: 256.14
     - _comment: used storage values greater than zero.
       datetime: '2025-01-01'
       source: Electricity Maps, 2025 zone average
-      value: 267.07
+      value: 273.25
     nuclear:
       datetime: '2020-01-01'
       source: UNECE 2022

--- a/config/zones/JP-CG.yaml
+++ b/config/zones/JP-CG.yaml
@@ -36,7 +36,7 @@ emissionFactors:
     - _comment: used storage values equal to zero.
       datetime: '2020-01-01'
       source: Electricity Maps, 2020 zone average
-      value: 509.31
+      value: 509.85
 fallbackZoneMixes:
   powerOriginRatios:
   - _source: Electricity Maps, 2017 average

--- a/config/zones/JP-HKD.yaml
+++ b/config/zones/JP-HKD.yaml
@@ -39,7 +39,7 @@ emissionFactors:
     - _comment: used storage values equal to zero.
       datetime: '2020-01-01'
       source: Electricity Maps, 2020 zone average
-      value: 523.33
+      value: 523.63
 fallbackZoneMixes:
   powerOriginRatios:
   - _source: Electricity Maps, 2017 average

--- a/config/zones/JP-HR.yaml
+++ b/config/zones/JP-HR.yaml
@@ -43,11 +43,11 @@ emissionFactors:
     - _comment: used storage values equal to zero.
       datetime: '2020-01-01'
       source: Electricity Maps, 2020 zone average
-      value: 441.69
+      value: 445.61
     - _comment: used storage values equal to zero.
       datetime: '2025-01-01'
       source: Electricity Maps, 2025 zone average
-      value: 483.29
+      value: 488.19
 fallbackZoneMixes:
   powerOriginRatios:
   - _source: Electricity Maps, 2017 average

--- a/config/zones/LT.yaml
+++ b/config/zones/LT.yaml
@@ -180,7 +180,7 @@ emissionFactors:
     - _comment: used storage values greater than zero.
       datetime: '2025-01-01'
       source: Electricity Maps, 2025 zone average
-      value: 106.36
+      value: 105.31
     biomass:
       datetime: '2021-01-01'
       source: BEIS 2021
@@ -227,15 +227,15 @@ emissionFactors:
     - _comment: used storage values greater than zero.
       datetime: '2023-01-01'
       source: Electricity Maps, 2023 zone average
-      value: 132.91
+      value: 133.53
     - _comment: used storage values greater than zero.
       datetime: '2024-01-01'
       source: Electricity Maps, 2024 zone average
-      value: 112.96
+      value: 112.82
     - _comment: used storage values greater than zero.
       datetime: '2025-01-01'
       source: Electricity Maps, 2025 zone average
-      value: 86.44
+      value: 85.97
     oil:
     - datetime: '2021-01-01'
       source: EU-ETS, ENTSO-E 2021
@@ -248,7 +248,7 @@ emissionFactors:
     - _comment: used storage values greater than zero.
       datetime: '2025-01-01'
       source: Electricity Maps, 2025 zone average
-      value: 165.7
+      value: 164.66
     biomass:
       datetime: '2014-01-01'
       source: BEIS 2021; IPCC 2014
@@ -299,15 +299,15 @@ emissionFactors:
     - _comment: used storage values greater than zero.
       datetime: '2023-01-01'
       source: Electricity Maps, 2023 zone average
-      value: 180.14
+      value: 180.76
     - _comment: used storage values greater than zero.
       datetime: '2024-01-01'
       source: Electricity Maps, 2024 zone average
-      value: 158.58
+      value: 158.44
     - _comment: used storage values greater than zero.
       datetime: '2025-01-01'
       source: Electricity Maps, 2025 zone average
-      value: 135.81
+      value: 135.35
     nuclear:
       datetime: '2020-01-01'
       source: UNECE 2022

--- a/config/zones/LV.yaml
+++ b/config/zones/LV.yaml
@@ -133,7 +133,7 @@ emissionFactors:
     - _comment: used storage values equal to zero.
       datetime: '2025-01-01'
       source: Electricity Maps, 2025 zone average
-      value: 105.7
+      value: 102.01
     biomass:
       datetime: '2021-01-01'
       source: BEIS 2021
@@ -182,7 +182,7 @@ emissionFactors:
     - _comment: used storage values equal to zero.
       datetime: '2025-01-01'
       source: Electricity Maps, 2025 zone average
-      value: 159.19
+      value: 155.5
     biomass:
       datetime: '2014-01-01'
       source: BEIS 2021; IPCC 2014

--- a/config/zones/NO-NO2.yaml
+++ b/config/zones/NO-NO2.yaml
@@ -127,23 +127,23 @@ emissionFactors:
     - _comment: used storage values equal to zero.
       datetime: '2021-01-01'
       source: Electricity Maps, 2021 zone average
-      value: 41.74
+      value: 40.82
     - _comment: used storage values equal to zero.
       datetime: '2022-01-01'
       source: Electricity Maps, 2022 zone average
-      value: 55.1
+      value: 53.9
     - _comment: used storage values greater than zero.
       datetime: '2023-01-01'
       source: Electricity Maps, 2023 zone average
-      value: 86.67
+      value: 84.4
     - _comment: used storage values equal to zero.
       datetime: '2024-01-01'
       source: Electricity Maps, 2024 zone average
-      value: 36.45
+      value: 36.0
     - _comment: used storage values greater than zero.
       datetime: '2025-01-01'
       source: Electricity Maps, 2025 zone average
-      value: 29.54
+      value: 29.36
     oil:
       datetime: '2014-01-01'
       source: EIA 2020/BEIS 2021; IPCC 2014

--- a/config/zones/NO-NO3.yaml
+++ b/config/zones/NO-NO3.yaml
@@ -137,11 +137,11 @@ emissionFactors:
     - _comment: used storage values equal to zero.
       datetime: '2020-01-01'
       source: Electricity Maps, 2020 zone average
-      value: 29.14
+      value: 29.13
     - _comment: used storage values equal to zero.
       datetime: '2021-01-01'
       source: Electricity Maps, 2021 zone average
-      value: 25.88
+      value: 25.87
     - _comment: used storage values equal to zero.
       datetime: '2022-01-01'
       source: Electricity Maps, 2022 zone average

--- a/config/zones/NO-NO5.yaml
+++ b/config/zones/NO-NO5.yaml
@@ -120,11 +120,11 @@ emissionFactors:
     - _comment: used storage values equal to zero.
       datetime: '2021-01-01'
       source: Electricity Maps, 2021 zone average
-      value: 41.5
+      value: 41.44
     - _comment: used storage values equal to zero.
       datetime: '2022-01-01'
       source: Electricity Maps, 2022 zone average
-      value: 27.11
+      value: 27.09
     - _comment: used storage values equal to zero.
       datetime: '2023-01-01'
       source: Electricity Maps, 2023 zone average
@@ -132,7 +132,7 @@ emissionFactors:
     - _comment: used storage values equal to zero.
       datetime: '2024-01-01'
       source: Electricity Maps, 2024 zone average
-      value: 25.98
+      value: 25.97
     - _comment: used storage values greater than zero.
       datetime: '2025-01-01'
       source: Electricity Maps, 2025 zone average

--- a/config/zones/NO.yaml
+++ b/config/zones/NO.yaml
@@ -60,23 +60,23 @@ emissionFactors:
     - _comment: used storage values equal to zero.
       datetime: '2021-01-01'
       source: Electricity Maps, 2021 zone average
-      value: 36.22
+      value: 35.78
     - _comment: used storage values equal to zero.
       datetime: '2022-01-01'
       source: Electricity Maps, 2022 zone average
-      value: 36.51
+      value: 36.24
     - _comment: used storage values equal to zero.
       datetime: '2023-01-01'
       source: Electricity Maps, 2023 zone average
-      value: 32.77
+      value: 32.63
     - _comment: used storage values equal to zero.
       datetime: '2024-01-01'
       source: Electricity Maps, 2024 zone average
-      value: 36.9
+      value: 36.77
     - _comment: used storage values greater than zero.
       datetime: '2025-01-01'
       source: Electricity Maps, 2025 zone average
-      value: 33.34
+      value: 33.27
     oil:
       datetime: '2014-01-01'
       source: EIA 2020/BEIS 2021; IPCC 2014

--- a/config/zones/PL.yaml
+++ b/config/zones/PL.yaml
@@ -280,11 +280,11 @@ emissionFactors:
     - _comment: used storage values greater than zero.
       datetime: '2024-01-01'
       source: Electricity Maps, 2024 zone average
-      value: 488.93
+      value: 476.33
     - _comment: used storage values greater than zero.
       datetime: '2025-01-01'
       source: Electricity Maps, 2025 zone average
-      value: 576.32
+      value: 559.61
     oil:
     - datetime: '2021-01-01'
       source: EU-ETS, ENTSO-E 2021
@@ -355,11 +355,11 @@ emissionFactors:
     - _comment: used storage values greater than zero.
       datetime: '2024-01-01'
       source: Electricity Maps, 2024 zone average
-      value: 543.57
+      value: 530.98
     - _comment: used storage values greater than zero.
       datetime: '2025-01-01'
       source: Electricity Maps, 2025 zone average
-      value: 638.8
+      value: 622.09
     nuclear:
       datetime: '2020-01-01'
       source: UNECE 2022

--- a/config/zones/PT.yaml
+++ b/config/zones/PT.yaml
@@ -266,11 +266,11 @@ emissionFactors:
     - _comment: used storage values greater than zero.
       datetime: '2024-01-01'
       source: Electricity Maps, 2024 zone average
-      value: 51.4
+      value: 52.69
     - _comment: used storage values greater than zero.
       datetime: '2025-01-01'
       source: Electricity Maps, 2025 zone average
-      value: 65.05
+      value: 66.85
     oil:
     - datetime: '2021-01-01'
       source: EU-ETS, ENTSO-E 2021
@@ -329,11 +329,11 @@ emissionFactors:
     - _comment: used storage values greater than zero.
       datetime: '2024-01-01'
       source: Electricity Maps, 2024 zone average
-      value: 93.1
+      value: 94.39
     - _comment: used storage values greater than zero.
       datetime: '2025-01-01'
       source: Electricity Maps, 2025 zone average
-      value: 109.97
+      value: 111.77
     nuclear:
       datetime: '2020-01-01'
       source: UNECE 2022

--- a/config/zones/RO.yaml
+++ b/config/zones/RO.yaml
@@ -180,7 +180,7 @@ emissionFactors:
     - _comment: used storage values greater than zero.
       datetime: '2025-01-01'
       source: Electricity Maps, 2025 zone average
-      value: 285.65
+      value: 287.45
     biomass:
       datetime: '2021-01-01'
       source: BEIS 2021
@@ -229,7 +229,7 @@ emissionFactors:
     - _comment: used storage values greater than zero.
       datetime: '2025-01-01'
       source: Electricity Maps, 2025 zone average
-      value: 328.35
+      value: 330.15
     biomass:
       datetime: '2014-01-01'
       source: BEIS 2021; IPCC 2014

--- a/config/zones/SI.yaml
+++ b/config/zones/SI.yaml
@@ -209,15 +209,15 @@ emissionFactors:
     - _comment: used storage values greater than zero.
       datetime: '2023-01-01'
       source: Electricity Maps, 2023 zone average
-      value: 278.67
+      value: 281.03
     - _comment: used storage values equal to zero.
       datetime: '2024-01-01'
       source: Electricity Maps, 2024 zone average
-      value: 197.69
+      value: 198.73
     - _comment: used storage values equal to zero.
       datetime: '2025-01-01'
       source: Electricity Maps, 2025 zone average
-      value: 171.69
+      value: 172.81
     oil:
     - datetime: '2021-01-01'
       source: EU-ETS, ENTSO-E 2021
@@ -284,15 +284,15 @@ emissionFactors:
     - _comment: used storage values greater than zero.
       datetime: '2023-01-01'
       source: Electricity Maps, 2023 zone average
-      value: 318.53
+      value: 320.88
     - _comment: used storage values equal to zero.
       datetime: '2024-01-01'
       source: Electricity Maps, 2024 zone average
-      value: 227.9
+      value: 228.93
     - _comment: used storage values equal to zero.
       datetime: '2025-01-01'
       source: Electricity Maps, 2025 zone average
-      value: 205.62
+      value: 206.73
     nuclear:
       datetime: '2020-01-01'
       source: UNECE 2022

--- a/config/zones/SK.yaml
+++ b/config/zones/SK.yaml
@@ -172,15 +172,15 @@ emissionFactors:
     - _comment: used storage values greater than zero.
       datetime: '2023-01-01'
       source: Electricity Maps, 2023 zone average
-      value: 160.59
+      value: 193.67
     - _comment: used storage values greater than zero.
       datetime: '2024-01-01'
       source: Electricity Maps, 2024 zone average
-      value: 152.87
+      value: 147.1
     - _comment: used storage values greater than zero.
       datetime: '2025-01-01'
       source: Electricity Maps, 2025 zone average
-      value: 174.55
+      value: 165.68
     oil:
     - datetime: '2021-01-01'
       source: EU-ETS, ENTSO-E 2021
@@ -247,15 +247,15 @@ emissionFactors:
     - _comment: used storage values greater than zero.
       datetime: '2023-01-01'
       source: Electricity Maps, 2023 zone average
-      value: 195.37
+      value: 228.45
     - _comment: used storage values greater than zero.
       datetime: '2024-01-01'
       source: Electricity Maps, 2024 zone average
-      value: 188.49
+      value: 182.72
     - _comment: used storage values greater than zero.
       datetime: '2025-01-01'
       source: Electricity Maps, 2025 zone average
-      value: 212.44
+      value: 203.58
     nuclear:
       datetime: '2020-01-01'
       source: UNECE 2022

--- a/config/zones/UA.yaml
+++ b/config/zones/UA.yaml
@@ -28,15 +28,15 @@ emissionFactors:
     - _comment: used storage values greater than zero.
       datetime: '2020-01-01'
       source: Electricity Maps, 2020 zone average
-      value: 270.84
+      value: 231.06
     - _comment: used storage values greater than zero.
       datetime: '2021-01-01'
       source: Electricity Maps, 2021 zone average
-      value: 243.77
+      value: 197.61
     - _comment: used storage values greater than zero.
       datetime: '2022-01-01'
       source: Electricity Maps, 2022 zone average
-      value: 229.98
+      value: 188.55
     unknown:
       _comment: estimated yearly share of solar & wind in this mixed renewable category
         based on installed capacity in Y2018; assumes 50% solar, 50% wind renewable

--- a/config/zones/US-CAL-CISO.yaml
+++ b/config/zones/US-CAL-CISO.yaml
@@ -1022,19 +1022,19 @@ emissionFactors:
     - _comment: used storage values greater than zero.
       datetime: '2022-01-01'
       source: Electricity Maps, 2022 zone average
-      value: 165.93
+      value: 163.0
     - _comment: used storage values greater than zero.
       datetime: '2023-01-01'
       source: Electricity Maps, 2023 zone average
-      value: 164.17
+      value: 164.89
     - _comment: used storage values greater than zero.
       datetime: '2024-01-01'
       source: Electricity Maps, 2024 zone average
-      value: 129.21
+      value: 129.4
     - _comment: used storage values greater than zero.
       datetime: '2025-01-01'
       source: Electricity Maps, 2025 zone average
-      value: 105.65
+      value: 105.16
     biomass:
     - datetime: '2020-01-01'
       source: BEIS 2021
@@ -1099,19 +1099,19 @@ emissionFactors:
     - _comment: used storage values greater than zero.
       datetime: '2022-01-01'
       source: Electricity Maps, 2022 zone average
-      value: 168.33
+      value: 165.53
     - _comment: used storage values greater than zero.
       datetime: '2023-01-01'
       source: Electricity Maps, 2023 zone average
-      value: 156.31
+      value: 156.65
     - _comment: used storage values greater than zero.
       datetime: '2024-01-01'
       source: Electricity Maps, 2024 zone average
-      value: 75.64
+      value: 74.58
     - _comment: used storage values greater than zero.
       datetime: '2025-01-01'
       source: Electricity Maps, 2025 zone average
-      value: 71.42
+      value: 70.32
     oil:
     - datetime: '2020-01-01'
       source: eGrid 2020
@@ -1130,27 +1130,27 @@ emissionFactors:
     - _comment: used storage values greater than zero.
       datetime: '2020-01-01'
       source: Electricity Maps, 2020 zone average
-      value: 252.59
+      value: 255.9
     - _comment: used storage values greater than zero.
       datetime: '2021-01-01'
       source: Electricity Maps, 2021 zone average
-      value: 246.84
+      value: 246.51
     - _comment: used storage values greater than zero.
       datetime: '2022-01-01'
       source: Electricity Maps, 2022 zone average
-      value: 230.6
+      value: 227.3
     - _comment: used storage values greater than zero.
       datetime: '2023-01-01'
       source: Electricity Maps, 2023 zone average
-      value: 228.99
+      value: 229.61
     - _comment: used storage values greater than zero.
       datetime: '2024-01-01'
       source: Electricity Maps, 2024 zone average
-      value: 185.27
+      value: 185.35
     - _comment: used storage values greater than zero.
       datetime: '2025-01-01'
       source: Electricity Maps, 2025 zone average
-      value: 155.78
+      value: 155.17
     biomass:
     - _comment: Mean of all US zones
       datetime: '2020-01-01'
@@ -1211,27 +1211,27 @@ emissionFactors:
     - _comment: used storage values greater than zero.
       datetime: '2020-01-01'
       source: Electricity Maps, 2020 zone average
-      value: 230.02
+      value: 233.53
     - _comment: used storage values greater than zero.
       datetime: '2021-01-01'
       source: Electricity Maps, 2021 zone average
-      value: 190.92
+      value: 190.75
     - _comment: used storage values greater than zero.
       datetime: '2022-01-01'
       source: Electricity Maps, 2022 zone average
-      value: 234.19
+      value: 231.07
     - _comment: used storage values greater than zero.
       datetime: '2023-01-01'
       source: Electricity Maps, 2023 zone average
-      value: 219.84
+      value: 220.06
     - _comment: used storage values greater than zero.
       datetime: '2024-01-01'
       source: Electricity Maps, 2024 zone average
-      value: 119.73
+      value: 118.63
     - _comment: used storage values greater than zero.
       datetime: '2025-01-01'
       source: Electricity Maps, 2025 zone average
-      value: 114.35
+      value: 113.18
     oil:
     - datetime: '2020-01-01'
       source: eGrid 2020; IPCC 2014

--- a/config/zones/US-CAL-IID.yaml
+++ b/config/zones/US-CAL-IID.yaml
@@ -147,7 +147,7 @@ emissionFactors:
     - _comment: used storage values greater than zero.
       datetime: '2025-01-01'
       source: Electricity Maps, 2025 zone average
-      value: 126.46
+      value: 98.98
     biomass:
     - datetime: '2020-01-01'
       source: BEIS 2021
@@ -208,11 +208,11 @@ emissionFactors:
     - _comment: used storage values greater than zero.
       datetime: '2024-01-01'
       source: Electricity Maps, 2024 zone average
-      value: 292.25
+      value: 291.91
     - _comment: used storage values greater than zero.
       datetime: '2025-01-01'
       source: Electricity Maps, 2025 zone average
-      value: 136.1
+      value: 86.51
     oil:
     - _comment: Mean of all US zones
       datetime: '2020-01-01'
@@ -235,7 +235,7 @@ emissionFactors:
     - _comment: used storage values greater than zero.
       datetime: '2025-01-01'
       source: Electricity Maps, 2025 zone average
-      value: 173.27
+      value: 146.43
     biomass:
     - _comment: Mean of all US zones
       datetime: '2020-01-01'
@@ -300,11 +300,11 @@ emissionFactors:
     - _comment: used storage values greater than zero.
       datetime: '2024-01-01'
       source: Electricity Maps, 2024 zone average
-      value: 368.76
+      value: 368.42
     - _comment: used storage values greater than zero.
       datetime: '2025-01-01'
       source: Electricity Maps, 2025 zone average
-      value: 163.99
+      value: 126.06
     oil:
     - _comment: Mean of all US zones
       datetime: '2020-01-01'

--- a/config/zones/US-CAL-LDWP.yaml
+++ b/config/zones/US-CAL-LDWP.yaml
@@ -231,11 +231,11 @@ emissionFactors:
     - _comment: used storage values equal to zero.
       datetime: '2022-01-01'
       source: Electricity Maps, 2022 zone average
-      value: 416.94
+      value: 425.63
     - _comment: used storage values equal to zero.
       datetime: '2025-01-01'
       source: Electricity Maps, 2025 zone average
-      value: 268.66
+      value: 279.85
     biomass:
     - datetime: '2020-01-01'
       source: BEIS 2021
@@ -300,15 +300,15 @@ emissionFactors:
     - _comment: used storage values greater than zero.
       datetime: '2021-01-01'
       source: Electricity Maps, 2021 zone average
-      value: 343.41
+      value: 343.4
     - _comment: used storage values equal to zero.
       datetime: '2022-01-01'
       source: Electricity Maps, 2022 zone average
-      value: 347.28
+      value: 355.09
     - _comment: used storage values equal to zero.
       datetime: '2025-01-01'
       source: Electricity Maps, 2025 zone average
-      value: 267.88
+      value: 278.98
     oil:
     - _comment: Mean of all US zones
       datetime: '2020-01-01'
@@ -331,11 +331,11 @@ emissionFactors:
     - _comment: used storage values equal to zero.
       datetime: '2022-01-01'
       source: Electricity Maps, 2022 zone average
-      value: 495.54
+      value: 504.22
     - _comment: used storage values equal to zero.
       datetime: '2025-01-01'
       source: Electricity Maps, 2025 zone average
-      value: 329.38
+      value: 340.66
     biomass:
     - _comment: Mean of all US zones
       datetime: '2020-01-01'
@@ -400,19 +400,19 @@ emissionFactors:
     - _comment: used storage values greater than zero.
       datetime: '2020-01-01'
       source: Electricity Maps, 2020 zone average
-      value: 463.24
+      value: 463.34
     - _comment: used storage values greater than zero.
       datetime: '2021-01-01'
       source: Electricity Maps, 2021 zone average
-      value: 406.93
+      value: 407.05
     - _comment: used storage values equal to zero.
       datetime: '2022-01-01'
       source: Electricity Maps, 2022 zone average
-      value: 416.23
+      value: 424.04
     - _comment: used storage values equal to zero.
       datetime: '2025-01-01'
       source: Electricity Maps, 2025 zone average
-      value: 329.07
+      value: 340.25
     oil:
     - _comment: Mean of all US zones
       datetime: '2020-01-01'

--- a/config/zones/US-CAL-TIDC.yaml
+++ b/config/zones/US-CAL-TIDC.yaml
@@ -135,7 +135,7 @@ emissionFactors:
     - _comment: used storage values equal to zero.
       datetime: '2022-01-01'
       source: Electricity Maps, 2022 zone average
-      value: 363.08
+      value: 354.28
     oil:
     - _comment: Mean of all US zones
       datetime: '2020-01-01'
@@ -222,7 +222,7 @@ emissionFactors:
     - _comment: used storage values equal to zero.
       datetime: '2022-01-01'
       source: Electricity Maps, 2022 zone average
-      value: 455.87
+      value: 449.6
     oil:
     - _comment: Mean of all US zones
       datetime: '2020-01-01'

--- a/config/zones/US-CAR-CPLE.yaml
+++ b/config/zones/US-CAR-CPLE.yaml
@@ -264,7 +264,7 @@ emissionFactors:
     - _comment: used storage values greater than zero.
       datetime: '2025-01-01'
       source: Electricity Maps, 2025 zone average
-      value: 303.22
+      value: 304.52
     biomass:
     - datetime: '2020-01-01'
       source: BEIS 2021
@@ -325,23 +325,23 @@ emissionFactors:
     - _comment: used storage values greater than zero.
       datetime: '2020-01-01'
       source: Electricity Maps, 2020 zone average
-      value: 240.65
+      value: 243.81
     - _comment: used storage values greater than zero.
       datetime: '2021-01-01'
       source: Electricity Maps, 2021 zone average
-      value: 142.99
+      value: 142.98
     - _comment: used storage values greater than zero.
       datetime: '2022-01-01'
       source: Electricity Maps, 2022 zone average
-      value: 192.62
+      value: 195.85
     - _comment: used storage values greater than zero.
       datetime: '2023-01-01'
       source: Electricity Maps, 2023 zone average
-      value: 230.14
+      value: 228.69
     - _comment: used storage values greater than zero.
       datetime: '2025-01-01'
       source: Electricity Maps, 2025 zone average
-      value: 283.16
+      value: 283.85
     oil:
     - _comment: Mean of all US zones
       datetime: '2020-01-01'
@@ -364,7 +364,7 @@ emissionFactors:
     - _comment: used storage values greater than zero.
       datetime: '2025-01-01'
       source: Electricity Maps, 2025 zone average
-      value: 368.3
+      value: 360.03
     biomass:
     - _comment: Mean of all US zones
       datetime: '2020-01-01'
@@ -429,23 +429,23 @@ emissionFactors:
     - _comment: used storage values greater than zero.
       datetime: '2020-01-01'
       source: Electricity Maps, 2020 zone average
-      value: 299.75
+      value: 296.98
     - _comment: used storage values greater than zero.
       datetime: '2021-01-01'
       source: Electricity Maps, 2021 zone average
-      value: 183.89
+      value: 179.95
     - _comment: used storage values greater than zero.
       datetime: '2022-01-01'
       source: Electricity Maps, 2022 zone average
-      value: 249.22
+      value: 250.69
     - _comment: used storage values greater than zero.
       datetime: '2023-01-01'
       source: Electricity Maps, 2023 zone average
-      value: 285.01
+      value: 282.74
     - _comment: used storage values greater than zero.
       datetime: '2025-01-01'
       source: Electricity Maps, 2025 zone average
-      value: 347.35
+      value: 339.85
     oil:
     - _comment: Mean of all US zones
       datetime: '2020-01-01'

--- a/config/zones/US-CAR-CPLW.yaml
+++ b/config/zones/US-CAR-CPLW.yaml
@@ -154,27 +154,27 @@ emissionFactors:
     - _comment: used storage values greater than zero.
       datetime: '2020-01-01'
       source: Electricity Maps, 2020 zone average
-      value: 298.47
+      value: 298.58
     - _comment: used storage values greater than zero.
       datetime: '2021-01-01'
       source: Electricity Maps, 2021 zone average
-      value: 420.91
+      value: 418.32
     - _comment: used storage values greater than zero.
       datetime: '2022-01-01'
       source: Electricity Maps, 2022 zone average
-      value: 416.87
+      value: 418.59
     - _comment: used storage values greater than zero.
       datetime: '2023-01-01'
       source: Electricity Maps, 2023 zone average
-      value: 448.28
+      value: 449.0
     - _comment: used storage values greater than zero.
       datetime: '2024-01-01'
       source: Electricity Maps, 2024 zone average
-      value: 403.28
+      value: 404.87
     - _comment: used storage values greater than zero.
       datetime: '2025-01-01'
       source: Electricity Maps, 2025 zone average
-      value: 432.91
+      value: 435.05
     oil:
     - _comment: Mean of all US zones
       datetime: '2020-01-01'
@@ -268,27 +268,27 @@ emissionFactors:
     - _comment: used storage values greater than zero.
       datetime: '2020-01-01'
       source: Electricity Maps, 2020 zone average
-      value: 343.7
+      value: 376.73
     - _comment: used storage values greater than zero.
       datetime: '2021-01-01'
       source: Electricity Maps, 2021 zone average
-      value: 498.13
+      value: 527.09
     - _comment: used storage values greater than zero.
       datetime: '2022-01-01'
       source: Electricity Maps, 2022 zone average
-      value: 488.86
+      value: 522.09
     - _comment: used storage values greater than zero.
       datetime: '2023-01-01'
       source: Electricity Maps, 2023 zone average
-      value: 541.98
+      value: 569.47
     - _comment: used storage values greater than zero.
       datetime: '2024-01-01'
       source: Electricity Maps, 2024 zone average
-      value: 475.1
+      value: 506.29
     - _comment: used storage values greater than zero.
       datetime: '2025-01-01'
       source: Electricity Maps, 2025 zone average
-      value: 505.71
+      value: 541.5
     oil:
     - _comment: Mean of all US zones
       datetime: '2020-01-01'

--- a/config/zones/US-CAR-DUK.yaml
+++ b/config/zones/US-CAR-DUK.yaml
@@ -354,7 +354,7 @@ emissionFactors:
     - _comment: used storage values greater than zero.
       datetime: '2025-01-01'
       source: Electricity Maps, 2025 zone average
-      value: 229.18
+      value: 248.3
     biomass:
     - datetime: '2020-01-01'
       source: BEIS 2021
@@ -416,23 +416,23 @@ emissionFactors:
     - _comment: used storage values greater than zero.
       datetime: '2020-01-01'
       source: Electricity Maps, 2020 zone average
-      value: 215.21
+      value: 214.4
     - _comment: used storage values greater than zero.
       datetime: '2021-01-01'
       source: Electricity Maps, 2021 zone average
-      value: 226.0
+      value: 225.36
     - _comment: used storage values greater than zero.
       datetime: '2022-01-01'
       source: Electricity Maps, 2022 zone average
-      value: 234.65
+      value: 299.81
     - _comment: used storage values greater than zero.
       datetime: '2023-01-01'
       source: Electricity Maps, 2023 zone average
-      value: 230.33
+      value: 247.62
     - _comment: used storage values greater than zero.
       datetime: '2025-01-01'
       source: Electricity Maps, 2025 zone average
-      value: 230.38
+      value: 248.69
     oil:
     - _comment: Mean of all US zones
       datetime: '2020-01-01'
@@ -454,7 +454,7 @@ emissionFactors:
     - _comment: used storage values greater than zero.
       datetime: '2025-01-01'
       source: Electricity Maps, 2025 zone average
-      value: 279.86
+      value: 294.71
     biomass:
     - _comment: Mean of all US zones
       datetime: '2020-01-01'
@@ -520,23 +520,23 @@ emissionFactors:
     - _comment: used storage values greater than zero.
       datetime: '2020-01-01'
       source: Electricity Maps, 2020 zone average
-      value: 262.17
+      value: 257.66
     - _comment: used storage values greater than zero.
       datetime: '2021-01-01'
       source: Electricity Maps, 2021 zone average
-      value: 275.0
+      value: 270.01
     - _comment: used storage values greater than zero.
       datetime: '2022-01-01'
       source: Electricity Maps, 2022 zone average
-      value: 284.88
+      value: 345.44
     - _comment: used storage values greater than zero.
       datetime: '2023-01-01'
       source: Electricity Maps, 2023 zone average
-      value: 280.42
+      value: 293.24
     - _comment: used storage values greater than zero.
       datetime: '2025-01-01'
       source: Electricity Maps, 2025 zone average
-      value: 280.98
+      value: 294.9
     oil:
     - _comment: Mean of all US zones
       datetime: '2020-01-01'

--- a/config/zones/US-CAR-SC.yaml
+++ b/config/zones/US-CAR-SC.yaml
@@ -173,23 +173,23 @@ emissionFactors:
     - _comment: used storage values greater than zero.
       datetime: '2021-01-01'
       source: Electricity Maps, 2021 zone average
-      value: 667.35
+      value: 667.34
     - _comment: used storage values greater than zero.
       datetime: '2022-01-01'
       source: Electricity Maps, 2022 zone average
-      value: 595.24
+      value: 587.15
     - _comment: used storage values greater than zero.
       datetime: '2023-01-01'
       source: Electricity Maps, 2023 zone average
-      value: 566.08
+      value: 562.85
     - _comment: used storage values greater than zero.
       datetime: '2024-01-01'
       source: Electricity Maps, 2024 zone average
-      value: 596.74
+      value: 591.74
     - _comment: used storage values greater than zero.
       datetime: '2025-01-01'
       source: Electricity Maps, 2025 zone average
-      value: 633.53
+      value: 626.98
     oil:
     - _comment: Mean of all US zones
       datetime: '2020-01-01'
@@ -271,23 +271,23 @@ emissionFactors:
     - _comment: used storage values greater than zero.
       datetime: '2021-01-01'
       source: Electricity Maps, 2021 zone average
-      value: 753.85
+      value: 737.5
     - _comment: used storage values greater than zero.
       datetime: '2022-01-01'
       source: Electricity Maps, 2022 zone average
-      value: 674.23
+      value: 651.62
     - _comment: used storage values greater than zero.
       datetime: '2023-01-01'
       source: Electricity Maps, 2023 zone average
-      value: 648.96
+      value: 633.24
     - _comment: used storage values greater than zero.
       datetime: '2024-01-01'
       source: Electricity Maps, 2024 zone average
-      value: 680.24
+      value: 661.48
     - _comment: used storage values greater than zero.
       datetime: '2025-01-01'
       source: Electricity Maps, 2025 zone average
-      value: 718.7
+      value: 697.02
     oil:
     - _comment: Mean of all US zones
       datetime: '2020-01-01'

--- a/config/zones/US-CAR-SCEG.yaml
+++ b/config/zones/US-CAR-SCEG.yaml
@@ -267,7 +267,7 @@ emissionFactors:
     - _comment: used storage values equal to zero.
       datetime: '2022-01-01'
       source: Electricity Maps, 2022 zone average
-      value: 382.77
+      value: 385.11
     oil:
     - _comment: Mean of all US zones
       datetime: '2020-01-01'
@@ -349,7 +349,7 @@ emissionFactors:
     - _comment: used storage values equal to zero.
       datetime: '2022-01-01'
       source: Electricity Maps, 2022 zone average
-      value: 469.58
+      value: 469.49
     oil:
     - _comment: Mean of all US zones
       datetime: '2020-01-01'

--- a/config/zones/US-FLA-FPC.yaml
+++ b/config/zones/US-FLA-FPC.yaml
@@ -216,11 +216,11 @@ emissionFactors:
     - _comment: used storage values greater than zero.
       datetime: '2022-01-01'
       source: Electricity Maps, 2022 zone average
-      value: 429.95
+      value: 430.87
     - _comment: used storage values greater than zero.
       datetime: '2025-01-01'
       source: Electricity Maps, 2025 zone average
-      value: 396.86
+      value: 464.7
     biomass:
     - datetime: '2020-01-01'
       source: BEIS 2021
@@ -282,7 +282,7 @@ emissionFactors:
     - _comment: used storage values equal to zero.
       datetime: '2022-01-01'
       source: Electricity Maps, 2022 zone average
-      value: 420.27
+      value: 421.29
     oil:
     - datetime: '2020-01-01'
       source: eGrid 2020
@@ -301,11 +301,11 @@ emissionFactors:
     - _comment: used storage values greater than zero.
       datetime: '2022-01-01'
       source: Electricity Maps, 2022 zone average
-      value: 537.12
+      value: 538.03
     - _comment: used storage values greater than zero.
       datetime: '2025-01-01'
       source: Electricity Maps, 2025 zone average
-      value: 501.95
+      value: 569.79
     biomass:
     - _comment: Mean of all US zones
       datetime: '2020-01-01'
@@ -371,7 +371,7 @@ emissionFactors:
     - _comment: used storage values equal to zero.
       datetime: '2022-01-01'
       source: Electricity Maps, 2022 zone average
-      value: 525.9
+      value: 526.92
     oil:
     - datetime: '2020-01-01'
       source: eGrid 2020; IPCC 2014

--- a/config/zones/US-FLA-FPL.yaml
+++ b/config/zones/US-FLA-FPL.yaml
@@ -216,7 +216,7 @@ emissionFactors:
     - _comment: used storage values greater than zero.
       datetime: '2025-01-01'
       source: Electricity Maps, 2025 zone average
-      value: 247.04
+      value: 248.93
     biomass:
     - datetime: '2020-01-01'
       source: BEIS 2021
@@ -295,7 +295,7 @@ emissionFactors:
     - _comment: used storage values greater than zero.
       datetime: '2025-01-01'
       source: Electricity Maps, 2025 zone average
-      value: 324.51
+      value: 330.33
     biomass:
     - _comment: Mean of all US zones
       datetime: '2020-01-01'

--- a/config/zones/US-MIDA-PJM.yaml
+++ b/config/zones/US-MIDA-PJM.yaml
@@ -1151,27 +1151,27 @@ emissionFactors:
     - _comment: used storage values equal to zero.
       datetime: '2020-01-01'
       source: Electricity Maps, 2020 zone average
-      value: 352.79
+      value: 353.73
     - _comment: used storage values equal to zero.
       datetime: '2021-01-01'
       source: Electricity Maps, 2021 zone average
-      value: 373.14
+      value: 373.76
     - _comment: used storage values equal to zero.
       datetime: '2022-01-01'
       source: Electricity Maps, 2022 zone average
-      value: 361.04
+      value: 367.08
     - _comment: used storage values greater than zero.
       datetime: '2023-01-01'
       source: Electricity Maps, 2023 zone average
-      value: 325.83
+      value: 329.11
     - _comment: used storage values greater than zero.
       datetime: '2024-01-01'
       source: Electricity Maps, 2024 zone average
-      value: 334.17
+      value: 337.04
     - _comment: used storage values greater than zero.
       datetime: '2025-01-01'
       source: Electricity Maps, 2025 zone average
-      value: 382.49
+      value: 387.65
     biomass:
     - datetime: '2020-01-01'
       source: BEIS 2021
@@ -1246,27 +1246,27 @@ emissionFactors:
     - _comment: used storage values equal to zero.
       datetime: '2020-01-01'
       source: Electricity Maps, 2020 zone average
-      value: 422.35
+      value: 419.64
     - _comment: used storage values equal to zero.
       datetime: '2021-01-01'
       source: Electricity Maps, 2021 zone average
-      value: 442.62
+      value: 439.08
     - _comment: used storage values equal to zero.
       datetime: '2022-01-01'
       source: Electricity Maps, 2022 zone average
-      value: 431.42
+      value: 433.68
     - _comment: used storage values greater than zero.
       datetime: '2023-01-01'
       source: Electricity Maps, 2023 zone average
-      value: 397.08
+      value: 397.57
     - _comment: used storage values greater than zero.
       datetime: '2024-01-01'
       source: Electricity Maps, 2024 zone average
-      value: 407.77
+      value: 407.87
     - _comment: used storage values greater than zero.
       datetime: '2025-01-01'
       source: Electricity Maps, 2025 zone average
-      value: 455.64
+      value: 456.74
     biomass:
     - _comment: Mean of all US zones
       datetime: '2020-01-01'

--- a/config/zones/US-MIDW-LGEE.yaml
+++ b/config/zones/US-MIDW-LGEE.yaml
@@ -175,11 +175,11 @@ emissionFactors:
     - _comment: used storage values equal to zero.
       datetime: '2022-01-01'
       source: Electricity Maps, 2022 zone average
-      value: 751.76
+      value: 746.14
     - _comment: used storage values greater than zero.
       datetime: '2025-01-01'
       source: Electricity Maps, 2025 zone average
-      value: 751.79
+      value: 771.27
     oil:
     - _comment: Mean of all US zones
       datetime: '2020-01-01'
@@ -262,19 +262,19 @@ emissionFactors:
     - _comment: used storage values equal to zero.
       datetime: '2020-01-01'
       source: Electricity Maps, 2020 zone average
-      value: 902.02
+      value: 868.17
     - _comment: used storage values equal to zero.
       datetime: '2021-01-01'
       source: Electricity Maps, 2021 zone average
-      value: 853.98
+      value: 824.96
     - _comment: used storage values equal to zero.
       datetime: '2022-01-01'
       source: Electricity Maps, 2022 zone average
-      value: 852.7
+      value: 818.49
     - _comment: used storage values greater than zero.
       datetime: '2025-01-01'
       source: Electricity Maps, 2025 zone average
-      value: 850.42
+      value: 840.66
     oil:
     - _comment: Mean of all US zones
       datetime: '2020-01-01'

--- a/config/zones/US-MIDW-MISO.yaml
+++ b/config/zones/US-MIDW-MISO.yaml
@@ -1232,7 +1232,7 @@ emissionFactors:
     - _comment: used storage values greater than zero.
       datetime: '2025-01-01'
       source: Electricity Maps, 2025 zone average
-      value: 426.81
+      value: 419.96
     biomass:
     - datetime: '2020-01-01'
       source: BEIS 2021
@@ -1307,7 +1307,7 @@ emissionFactors:
     - _comment: used storage values greater than zero.
       datetime: '2025-01-01'
       source: Electricity Maps, 2025 zone average
-      value: 491.68
+      value: 484.08
     biomass:
     - _comment: Mean of all US zones
       datetime: '2020-01-01'

--- a/config/zones/US-NE-ISNE.yaml
+++ b/config/zones/US-NE-ISNE.yaml
@@ -863,19 +863,19 @@ emissionFactors:
     - _comment: used storage values equal to zero.
       datetime: '2022-01-01'
       source: Electricity Maps, 2022 zone average
-      value: 162.93
+      value: 164.74
     - _comment: used storage values equal to zero.
       datetime: '2023-01-01'
       source: Electricity Maps, 2023 zone average
-      value: 183.04
+      value: 182.77
     - _comment: used storage values equal to zero.
       datetime: '2024-01-01'
       source: Electricity Maps, 2024 zone average
-      value: 205.92
+      value: 205.61
     - _comment: used storage values equal to zero.
       datetime: '2025-01-01'
       source: Electricity Maps, 2025 zone average
-      value: 205.98
+      value: 208.79
     biomass:
     - datetime: '2020-01-01'
       source: BEIS 2021
@@ -950,27 +950,27 @@ emissionFactors:
     - _comment: used storage values equal to zero.
       datetime: '2020-01-01'
       source: Electricity Maps, 2020 zone average
-      value: 251.91
+      value: 243.49
     - _comment: used storage values equal to zero.
       datetime: '2021-01-01'
       source: Electricity Maps, 2021 zone average
-      value: 239.03
+      value: 238.98
     - _comment: used storage values equal to zero.
       datetime: '2022-01-01'
       source: Electricity Maps, 2022 zone average
-      value: 235.33
+      value: 236.75
     - _comment: used storage values equal to zero.
       datetime: '2023-01-01'
       source: Electricity Maps, 2023 zone average
-      value: 260.67
+      value: 260.59
     - _comment: used storage values equal to zero.
       datetime: '2024-01-01'
       source: Electricity Maps, 2024 zone average
-      value: 288.26
+      value: 288.12
     - _comment: used storage values equal to zero.
       datetime: '2025-01-01'
       source: Electricity Maps, 2025 zone average
-      value: 287.08
+      value: 289.85
     biomass:
     - _comment: Mean of all US zones
       datetime: '2020-01-01'

--- a/config/zones/US-NW-AVA.yaml
+++ b/config/zones/US-NW-AVA.yaml
@@ -156,7 +156,7 @@ emissionFactors:
     - _comment: used storage values greater than zero.
       datetime: '2025-01-01'
       source: Electricity Maps, 2025 zone average
-      value: 174.26
+      value: 183.93
     oil:
     - _comment: Mean of all US zones
       datetime: '2020-01-01'
@@ -243,7 +243,7 @@ emissionFactors:
     - _comment: used storage values greater than zero.
       datetime: '2025-01-01'
       source: Electricity Maps, 2025 zone average
-      value: 219.88
+      value: 238.74
     oil:
     - _comment: Mean of all US zones
       datetime: '2020-01-01'

--- a/config/zones/US-NW-IPCO.yaml
+++ b/config/zones/US-NW-IPCO.yaml
@@ -207,7 +207,7 @@ emissionFactors:
     - _comment: used storage values greater than zero.
       datetime: '2025-01-01'
       source: Electricity Maps, 2025 zone average
-      value: 238.32
+      value: 246.67
     biomass:
     - datetime: '2020-01-01'
       source: BEIS 2021
@@ -286,7 +286,7 @@ emissionFactors:
     - _comment: used storage values greater than zero.
       datetime: '2025-01-01'
       source: Electricity Maps, 2025 zone average
-      value: 257.58
+      value: 296.75
     biomass:
     - _comment: Mean of all US zones
       datetime: '2020-01-01'

--- a/config/zones/US-NW-NEVP.yaml
+++ b/config/zones/US-NW-NEVP.yaml
@@ -325,7 +325,7 @@ emissionFactors:
     - _comment: used storage values equal to zero.
       datetime: '2022-01-01'
       source: Electricity Maps, 2022 zone average
-      value: 443.14
+      value: 436.76
     oil:
     - _comment: Mean of all US zones
       datetime: '2020-01-01'
@@ -404,7 +404,7 @@ emissionFactors:
     - _comment: used storage values equal to zero.
       datetime: '2022-01-01'
       source: Electricity Maps, 2022 zone average
-      value: 537.87
+      value: 527.18
     oil:
     - _comment: Mean of all US zones
       datetime: '2020-01-01'

--- a/config/zones/US-NW-NWMT.yaml
+++ b/config/zones/US-NW-NWMT.yaml
@@ -224,7 +224,7 @@ emissionFactors:
     - _comment: used storage values greater than zero.
       datetime: '2024-01-01'
       source: Electricity Maps, 2024 zone average
-      value: 860.24
+      value: 867.14
     oil:
     - datetime: '2020-01-01'
       source: eGrid 2020
@@ -303,7 +303,7 @@ emissionFactors:
     - _comment: used storage values greater than zero.
       datetime: '2024-01-01'
       source: Electricity Maps, 2024 zone average
-      value: 878.4
+      value: 927.68
     oil:
     - datetime: '2020-01-01'
       source: eGrid 2020; IPCC 2014

--- a/config/zones/US-NW-PACW.yaml
+++ b/config/zones/US-NW-PACW.yaml
@@ -259,11 +259,11 @@ emissionFactors:
     - _comment: used storage values greater than zero.
       datetime: '2020-01-01'
       source: Electricity Maps, 2020 zone average
-      value: 187.49
+      value: 187.81
     - _comment: used storage values greater than zero.
       datetime: '2021-01-01'
       source: Electricity Maps, 2021 zone average
-      value: 397.6
+      value: 395.8
     oil:
     - _comment: Mean of all US zones
       datetime: '2020-01-01'
@@ -350,11 +350,11 @@ emissionFactors:
     - _comment: used storage values greater than zero.
       datetime: '2020-01-01'
       source: Electricity Maps, 2020 zone average
-      value: 178.38
+      value: 219.99
     - _comment: used storage values greater than zero.
       datetime: '2021-01-01'
       source: Electricity Maps, 2021 zone average
-      value: 370.39
+      value: 447.07
     oil:
     - _comment: Mean of all US zones
       datetime: '2020-01-01'

--- a/config/zones/US-NW-PGE.yaml
+++ b/config/zones/US-NW-PGE.yaml
@@ -189,7 +189,7 @@ emissionFactors:
     - _comment: used storage values greater than zero.
       datetime: '2025-01-01'
       source: Electricity Maps, 2025 zone average
-      value: 203.44
+      value: 213.1
     biomass:
     - datetime: '2020-01-01'
       source: BEIS 2021
@@ -271,7 +271,7 @@ emissionFactors:
     - _comment: used storage values greater than zero.
       datetime: '2025-01-01'
       source: Electricity Maps, 2025 zone average
-      value: 264.51
+      value: 274.46
     biomass:
     - _comment: Mean of all US zones
       datetime: '2020-01-01'

--- a/config/zones/US-NW-PSCO.yaml
+++ b/config/zones/US-NW-PSCO.yaml
@@ -312,7 +312,7 @@ emissionFactors:
     - _comment: used storage values greater than zero.
       datetime: '2025-01-01'
       source: Electricity Maps, 2025 zone average
-      value: 324.49
+      value: 324.03
     biomass:
     - datetime: '2020-01-01'
       source: BEIS 2021
@@ -391,7 +391,7 @@ emissionFactors:
     - _comment: used storage values greater than zero.
       datetime: '2025-01-01'
       source: Electricity Maps, 2025 zone average
-      value: 376.41
+      value: 379.35
     biomass:
     - _comment: Mean of all US zones
       datetime: '2020-01-01'

--- a/config/zones/US-NW-WACM.yaml
+++ b/config/zones/US-NW-WACM.yaml
@@ -353,7 +353,7 @@ emissionFactors:
     - _comment: used storage values greater than zero.
       datetime: '2025-01-01'
       source: Electricity Maps, 2025 zone average
-      value: 660.87
+      value: 671.46
     oil:
     - datetime: '2020-01-01'
       source: eGrid 2020
@@ -432,7 +432,7 @@ emissionFactors:
     - _comment: used storage values greater than zero.
       datetime: '2025-01-01'
       source: Electricity Maps, 2025 zone average
-      value: 689.36
+      value: 723.56
     oil:
     - datetime: '2020-01-01'
       source: eGrid 2020; IPCC 2014

--- a/config/zones/US-SE-SOCO.yaml
+++ b/config/zones/US-SE-SOCO.yaml
@@ -469,7 +469,7 @@ emissionFactors:
     - _comment: used storage values greater than zero.
       datetime: '2025-01-01'
       source: Electricity Maps, 2025 zone average
-      value: 341.71
+      value: 385.89
     biomass:
     - datetime: '2020-01-01'
       source: BEIS 2021
@@ -530,7 +530,7 @@ emissionFactors:
     - _comment: used storage values greater than zero.
       datetime: '2025-01-01'
       source: Electricity Maps, 2025 zone average
-      value: 343.44
+      value: 388.09
     oil:
     - datetime: '2020-01-01'
       source: eGrid 2020
@@ -549,7 +549,7 @@ emissionFactors:
     - _comment: used storage values greater than zero.
       datetime: '2025-01-01'
       source: Electricity Maps, 2025 zone average
-      value: 418.7
+      value: 459.84
     biomass:
     - _comment: Mean of all US zones
       datetime: '2020-01-01'
@@ -614,7 +614,7 @@ emissionFactors:
     - _comment: used storage values greater than zero.
       datetime: '2025-01-01'
       source: Electricity Maps, 2025 zone average
-      value: 420.3
+      value: 461.86
     oil:
     - datetime: '2020-01-01'
       source: eGrid 2020; IPCC 2014

--- a/config/zones/US-SW-AZPS.yaml
+++ b/config/zones/US-SW-AZPS.yaml
@@ -193,7 +193,7 @@ emissionFactors:
     - _comment: used storage values greater than zero.
       datetime: '2025-01-01'
       source: Electricity Maps, 2025 zone average
-      value: 273.16
+      value: 261.31
     biomass:
     - datetime: '2020-01-01'
       source: BEIS 2021
@@ -272,7 +272,7 @@ emissionFactors:
     - _comment: used storage values greater than zero.
       datetime: '2025-01-01'
       source: Electricity Maps, 2025 zone average
-      value: 319.13
+      value: 314.3
     biomass:
     - _comment: Mean of all US zones
       datetime: '2020-01-01'

--- a/config/zones/US-SW-PNM.yaml
+++ b/config/zones/US-SW-PNM.yaml
@@ -262,15 +262,15 @@ emissionFactors:
     - _comment: used storage values greater than zero.
       datetime: '2023-01-01'
       source: Electricity Maps, 2023 zone average
-      value: 382.92
+      value: 350.94
     - _comment: used storage values greater than zero.
       datetime: '2024-01-01'
       source: Electricity Maps, 2024 zone average
-      value: 298.46
+      value: 281.11
     - _comment: used storage values greater than zero.
       datetime: '2025-01-01'
       source: Electricity Maps, 2025 zone average
-      value: 203.01
+      value: 185.38
     biomass:
     - datetime: '2020-01-01'
       source: BEIS 2021
@@ -332,15 +332,15 @@ emissionFactors:
     - _comment: used storage values greater than zero.
       datetime: '2022-01-01'
       source: Electricity Maps, 2022 zone average
-      value: 617.44
+      value: 619.21
     - _comment: used storage values greater than zero.
       datetime: '2023-01-01'
       source: Electricity Maps, 2023 zone average
-      value: 383.18
+      value: 353.13
     - _comment: used storage values greater than zero.
       datetime: '2024-01-01'
       source: Electricity Maps, 2024 zone average
-      value: 179.13
+      value: 161.54
     oil:
     - _comment: Mean of all US zones
       datetime: '2020-01-01'
@@ -363,15 +363,15 @@ emissionFactors:
     - _comment: used storage values greater than zero.
       datetime: '2023-01-01'
       source: Electricity Maps, 2023 zone average
-      value: 435.3
+      value: 406.83
     - _comment: used storage values greater than zero.
       datetime: '2024-01-01'
       source: Electricity Maps, 2024 zone average
-      value: 352.53
+      value: 337.44
     - _comment: used storage values greater than zero.
       datetime: '2025-01-01'
       source: Electricity Maps, 2025 zone average
-      value: 240.46
+      value: 224.72
     biomass:
     - _comment: Mean of all US zones
       datetime: '2020-01-01'
@@ -437,15 +437,15 @@ emissionFactors:
     - _comment: used storage values greater than zero.
       datetime: '2022-01-01'
       source: Electricity Maps, 2022 zone average
-      value: 677.68
+      value: 685.96
     - _comment: used storage values greater than zero.
       datetime: '2023-01-01'
       source: Electricity Maps, 2023 zone average
-      value: 436.85
+      value: 410.18
     - _comment: used storage values greater than zero.
       datetime: '2024-01-01'
       source: Electricity Maps, 2024 zone average
-      value: 213.14
+      value: 197.36
     oil:
     - _comment: Mean of all US zones
       datetime: '2020-01-01'

--- a/config/zones/US-SW-SRP.yaml
+++ b/config/zones/US-SW-SRP.yaml
@@ -171,15 +171,15 @@ emissionFactors:
     - _comment: used storage values greater than zero.
       datetime: '2023-01-01'
       source: Electricity Maps, 2023 zone average
-      value: 236.92
+      value: 250.01
     - _comment: used storage values greater than zero.
       datetime: '2024-01-01'
       source: Electricity Maps, 2024 zone average
-      value: 230.77
+      value: 242.56
     - _comment: used storage values greater than zero.
       datetime: '2025-01-01'
       source: Electricity Maps, 2025 zone average
-      value: 228.62
+      value: 241.8
     biomass:
     - datetime: '2020-01-01'
       source: BEIS 2021
@@ -240,7 +240,7 @@ emissionFactors:
     - _comment: used storage values greater than zero.
       datetime: '2020-01-01'
       source: Electricity Maps, 2020 zone average
-      value: 237.06
+      value: 237.84
     - _comment: used storage values greater than zero.
       datetime: '2021-01-01'
       source: Electricity Maps, 2021 zone average
@@ -248,19 +248,19 @@ emissionFactors:
     - _comment: used storage values greater than zero.
       datetime: '2022-01-01'
       source: Electricity Maps, 2022 zone average
-      value: 204.58
+      value: 206.8
     - _comment: used storage values greater than zero.
       datetime: '2023-01-01'
       source: Electricity Maps, 2023 zone average
-      value: 252.79
+      value: 267.03
     - _comment: used storage values greater than zero.
       datetime: '2024-01-01'
       source: Electricity Maps, 2024 zone average
-      value: 222.23
+      value: 234.07
     - _comment: used storage values greater than zero.
       datetime: '2025-01-01'
       source: Electricity Maps, 2025 zone average
-      value: 229.9
+      value: 241.52
     oil:
     - _comment: Mean of all US zones
       datetime: '2020-01-01'
@@ -283,15 +283,15 @@ emissionFactors:
     - _comment: used storage values greater than zero.
       datetime: '2023-01-01'
       source: Electricity Maps, 2023 zone average
-      value: 292.87
+      value: 305.97
     - _comment: used storage values greater than zero.
       datetime: '2024-01-01'
       source: Electricity Maps, 2024 zone average
-      value: 281.29
+      value: 293.07
     - _comment: used storage values greater than zero.
       datetime: '2025-01-01'
       source: Electricity Maps, 2025 zone average
-      value: 285.96
+      value: 299.15
     biomass:
     - _comment: Mean of all US zones
       datetime: '2020-01-01'
@@ -356,7 +356,7 @@ emissionFactors:
     - _comment: used storage values greater than zero.
       datetime: '2020-01-01'
       source: Electricity Maps, 2020 zone average
-      value: 302.69
+      value: 303.47
     - _comment: used storage values greater than zero.
       datetime: '2021-01-01'
       source: Electricity Maps, 2021 zone average
@@ -364,19 +364,19 @@ emissionFactors:
     - _comment: used storage values greater than zero.
       datetime: '2022-01-01'
       source: Electricity Maps, 2022 zone average
-      value: 257.42
+      value: 259.64
     - _comment: used storage values greater than zero.
       datetime: '2023-01-01'
       source: Electricity Maps, 2023 zone average
-      value: 312.62
+      value: 326.86
     - _comment: used storage values greater than zero.
       datetime: '2024-01-01'
       source: Electricity Maps, 2024 zone average
-      value: 273.76
+      value: 285.6
     - _comment: used storage values greater than zero.
       datetime: '2025-01-01'
       source: Electricity Maps, 2025 zone average
-      value: 280.73
+      value: 292.35
     oil:
     - _comment: Mean of all US zones
       datetime: '2020-01-01'

--- a/config/zones/US-SW-TEPC.yaml
+++ b/config/zones/US-SW-TEPC.yaml
@@ -138,7 +138,7 @@ emissionFactors:
     - _comment: used storage values greater than zero.
       datetime: '2025-01-01'
       source: Electricity Maps, 2025 zone average
-      value: 506.37
+      value: 405.46
     biomass:
     - datetime: '2020-01-01'
       source: BEIS 2021
@@ -217,7 +217,7 @@ emissionFactors:
     - _comment: used storage values greater than zero.
       datetime: '2025-01-01'
       source: Electricity Maps, 2025 zone average
-      value: 587.8
+      value: 486.89
     biomass:
     - _comment: Mean of all US zones
       datetime: '2020-01-01'

--- a/config/zones/US-SW-WALC.yaml
+++ b/config/zones/US-SW-WALC.yaml
@@ -201,11 +201,11 @@ emissionFactors:
     - _comment: used storage values greater than zero.
       datetime: '2024-01-01'
       source: Electricity Maps, 2024 zone average
-      value: 262.83
+      value: 250.74
     - _comment: used storage values greater than zero.
       datetime: '2025-01-01'
       source: Electricity Maps, 2025 zone average
-      value: 651.16
+      value: 538.35
     oil:
     - _comment: Mean of all US zones
       datetime: '2020-01-01'
@@ -289,11 +289,11 @@ emissionFactors:
     - _comment: used storage values greater than zero.
       datetime: '2024-01-01'
       source: Electricity Maps, 2024 zone average
-      value: 333.56
+      value: 321.72
     - _comment: used storage values greater than zero.
       datetime: '2025-01-01'
       source: Electricity Maps, 2025 zone average
-      value: 708.65
+      value: 597.93
     oil:
     - _comment: Mean of all US zones
       datetime: '2020-01-01'

--- a/config/zones/US-TEN-TVA.yaml
+++ b/config/zones/US-TEN-TVA.yaml
@@ -276,11 +276,11 @@ emissionFactors:
     - _comment: used storage values equal to zero.
       datetime: '2024-01-01'
       source: Electricity Maps, 2024 zone average
-      value: 359.56
+      value: 366.23
     - _comment: used storage values equal to zero.
       datetime: '2025-01-01'
       source: Electricity Maps, 2025 zone average
-      value: 329.03
+      value: 337.49
     biomass:
     - datetime: '2020-01-01'
       source: BEIS 2021
@@ -345,19 +345,19 @@ emissionFactors:
     - _comment: used storage values greater than zero.
       datetime: '2022-01-01'
       source: Electricity Maps, 2022 zone average
-      value: 359.83
+      value: 364.52
     - _comment: used storage values greater than zero.
       datetime: '2023-01-01'
       source: Electricity Maps, 2023 zone average
-      value: 317.35
+      value: 325.56
     - _comment: used storage values greater than zero.
       datetime: '2024-01-01'
       source: Electricity Maps, 2024 zone average
-      value: 358.39
+      value: 365.26
     - _comment: used storage values greater than zero.
       datetime: '2025-01-01'
       source: Electricity Maps, 2025 zone average
-      value: 332.83
+      value: 341.49
     oil:
     - datetime: '2020-01-01'
       source: eGrid 2020
@@ -379,11 +379,11 @@ emissionFactors:
     - _comment: used storage values equal to zero.
       datetime: '2024-01-01'
       source: Electricity Maps, 2024 zone average
-      value: 430.72
+      value: 433.69
     - _comment: used storage values equal to zero.
       datetime: '2025-01-01'
       source: Electricity Maps, 2025 zone average
-      value: 390.44
+      value: 394.99
     biomass:
     - _comment: Mean of all US zones
       datetime: '2020-01-01'
@@ -448,23 +448,23 @@ emissionFactors:
     - _comment: used storage values greater than zero.
       datetime: '2021-01-01'
       source: Electricity Maps, 2021 zone average
-      value: 390.47
+      value: 386.34
     - _comment: used storage values greater than zero.
       datetime: '2022-01-01'
       source: Electricity Maps, 2022 zone average
-      value: 422.98
+      value: 423.24
     - _comment: used storage values greater than zero.
       datetime: '2023-01-01'
       source: Electricity Maps, 2023 zone average
-      value: 375.82
+      value: 380.26
     - _comment: used storage values greater than zero.
       datetime: '2024-01-01'
       source: Electricity Maps, 2024 zone average
-      value: 428.8
+      value: 431.93
     - _comment: used storage values greater than zero.
       datetime: '2025-01-01'
       source: Electricity Maps, 2025 zone average
-      value: 394.55
+      value: 399.24
     oil:
     - datetime: '2020-01-01'
       source: eGrid 2020; IPCC 2014

--- a/config/zones/US-TEX-ERCO.yaml
+++ b/config/zones/US-TEX-ERCO.yaml
@@ -845,7 +845,7 @@ emissionFactors:
     - _comment: used storage values greater than zero.
       datetime: '2025-01-01'
       source: Electricity Maps, 2025 zone average
-      value: 264.87
+      value: 268.51
     biomass:
     - datetime: '2020-01-01'
       source: BEIS 2021
@@ -920,7 +920,7 @@ emissionFactors:
     - _comment: used storage values greater than zero.
       datetime: '2025-01-01'
       source: Electricity Maps, 2025 zone average
-      value: 320.31
+      value: 326.64
     biomass:
     - _comment: Mean of all US zones
       datetime: '2020-01-01'

--- a/config/zones/ZA.yaml
+++ b/config/zones/ZA.yaml
@@ -155,7 +155,7 @@ emissionFactors:
     - _comment: used storage values greater than zero.
       datetime: '2025-01-01'
       source: Electricity Maps, 2025 zone average
-      value: 701.23
+      value: 701.24
 fallbackZoneMixes:
   powerOriginRatios:
   - _source: Electricity Maps, 2015 average


### PR DESCRIPTION
Same as #8567 but that script was using the unfixed emission factors (i.e. the numbers that are on master, not the numbers that are on the target branch) as source input leading to incorrect numbers.