### PR TITLE
feat(emission-factors): improve new method for hydro and battery discharge

### DIFF
--- a/config/zones/AR.yaml
+++ b/config/zones/AR.yaml
@@ -174,16 +174,40 @@ emissionFactors:
       datetime: '2021-01-01'
       source: Electricity Maps, 2021 zone average
       value: 278.69
+    - _comment: used default IPCC 2014 value of 0.0
+      datetime: '2022-01-01'
+      source: Electricity Maps, 2022 zone average
+      value: 0.0
+    - _comment: used default IPCC 2014 value of 0.0
+      datetime: '2023-01-01'
+      source: Electricity Maps, 2023 zone average
+      value: 0.0
+    - _comment: used default IPCC 2014 value of 0.0
+      datetime: '2025-01-01'
+      source: Electricity Maps, 2025 zone average
+      value: 0.0
   lifecycle:
     hydro discharge:
     - _comment: used storage values greater than zero.
       datetime: '2020-01-01'
-      source: Electricity Maps, 2020 zone average
-      value: 342.12
+      source: Electricity Maps, 2020 zone average; IPCC 2014
+      value: 279.55
     - _comment: used storage values greater than zero.
       datetime: '2021-01-01'
-      source: Electricity Maps, 2021 zone average
-      value: 369.61
+      source: Electricity Maps, 2021 zone average; IPCC 2014
+      value: 302.69
+    - _comment: used default IPCC 2014 value of 24.0
+      datetime: '2022-01-01'
+      source: Electricity Maps, 2022 zone average; IPCC 2014
+      value: 24.0
+    - _comment: used default IPCC 2014 value of 24.0
+      datetime: '2023-01-01'
+      source: Electricity Maps, 2023 zone average; IPCC 2014
+      value: 24.0
+    - _comment: used default IPCC 2014 value of 24.0
+      datetime: '2025-01-01'
+      source: Electricity Maps, 2025 zone average; IPCC 2014
+      value: 24.0
 fallbackZoneMixes:
   powerOriginRatios:
   - _source: Electricity Maps, 2017 average

--- a/config/zones/AT.yaml
+++ b/config/zones/AT.yaml
@@ -279,7 +279,7 @@ emissionFactors:
     - _comment: used storage values greater than zero.
       datetime: '2024-01-01'
       source: Electricity Maps, 2024 zone average
-      value: 77.79
+      value: 77.83
     - _comment: used storage values greater than zero.
       datetime: '2025-01-01'
       source: Electricity Maps, 2025 zone average
@@ -348,7 +348,7 @@ emissionFactors:
     - _comment: used storage values greater than zero.
       datetime: '2024-01-01'
       source: Electricity Maps, 2024 zone average
-      value: 115.57
+      value: 115.64
     - _comment: used storage values greater than zero.
       datetime: '2025-01-01'
       source: Electricity Maps, 2025 zone average

--- a/config/zones/AT.yaml
+++ b/config/zones/AT.yaml
@@ -263,19 +263,19 @@ emissionFactors:
     - _comment: used storage values greater than zero.
       datetime: '2020-01-01'
       source: Electricity Maps, 2020 zone average
-      value: 150.82
+      value: 151.02
     - _comment: used storage values greater than zero.
       datetime: '2021-01-01'
       source: Electricity Maps, 2021 zone average
-      value: 190.45
+      value: 190.65
     - _comment: used storage values greater than zero.
       datetime: '2022-01-01'
       source: Electricity Maps, 2022 zone average
-      value: 201.94
+      value: 202.22
     - _comment: used storage values greater than zero.
       datetime: '2023-01-01'
       source: Electricity Maps, 2023 zone average
-      value: 113.14
+      value: 113.25
     - _comment: used storage values greater than zero.
       datetime: '2024-01-01'
       source: Electricity Maps, 2024 zone average
@@ -283,7 +283,7 @@ emissionFactors:
     - _comment: used storage values greater than zero.
       datetime: '2025-01-01'
       source: Electricity Maps, 2025 zone average
-      value: 109.33
+      value: 109.4
     oil:
     - datetime: '2021-01-01'
       source: EU-ETS, ENTSO-E 2021
@@ -331,28 +331,28 @@ emissionFactors:
     hydro discharge:
     - _comment: used storage values greater than zero.
       datetime: '2020-01-01'
-      source: Electricity Maps, 2020 zone average
-      value: 198.1
+      source: Electricity Maps, 2020 zone average; IPCC 2014
+      value: 175.02
     - _comment: used storage values greater than zero.
       datetime: '2021-01-01'
-      source: Electricity Maps, 2021 zone average
-      value: 241.14
+      source: Electricity Maps, 2021 zone average; IPCC 2014
+      value: 214.65
     - _comment: used storage values greater than zero.
       datetime: '2022-01-01'
-      source: Electricity Maps, 2022 zone average
-      value: 255.66
+      source: Electricity Maps, 2022 zone average; IPCC 2014
+      value: 226.22
     - _comment: used storage values greater than zero.
       datetime: '2023-01-01'
-      source: Electricity Maps, 2023 zone average
-      value: 152.18
+      source: Electricity Maps, 2023 zone average; IPCC 2014
+      value: 137.25
     - _comment: used storage values greater than zero.
       datetime: '2024-01-01'
-      source: Electricity Maps, 2024 zone average
-      value: 115.64
+      source: Electricity Maps, 2024 zone average; IPCC 2014
+      value: 101.83
     - _comment: used storage values greater than zero.
       datetime: '2025-01-01'
-      source: Electricity Maps, 2025 zone average
-      value: 153.54
+      source: Electricity Maps, 2025 zone average; IPCC 2014
+      value: 133.4
     nuclear:
       datetime: '2020-01-01'
       source: UNECE 2022

--- a/config/zones/AU-NSW.yaml
+++ b/config/zones/AU-NSW.yaml
@@ -113,7 +113,7 @@ emissionFactors:
     - _comment: used storage values greater than zero.
       datetime: '2024-01-01'
       source: Electricity Maps, 2024 zone average
-      value: 469.91
+      value: 469.96
     - _comment: used storage values greater than zero.
       datetime: '2025-01-01'
       source: Electricity Maps, 2025 zone average
@@ -138,7 +138,7 @@ emissionFactors:
     - _comment: used storage values greater than zero.
       datetime: '2024-01-01'
       source: Electricity Maps, 2024 zone average
-      value: 387.6
+      value: 387.66
     - _comment: used storage values greater than zero.
       datetime: '2025-01-01'
       source: Electricity Maps, 2025 zone average
@@ -160,7 +160,7 @@ emissionFactors:
     - _comment: used storage values greater than zero.
       datetime: '2024-01-01'
       source: Electricity Maps, 2024 zone average
-      value: 521.82
+      value: 521.87
     - _comment: used storage values greater than zero.
       datetime: '2025-01-01'
       source: Electricity Maps, 2025 zone average
@@ -185,7 +185,7 @@ emissionFactors:
     - _comment: used storage values greater than zero.
       datetime: '2024-01-01'
       source: Electricity Maps, 2024 zone average
-      value: 437.87
+      value: 437.94
     - _comment: used storage values greater than zero.
       datetime: '2025-01-01'
       source: Electricity Maps, 2025 zone average

--- a/config/zones/AU-NSW.yaml
+++ b/config/zones/AU-NSW.yaml
@@ -105,11 +105,11 @@ emissionFactors:
     - _comment: used storage values greater than zero.
       datetime: '2022-01-01'
       source: Electricity Maps, 2022 zone average
-      value: 524.22
+      value: 524.23
     - _comment: used storage values greater than zero.
       datetime: '2023-01-01'
       source: Electricity Maps, 2023 zone average
-      value: 456.01
+      value: 456.05
     - _comment: used storage values greater than zero.
       datetime: '2024-01-01'
       source: Electricity Maps, 2024 zone average
@@ -117,7 +117,7 @@ emissionFactors:
     - _comment: used storage values greater than zero.
       datetime: '2025-01-01'
       source: Electricity Maps, 2025 zone average
-      value: 449.49
+      value: 450.61
     hydro discharge:
     - _comment: used storage values greater than zero.
       datetime: '2020-01-01'
@@ -126,15 +126,15 @@ emissionFactors:
     - _comment: used storage values greater than zero.
       datetime: '2021-01-01'
       source: Electricity Maps, 2021 zone average
-      value: 561.74
+      value: 561.75
     - _comment: used storage values greater than zero.
       datetime: '2022-01-01'
       source: Electricity Maps, 2022 zone average
-      value: 454.67
+      value: 454.79
     - _comment: used storage values greater than zero.
       datetime: '2023-01-01'
       source: Electricity Maps, 2023 zone average
-      value: 378.32
+      value: 378.37
     - _comment: used storage values greater than zero.
       datetime: '2024-01-01'
       source: Electricity Maps, 2024 zone average
@@ -142,54 +142,54 @@ emissionFactors:
     - _comment: used storage values greater than zero.
       datetime: '2025-01-01'
       source: Electricity Maps, 2025 zone average
-      value: 343.48
+      value: 344.83
   lifecycle:
     battery discharge:
     - _comment: used storage values greater than zero.
       datetime: '2021-01-01'
-      source: Electricity Maps, 2021 zone average
-      value: 450.04
+      source: Electricity Maps, 2021 zone average; National Laboratory of the Rockies
+      value: 430.37
     - _comment: used storage values greater than zero.
       datetime: '2022-01-01'
-      source: Electricity Maps, 2022 zone average
-      value: 577.59
+      source: Electricity Maps, 2022 zone average; National Laboratory of the Rockies
+      value: 557.23
     - _comment: used storage values greater than zero.
       datetime: '2023-01-01'
-      source: Electricity Maps, 2023 zone average
-      value: 507.31
+      source: Electricity Maps, 2023 zone average; National Laboratory of the Rockies
+      value: 489.05
     - _comment: used storage values greater than zero.
       datetime: '2024-01-01'
-      source: Electricity Maps, 2024 zone average
-      value: 521.87
+      source: Electricity Maps, 2024 zone average; National Laboratory of the Rockies
+      value: 502.96
     - _comment: used storage values greater than zero.
       datetime: '2025-01-01'
-      source: Electricity Maps, 2025 zone average
-      value: 500.3
+      source: Electricity Maps, 2025 zone average; National Laboratory of the Rockies
+      value: 483.61
     hydro discharge:
     - _comment: used storage values greater than zero.
       datetime: '2020-01-01'
-      source: Electricity Maps, 2020 zone average
-      value: 674.22
+      source: Electricity Maps, 2020 zone average; IPCC 2014
+      value: 643.68
     - _comment: used storage values greater than zero.
       datetime: '2021-01-01'
-      source: Electricity Maps, 2021 zone average
-      value: 614.49
+      source: Electricity Maps, 2021 zone average; IPCC 2014
+      value: 585.75
     - _comment: used storage values greater than zero.
       datetime: '2022-01-01'
-      source: Electricity Maps, 2022 zone average
-      value: 506.5
+      source: Electricity Maps, 2022 zone average; IPCC 2014
+      value: 478.79
     - _comment: used storage values greater than zero.
       datetime: '2023-01-01'
-      source: Electricity Maps, 2023 zone average
-      value: 428.55
+      source: Electricity Maps, 2023 zone average; IPCC 2014
+      value: 402.37
     - _comment: used storage values greater than zero.
       datetime: '2024-01-01'
-      source: Electricity Maps, 2024 zone average
-      value: 437.94
+      source: Electricity Maps, 2024 zone average; IPCC 2014
+      value: 411.66
     - _comment: used storage values greater than zero.
       datetime: '2025-01-01'
-      source: Electricity Maps, 2025 zone average
-      value: 392.54
+      source: Electricity Maps, 2025 zone average; IPCC 2014
+      value: 368.83
 fallbackZoneMixes:
   powerOriginRatios:
   - _source: Electricity Maps, 2015 average

--- a/config/zones/AU-QLD.yaml
+++ b/config/zones/AU-QLD.yaml
@@ -101,7 +101,7 @@ emissionFactors:
     - _comment: used storage values greater than zero.
       datetime: '2024-01-01'
       source: Electricity Maps, 2024 zone average
-      value: 493.02
+      value: 493.04
     - _comment: used storage values greater than zero.
       datetime: '2025-01-01'
       source: Electricity Maps, 2025 zone average
@@ -126,7 +126,7 @@ emissionFactors:
     - _comment: used storage values greater than zero.
       datetime: '2024-01-01'
       source: Electricity Maps, 2024 zone average
-      value: 369.22
+      value: 369.27
     - _comment: used storage values greater than zero.
       datetime: '2025-01-01'
       source: Electricity Maps, 2025 zone average
@@ -148,7 +148,7 @@ emissionFactors:
     - _comment: used storage values greater than zero.
       datetime: '2024-01-01'
       source: Electricity Maps, 2024 zone average
-      value: 549.1
+      value: 549.12
     - _comment: used storage values greater than zero.
       datetime: '2025-01-01'
       source: Electricity Maps, 2025 zone average
@@ -173,7 +173,7 @@ emissionFactors:
     - _comment: used storage values greater than zero.
       datetime: '2024-01-01'
       source: Electricity Maps, 2024 zone average
-      value: 422.51
+      value: 422.55
     - _comment: used storage values greater than zero.
       datetime: '2025-01-01'
       source: Electricity Maps, 2025 zone average

--- a/config/zones/AU-QLD.yaml
+++ b/config/zones/AU-QLD.yaml
@@ -93,11 +93,11 @@ emissionFactors:
     - _comment: used storage values greater than zero.
       datetime: '2022-01-01'
       source: Electricity Maps, 2022 zone average
-      value: 558.82
+      value: 558.86
     - _comment: used storage values greater than zero.
       datetime: '2023-01-01'
       source: Electricity Maps, 2023 zone average
-      value: 487.71
+      value: 487.73
     - _comment: used storage values greater than zero.
       datetime: '2024-01-01'
       source: Electricity Maps, 2024 zone average
@@ -105,7 +105,7 @@ emissionFactors:
     - _comment: used storage values greater than zero.
       datetime: '2025-01-01'
       source: Electricity Maps, 2025 zone average
-      value: 483.56
+      value: 484.58
     hydro discharge:
     - _comment: used storage values greater than zero.
       datetime: '2020-01-01'
@@ -114,15 +114,15 @@ emissionFactors:
     - _comment: used storage values greater than zero.
       datetime: '2021-01-01'
       source: Electricity Maps, 2021 zone average
-      value: 540.24
+      value: 540.25
     - _comment: used storage values greater than zero.
       datetime: '2022-01-01'
       source: Electricity Maps, 2022 zone average
-      value: 505.4
+      value: 505.58
     - _comment: used storage values greater than zero.
       datetime: '2023-01-01'
       source: Electricity Maps, 2023 zone average
-      value: 380.47
+      value: 380.51
     - _comment: used storage values greater than zero.
       datetime: '2024-01-01'
       source: Electricity Maps, 2024 zone average
@@ -130,54 +130,54 @@ emissionFactors:
     - _comment: used storage values greater than zero.
       datetime: '2025-01-01'
       source: Electricity Maps, 2025 zone average
-      value: 390.29
+      value: 391.3
   lifecycle:
     battery discharge:
     - _comment: used storage values greater than zero.
       datetime: '2021-01-01'
-      source: Electricity Maps, 2021 zone average
-      value: 584.88
+      source: Electricity Maps, 2021 zone average; National Laboratory of the Rockies
+      value: 557.81
     - _comment: used storage values greater than zero.
       datetime: '2022-01-01'
-      source: Electricity Maps, 2022 zone average
-      value: 619.08
+      source: Electricity Maps, 2022 zone average; National Laboratory of the Rockies
+      value: 591.86
     - _comment: used storage values greater than zero.
       datetime: '2023-01-01'
-      source: Electricity Maps, 2023 zone average
-      value: 544.06
+      source: Electricity Maps, 2023 zone average; National Laboratory of the Rockies
+      value: 520.73
     - _comment: used storage values greater than zero.
       datetime: '2024-01-01'
-      source: Electricity Maps, 2024 zone average
-      value: 549.12
+      source: Electricity Maps, 2024 zone average; National Laboratory of the Rockies
+      value: 526.04
     - _comment: used storage values greater than zero.
       datetime: '2025-01-01'
-      source: Electricity Maps, 2025 zone average
-      value: 538.34
+      source: Electricity Maps, 2025 zone average; National Laboratory of the Rockies
+      value: 517.58
     hydro discharge:
     - _comment: used storage values greater than zero.
       datetime: '2020-01-01'
-      source: Electricity Maps, 2020 zone average
-      value: 649.53
+      source: Electricity Maps, 2020 zone average; IPCC 2014
+      value: 613.24
     - _comment: used storage values greater than zero.
       datetime: '2021-01-01'
-      source: Electricity Maps, 2021 zone average
-      value: 598.44
+      source: Electricity Maps, 2021 zone average; IPCC 2014
+      value: 564.25
     - _comment: used storage values greater than zero.
       datetime: '2022-01-01'
-      source: Electricity Maps, 2022 zone average
-      value: 563.1
+      source: Electricity Maps, 2022 zone average; IPCC 2014
+      value: 529.58
     - _comment: used storage values greater than zero.
       datetime: '2023-01-01'
-      source: Electricity Maps, 2023 zone average
-      value: 434.03
+      source: Electricity Maps, 2023 zone average; IPCC 2014
+      value: 404.51
     - _comment: used storage values greater than zero.
       datetime: '2024-01-01'
-      source: Electricity Maps, 2024 zone average
-      value: 422.55
+      source: Electricity Maps, 2024 zone average; IPCC 2014
+      value: 393.27
     - _comment: used storage values greater than zero.
       datetime: '2025-01-01'
-      source: Electricity Maps, 2025 zone average
-      value: 443.54
+      source: Electricity Maps, 2025 zone average; IPCC 2014
+      value: 415.3
 fallbackZoneMixes:
   powerOriginRatios:
   - _source: Electricity Maps, 2015 average

--- a/config/zones/AU-SA.yaml
+++ b/config/zones/AU-SA.yaml
@@ -87,19 +87,19 @@ emissionFactors:
     - _comment: used storage values greater than zero.
       datetime: '2020-01-01'
       source: Electricity Maps, 2020 zone average
-      value: 161.25
+      value: 161.54
     - _comment: used storage values greater than zero.
       datetime: '2021-01-01'
       source: Electricity Maps, 2021 zone average
-      value: 127.08
+      value: 127.38
     - _comment: used storage values greater than zero.
       datetime: '2022-01-01'
       source: Electricity Maps, 2022 zone average
-      value: 96.32
+      value: 96.37
     - _comment: used storage values greater than zero.
       datetime: '2023-01-01'
       source: Electricity Maps, 2023 zone average
-      value: 105.53
+      value: 105.57
     - _comment: used storage values greater than zero.
       datetime: '2024-01-01'
       source: Electricity Maps, 2024 zone average
@@ -107,33 +107,33 @@ emissionFactors:
     - _comment: used storage values greater than zero.
       datetime: '2025-01-01'
       source: Electricity Maps, 2025 zone average
-      value: 88.52
+      value: 89.63
   lifecycle:
     battery discharge:
     - _comment: used storage values greater than zero.
       datetime: '2020-01-01'
-      source: Electricity Maps, 2020 zone average
-      value: 222.2
+      source: Electricity Maps, 2020 zone average; National Laboratory of the Rockies
+      value: 194.54
     - _comment: used storage values greater than zero.
       datetime: '2021-01-01'
-      source: Electricity Maps, 2021 zone average
-      value: 180.15
+      source: Electricity Maps, 2021 zone average; National Laboratory of the Rockies
+      value: 160.38
     - _comment: used storage values greater than zero.
       datetime: '2022-01-01'
-      source: Electricity Maps, 2022 zone average
-      value: 143.98
+      source: Electricity Maps, 2022 zone average; National Laboratory of the Rockies
+      value: 129.37
     - _comment: used storage values greater than zero.
       datetime: '2023-01-01'
-      source: Electricity Maps, 2023 zone average
-      value: 149.4
+      source: Electricity Maps, 2023 zone average; National Laboratory of the Rockies
+      value: 138.57
     - _comment: used storage values greater than zero.
       datetime: '2024-01-01'
-      source: Electricity Maps, 2024 zone average
-      value: 162.01
+      source: Electricity Maps, 2024 zone average; National Laboratory of the Rockies
+      value: 148.74
     - _comment: used storage values greater than zero.
       datetime: '2025-01-01'
-      source: Electricity Maps, 2025 zone average
-      value: 128.52
+      source: Electricity Maps, 2025 zone average; National Laboratory of the Rockies
+      value: 122.63
 fallbackZoneMixes:
   powerOriginRatios:
   - _source: Electricity Maps, 2015 average

--- a/config/zones/AU-SA.yaml
+++ b/config/zones/AU-SA.yaml
@@ -103,7 +103,7 @@ emissionFactors:
     - _comment: used storage values greater than zero.
       datetime: '2024-01-01'
       source: Electricity Maps, 2024 zone average
-      value: 115.71
+      value: 115.74
     - _comment: used storage values greater than zero.
       datetime: '2025-01-01'
       source: Electricity Maps, 2025 zone average
@@ -129,7 +129,7 @@ emissionFactors:
     - _comment: used storage values greater than zero.
       datetime: '2024-01-01'
       source: Electricity Maps, 2024 zone average
-      value: 161.96
+      value: 162.01
     - _comment: used storage values greater than zero.
       datetime: '2025-01-01'
       source: Electricity Maps, 2025 zone average

--- a/config/zones/AU-TAS-FI.yaml
+++ b/config/zones/AU-TAS-FI.yaml
@@ -46,7 +46,7 @@ emissionFactors:
     - _comment: used storage values greater than zero.
       datetime: '2024-01-01'
       source: Electricity Maps, 2024 zone average
-      value: 159.21
+      value: 159.41
     - _comment: used storage values greater than zero.
       datetime: '2025-01-01'
       source: Electricity Maps, 2025 zone average
@@ -72,7 +72,7 @@ emissionFactors:
     - _comment: used storage values greater than zero.
       datetime: '2024-01-01'
       source: Electricity Maps, 2024 zone average
-      value: 262.21
+      value: 262.54
     - _comment: used storage values greater than zero.
       datetime: '2025-01-01'
       source: Electricity Maps, 2025 zone average

--- a/config/zones/AU-TAS-FI.yaml
+++ b/config/zones/AU-TAS-FI.yaml
@@ -30,19 +30,19 @@ emissionFactors:
     - _comment: used storage values greater than zero.
       datetime: '2020-01-01'
       source: Electricity Maps, 2020 zone average
-      value: 150.79
+      value: 151.28
     - _comment: used storage values greater than zero.
       datetime: '2021-01-01'
       source: Electricity Maps, 2021 zone average
-      value: 142.99
+      value: 143.31
     - _comment: used storage values greater than zero.
       datetime: '2022-01-01'
       source: Electricity Maps, 2022 zone average
-      value: 173.51
+      value: 173.89
     - _comment: used storage values greater than zero.
       datetime: '2023-01-01'
       source: Electricity Maps, 2023 zone average
-      value: 166.1
+      value: 166.43
     - _comment: used storage values greater than zero.
       datetime: '2024-01-01'
       source: Electricity Maps, 2024 zone average
@@ -50,33 +50,33 @@ emissionFactors:
     - _comment: used storage values greater than zero.
       datetime: '2025-01-01'
       source: Electricity Maps, 2025 zone average
-      value: 188.33
+      value: 188.56
   lifecycle:
     battery discharge:
     - _comment: used storage values greater than zero.
       datetime: '2020-01-01'
-      source: Electricity Maps, 2020 zone average
-      value: 248.92
+      source: Electricity Maps, 2020 zone average; National Laboratory of the Rockies
+      value: 184.28
     - _comment: used storage values greater than zero.
       datetime: '2021-01-01'
-      source: Electricity Maps, 2021 zone average
-      value: 236.77
+      source: Electricity Maps, 2021 zone average; National Laboratory of the Rockies
+      value: 176.31
     - _comment: used storage values greater than zero.
       datetime: '2022-01-01'
-      source: Electricity Maps, 2022 zone average
-      value: 284.7
+      source: Electricity Maps, 2022 zone average; National Laboratory of the Rockies
+      value: 206.89
     - _comment: used storage values greater than zero.
       datetime: '2023-01-01'
-      source: Electricity Maps, 2023 zone average
-      value: 272.93
+      source: Electricity Maps, 2023 zone average; National Laboratory of the Rockies
+      value: 199.43
     - _comment: used storage values greater than zero.
       datetime: '2024-01-01'
-      source: Electricity Maps, 2024 zone average
-      value: 262.54
+      source: Electricity Maps, 2024 zone average; National Laboratory of the Rockies
+      value: 192.41
     - _comment: used storage values greater than zero.
       datetime: '2025-01-01'
-      source: Electricity Maps, 2025 zone average
-      value: 307.97
+      source: Electricity Maps, 2025 zone average; National Laboratory of the Rockies
+      value: 221.56
 fallbackZoneMixes:
   powerOriginRatios:
   - _source: Electricity Maps, 2021 average

--- a/config/zones/AU-TAS-KI.yaml
+++ b/config/zones/AU-TAS-KI.yaml
@@ -30,19 +30,19 @@ emissionFactors:
     - _comment: used storage values greater than zero.
       datetime: '2020-01-01'
       source: Electricity Maps, 2020 zone average
-      value: 137.74
+      value: 137.7
     - _comment: used storage values greater than zero.
       datetime: '2021-01-01'
       source: Electricity Maps, 2021 zone average
-      value: 175.79
+      value: 176.34
     - _comment: used storage values greater than zero.
       datetime: '2022-01-01'
       source: Electricity Maps, 2022 zone average
-      value: 223.56
+      value: 223.73
     - _comment: used storage values greater than zero.
       datetime: '2023-01-01'
       source: Electricity Maps, 2023 zone average
-      value: 305.68
+      value: 305.8
     - _comment: used storage values greater than zero.
       datetime: '2024-01-01'
       source: Electricity Maps, 2024 zone average
@@ -50,33 +50,33 @@ emissionFactors:
     - _comment: used storage values greater than zero.
       datetime: '2025-01-01'
       source: Electricity Maps, 2025 zone average
-      value: 290.91
+      value: 291.19
   lifecycle:
     battery discharge:
     - _comment: used storage values greater than zero.
       datetime: '2020-01-01'
-      source: Electricity Maps, 2020 zone average
-      value: 228.15
+      source: Electricity Maps, 2020 zone average; National Laboratory of the Rockies
+      value: 170.7
     - _comment: used storage values greater than zero.
       datetime: '2021-01-01'
-      source: Electricity Maps, 2021 zone average
-      value: 287.93
+      source: Electricity Maps, 2021 zone average; National Laboratory of the Rockies
+      value: 209.34
     - _comment: used storage values greater than zero.
       datetime: '2022-01-01'
-      source: Electricity Maps, 2022 zone average
-      value: 363.24
+      source: Electricity Maps, 2022 zone average; National Laboratory of the Rockies
+      value: 256.73
     - _comment: used storage values greater than zero.
       datetime: '2023-01-01'
-      source: Electricity Maps, 2023 zone average
-      value: 492.45
+      source: Electricity Maps, 2023 zone average; National Laboratory of the Rockies
+      value: 338.8
     - _comment: used storage values greater than zero.
       datetime: '2024-01-01'
-      source: Electricity Maps, 2024 zone average
-      value: 454.5
+      source: Electricity Maps, 2024 zone average; National Laboratory of the Rockies
+      value: 312.41
     - _comment: used storage values greater than zero.
       datetime: '2025-01-01'
-      source: Electricity Maps, 2025 zone average
-      value: 473.59
+      source: Electricity Maps, 2025 zone average; National Laboratory of the Rockies
+      value: 324.19
 fallbackZoneMixes:
   powerOriginRatios:
   - _source: Electricity Maps, 2020 average

--- a/config/zones/AU-TAS-KI.yaml
+++ b/config/zones/AU-TAS-KI.yaml
@@ -46,7 +46,7 @@ emissionFactors:
     - _comment: used storage values greater than zero.
       datetime: '2024-01-01'
       source: Electricity Maps, 2024 zone average
-      value: 279.07
+      value: 279.41
     - _comment: used storage values greater than zero.
       datetime: '2025-01-01'
       source: Electricity Maps, 2025 zone average
@@ -72,7 +72,7 @@ emissionFactors:
     - _comment: used storage values greater than zero.
       datetime: '2024-01-01'
       source: Electricity Maps, 2024 zone average
-      value: 453.94
+      value: 454.5
     - _comment: used storage values greater than zero.
       datetime: '2025-01-01'
       source: Electricity Maps, 2025 zone average

--- a/config/zones/AU-TAS.yaml
+++ b/config/zones/AU-TAS.yaml
@@ -55,8 +55,8 @@ emissionFactors:
     battery discharge:
     - _comment: used storage values greater than zero.
       datetime: '2022-01-01'
-      source: Electricity Maps, 2022 zone average
-      value: 21.58
+      source: Electricity Maps, 2022 zone average; National Laboratory of the Rockies
+      value: 33.38
 fallbackZoneMixes:
   powerOriginRatios:
   - _source: Electricity Maps, 2015 average

--- a/config/zones/AU-VIC.yaml
+++ b/config/zones/AU-VIC.yaml
@@ -102,7 +102,7 @@ emissionFactors:
     - _comment: used storage values greater than zero.
       datetime: '2024-01-01'
       source: Electricity Maps, 2024 zone average
-      value: 441.88
+      value: 441.94
     - _comment: used storage values greater than zero.
       datetime: '2025-01-01'
       source: Electricity Maps, 2025 zone average
@@ -128,7 +128,7 @@ emissionFactors:
     - _comment: used storage values greater than zero.
       datetime: '2024-01-01'
       source: Electricity Maps, 2024 zone average
-      value: 489.79
+      value: 489.86
     - _comment: used storage values greater than zero.
       datetime: '2025-01-01'
       source: Electricity Maps, 2025 zone average

--- a/config/zones/AU-VIC.yaml
+++ b/config/zones/AU-VIC.yaml
@@ -86,19 +86,19 @@ emissionFactors:
     - _comment: used storage values greater than zero.
       datetime: '2020-01-01'
       source: Electricity Maps, 2020 zone average
-      value: 595.17
+      value: 595.22
     - _comment: used storage values greater than zero.
       datetime: '2021-01-01'
       source: Electricity Maps, 2021 zone average
-      value: 542.29
+      value: 542.33
     - _comment: used storage values greater than zero.
       datetime: '2022-01-01'
       source: Electricity Maps, 2022 zone average
-      value: 486.07
+      value: 486.12
     - _comment: used storage values greater than zero.
       datetime: '2023-01-01'
       source: Electricity Maps, 2023 zone average
-      value: 420.51
+      value: 420.58
     - _comment: used storage values greater than zero.
       datetime: '2024-01-01'
       source: Electricity Maps, 2024 zone average
@@ -106,33 +106,33 @@ emissionFactors:
     - _comment: used storage values greater than zero.
       datetime: '2025-01-01'
       source: Electricity Maps, 2025 zone average
-      value: 409.31
+      value: 410.59
   lifecycle:
     battery discharge:
     - _comment: used storage values greater than zero.
       datetime: '2020-01-01'
-      source: Electricity Maps, 2020 zone average
-      value: 647.87
+      source: Electricity Maps, 2020 zone average; National Laboratory of the Rockies
+      value: 628.22
     - _comment: used storage values greater than zero.
       datetime: '2021-01-01'
-      source: Electricity Maps, 2021 zone average
-      value: 591.87
+      source: Electricity Maps, 2021 zone average; National Laboratory of the Rockies
+      value: 575.33
     - _comment: used storage values greater than zero.
       datetime: '2022-01-01'
-      source: Electricity Maps, 2022 zone average
-      value: 535.07
+      source: Electricity Maps, 2022 zone average; National Laboratory of the Rockies
+      value: 519.12
     - _comment: used storage values greater than zero.
       datetime: '2023-01-01'
-      source: Electricity Maps, 2023 zone average
-      value: 466.37
+      source: Electricity Maps, 2023 zone average; National Laboratory of the Rockies
+      value: 453.58
     - _comment: used storage values greater than zero.
       datetime: '2024-01-01'
-      source: Electricity Maps, 2024 zone average
-      value: 489.86
+      source: Electricity Maps, 2024 zone average; National Laboratory of the Rockies
+      value: 474.94
     - _comment: used storage values greater than zero.
       datetime: '2025-01-01'
-      source: Electricity Maps, 2025 zone average
-      value: 453.91
+      source: Electricity Maps, 2025 zone average; National Laboratory of the Rockies
+      value: 443.59
 fallbackZoneMixes:
   powerOriginRatios:
   - _source: Electricity Maps, 2015 average

--- a/config/zones/AU-WA-RI.yaml
+++ b/config/zones/AU-WA-RI.yaml
@@ -45,7 +45,7 @@ emissionFactors:
     - _comment: used storage values equal to zero.
       datetime: '2024-01-01'
       source: Electricity Maps, 2024 zone average
-      value: 322.04
+      value: 322.11
     - _comment: used storage values equal to zero.
       datetime: '2025-01-01'
       source: Electricity Maps, 2025 zone average
@@ -71,7 +71,7 @@ emissionFactors:
     - _comment: used storage values equal to zero.
       datetime: '2024-01-01'
       source: Electricity Maps, 2024 zone average
-      value: 519.91
+      value: 520.01
     - _comment: used storage values equal to zero.
       datetime: '2025-01-01'
       source: Electricity Maps, 2025 zone average

--- a/config/zones/AU-WA-RI.yaml
+++ b/config/zones/AU-WA-RI.yaml
@@ -26,56 +26,56 @@ currency: AUD
 emissionFactors:
   direct:
     battery discharge:
-    - _comment: used storage values equal to zero.
+    - _comment: used non-null storage values
       datetime: '2020-01-01'
       source: Electricity Maps, 2020 zone average
-      value: 311.22
-    - _comment: used storage values equal to zero.
+      value: 311.06
+    - _comment: used non-null storage values
       datetime: '2021-01-01'
       source: Electricity Maps, 2021 zone average
-      value: 311.06
-    - _comment: used storage values equal to zero.
+      value: 310.93
+    - _comment: used non-null storage values
       datetime: '2022-01-01'
       source: Electricity Maps, 2022 zone average
-      value: 311.06
-    - _comment: used storage values equal to zero.
+      value: 310.92
+    - _comment: used non-null storage values
       datetime: '2023-01-01'
       source: Electricity Maps, 2023 zone average
-      value: 304.49
-    - _comment: used storage values equal to zero.
+      value: 304.5
+    - _comment: used non-null storage values
       datetime: '2024-01-01'
       source: Electricity Maps, 2024 zone average
       value: 322.11
-    - _comment: used storage values equal to zero.
+    - _comment: used non-null storage values
       datetime: '2025-01-01'
       source: Electricity Maps, 2025 zone average
-      value: 305.27
+      value: 305.26
   lifecycle:
     battery discharge:
-    - _comment: used storage values equal to zero.
+    - _comment: used non-null storage values
       datetime: '2020-01-01'
-      source: Electricity Maps, 2020 zone average
-      value: 503.25
-    - _comment: used storage values equal to zero.
+      source: Electricity Maps, 2020 zone average; National Laboratory of the Rockies
+      value: 344.06
+    - _comment: used non-null storage values
       datetime: '2021-01-01'
-      source: Electricity Maps, 2021 zone average
-      value: 503.06
-    - _comment: used storage values equal to zero.
+      source: Electricity Maps, 2021 zone average; National Laboratory of the Rockies
+      value: 343.93
+    - _comment: used non-null storage values
       datetime: '2022-01-01'
-      source: Electricity Maps, 2022 zone average
-      value: 503.06
-    - _comment: used storage values equal to zero.
+      source: Electricity Maps, 2022 zone average; National Laboratory of the Rockies
+      value: 343.92
+    - _comment: used non-null storage values
       datetime: '2023-01-01'
-      source: Electricity Maps, 2023 zone average
-      value: 492.91
-    - _comment: used storage values equal to zero.
+      source: Electricity Maps, 2023 zone average; National Laboratory of the Rockies
+      value: 337.5
+    - _comment: used non-null storage values
       datetime: '2024-01-01'
-      source: Electricity Maps, 2024 zone average
-      value: 520.01
-    - _comment: used storage values equal to zero.
+      source: Electricity Maps, 2024 zone average; National Laboratory of the Rockies
+      value: 355.11
+    - _comment: used non-null storage values
       datetime: '2025-01-01'
-      source: Electricity Maps, 2025 zone average
-      value: 494.05
+      source: Electricity Maps, 2025 zone average; National Laboratory of the Rockies
+      value: 338.26
 fallbackZoneMixes:
   powerOriginRatios:
   - _source: Electricity Maps, 2021 average

--- a/config/zones/AU-WA.yaml
+++ b/config/zones/AU-WA.yaml
@@ -81,7 +81,7 @@ emissionFactors:
     - _comment: used storage values greater than zero.
       datetime: '2023-01-01'
       source: Electricity Maps, 2023 zone average
-      value: 310.98
+      value: 311.0
     - _comment: used storage values greater than zero.
       datetime: '2024-01-01'
       source: Electricity Maps, 2024 zone average
@@ -89,25 +89,25 @@ emissionFactors:
     - _comment: used storage values greater than zero.
       datetime: '2025-01-01'
       source: Electricity Maps, 2025 zone average
-      value: 281.74
+      value: 281.99
   lifecycle:
     battery discharge:
     - _comment: used storage values greater than zero.
       datetime: '2020-01-01'
-      source: Electricity Maps, 2020 zone average
-      value: 348.67
+      source: Electricity Maps, 2020 zone average; National Laboratory of the Rockies
+      value: 321.89
     - _comment: used storage values greater than zero.
       datetime: '2023-01-01'
-      source: Electricity Maps, 2023 zone average
-      value: 374.21
+      source: Electricity Maps, 2023 zone average; National Laboratory of the Rockies
+      value: 344.0
     - _comment: used storage values greater than zero.
       datetime: '2024-01-01'
-      source: Electricity Maps, 2024 zone average
-      value: 368.78
+      source: Electricity Maps, 2024 zone average; National Laboratory of the Rockies
+      value: 336.91
     - _comment: used storage values greater than zero.
       datetime: '2025-01-01'
-      source: Electricity Maps, 2025 zone average
-      value: 344.39
+      source: Electricity Maps, 2025 zone average; National Laboratory of the Rockies
+      value: 314.99
 fallbackZoneMixes:
   powerOriginRatios:
   - _source: Electricity Maps, 2015 average

--- a/config/zones/AU-WA.yaml
+++ b/config/zones/AU-WA.yaml
@@ -85,7 +85,7 @@ emissionFactors:
     - _comment: used storage values greater than zero.
       datetime: '2024-01-01'
       source: Electricity Maps, 2024 zone average
-      value: 303.78
+      value: 303.91
     - _comment: used storage values greater than zero.
       datetime: '2025-01-01'
       source: Electricity Maps, 2025 zone average
@@ -103,7 +103,7 @@ emissionFactors:
     - _comment: used storage values greater than zero.
       datetime: '2024-01-01'
       source: Electricity Maps, 2024 zone average
-      value: 368.61
+      value: 368.78
     - _comment: used storage values greater than zero.
       datetime: '2025-01-01'
       source: Electricity Maps, 2025 zone average

--- a/config/zones/AU.yaml
+++ b/config/zones/AU.yaml
@@ -39,19 +39,19 @@ emissionFactors:
     - _comment: used storage values greater than zero.
       datetime: '2020-01-01'
       source: Electricity Maps, 2020 zone average
-      value: 545.01
+      value: 545.09
     - _comment: used storage values greater than zero.
       datetime: '2021-01-01'
       source: Electricity Maps, 2021 zone average
-      value: 507.73
+      value: 507.82
     - _comment: used storage values greater than zero.
       datetime: '2022-01-01'
       source: Electricity Maps, 2022 zone average
-      value: 459.37
+      value: 459.51
     - _comment: used storage values greater than zero.
       datetime: '2023-01-01'
       source: Electricity Maps, 2023 zone average
-      value: 397.31
+      value: 397.4
     - _comment: used storage values greater than zero.
       datetime: '2024-01-01'
       source: Electricity Maps, 2024 zone average
@@ -59,24 +59,24 @@ emissionFactors:
     - _comment: used storage values greater than zero.
       datetime: '2025-01-01'
       source: Electricity Maps, 2025 zone average
-      value: 384.7
+      value: 385.9
     hydro discharge:
     - _comment: used storage values greater than zero.
       datetime: '2020-01-01'
       source: Electricity Maps, 2020 zone average
-      value: 526.93
+      value: 527.08
     - _comment: used storage values greater than zero.
       datetime: '2021-01-01'
       source: Electricity Maps, 2021 zone average
-      value: 479.34
+      value: 479.51
     - _comment: used storage values greater than zero.
       datetime: '2022-01-01'
       source: Electricity Maps, 2022 zone average
-      value: 424.64
+      value: 425.02
     - _comment: used storage values greater than zero.
       datetime: '2023-01-01'
       source: Electricity Maps, 2023 zone average
-      value: 355.85
+      value: 356.0
     - _comment: used storage values greater than zero.
       datetime: '2024-01-01'
       source: Electricity Maps, 2024 zone average
@@ -84,58 +84,58 @@ emissionFactors:
     - _comment: used storage values greater than zero.
       datetime: '2025-01-01'
       source: Electricity Maps, 2025 zone average
-      value: 335.42
+      value: 336.89
   lifecycle:
     battery discharge:
     - _comment: used storage values greater than zero.
       datetime: '2020-01-01'
-      source: Electricity Maps, 2020 zone average
-      value: 602.7
+      source: Electricity Maps, 2020 zone average; National Laboratory of the Rockies
+      value: 578.09
     - _comment: used storage values greater than zero.
       datetime: '2021-01-01'
-      source: Electricity Maps, 2021 zone average
-      value: 562.39
+      source: Electricity Maps, 2021 zone average; National Laboratory of the Rockies
+      value: 540.82
     - _comment: used storage values greater than zero.
       datetime: '2022-01-01'
-      source: Electricity Maps, 2022 zone average
-      value: 513.9
+      source: Electricity Maps, 2022 zone average; National Laboratory of the Rockies
+      value: 492.51
     - _comment: used storage values greater than zero.
       datetime: '2023-01-01'
-      source: Electricity Maps, 2023 zone average
-      value: 448.98
+      source: Electricity Maps, 2023 zone average; National Laboratory of the Rockies
+      value: 430.4
     - _comment: used storage values greater than zero.
       datetime: '2024-01-01'
-      source: Electricity Maps, 2024 zone average
-      value: 458.9
+      source: Electricity Maps, 2024 zone average; National Laboratory of the Rockies
+      value: 439.66
     - _comment: used storage values greater than zero.
       datetime: '2025-01-01'
-      source: Electricity Maps, 2025 zone average
-      value: 435.4
+      source: Electricity Maps, 2025 zone average; National Laboratory of the Rockies
+      value: 418.9
     hydro discharge:
     - _comment: used storage values greater than zero.
       datetime: '2020-01-01'
-      source: Electricity Maps, 2020 zone average
-      value: 583.48
+      source: Electricity Maps, 2020 zone average; IPCC 2014
+      value: 551.08
     - _comment: used storage values greater than zero.
       datetime: '2021-01-01'
-      source: Electricity Maps, 2021 zone average
-      value: 532.92
+      source: Electricity Maps, 2021 zone average; IPCC 2014
+      value: 503.51
     - _comment: used storage values greater than zero.
       datetime: '2022-01-01'
-      source: Electricity Maps, 2022 zone average
-      value: 477.7
+      source: Electricity Maps, 2022 zone average; IPCC 2014
+      value: 449.02
     - _comment: used storage values greater than zero.
       datetime: '2023-01-01'
-      source: Electricity Maps, 2023 zone average
-      value: 406.89
+      source: Electricity Maps, 2023 zone average; IPCC 2014
+      value: 380.0
     - _comment: used storage values greater than zero.
       datetime: '2024-01-01'
-      source: Electricity Maps, 2024 zone average
-      value: 414.79
+      source: Electricity Maps, 2024 zone average; IPCC 2014
+      value: 387.54
     - _comment: used storage values greater than zero.
       datetime: '2025-01-01'
-      source: Electricity Maps, 2025 zone average
-      value: 385.26
+      source: Electricity Maps, 2025 zone average; IPCC 2014
+      value: 360.89
 fallbackZoneMixes:
   powerOriginRatios:
   - _source: Electricity Maps, 2017 average

--- a/config/zones/AU.yaml
+++ b/config/zones/AU.yaml
@@ -55,7 +55,7 @@ emissionFactors:
     - _comment: used storage values greater than zero.
       datetime: '2024-01-01'
       source: Electricity Maps, 2024 zone average
-      value: 406.52
+      value: 406.66
     - _comment: used storage values greater than zero.
       datetime: '2025-01-01'
       source: Electricity Maps, 2025 zone average
@@ -80,7 +80,7 @@ emissionFactors:
     - _comment: used storage values greater than zero.
       datetime: '2024-01-01'
       source: Electricity Maps, 2024 zone average
-      value: 363.29
+      value: 363.54
     - _comment: used storage values greater than zero.
       datetime: '2025-01-01'
       source: Electricity Maps, 2025 zone average
@@ -106,7 +106,7 @@ emissionFactors:
     - _comment: used storage values greater than zero.
       datetime: '2024-01-01'
       source: Electricity Maps, 2024 zone average
-      value: 458.74
+      value: 458.9
     - _comment: used storage values greater than zero.
       datetime: '2025-01-01'
       source: Electricity Maps, 2025 zone average
@@ -131,7 +131,7 @@ emissionFactors:
     - _comment: used storage values greater than zero.
       datetime: '2024-01-01'
       source: Electricity Maps, 2024 zone average
-      value: 414.5
+      value: 414.79
     - _comment: used storage values greater than zero.
       datetime: '2025-01-01'
       source: Electricity Maps, 2025 zone average

--- a/config/zones/BA.yaml
+++ b/config/zones/BA.yaml
@@ -80,7 +80,7 @@ emissionFactors:
     - _comment: used storage values greater than zero.
       datetime: '2024-01-01'
       source: Electricity Maps, 2024 zone average
-      value: 314.09
+      value: 316.88
     - _comment: used storage values greater than zero.
       datetime: '2025-01-01'
       source: Electricity Maps, 2025 zone average
@@ -106,7 +106,7 @@ emissionFactors:
     - _comment: used storage values greater than zero.
       datetime: '2024-01-01'
       source: Electricity Maps, 2024 zone average
-      value: 354.55
+      value: 357.69
     - _comment: used storage values greater than zero.
       datetime: '2025-01-01'
       source: Electricity Maps, 2025 zone average

--- a/config/zones/BA.yaml
+++ b/config/zones/BA.yaml
@@ -65,18 +65,18 @@ delays:
 emissionFactors:
   direct:
     hydro discharge:
-    - _comment: used storage values equal to zero.
+    - _comment: used default IPCC 2014 value of 0.0
       datetime: '2021-01-01'
       source: Electricity Maps, 2021 zone average
-      value: 538.88
-    - _comment: used storage values equal to zero.
+      value: 0.0
+    - _comment: used default IPCC 2014 value of 0.0
       datetime: '2022-01-01'
       source: Electricity Maps, 2022 zone average
-      value: 519.36
+      value: 0.0
     - _comment: used storage values greater than zero.
       datetime: '2023-01-01'
       source: Electricity Maps, 2023 zone average
-      value: 606.2
+      value: 606.56
     - _comment: used storage values greater than zero.
       datetime: '2024-01-01'
       source: Electricity Maps, 2024 zone average
@@ -91,26 +91,26 @@ emissionFactors:
       source: UNECE 2022
       value: 10.7
     hydro discharge:
-    - _comment: used storage values equal to zero.
+    - _comment: used default IPCC 2014 value of 24.0
       datetime: '2021-01-01'
-      source: Electricity Maps, 2021 zone average
-      value: 586.33
-    - _comment: used storage values equal to zero.
+      source: Electricity Maps, 2021 zone average; IPCC 2014
+      value: 24.0
+    - _comment: used default IPCC 2014 value of 24.0
       datetime: '2022-01-01'
-      source: Electricity Maps, 2022 zone average
-      value: 565.25
+      source: Electricity Maps, 2022 zone average; IPCC 2014
+      value: 24.0
     - _comment: used storage values greater than zero.
       datetime: '2023-01-01'
-      source: Electricity Maps, 2023 zone average
-      value: 657.76
+      source: Electricity Maps, 2023 zone average; IPCC 2014
+      value: 630.56
     - _comment: used storage values greater than zero.
       datetime: '2024-01-01'
-      source: Electricity Maps, 2024 zone average
-      value: 357.69
+      source: Electricity Maps, 2024 zone average; IPCC 2014
+      value: 340.88
     - _comment: used storage values greater than zero.
       datetime: '2025-01-01'
-      source: Electricity Maps, 2025 zone average
-      value: 523.23
+      source: Electricity Maps, 2025 zone average; IPCC 2014
+      value: 505.19
     nuclear:
       datetime: '2020-01-01'
       source: UNECE 2022

--- a/config/zones/BE.yaml
+++ b/config/zones/BE.yaml
@@ -208,10 +208,14 @@ delays:
 emissionFactors:
   direct:
     battery discharge:
-    - _comment: used storage values equal to zero.
+    - _comment: used non-null storage values
+      datetime: '2024-01-01'
+      source: Electricity Maps, 2024 zone average
+      value: 77.27
+    - _comment: used non-null storage values
       datetime: '2025-01-01'
       source: Electricity Maps, 2025 zone average
-      value: 144.46
+      value: 135.65
     biomass:
       datetime: '2021-01-01'
       source: BEIS 2021
@@ -246,19 +250,19 @@ emissionFactors:
     - _comment: used storage values greater than zero.
       datetime: '2020-01-01'
       source: Electricity Maps, 2020 zone average
-      value: 151.28
+      value: 151.33
     - _comment: used storage values greater than zero.
       datetime: '2021-01-01'
       source: Electricity Maps, 2021 zone average
-      value: 123.46
+      value: 123.5
     - _comment: used storage values greater than zero.
       datetime: '2022-01-01'
       source: Electricity Maps, 2022 zone average
-      value: 131.73
+      value: 131.76
     - _comment: used storage values greater than zero.
       datetime: '2023-01-01'
       source: Electricity Maps, 2023 zone average
-      value: 118.82
+      value: 118.89
     - _comment: used storage values greater than zero.
       datetime: '2024-01-01'
       source: Electricity Maps, 2024 zone average
@@ -266,7 +270,7 @@ emissionFactors:
     - _comment: used storage values greater than zero.
       datetime: '2025-01-01'
       source: Electricity Maps, 2025 zone average
-      value: 119.72
+      value: 120.07
     oil:
     - datetime: '2021-01-01'
       source: EU-ETS, ENTSO-E 2021
@@ -282,10 +286,14 @@ emissionFactors:
       value: 889.87
   lifecycle:
     battery discharge:
-    - _comment: used storage values equal to zero.
+    - _comment: used non-null storage values
+      datetime: '2024-01-01'
+      source: Electricity Maps, 2024 zone average; National Laboratory of the Rockies
+      value: 110.27
+    - _comment: used non-null storage values
       datetime: '2025-01-01'
-      source: Electricity Maps, 2025 zone average
-      value: 198.24
+      source: Electricity Maps, 2025 zone average; National Laboratory of the Rockies
+      value: 168.65
     biomass:
       datetime: '2014-01-01'
       source: BEIS 2021; IPCC 2014
@@ -325,28 +333,28 @@ emissionFactors:
     hydro discharge:
     - _comment: used storage values greater than zero.
       datetime: '2020-01-01'
-      source: Electricity Maps, 2020 zone average
-      value: 210.12
+      source: Electricity Maps, 2020 zone average; IPCC 2014
+      value: 175.33
     - _comment: used storage values greater than zero.
       datetime: '2021-01-01'
-      source: Electricity Maps, 2021 zone average
-      value: 172.14
+      source: Electricity Maps, 2021 zone average; IPCC 2014
+      value: 147.5
     - _comment: used storage values greater than zero.
       datetime: '2022-01-01'
-      source: Electricity Maps, 2022 zone average
-      value: 184.44
+      source: Electricity Maps, 2022 zone average; IPCC 2014
+      value: 155.76
     - _comment: used storage values greater than zero.
       datetime: '2023-01-01'
-      source: Electricity Maps, 2023 zone average
-      value: 166.77
+      source: Electricity Maps, 2023 zone average; IPCC 2014
+      value: 142.89
     - _comment: used storage values greater than zero.
       datetime: '2024-01-01'
-      source: Electricity Maps, 2024 zone average
-      value: 143.89
+      source: Electricity Maps, 2024 zone average; IPCC 2014
+      value: 125.16
     - _comment: used storage values greater than zero.
       datetime: '2025-01-01'
-      source: Electricity Maps, 2025 zone average
-      value: 169.3
+      source: Electricity Maps, 2025 zone average; IPCC 2014
+      value: 144.07
     nuclear:
       datetime: '2020-01-01'
       source: UNECE 2022

--- a/config/zones/BE.yaml
+++ b/config/zones/BE.yaml
@@ -262,7 +262,7 @@ emissionFactors:
     - _comment: used storage values greater than zero.
       datetime: '2024-01-01'
       source: Electricity Maps, 2024 zone average
-      value: 101.06
+      value: 101.16
     - _comment: used storage values greater than zero.
       datetime: '2025-01-01'
       source: Electricity Maps, 2025 zone average
@@ -342,7 +342,7 @@ emissionFactors:
     - _comment: used storage values greater than zero.
       datetime: '2024-01-01'
       source: Electricity Maps, 2024 zone average
-      value: 143.74
+      value: 143.89
     - _comment: used storage values greater than zero.
       datetime: '2025-01-01'
       source: Electricity Maps, 2025 zone average

--- a/config/zones/CA-AB.yaml
+++ b/config/zones/CA-AB.yaml
@@ -38,24 +38,24 @@ emissionFactors:
     battery discharge:
     - _comment: used storage values greater than zero.
       datetime: '2021-01-01'
-      source: Electricity Maps, 2021 zone average
-      value: 484.7
+      source: Electricity Maps, 2021 zone average; National Laboratory of the Rockies
+      value: 418.87
     - _comment: used storage values greater than zero.
       datetime: '2022-01-01'
-      source: Electricity Maps, 2022 zone average
-      value: 458.23
+      source: Electricity Maps, 2022 zone average; National Laboratory of the Rockies
+      value: 387.9
     - _comment: used storage values greater than zero.
       datetime: '2023-01-01'
-      source: Electricity Maps, 2023 zone average
-      value: 434.31
+      source: Electricity Maps, 2023 zone average; National Laboratory of the Rockies
+      value: 368.27
     - _comment: used storage values greater than zero.
       datetime: '2024-01-01'
-      source: Electricity Maps, 2024 zone average
-      value: 418.35
+      source: Electricity Maps, 2024 zone average; National Laboratory of the Rockies
+      value: 346.76
     - _comment: used storage values greater than zero.
       datetime: '2025-01-01'
-      source: Electricity Maps, 2025 zone average
-      value: 385.36
+      source: Electricity Maps, 2025 zone average; National Laboratory of the Rockies
+      value: 316.86
     unknown:
       source: assumes 50% coal and 50% natural gas from Battle River dual fuel power
         plant

--- a/config/zones/CA.yaml
+++ b/config/zones/CA.yaml
@@ -170,29 +170,29 @@ emissionFactors:
     - _comment: used storage values greater than zero.
       datetime: '2025-01-01'
       source: Electricity Maps, 2025 zone average
-      value: 92.49
+      value: 92.35
   lifecycle:
     battery discharge:
     - _comment: used storage values greater than zero.
       datetime: '2021-01-01'
-      source: Electricity Maps, 2021 zone average
-      value: 141.97
+      source: Electricity Maps, 2021 zone average; National Laboratory of the Rockies
+      value: 132.03
     - _comment: used storage values greater than zero.
       datetime: '2022-01-01'
-      source: Electricity Maps, 2022 zone average
-      value: 133.29
+      source: Electricity Maps, 2022 zone average; National Laboratory of the Rockies
+      value: 122.69
     - _comment: used storage values greater than zero.
       datetime: '2023-01-01'
-      source: Electricity Maps, 2023 zone average
-      value: 133.88
+      source: Electricity Maps, 2023 zone average; National Laboratory of the Rockies
+      value: 122.48
     - _comment: used storage values greater than zero.
       datetime: '2024-01-01'
-      source: Electricity Maps, 2024 zone average
-      value: 134.78
+      source: Electricity Maps, 2024 zone average; National Laboratory of the Rockies
+      value: 122.07
     - _comment: used storage values greater than zero.
       datetime: '2025-01-01'
-      source: Electricity Maps, 2025 zone average
-      value: 139.59
+      source: Electricity Maps, 2025 zone average; National Laboratory of the Rockies
+      value: 125.35
 parsers:
   productionCapacity: EMBER.fetch_production_capacity
 region: Americas

--- a/config/zones/CZ.yaml
+++ b/config/zones/CZ.yaml
@@ -200,7 +200,7 @@ emissionFactors:
     - _comment: used storage values equal to zero.
       datetime: '2024-01-01'
       source: Electricity Maps, 2024 zone average
-      value: 424.39
+      value: 424.54
     - _comment: used storage values greater than zero.
       datetime: '2025-01-01'
       source: Electricity Maps, 2025 zone average
@@ -269,7 +269,7 @@ emissionFactors:
     - _comment: used storage values equal to zero.
       datetime: '2024-01-01'
       source: Electricity Maps, 2024 zone average
-      value: 465.47
+      value: 465.64
     - _comment: used storage values greater than zero.
       datetime: '2025-01-01'
       source: Electricity Maps, 2025 zone average

--- a/config/zones/CZ.yaml
+++ b/config/zones/CZ.yaml
@@ -184,27 +184,27 @@ emissionFactors:
     - _comment: used storage values greater than zero.
       datetime: '2020-01-01'
       source: Electricity Maps, 2020 zone average
-      value: 445.88
+      value: 446.17
     - _comment: used storage values greater than zero.
       datetime: '2021-01-01'
       source: Electricity Maps, 2021 zone average
-      value: 490.27
+      value: 490.53
     - _comment: used storage values greater than zero.
       datetime: '2022-01-01'
       source: Electricity Maps, 2022 zone average
-      value: 515.36
-    - _comment: used storage values equal to zero.
+      value: 515.37
+    - _comment: used default IPCC 2014 value of 0.0
       datetime: '2023-01-01'
       source: Electricity Maps, 2023 zone average
-      value: 464.93
-    - _comment: used storage values equal to zero.
+      value: 0.0
+    - _comment: used default IPCC 2014 value of 0.0
       datetime: '2024-01-01'
       source: Electricity Maps, 2024 zone average
-      value: 424.54
+      value: 0.0
     - _comment: used storage values greater than zero.
       datetime: '2025-01-01'
       source: Electricity Maps, 2025 zone average
-      value: 467.02
+      value: 467.9
     oil:
     - datetime: '2021-01-01'
       source: EU-ETS, ENTSO-E 2021
@@ -252,28 +252,28 @@ emissionFactors:
     hydro discharge:
     - _comment: used storage values greater than zero.
       datetime: '2020-01-01'
-      source: Electricity Maps, 2020 zone average
-      value: 470.01
+      source: Electricity Maps, 2020 zone average; IPCC 2014
+      value: 470.17
     - _comment: used storage values greater than zero.
       datetime: '2021-01-01'
-      source: Electricity Maps, 2021 zone average
-      value: 515.66
+      source: Electricity Maps, 2021 zone average; IPCC 2014
+      value: 514.53
     - _comment: used storage values greater than zero.
       datetime: '2022-01-01'
-      source: Electricity Maps, 2022 zone average
-      value: 533.94
-    - _comment: used storage values equal to zero.
+      source: Electricity Maps, 2022 zone average; IPCC 2014
+      value: 539.37
+    - _comment: used default IPCC 2014 value of 24.0
       datetime: '2023-01-01'
-      source: Electricity Maps, 2023 zone average
-      value: 506.46
-    - _comment: used storage values equal to zero.
+      source: Electricity Maps, 2023 zone average; IPCC 2014
+      value: 24.0
+    - _comment: used default IPCC 2014 value of 24.0
       datetime: '2024-01-01'
-      source: Electricity Maps, 2024 zone average
-      value: 465.64
+      source: Electricity Maps, 2024 zone average; IPCC 2014
+      value: 24.0
     - _comment: used storage values greater than zero.
       datetime: '2025-01-01'
-      source: Electricity Maps, 2025 zone average
-      value: 509.56
+      source: Electricity Maps, 2025 zone average; IPCC 2014
+      value: 491.9
     nuclear:
       datetime: '2020-01-01'
       source: UNECE 2022

--- a/config/zones/DE.yaml
+++ b/config/zones/DE.yaml
@@ -338,7 +338,7 @@ emissionFactors:
     - _comment: used storage values greater than zero.
       datetime: '2024-01-01'
       source: Electricity Maps, 2024 zone average
-      value: 241.63
+      value: 241.9
     - _comment: used storage values greater than zero.
       datetime: '2025-01-01'
       source: Electricity Maps, 2025 zone average
@@ -413,7 +413,7 @@ emissionFactors:
     - _comment: used storage values greater than zero.
       datetime: '2024-01-01'
       source: Electricity Maps, 2024 zone average
-      value: 299.41
+      value: 299.75
     - _comment: used storage values greater than zero.
       datetime: '2025-01-01'
       source: Electricity Maps, 2025 zone average

--- a/config/zones/DE.yaml
+++ b/config/zones/DE.yaml
@@ -322,19 +322,19 @@ emissionFactors:
     - _comment: used storage values greater than zero.
       datetime: '2020-01-01'
       source: Electricity Maps, 2020 zone average
-      value: 306.95
+      value: 307.31
     - _comment: used storage values greater than zero.
       datetime: '2021-01-01'
       source: Electricity Maps, 2021 zone average
-      value: 338.73
+      value: 339.15
     - _comment: used storage values greater than zero.
       datetime: '2022-01-01'
       source: Electricity Maps, 2022 zone average
-      value: 376.37
+      value: 376.61
     - _comment: used storage values greater than zero.
       datetime: '2023-01-01'
       source: Electricity Maps, 2023 zone average
-      value: 274.62
+      value: 274.86
     - _comment: used storage values greater than zero.
       datetime: '2024-01-01'
       source: Electricity Maps, 2024 zone average
@@ -342,7 +342,7 @@ emissionFactors:
     - _comment: used storage values greater than zero.
       datetime: '2025-01-01'
       source: Electricity Maps, 2025 zone average
-      value: 236.44
+      value: 236.66
     oil:
     - datetime: '2021-01-01'
       source: EU-ETS, ENTSO-E 2021
@@ -396,28 +396,28 @@ emissionFactors:
     hydro discharge:
     - _comment: used storage values greater than zero.
       datetime: '2020-01-01'
-      source: Electricity Maps, 2020 zone average
-      value: 371.38
+      source: Electricity Maps, 2020 zone average; IPCC 2014
+      value: 331.31
     - _comment: used storage values greater than zero.
       datetime: '2021-01-01'
-      source: Electricity Maps, 2021 zone average
-      value: 402.36
+      source: Electricity Maps, 2021 zone average; IPCC 2014
+      value: 363.15
     - _comment: used storage values greater than zero.
       datetime: '2022-01-01'
-      source: Electricity Maps, 2022 zone average
-      value: 441.01
+      source: Electricity Maps, 2022 zone average; IPCC 2014
+      value: 400.61
     - _comment: used storage values greater than zero.
       datetime: '2023-01-01'
-      source: Electricity Maps, 2023 zone average
-      value: 333.67
+      source: Electricity Maps, 2023 zone average; IPCC 2014
+      value: 298.86
     - _comment: used storage values greater than zero.
       datetime: '2024-01-01'
-      source: Electricity Maps, 2024 zone average
-      value: 299.75
+      source: Electricity Maps, 2024 zone average; IPCC 2014
+      value: 265.9
     - _comment: used storage values greater than zero.
       datetime: '2025-01-01'
-      source: Electricity Maps, 2025 zone average
-      value: 294.74
+      source: Electricity Maps, 2025 zone average; IPCC 2014
+      value: 260.66
     nuclear:
       datetime: '2020-01-01'
       source: UNECE 2022

--- a/config/zones/ES-CE.yaml
+++ b/config/zones/ES-CE.yaml
@@ -20,82 +20,82 @@ currency: EUR
 emissionFactors:
   direct:
     battery discharge:
-    - _comment: used storage values equal to zero.
+    - _comment: used non-null storage values
       datetime: '2020-01-01'
       source: Electricity Maps, 2020 zone average
-      value: 405.87
-    - _comment: used storage values equal to zero.
+      value: 405.89
+    - _comment: used non-null storage values
       datetime: '2021-01-01'
       source: Electricity Maps, 2021 zone average
       value: 389.51
-    - _comment: used storage values equal to zero.
+    - _comment: used non-null storage values
       datetime: '2022-01-01'
       source: Electricity Maps, 2022 zone average
-      value: 405.92
-    - _comment: used storage values equal to zero.
+      value: 405.93
+    - _comment: used non-null storage values
       datetime: '2023-01-01'
       source: Electricity Maps, 2023 zone average
-      value: 405.95
-    - _comment: used storage values equal to zero.
+      value: 405.96
+    - _comment: used non-null storage values
       datetime: '2024-01-01'
       source: Electricity Maps, 2024 zone average
       value: 405.82
-    - _comment: used storage values equal to zero.
+    - _comment: used non-null storage values
       datetime: '2025-01-01'
       source: Electricity Maps, 2025 zone average
       value: 405.86
     hydro discharge:
-    - _comment: used storage values equal to zero.
+    - _comment: used default IPCC 2014 value of 0.0
       datetime: '2020-01-01'
       source: Electricity Maps, 2020 zone average
-      value: 405.87
-    - _comment: used storage values equal to zero.
+      value: 0.0
+    - _comment: used default IPCC 2014 value of 0.0
       datetime: '2021-01-01'
       source: Electricity Maps, 2021 zone average
-      value: 389.51
-    - _comment: used storage values equal to zero.
+      value: 0.0
+    - _comment: used default IPCC 2014 value of 0.0
       datetime: '2022-01-01'
       source: Electricity Maps, 2022 zone average
-      value: 405.99
+      value: 0.0
   lifecycle:
     battery discharge:
-    - _comment: used storage values equal to zero.
+    - _comment: used non-null storage values
       datetime: '2020-01-01'
-      source: Electricity Maps, 2020 zone average
-      value: 649.49
-    - _comment: used storage values equal to zero.
+      source: Electricity Maps, 2020 zone average; National Laboratory of the Rockies
+      value: 438.89
+    - _comment: used non-null storage values
       datetime: '2021-01-01'
-      source: Electricity Maps, 2021 zone average
-      value: 576.72
-    - _comment: used storage values equal to zero.
+      source: Electricity Maps, 2021 zone average; National Laboratory of the Rockies
+      value: 422.51
+    - _comment: used non-null storage values
       datetime: '2022-01-01'
-      source: Electricity Maps, 2022 zone average
-      value: 649.66
-    - _comment: used storage values equal to zero.
+      source: Electricity Maps, 2022 zone average; National Laboratory of the Rockies
+      value: 438.93
+    - _comment: used non-null storage values
       datetime: '2023-01-01'
-      source: Electricity Maps, 2023 zone average
-      value: 649.8
-    - _comment: used storage values equal to zero.
+      source: Electricity Maps, 2023 zone average; National Laboratory of the Rockies
+      value: 438.96
+    - _comment: used non-null storage values
       datetime: '2024-01-01'
-      source: Electricity Maps, 2024 zone average
-      value: 649.21
-    - _comment: used storage values equal to zero.
+      source: Electricity Maps, 2024 zone average; National Laboratory of the Rockies
+      value: 438.82
+    - _comment: used non-null storage values
       datetime: '2025-01-01'
-      source: Electricity Maps, 2025 zone average
-      value: 649.38
+      source: Electricity Maps, 2025 zone average; National Laboratory of the Rockies
+      value: 438.86
     hydro discharge:
-    - _comment: used storage values equal to zero.
+    - _comment: used default IPCC 2014 value of 24.0
       datetime: '2020-01-01'
-      source: Electricity Maps, 2020 zone average
-      value: 649.49
-    - _comment: used storage values equal to zero.
+      source: Electricity Maps, 2020 zone average; IPCC 2014
+      value: 24.0
+    - _comment: used default IPCC 2014 value of 24.0
       datetime: '2021-01-01'
-      source: Electricity Maps, 2021 zone average
-      value: 576.72
-    - _comment: used storage values equal to zero.
+      source: Electricity Maps, 2021 zone average; IPCC 2014
+      value: 24.0
+    - _comment: used default IPCC 2014 value of 24.0
       datetime: '2022-01-01'
-      source: Electricity Maps, 2022 zone average
-      value: 649.98
+      source: Electricity Maps, 2022 zone average; IPCC 2014
+      value: 24.0
 fallbackZoneMixes:
   powerOriginRatios:
   - _source: Electricity Maps, 2022 average

--- a/config/zones/ES-CE.yaml
+++ b/config/zones/ES-CE.yaml
@@ -78,7 +78,7 @@ emissionFactors:
     - _comment: used storage values equal to zero.
       datetime: '2024-01-01'
       source: Electricity Maps, 2024 zone average
-      value: 649.2
+      value: 649.21
     - _comment: used storage values equal to zero.
       datetime: '2025-01-01'
       source: Electricity Maps, 2025 zone average

--- a/config/zones/ES-CN-FV.yaml
+++ b/config/zones/ES-CN-FV.yaml
@@ -33,30 +33,30 @@ emissionFactors:
       source: EU-ETS, ENTSO-E 2022
       value: 426.61
     hydro discharge:
-    - _comment: used storage values equal to zero.
+    - _comment: used default IPCC 2014 value of 0.0
       datetime: '2020-01-01'
       source: Electricity Maps, 2020 zone average
-      value: 646.31
-    - _comment: used storage values equal to zero.
+      value: 0.0
+    - _comment: used default IPCC 2014 value of 0.0
       datetime: '2021-01-01'
       source: Electricity Maps, 2021 zone average
-      value: 579.56
-    - _comment: used storage values equal to zero.
+      value: 0.0
+    - _comment: used default IPCC 2014 value of 0.0
       datetime: '2022-01-01'
       source: Electricity Maps, 2022 zone average
-      value: 630.33
-    - _comment: used storage values equal to zero.
+      value: 0.0
+    - _comment: used default IPCC 2014 value of 0.0
       datetime: '2023-01-01'
       source: Electricity Maps, 2023 zone average
-      value: 596.45
-    - _comment: used storage values equal to zero.
+      value: 0.0
+    - _comment: used default IPCC 2014 value of 0.0
       datetime: '2024-01-01'
       source: Electricity Maps, 2024 zone average
-      value: 566.14
-    - _comment: used storage values equal to zero.
+      value: 0.0
+    - _comment: used default IPCC 2014 value of 0.0
       datetime: '2025-01-01'
       source: Electricity Maps, 2025 zone average
-      value: 560.02
+      value: 0.0
     oil:
     - datetime: '2017-01-01'
       source: EU-ETS, REE
@@ -108,30 +108,30 @@ emissionFactors:
       source: UNECE 2022
       value: 10.7
     hydro discharge:
-    - _comment: used storage values equal to zero.
+    - _comment: used default IPCC 2014 value of 24.0
       datetime: '2020-01-01'
-      source: Electricity Maps, 2020 zone average
-      value: 859.13
-    - _comment: used storage values equal to zero.
+      source: Electricity Maps, 2020 zone average; IPCC 2014
+      value: 24.0
+    - _comment: used default IPCC 2014 value of 24.0
       datetime: '2021-01-01'
-      source: Electricity Maps, 2021 zone average
-      value: 779.52
-    - _comment: used storage values equal to zero.
+      source: Electricity Maps, 2021 zone average; IPCC 2014
+      value: 24.0
+    - _comment: used default IPCC 2014 value of 24.0
       datetime: '2022-01-01'
-      source: Electricity Maps, 2022 zone average
-      value: 827.1
-    - _comment: used storage values equal to zero.
+      source: Electricity Maps, 2022 zone average; IPCC 2014
+      value: 24.0
+    - _comment: used default IPCC 2014 value of 24.0
       datetime: '2023-01-01'
-      source: Electricity Maps, 2023 zone average
-      value: 796.36
-    - _comment: used storage values equal to zero.
+      source: Electricity Maps, 2023 zone average; IPCC 2014
+      value: 24.0
+    - _comment: used default IPCC 2014 value of 24.0
       datetime: '2024-01-01'
-      source: Electricity Maps, 2024 zone average
-      value: 756.24
-    - _comment: used storage values equal to zero.
+      source: Electricity Maps, 2024 zone average; IPCC 2014
+      value: 24.0
+    - _comment: used default IPCC 2014 value of 24.0
       datetime: '2025-01-01'
-      source: Electricity Maps, 2025 zone average
-      value: 748.47
+      source: Electricity Maps, 2025 zone average; IPCC 2014
+      value: 24.0
     nuclear:
       datetime: '2020-01-01'
       source: UNECE 2022

--- a/config/zones/ES-CN-GC.yaml
+++ b/config/zones/ES-CN-GC.yaml
@@ -31,30 +31,30 @@ emissionFactors:
       source: EU-ETS, ENTSO-E 2022
       value: 426.61
     hydro discharge:
-    - _comment: used storage values equal to zero.
+    - _comment: used default IPCC 2014 value of 0.0
       datetime: '2020-01-01'
       source: Electricity Maps, 2020 zone average
-      value: 567.81
-    - _comment: used storage values equal to zero.
+      value: 0.0
+    - _comment: used default IPCC 2014 value of 0.0
       datetime: '2021-01-01'
       source: Electricity Maps, 2021 zone average
-      value: 543.28
-    - _comment: used storage values equal to zero.
+      value: 0.0
+    - _comment: used default IPCC 2014 value of 0.0
       datetime: '2022-01-01'
       source: Electricity Maps, 2022 zone average
-      value: 521.08
-    - _comment: used storage values equal to zero.
+      value: 0.0
+    - _comment: used default IPCC 2014 value of 0.0
       datetime: '2023-01-01'
       source: Electricity Maps, 2023 zone average
-      value: 529.05
-    - _comment: used storage values equal to zero.
+      value: 0.0
+    - _comment: used default IPCC 2014 value of 0.0
       datetime: '2024-01-01'
       source: Electricity Maps, 2024 zone average
-      value: 512.88
-    - _comment: used storage values equal to zero.
+      value: 0.0
+    - _comment: used default IPCC 2014 value of 0.0
       datetime: '2025-01-01'
       source: Electricity Maps, 2025 zone average
-      value: 501.39
+      value: 0.0
     oil:
     - datetime: '2017-01-01'
       source: EU-ETS, REE
@@ -106,30 +106,30 @@ emissionFactors:
       source: UNECE 2022
       value: 10.7
     hydro discharge:
-    - _comment: used storage values equal to zero.
+    - _comment: used default IPCC 2014 value of 24.0
       datetime: '2020-01-01'
-      source: Electricity Maps, 2020 zone average
-      value: 771.45
-    - _comment: used storage values equal to zero.
+      source: Electricity Maps, 2020 zone average; IPCC 2014
+      value: 24.0
+    - _comment: used default IPCC 2014 value of 24.0
       datetime: '2021-01-01'
-      source: Electricity Maps, 2021 zone average
-      value: 737.73
-    - _comment: used storage values equal to zero.
+      source: Electricity Maps, 2021 zone average; IPCC 2014
+      value: 24.0
+    - _comment: used default IPCC 2014 value of 24.0
       datetime: '2022-01-01'
-      source: Electricity Maps, 2022 zone average
-      value: 709.36
-    - _comment: used storage values equal to zero.
+      source: Electricity Maps, 2022 zone average; IPCC 2014
+      value: 24.0
+    - _comment: used default IPCC 2014 value of 24.0
       datetime: '2023-01-01'
-      source: Electricity Maps, 2023 zone average
-      value: 719.76
-    - _comment: used storage values equal to zero.
+      source: Electricity Maps, 2023 zone average; IPCC 2014
+      value: 24.0
+    - _comment: used default IPCC 2014 value of 24.0
       datetime: '2024-01-01'
-      source: Electricity Maps, 2024 zone average
-      value: 698.04
-    - _comment: used storage values equal to zero.
+      source: Electricity Maps, 2024 zone average; IPCC 2014
+      value: 24.0
+    - _comment: used default IPCC 2014 value of 24.0
       datetime: '2025-01-01'
-      source: Electricity Maps, 2025 zone average
-      value: 682.89
+      source: Electricity Maps, 2025 zone average; IPCC 2014
+      value: 24.0
     nuclear:
       datetime: '2020-01-01'
       source: UNECE 2022

--- a/config/zones/ES-CN-HI.yaml
+++ b/config/zones/ES-CN-HI.yaml
@@ -54,7 +54,7 @@ emissionFactors:
     - _comment: used storage values greater than zero.
       datetime: '2024-01-01'
       source: Electricity Maps, 2024 zone average
-      value: 195.08
+      value: 195.51
     - _comment: used storage values greater than zero.
       datetime: '2025-01-01'
       source: Electricity Maps, 2025 zone average
@@ -129,7 +129,7 @@ emissionFactors:
     - _comment: used storage values greater than zero.
       datetime: '2024-01-01'
       source: Electricity Maps, 2024 zone average
-      value: 271.09
+      value: 271.7
     - _comment: used storage values greater than zero.
       datetime: '2025-01-01'
       source: Electricity Maps, 2025 zone average

--- a/config/zones/ES-CN-HI.yaml
+++ b/config/zones/ES-CN-HI.yaml
@@ -35,22 +35,22 @@ emissionFactors:
       source: EU-ETS, ENTSO-E 2022
       value: 426.61
     hydro discharge:
-    - _comment: used storage values equal to zero.
+    - _comment: used default IPCC 2014 value of 0.0
       datetime: '2020-01-01'
       source: Electricity Maps, 2020 zone average
-      value: 348.45
-    - _comment: used storage values equal to zero.
+      value: 0.0
+    - _comment: used default IPCC 2014 value of 0.0
       datetime: '2021-01-01'
       source: Electricity Maps, 2021 zone average
-      value: 310.64
+      value: 0.0
     - _comment: used storage values greater than zero.
       datetime: '2022-01-01'
       source: Electricity Maps, 2022 zone average
-      value: 180.84
+      value: 181.37
     - _comment: used storage values greater than zero.
       datetime: '2023-01-01'
       source: Electricity Maps, 2023 zone average
-      value: 242.56
+      value: 243.08
     - _comment: used storage values greater than zero.
       datetime: '2024-01-01'
       source: Electricity Maps, 2024 zone average
@@ -58,7 +58,7 @@ emissionFactors:
     - _comment: used storage values greater than zero.
       datetime: '2025-01-01'
       source: Electricity Maps, 2025 zone average
-      value: 210.58
+      value: 211.13
     oil:
     - datetime: '2017-01-01'
       source: EU-ETS, REE
@@ -110,30 +110,30 @@ emissionFactors:
       source: UNECE 2022
       value: 10.7
     hydro discharge:
-    - _comment: used storage values equal to zero.
+    - _comment: used default IPCC 2014 value of 24.0
       datetime: '2020-01-01'
-      source: Electricity Maps, 2020 zone average
-      value: 477.34
-    - _comment: used storage values equal to zero.
+      source: Electricity Maps, 2020 zone average; IPCC 2014
+      value: 24.0
+    - _comment: used default IPCC 2014 value of 24.0
       datetime: '2021-01-01'
-      source: Electricity Maps, 2021 zone average
-      value: 424.6
+      source: Electricity Maps, 2021 zone average; IPCC 2014
+      value: 24.0
     - _comment: used storage values greater than zero.
       datetime: '2022-01-01'
-      source: Electricity Maps, 2022 zone average
-      value: 251.78
+      source: Electricity Maps, 2022 zone average; IPCC 2014
+      value: 205.37
     - _comment: used storage values greater than zero.
       datetime: '2023-01-01'
-      source: Electricity Maps, 2023 zone average
-      value: 334.23
+      source: Electricity Maps, 2023 zone average; IPCC 2014
+      value: 267.08
     - _comment: used storage values greater than zero.
       datetime: '2024-01-01'
-      source: Electricity Maps, 2024 zone average
-      value: 271.7
+      source: Electricity Maps, 2024 zone average; IPCC 2014
+      value: 219.51
     - _comment: used storage values greater than zero.
       datetime: '2025-01-01'
-      source: Electricity Maps, 2025 zone average
-      value: 291.63
+      source: Electricity Maps, 2025 zone average; IPCC 2014
+      value: 235.13
     nuclear:
       datetime: '2020-01-01'
       source: UNECE 2022

--- a/config/zones/ES-CN-IG.yaml
+++ b/config/zones/ES-CN-IG.yaml
@@ -33,30 +33,30 @@ emissionFactors:
       source: EU-ETS, ENTSO-E 2022
       value: 426.61
     hydro discharge:
-    - _comment: used storage values equal to zero.
+    - _comment: used default IPCC 2014 value of 0.0
       datetime: '2020-01-01'
       source: Electricity Maps, 2020 zone average
-      value: 697.26
-    - _comment: used storage values equal to zero.
+      value: 0.0
+    - _comment: used default IPCC 2014 value of 0.0
       datetime: '2021-01-01'
       source: Electricity Maps, 2021 zone average
-      value: 707.21
-    - _comment: used storage values equal to zero.
+      value: 0.0
+    - _comment: used default IPCC 2014 value of 0.0
       datetime: '2022-01-01'
       source: Electricity Maps, 2022 zone average
-      value: 693.55
-    - _comment: used storage values equal to zero.
+      value: 0.0
+    - _comment: used default IPCC 2014 value of 0.0
       datetime: '2023-01-01'
       source: Electricity Maps, 2023 zone average
-      value: 662.28
-    - _comment: used storage values equal to zero.
+      value: 0.0
+    - _comment: used default IPCC 2014 value of 0.0
       datetime: '2024-01-01'
       source: Electricity Maps, 2024 zone average
-      value: 615.08
-    - _comment: used storage values equal to zero.
+      value: 0.0
+    - _comment: used default IPCC 2014 value of 0.0
       datetime: '2025-01-01'
       source: Electricity Maps, 2025 zone average
-      value: 610.78
+      value: 0.0
     oil:
     - datetime: '2017-01-01'
       source: EU-ETS, REE
@@ -108,30 +108,30 @@ emissionFactors:
       source: UNECE 2022
       value: 10.7
     hydro discharge:
-    - _comment: used storage values equal to zero.
+    - _comment: used default IPCC 2014 value of 24.0
       datetime: '2020-01-01'
-      source: Electricity Maps, 2020 zone average
-      value: 941.23
-    - _comment: used storage values equal to zero.
+      source: Electricity Maps, 2020 zone average; IPCC 2014
+      value: 24.0
+    - _comment: used default IPCC 2014 value of 24.0
       datetime: '2021-01-01'
-      source: Electricity Maps, 2021 zone average
-      value: 951.18
-    - _comment: used storage values equal to zero.
+      source: Electricity Maps, 2021 zone average; IPCC 2014
+      value: 24.0
+    - _comment: used default IPCC 2014 value of 24.0
       datetime: '2022-01-01'
-      source: Electricity Maps, 2022 zone average
-      value: 937.53
-    - _comment: used storage values equal to zero.
+      source: Electricity Maps, 2022 zone average; IPCC 2014
+      value: 24.0
+    - _comment: used default IPCC 2014 value of 24.0
       datetime: '2023-01-01'
-      source: Electricity Maps, 2023 zone average
-      value: 889.73
-    - _comment: used storage values equal to zero.
+      source: Electricity Maps, 2023 zone average; IPCC 2014
+      value: 24.0
+    - _comment: used default IPCC 2014 value of 24.0
       datetime: '2024-01-01'
-      source: Electricity Maps, 2024 zone average
-      value: 835.67
-    - _comment: used storage values equal to zero.
+      source: Electricity Maps, 2024 zone average; IPCC 2014
+      value: 24.0
+    - _comment: used default IPCC 2014 value of 24.0
       datetime: '2025-01-01'
-      source: Electricity Maps, 2025 zone average
-      value: 829.93
+      source: Electricity Maps, 2025 zone average; IPCC 2014
+      value: 24.0
     nuclear:
       datetime: '2020-01-01'
       source: UNECE 2022

--- a/config/zones/ES-CN-IG.yaml
+++ b/config/zones/ES-CN-IG.yaml
@@ -52,7 +52,7 @@ emissionFactors:
     - _comment: used storage values equal to zero.
       datetime: '2024-01-01'
       source: Electricity Maps, 2024 zone average
-      value: 615.07
+      value: 615.08
     - _comment: used storage values equal to zero.
       datetime: '2025-01-01'
       source: Electricity Maps, 2025 zone average
@@ -127,7 +127,7 @@ emissionFactors:
     - _comment: used storage values equal to zero.
       datetime: '2024-01-01'
       source: Electricity Maps, 2024 zone average
-      value: 835.66
+      value: 835.67
     - _comment: used storage values equal to zero.
       datetime: '2025-01-01'
       source: Electricity Maps, 2025 zone average

--- a/config/zones/ES-CN-LP.yaml
+++ b/config/zones/ES-CN-LP.yaml
@@ -31,30 +31,30 @@ emissionFactors:
       source: EU-ETS, ENTSO-E 2022
       value: 426.61
     hydro discharge:
-    - _comment: used storage values equal to zero.
+    - _comment: used default IPCC 2014 value of 0.0
       datetime: '2020-01-01'
       source: Electricity Maps, 2020 zone average
-      value: 610.45
-    - _comment: used storage values equal to zero.
+      value: 0.0
+    - _comment: used default IPCC 2014 value of 0.0
       datetime: '2021-01-01'
       source: Electricity Maps, 2021 zone average
-      value: 610.7
-    - _comment: used storage values equal to zero.
+      value: 0.0
+    - _comment: used default IPCC 2014 value of 0.0
       datetime: '2022-01-01'
       source: Electricity Maps, 2022 zone average
-      value: 629.47
-    - _comment: used storage values equal to zero.
+      value: 0.0
+    - _comment: used default IPCC 2014 value of 0.0
       datetime: '2023-01-01'
       source: Electricity Maps, 2023 zone average
-      value: 629.11
-    - _comment: used storage values equal to zero.
+      value: 0.0
+    - _comment: used default IPCC 2014 value of 0.0
       datetime: '2024-01-01'
       source: Electricity Maps, 2024 zone average
-      value: 611.76
-    - _comment: used storage values equal to zero.
+      value: 0.0
+    - _comment: used default IPCC 2014 value of 0.0
       datetime: '2025-01-01'
       source: Electricity Maps, 2025 zone average
-      value: 617.22
+      value: 0.0
     oil:
     - datetime: '2017-01-01'
       source: EU-ETS, REE
@@ -106,30 +106,30 @@ emissionFactors:
       source: UNECE 2022
       value: 10.7
     hydro discharge:
-    - _comment: used storage values equal to zero.
+    - _comment: used default IPCC 2014 value of 24.0
       datetime: '2020-01-01'
-      source: Electricity Maps, 2020 zone average
-      value: 830.81
-    - _comment: used storage values equal to zero.
+      source: Electricity Maps, 2020 zone average; IPCC 2014
+      value: 24.0
+    - _comment: used default IPCC 2014 value of 24.0
       datetime: '2021-01-01'
-      source: Electricity Maps, 2021 zone average
-      value: 831.82
-    - _comment: used storage values equal to zero.
+      source: Electricity Maps, 2021 zone average; IPCC 2014
+      value: 24.0
+    - _comment: used default IPCC 2014 value of 24.0
       datetime: '2022-01-01'
-      source: Electricity Maps, 2022 zone average
-      value: 855.41
-    - _comment: used storage values equal to zero.
+      source: Electricity Maps, 2022 zone average; IPCC 2014
+      value: 24.0
+    - _comment: used default IPCC 2014 value of 24.0
       datetime: '2023-01-01'
-      source: Electricity Maps, 2023 zone average
-      value: 856.95
-    - _comment: used storage values equal to zero.
+      source: Electricity Maps, 2023 zone average; IPCC 2014
+      value: 24.0
+    - _comment: used default IPCC 2014 value of 24.0
       datetime: '2024-01-01'
-      source: Electricity Maps, 2024 zone average
-      value: 835.94
-    - _comment: used storage values equal to zero.
+      source: Electricity Maps, 2024 zone average; IPCC 2014
+      value: 24.0
+    - _comment: used default IPCC 2014 value of 24.0
       datetime: '2025-01-01'
-      source: Electricity Maps, 2025 zone average
-      value: 843.31
+      source: Electricity Maps, 2025 zone average; IPCC 2014
+      value: 24.0
     nuclear:
       datetime: '2020-01-01'
       source: UNECE 2022

--- a/config/zones/ES-CN-LZ.yaml
+++ b/config/zones/ES-CN-LZ.yaml
@@ -33,30 +33,30 @@ emissionFactors:
       source: EU-ETS, ENTSO-E 2022
       value: 426.61
     hydro discharge:
-    - _comment: used storage values equal to zero.
+    - _comment: used default IPCC 2014 value of 0.0
       datetime: '2020-01-01'
       source: Electricity Maps, 2020 zone average
-      value: 617.33
-    - _comment: used storage values equal to zero.
+      value: 0.0
+    - _comment: used default IPCC 2014 value of 0.0
       datetime: '2021-01-01'
       source: Electricity Maps, 2021 zone average
-      value: 612.84
-    - _comment: used storage values equal to zero.
+      value: 0.0
+    - _comment: used default IPCC 2014 value of 0.0
       datetime: '2022-01-01'
       source: Electricity Maps, 2022 zone average
-      value: 601.75
-    - _comment: used storage values equal to zero.
+      value: 0.0
+    - _comment: used default IPCC 2014 value of 0.0
       datetime: '2023-01-01'
       source: Electricity Maps, 2023 zone average
-      value: 599.98
-    - _comment: used storage values equal to zero.
+      value: 0.0
+    - _comment: used default IPCC 2014 value of 0.0
       datetime: '2024-01-01'
       source: Electricity Maps, 2024 zone average
-      value: 590.11
-    - _comment: used storage values equal to zero.
+      value: 0.0
+    - _comment: used default IPCC 2014 value of 0.0
       datetime: '2025-01-01'
       source: Electricity Maps, 2025 zone average
-      value: 573.65
+      value: 0.0
     oil:
     - datetime: '2017-01-01'
       source: EU-ETS, REE
@@ -108,30 +108,30 @@ emissionFactors:
       source: UNECE 2022
       value: 10.7
     hydro discharge:
-    - _comment: used storage values equal to zero.
+    - _comment: used default IPCC 2014 value of 24.0
       datetime: '2020-01-01'
-      source: Electricity Maps, 2020 zone average
-      value: 839.55
-    - _comment: used storage values equal to zero.
+      source: Electricity Maps, 2020 zone average; IPCC 2014
+      value: 24.0
+    - _comment: used default IPCC 2014 value of 24.0
       datetime: '2021-01-01'
-      source: Electricity Maps, 2021 zone average
-      value: 831.14
-    - _comment: used storage values equal to zero.
+      source: Electricity Maps, 2021 zone average; IPCC 2014
+      value: 24.0
+    - _comment: used default IPCC 2014 value of 24.0
       datetime: '2022-01-01'
-      source: Electricity Maps, 2022 zone average
-      value: 820.72
-    - _comment: used storage values equal to zero.
+      source: Electricity Maps, 2022 zone average; IPCC 2014
+      value: 24.0
+    - _comment: used default IPCC 2014 value of 24.0
       datetime: '2023-01-01'
-      source: Electricity Maps, 2023 zone average
-      value: 825.37
-    - _comment: used storage values equal to zero.
+      source: Electricity Maps, 2023 zone average; IPCC 2014
+      value: 24.0
+    - _comment: used default IPCC 2014 value of 24.0
       datetime: '2024-01-01'
-      source: Electricity Maps, 2024 zone average
-      value: 812.75
-    - _comment: used storage values equal to zero.
+      source: Electricity Maps, 2024 zone average; IPCC 2014
+      value: 24.0
+    - _comment: used default IPCC 2014 value of 24.0
       datetime: '2025-01-01'
-      source: Electricity Maps, 2025 zone average
-      value: 790.53
+      source: Electricity Maps, 2025 zone average; IPCC 2014
+      value: 24.0
     nuclear:
       datetime: '2020-01-01'
       source: UNECE 2022

--- a/config/zones/ES-CN-TE.yaml
+++ b/config/zones/ES-CN-TE.yaml
@@ -31,30 +31,30 @@ emissionFactors:
       source: EU-ETS, ENTSO-E 2022
       value: 426.61
     hydro discharge:
-    - _comment: used storage values equal to zero.
+    - _comment: used default IPCC 2014 value of 0.0
       datetime: '2020-01-01'
       source: Electricity Maps, 2020 zone average
-      value: 558.85
-    - _comment: used storage values equal to zero.
+      value: 0.0
+    - _comment: used default IPCC 2014 value of 0.0
       datetime: '2021-01-01'
       source: Electricity Maps, 2021 zone average
-      value: 551.18
-    - _comment: used storage values equal to zero.
+      value: 0.0
+    - _comment: used default IPCC 2014 value of 0.0
       datetime: '2022-01-01'
       source: Electricity Maps, 2022 zone average
-      value: 557.32
-    - _comment: used storage values equal to zero.
+      value: 0.0
+    - _comment: used default IPCC 2014 value of 0.0
       datetime: '2023-01-01'
       source: Electricity Maps, 2023 zone average
-      value: 561.79
-    - _comment: used storage values equal to zero.
+      value: 0.0
+    - _comment: used default IPCC 2014 value of 0.0
       datetime: '2024-01-01'
       source: Electricity Maps, 2024 zone average
-      value: 560.55
-    - _comment: used storage values equal to zero.
+      value: 0.0
+    - _comment: used default IPCC 2014 value of 0.0
       datetime: '2025-01-01'
       source: Electricity Maps, 2025 zone average
-      value: 560.28
+      value: 0.0
     oil:
     - datetime: '2017-01-01'
       source: EU-ETS, REE
@@ -106,30 +106,30 @@ emissionFactors:
       source: UNECE 2022
       value: 10.7
     hydro discharge:
-    - _comment: used storage values equal to zero.
+    - _comment: used default IPCC 2014 value of 24.0
       datetime: '2020-01-01'
-      source: Electricity Maps, 2020 zone average
-      value: 755.93
-    - _comment: used storage values equal to zero.
+      source: Electricity Maps, 2020 zone average; IPCC 2014
+      value: 24.0
+    - _comment: used default IPCC 2014 value of 24.0
       datetime: '2021-01-01'
-      source: Electricity Maps, 2021 zone average
-      value: 746.32
-    - _comment: used storage values equal to zero.
+      source: Electricity Maps, 2021 zone average; IPCC 2014
+      value: 24.0
+    - _comment: used default IPCC 2014 value of 24.0
       datetime: '2022-01-01'
-      source: Electricity Maps, 2022 zone average
-      value: 757.04
-    - _comment: used storage values equal to zero.
+      source: Electricity Maps, 2022 zone average; IPCC 2014
+      value: 24.0
+    - _comment: used default IPCC 2014 value of 24.0
       datetime: '2023-01-01'
-      source: Electricity Maps, 2023 zone average
-      value: 762.22
-    - _comment: used storage values equal to zero.
+      source: Electricity Maps, 2023 zone average; IPCC 2014
+      value: 24.0
+    - _comment: used default IPCC 2014 value of 24.0
       datetime: '2024-01-01'
-      source: Electricity Maps, 2024 zone average
-      value: 761.18
-    - _comment: used storage values equal to zero.
+      source: Electricity Maps, 2024 zone average; IPCC 2014
+      value: 24.0
+    - _comment: used default IPCC 2014 value of 24.0
       datetime: '2025-01-01'
-      source: Electricity Maps, 2025 zone average
-      value: 760.83
+      source: Electricity Maps, 2025 zone average; IPCC 2014
+      value: 24.0
     nuclear:
       datetime: '2020-01-01'
       source: UNECE 2022

--- a/config/zones/ES-IB-MA.yaml
+++ b/config/zones/ES-IB-MA.yaml
@@ -15,10 +15,10 @@ delays:
 emissionFactors:
   direct:
     battery discharge:
-    - _comment: used storage values equal to zero.
+    - _comment: used non-null storage values
       datetime: '2022-01-01'
       source: Electricity Maps, 2022 zone average
-      value: 378.26
+      value: 378.29
     biomass:
       datetime: '2021-01-01'
       source: BEIS 2021
@@ -38,10 +38,10 @@ emissionFactors:
       source: EU-ETS, ENTSO-E 2022
       value: 426.61
     hydro discharge:
-    - _comment: used storage values equal to zero.
+    - _comment: used default IPCC 2014 value of 0.0
       datetime: '2022-01-01'
       source: Electricity Maps, 2022 zone average
-      value: 378.26
+      value: 0.0
     oil:
     - datetime: '2021-01-01'
       source: EU-ETS, ENTSO-E 2021
@@ -51,10 +51,10 @@ emissionFactors:
       value: 925.95
   lifecycle:
     battery discharge:
-    - _comment: used storage values equal to zero.
+    - _comment: used non-null storage values
       datetime: '2022-01-01'
-      source: Electricity Maps, 2022 zone average
-      value: 492.81
+      source: Electricity Maps, 2022 zone average; National Laboratory of the Rockies
+      value: 411.29
     biomass:
       datetime: '2014-01-01'
       source: BEIS 2021; IPCC 2014
@@ -80,10 +80,10 @@ emissionFactors:
       source: UNECE 2022
       value: 10.7
     hydro discharge:
-    - _comment: used storage values equal to zero.
+    - _comment: used default IPCC 2014 value of 24.0
       datetime: '2022-01-01'
-      source: Electricity Maps, 2022 zone average
-      value: 492.81
+      source: Electricity Maps, 2022 zone average; IPCC 2014
+      value: 24.0
     nuclear:
       datetime: '2020-01-01'
       source: UNECE 2022

--- a/config/zones/ES-ML.yaml
+++ b/config/zones/ES-ML.yaml
@@ -32,56 +32,56 @@ currency: EUR
 emissionFactors:
   direct:
     battery discharge:
-    - _comment: used storage values equal to zero.
+    - _comment: used non-null storage values
       datetime: '2020-01-01'
       source: Electricity Maps, 2020 zone average
-      value: 375.63
-    - _comment: used storage values equal to zero.
+      value: 375.65
+    - _comment: used non-null storage values
       datetime: '2021-01-01'
       source: Electricity Maps, 2021 zone average
       value: 372.63
-    - _comment: used storage values equal to zero.
+    - _comment: used non-null storage values
       datetime: '2022-01-01'
       source: Electricity Maps, 2022 zone average
       value: 375.17
-    - _comment: used storage values equal to zero.
+    - _comment: used non-null storage values
       datetime: '2023-01-01'
       source: Electricity Maps, 2023 zone average
       value: 377.19
-    - _comment: used storage values equal to zero.
+    - _comment: used non-null storage values
       datetime: '2024-01-01'
       source: Electricity Maps, 2024 zone average
       value: 376.11
-    - _comment: used storage values equal to zero.
+    - _comment: used non-null storage values
       datetime: '2025-01-01'
       source: Electricity Maps, 2025 zone average
       value: 374.15
   lifecycle:
     battery discharge:
-    - _comment: used storage values equal to zero.
+    - _comment: used non-null storage values
       datetime: '2020-01-01'
-      source: Electricity Maps, 2020 zone average
-      value: 618.5
-    - _comment: used storage values equal to zero.
+      source: Electricity Maps, 2020 zone average; National Laboratory of the Rockies
+      value: 408.65
+    - _comment: used non-null storage values
       datetime: '2021-01-01'
-      source: Electricity Maps, 2021 zone average
-      value: 585.1
-    - _comment: used storage values equal to zero.
+      source: Electricity Maps, 2021 zone average; National Laboratory of the Rockies
+      value: 405.63
+    - _comment: used non-null storage values
       datetime: '2022-01-01'
-      source: Electricity Maps, 2022 zone average
-      value: 618.0
-    - _comment: used storage values equal to zero.
+      source: Electricity Maps, 2022 zone average; National Laboratory of the Rockies
+      value: 408.17
+    - _comment: used non-null storage values
       datetime: '2023-01-01'
-      source: Electricity Maps, 2023 zone average
-      value: 620.17
-    - _comment: used storage values equal to zero.
+      source: Electricity Maps, 2023 zone average; National Laboratory of the Rockies
+      value: 410.19
+    - _comment: used non-null storage values
       datetime: '2024-01-01'
-      source: Electricity Maps, 2024 zone average
-      value: 618.92
-    - _comment: used storage values equal to zero.
+      source: Electricity Maps, 2024 zone average; National Laboratory of the Rockies
+      value: 409.11
+    - _comment: used non-null storage values
       datetime: '2025-01-01'
-      source: Electricity Maps, 2025 zone average
-      value: 616.99
+      source: Electricity Maps, 2025 zone average; National Laboratory of the Rockies
+      value: 407.15
 fallbackZoneMixes:
   powerOriginRatios:
   - _source: Electricity Maps, 2022 average

--- a/config/zones/ES.yaml
+++ b/config/zones/ES.yaml
@@ -236,10 +236,10 @@ delays:
 emissionFactors:
   direct:
     battery discharge:
-    - _comment: used storage values equal to zero.
+    - _comment: used non-null storage values
       datetime: '2025-01-01'
       source: Electricity Maps, 2025 zone average
-      value: 99.49
+      value: 105.43
     biomass:
       datetime: '2021-01-01'
       source: BEIS 2021
@@ -274,19 +274,19 @@ emissionFactors:
     - _comment: used storage values greater than zero.
       datetime: '2020-01-01'
       source: Electricity Maps, 2020 zone average
-      value: 130.19
+      value: 130.36
     - _comment: used storage values greater than zero.
       datetime: '2021-01-01'
       source: Electricity Maps, 2021 zone average
-      value: 118.73
+      value: 118.86
     - _comment: used storage values greater than zero.
       datetime: '2022-01-01'
       source: Electricity Maps, 2022 zone average
-      value: 164.03
+      value: 164.11
     - _comment: used storage values greater than zero.
       datetime: '2023-01-01'
       source: Electricity Maps, 2023 zone average
-      value: 88.87
+      value: 88.93
     - _comment: used storage values greater than zero.
       datetime: '2024-01-01'
       source: Electricity Maps, 2024 zone average
@@ -294,7 +294,7 @@ emissionFactors:
     - _comment: used storage values greater than zero.
       datetime: '2025-01-01'
       source: Electricity Maps, 2025 zone average
-      value: 66.52
+      value: 66.56
     oil:
     - datetime: '2021-01-01'
       source: EU-ETS, ENTSO-E 2021
@@ -310,10 +310,10 @@ emissionFactors:
       value: 889.87
   lifecycle:
     battery discharge:
-    - _comment: used storage values equal to zero.
+    - _comment: used non-null storage values
       datetime: '2025-01-01'
-      source: Electricity Maps, 2025 zone average
-      value: 141.55
+      source: Electricity Maps, 2025 zone average; National Laboratory of the Rockies
+      value: 138.43
     biomass:
       datetime: '2014-01-01'
       source: BEIS 2021; IPCC 2014
@@ -353,28 +353,28 @@ emissionFactors:
     hydro discharge:
     - _comment: used storage values greater than zero.
       datetime: '2020-01-01'
-      source: Electricity Maps, 2020 zone average
-      value: 177.66
+      source: Electricity Maps, 2020 zone average; IPCC 2014
+      value: 154.36
     - _comment: used storage values greater than zero.
       datetime: '2021-01-01'
-      source: Electricity Maps, 2021 zone average
-      value: 163.32
+      source: Electricity Maps, 2021 zone average; IPCC 2014
+      value: 142.86
     - _comment: used storage values greater than zero.
       datetime: '2022-01-01'
-      source: Electricity Maps, 2022 zone average
-      value: 215.7
+      source: Electricity Maps, 2022 zone average; IPCC 2014
+      value: 188.11
     - _comment: used storage values greater than zero.
       datetime: '2023-01-01'
-      source: Electricity Maps, 2023 zone average
-      value: 126.58
+      source: Electricity Maps, 2023 zone average; IPCC 2014
+      value: 112.93
     - _comment: used storage values greater than zero.
       datetime: '2024-01-01'
-      source: Electricity Maps, 2024 zone average
-      value: 98.48
+      source: Electricity Maps, 2024 zone average; IPCC 2014
+      value: 89.94
     - _comment: used storage values greater than zero.
       datetime: '2025-01-01'
-      source: Electricity Maps, 2025 zone average
-      value: 102.0
+      source: Electricity Maps, 2025 zone average; IPCC 2014
+      value: 90.56
     nuclear:
       datetime: '2020-01-01'
       source: UNECE 2022

--- a/config/zones/ES.yaml
+++ b/config/zones/ES.yaml
@@ -290,7 +290,7 @@ emissionFactors:
     - _comment: used storage values greater than zero.
       datetime: '2024-01-01'
       source: Electricity Maps, 2024 zone average
-      value: 65.89
+      value: 65.94
     - _comment: used storage values greater than zero.
       datetime: '2025-01-01'
       source: Electricity Maps, 2025 zone average
@@ -370,7 +370,7 @@ emissionFactors:
     - _comment: used storage values greater than zero.
       datetime: '2024-01-01'
       source: Electricity Maps, 2024 zone average
-      value: 98.4
+      value: 98.48
     - _comment: used storage values greater than zero.
       datetime: '2025-01-01'
       source: Electricity Maps, 2025 zone average

--- a/config/zones/FR-COR.yaml
+++ b/config/zones/FR-COR.yaml
@@ -29,7 +29,7 @@ emissionFactors:
     - _comment: used storage values greater than zero.
       datetime: '2024-01-01'
       source: Electricity Maps, 2024 zone average
-      value: 444.58
+      value: 447.32
     - _comment: used storage values greater than zero.
       datetime: '2025-01-01'
       source: Electricity Maps, 2025 zone average
@@ -86,7 +86,7 @@ emissionFactors:
     - _comment: used storage values greater than zero.
       datetime: '2024-01-01'
       source: Electricity Maps, 2024 zone average
-      value: 554.25
+      value: 557.67
     - _comment: used storage values greater than zero.
       datetime: '2025-01-01'
       source: Electricity Maps, 2025 zone average

--- a/config/zones/FR-COR.yaml
+++ b/config/zones/FR-COR.yaml
@@ -25,7 +25,7 @@ emissionFactors:
     - _comment: used storage values greater than zero.
       datetime: '2023-01-01'
       source: Electricity Maps, 2023 zone average
-      value: 321.52
+      value: 323.13
     - _comment: used storage values greater than zero.
       datetime: '2024-01-01'
       source: Electricity Maps, 2024 zone average
@@ -33,7 +33,7 @@ emissionFactors:
     - _comment: used storage values greater than zero.
       datetime: '2025-01-01'
       source: Electricity Maps, 2025 zone average
-      value: 497.36
+      value: 498.49
     biomass:
       datetime: '2021-01-01'
       source: BEIS 2021
@@ -81,16 +81,16 @@ emissionFactors:
     battery discharge:
     - _comment: used storage values greater than zero.
       datetime: '2023-01-01'
-      source: Electricity Maps, 2023 zone average
-      value: 425.6
+      source: Electricity Maps, 2023 zone average; National Laboratory of the Rockies
+      value: 356.13
     - _comment: used storage values greater than zero.
       datetime: '2024-01-01'
-      source: Electricity Maps, 2024 zone average
-      value: 557.67
+      source: Electricity Maps, 2024 zone average; National Laboratory of the Rockies
+      value: 480.32
     - _comment: used storage values greater than zero.
       datetime: '2025-01-01'
-      source: Electricity Maps, 2025 zone average
-      value: 632.93
+      source: Electricity Maps, 2025 zone average; National Laboratory of the Rockies
+      value: 531.49
     biomass:
       datetime: '2014-01-01'
       source: BEIS 2021; IPCC 2014

--- a/config/zones/FR.yaml
+++ b/config/zones/FR.yaml
@@ -281,7 +281,7 @@ emissionFactors:
     - _comment: used storage values greater than zero.
       datetime: '2023-01-01'
       source: Electricity Maps, 2023 zone average
-      value: 23.09
+      value: 23.36
     - _comment: used storage values greater than zero.
       datetime: '2024-01-01'
       source: Electricity Maps, 2024 zone average
@@ -289,7 +289,7 @@ emissionFactors:
     - _comment: used storage values greater than zero.
       datetime: '2025-01-01'
       source: Electricity Maps, 2025 zone average
-      value: 16.81
+      value: 17.04
     biomass:
       datetime: '2021-01-01'
       source: BEIS 2021
@@ -332,11 +332,11 @@ emissionFactors:
     - _comment: used storage values greater than zero.
       datetime: '2022-01-01'
       source: Electricity Maps, 2022 zone average
-      value: 56.7
+      value: 56.72
     - _comment: used storage values greater than zero.
       datetime: '2023-01-01'
       source: Electricity Maps, 2023 zone average
-      value: 27.72
+      value: 27.73
     - _comment: used storage values greater than zero.
       datetime: '2024-01-01'
       source: Electricity Maps, 2024 zone average
@@ -362,16 +362,16 @@ emissionFactors:
     battery discharge:
     - _comment: used storage values greater than zero.
       datetime: '2023-01-01'
-      source: Electricity Maps, 2023 zone average
-      value: 40.19
+      source: Electricity Maps, 2023 zone average; National Laboratory of the Rockies
+      value: 56.36
     - _comment: used storage values greater than zero.
       datetime: '2024-01-01'
-      source: Electricity Maps, 2024 zone average
-      value: 35.95
+      source: Electricity Maps, 2024 zone average; National Laboratory of the Rockies
+      value: 52.99
     - _comment: used storage values greater than zero.
       datetime: '2025-01-01'
-      source: Electricity Maps, 2025 zone average
-      value: 32.55
+      source: Electricity Maps, 2025 zone average; National Laboratory of the Rockies
+      value: 50.04
     biomass:
       datetime: '2014-01-01'
       source: BEIS 2021; IPCC 2014
@@ -411,28 +411,28 @@ emissionFactors:
     hydro discharge:
     - _comment: used storage values greater than zero.
       datetime: '2020-01-01'
-      source: Electricity Maps, 2020 zone average
-      value: 48.9
+      source: Electricity Maps, 2020 zone average; IPCC 2014
+      value: 52.88
     - _comment: used storage values greater than zero.
       datetime: '2021-01-01'
-      source: Electricity Maps, 2021 zone average
-      value: 52.66
+      source: Electricity Maps, 2021 zone average; IPCC 2014
+      value: 56.61
     - _comment: used storage values greater than zero.
       datetime: '2022-01-01'
-      source: Electricity Maps, 2022 zone average
-      value: 84.18
+      source: Electricity Maps, 2022 zone average; IPCC 2014
+      value: 80.72
     - _comment: used storage values greater than zero.
       datetime: '2023-01-01'
-      source: Electricity Maps, 2023 zone average
-      value: 46.45
+      source: Electricity Maps, 2023 zone average; IPCC 2014
+      value: 51.73
     - _comment: used storage values greater than zero.
       datetime: '2024-01-01'
-      source: Electricity Maps, 2024 zone average
-      value: 29.22
+      source: Electricity Maps, 2024 zone average; IPCC 2014
+      value: 38.02
     - _comment: used storage values greater than zero.
       datetime: '2025-01-01'
-      source: Electricity Maps, 2025 zone average
-      value: 27.14
+      source: Electricity Maps, 2025 zone average; IPCC 2014
+      value: 35.6
     nuclear:
       datetime: '2020-01-01'
       source: UNECE 2022

--- a/config/zones/FR.yaml
+++ b/config/zones/FR.yaml
@@ -285,7 +285,7 @@ emissionFactors:
     - _comment: used storage values greater than zero.
       datetime: '2024-01-01'
       source: Electricity Maps, 2024 zone average
-      value: 19.72
+      value: 19.99
     - _comment: used storage values greater than zero.
       datetime: '2025-01-01'
       source: Electricity Maps, 2025 zone average
@@ -340,7 +340,7 @@ emissionFactors:
     - _comment: used storage values greater than zero.
       datetime: '2024-01-01'
       source: Electricity Maps, 2024 zone average
-      value: 14.01
+      value: 14.02
     - _comment: used storage values greater than zero.
       datetime: '2025-01-01'
       source: Electricity Maps, 2025 zone average
@@ -367,7 +367,7 @@ emissionFactors:
     - _comment: used storage values greater than zero.
       datetime: '2024-01-01'
       source: Electricity Maps, 2024 zone average
-      value: 35.45
+      value: 35.95
     - _comment: used storage values greater than zero.
       datetime: '2025-01-01'
       source: Electricity Maps, 2025 zone average
@@ -428,7 +428,7 @@ emissionFactors:
     - _comment: used storage values greater than zero.
       datetime: '2024-01-01'
       source: Electricity Maps, 2024 zone average
-      value: 29.21
+      value: 29.22
     - _comment: used storage values greater than zero.
       datetime: '2025-01-01'
       source: Electricity Maps, 2025 zone average

--- a/config/zones/GB.yaml
+++ b/config/zones/GB.yaml
@@ -199,19 +199,19 @@ emissionFactors:
     - _comment: used storage values greater than zero.
       datetime: '2020-01-01'
       source: Electricity Maps, 2020 zone average
-      value: 151.46
+      value: 151.56
     - _comment: used storage values greater than zero.
       datetime: '2021-01-01'
       source: Electricity Maps, 2021 zone average
-      value: 165.82
+      value: 165.97
     - _comment: used storage values greater than zero.
       datetime: '2022-01-01'
       source: Electricity Maps, 2022 zone average
-      value: 164.66
+      value: 164.75
     - _comment: used storage values greater than zero.
       datetime: '2023-01-01'
       source: Electricity Maps, 2023 zone average
-      value: 137.84
+      value: 137.98
     - _comment: used storage values greater than zero.
       datetime: '2024-01-01'
       source: Electricity Maps, 2024 zone average
@@ -219,7 +219,7 @@ emissionFactors:
     - _comment: used storage values greater than zero.
       datetime: '2025-01-01'
       source: Electricity Maps, 2025 zone average
-      value: 119.34
+      value: 119.58
   lifecycle:
     hydro:
       datetime: '2020-01-01'
@@ -228,28 +228,28 @@ emissionFactors:
     hydro discharge:
     - _comment: used storage values greater than zero.
       datetime: '2020-01-01'
-      source: Electricity Maps, 2020 zone average
-      value: 218.91
+      source: Electricity Maps, 2020 zone average; IPCC 2014
+      value: 175.56
     - _comment: used storage values greater than zero.
       datetime: '2021-01-01'
-      source: Electricity Maps, 2021 zone average
-      value: 237.69
+      source: Electricity Maps, 2021 zone average; IPCC 2014
+      value: 189.97
     - _comment: used storage values greater than zero.
       datetime: '2022-01-01'
-      source: Electricity Maps, 2022 zone average
-      value: 233.41
+      source: Electricity Maps, 2022 zone average; IPCC 2014
+      value: 188.75
     - _comment: used storage values greater than zero.
       datetime: '2023-01-01'
-      source: Electricity Maps, 2023 zone average
-      value: 199.18
+      source: Electricity Maps, 2023 zone average; IPCC 2014
+      value: 161.98
     - _comment: used storage values greater than zero.
       datetime: '2024-01-01'
-      source: Electricity Maps, 2024 zone average
-      value: 173.9
+      source: Electricity Maps, 2024 zone average; IPCC 2014
+      value: 138.46
     - _comment: used storage values greater than zero.
       datetime: '2025-01-01'
-      source: Electricity Maps, 2025 zone average
-      value: 181.79
+      source: Electricity Maps, 2025 zone average; IPCC 2014
+      value: 143.58
     nuclear:
       datetime: '2020-01-01'
       source: UNECE 2022

--- a/config/zones/GB.yaml
+++ b/config/zones/GB.yaml
@@ -215,7 +215,7 @@ emissionFactors:
     - _comment: used storage values greater than zero.
       datetime: '2024-01-01'
       source: Electricity Maps, 2024 zone average
-      value: 114.28
+      value: 114.46
     - _comment: used storage values greater than zero.
       datetime: '2025-01-01'
       source: Electricity Maps, 2025 zone average
@@ -245,7 +245,7 @@ emissionFactors:
     - _comment: used storage values greater than zero.
       datetime: '2024-01-01'
       source: Electricity Maps, 2024 zone average
-      value: 173.62
+      value: 173.9
     - _comment: used storage values greater than zero.
       datetime: '2025-01-01'
       source: Electricity Maps, 2025 zone average

--- a/config/zones/GP.yaml
+++ b/config/zones/GP.yaml
@@ -28,8 +28,8 @@ emissionFactors:
     battery discharge:
     - _comment: used storage values greater than zero.
       datetime: '2022-01-01'
-      source: Electricity Maps, 2022 zone average
-      value: 555.38
+      source: Electricity Maps, 2022 zone average; National Laboratory of the Rockies
+      value: 438.21
 fallbackZoneMixes:
   powerOriginRatios:
   - _source: Electricity Maps, 2016 average

--- a/config/zones/GR.yaml
+++ b/config/zones/GR.yaml
@@ -220,7 +220,7 @@ emissionFactors:
     - _comment: used storage values equal to zero.
       datetime: '2024-01-01'
       source: Electricity Maps, 2024 zone average
-      value: 239.34
+      value: 239.35
     - _comment: used storage values equal to zero.
       datetime: '2025-01-01'
       source: Electricity Maps, 2025 zone average
@@ -289,7 +289,7 @@ emissionFactors:
     - _comment: used storage values equal to zero.
       datetime: '2024-01-01'
       source: Electricity Maps, 2024 zone average
-      value: 296.3
+      value: 296.31
     - _comment: used storage values equal to zero.
       datetime: '2025-01-01'
       source: Electricity Maps, 2025 zone average

--- a/config/zones/GR.yaml
+++ b/config/zones/GR.yaml
@@ -204,27 +204,27 @@ emissionFactors:
     - _comment: used storage values greater than zero.
       datetime: '2020-01-01'
       source: Electricity Maps, 2020 zone average
-      value: 594.89
-    - _comment: used storage values equal to zero.
+      value: 594.91
+    - _comment: used default IPCC 2014 value of 0.0
       datetime: '2021-01-01'
       source: Electricity Maps, 2021 zone average
-      value: 411.88
-    - _comment: used storage values equal to zero.
+      value: 0.0
+    - _comment: used default IPCC 2014 value of 0.0
       datetime: '2022-01-01'
       source: Electricity Maps, 2022 zone average
-      value: 414.63
-    - _comment: used storage values equal to zero.
+      value: 0.0
+    - _comment: used default IPCC 2014 value of 0.0
       datetime: '2023-01-01'
       source: Electricity Maps, 2023 zone average
-      value: 312.33
-    - _comment: used storage values equal to zero.
+      value: 0.0
+    - _comment: used default IPCC 2014 value of 0.0
       datetime: '2024-01-01'
       source: Electricity Maps, 2024 zone average
-      value: 239.35
-    - _comment: used storage values equal to zero.
+      value: 0.0
+    - _comment: used default IPCC 2014 value of 0.0
       datetime: '2025-01-01'
       source: Electricity Maps, 2025 zone average
-      value: 216.33
+      value: 0.0
     oil:
     - datetime: '2021-01-01'
       source: EU-ETS, ENTSO-E 2021
@@ -272,28 +272,28 @@ emissionFactors:
     hydro discharge:
     - _comment: used storage values greater than zero.
       datetime: '2020-01-01'
-      source: Electricity Maps, 2020 zone average
-      value: 663.49
-    - _comment: used storage values equal to zero.
+      source: Electricity Maps, 2020 zone average; IPCC 2014
+      value: 618.91
+    - _comment: used default IPCC 2014 value of 24.0
       datetime: '2021-01-01'
-      source: Electricity Maps, 2021 zone average
-      value: 473.58
-    - _comment: used storage values equal to zero.
+      source: Electricity Maps, 2021 zone average; IPCC 2014
+      value: 24.0
+    - _comment: used default IPCC 2014 value of 24.0
       datetime: '2022-01-01'
-      source: Electricity Maps, 2022 zone average
-      value: 469.9
-    - _comment: used storage values equal to zero.
+      source: Electricity Maps, 2022 zone average; IPCC 2014
+      value: 24.0
+    - _comment: used default IPCC 2014 value of 24.0
       datetime: '2023-01-01'
-      source: Electricity Maps, 2023 zone average
-      value: 368.2
-    - _comment: used storage values equal to zero.
+      source: Electricity Maps, 2023 zone average; IPCC 2014
+      value: 24.0
+    - _comment: used default IPCC 2014 value of 24.0
       datetime: '2024-01-01'
-      source: Electricity Maps, 2024 zone average
-      value: 296.31
-    - _comment: used storage values equal to zero.
+      source: Electricity Maps, 2024 zone average; IPCC 2014
+      value: 24.0
+    - _comment: used default IPCC 2014 value of 24.0
       datetime: '2025-01-01'
-      source: Electricity Maps, 2025 zone average
-      value: 274.04
+      source: Electricity Maps, 2025 zone average; IPCC 2014
+      value: 24.0
     nuclear:
       datetime: '2020-01-01'
       source: UNECE 2022

--- a/config/zones/HR.yaml
+++ b/config/zones/HR.yaml
@@ -242,7 +242,7 @@ emissionFactors:
     - _comment: used storage values greater than zero.
       datetime: '2024-01-01'
       source: Electricity Maps, 2024 zone average
-      value: 188.25
+      value: 188.92
     - _comment: used storage values greater than zero.
       datetime: '2025-01-01'
       source: Electricity Maps, 2025 zone average
@@ -317,7 +317,7 @@ emissionFactors:
     - _comment: used storage values greater than zero.
       datetime: '2024-01-01'
       source: Electricity Maps, 2024 zone average
-      value: 233.77
+      value: 234.59
     - _comment: used storage values greater than zero.
       datetime: '2025-01-01'
       source: Electricity Maps, 2025 zone average

--- a/config/zones/HR.yaml
+++ b/config/zones/HR.yaml
@@ -226,19 +226,19 @@ emissionFactors:
     - _comment: used storage values greater than zero.
       datetime: '2020-01-01'
       source: Electricity Maps, 2020 zone average
-      value: 262.8
+      value: 264.14
     - _comment: used storage values greater than zero.
       datetime: '2021-01-01'
       source: Electricity Maps, 2021 zone average
-      value: 292.94
+      value: 294.01
     - _comment: used storage values greater than zero.
       datetime: '2022-01-01'
       source: Electricity Maps, 2022 zone average
-      value: 326.5
+      value: 327.35
     - _comment: used storage values greater than zero.
       datetime: '2023-01-01'
       source: Electricity Maps, 2023 zone average
-      value: 257.6
+      value: 258.08
     - _comment: used storage values greater than zero.
       datetime: '2024-01-01'
       source: Electricity Maps, 2024 zone average
@@ -246,7 +246,7 @@ emissionFactors:
     - _comment: used storage values greater than zero.
       datetime: '2025-01-01'
       source: Electricity Maps, 2025 zone average
-      value: 205.24
+      value: 206.6
     oil:
     - datetime: '2021-01-01'
       source: EU-ETS, ENTSO-E 2021
@@ -300,28 +300,28 @@ emissionFactors:
     hydro discharge:
     - _comment: used storage values greater than zero.
       datetime: '2020-01-01'
-      source: Electricity Maps, 2020 zone average
-      value: 321.78
+      source: Electricity Maps, 2020 zone average; IPCC 2014
+      value: 288.14
     - _comment: used storage values greater than zero.
       datetime: '2021-01-01'
-      source: Electricity Maps, 2021 zone average
-      value: 351.85
+      source: Electricity Maps, 2021 zone average; IPCC 2014
+      value: 318.01
     - _comment: used storage values greater than zero.
       datetime: '2022-01-01'
-      source: Electricity Maps, 2022 zone average
-      value: 391.84
+      source: Electricity Maps, 2022 zone average; IPCC 2014
+      value: 351.35
     - _comment: used storage values greater than zero.
       datetime: '2023-01-01'
-      source: Electricity Maps, 2023 zone average
-      value: 308.24
+      source: Electricity Maps, 2023 zone average; IPCC 2014
+      value: 282.08
     - _comment: used storage values greater than zero.
       datetime: '2024-01-01'
-      source: Electricity Maps, 2024 zone average
-      value: 234.59
+      source: Electricity Maps, 2024 zone average; IPCC 2014
+      value: 212.92
     - _comment: used storage values greater than zero.
       datetime: '2025-01-01'
-      source: Electricity Maps, 2025 zone average
-      value: 252.35
+      source: Electricity Maps, 2025 zone average; IPCC 2014
+      value: 230.6
     nuclear:
       datetime: '2020-01-01'
       source: UNECE 2022

--- a/config/zones/IN-KA.yaml
+++ b/config/zones/IN-KA.yaml
@@ -21,48 +21,48 @@ currency: INR
 emissionFactors:
   direct:
     hydro discharge:
-    - _comment: used storage values equal to zero.
+    - _comment: used default IPCC 2014 value of 0.0
       datetime: '2020-01-01'
       source: Electricity Maps, 2020 zone average
-      value: 328.34
-    - _comment: used storage values equal to zero.
+      value: 0.0
+    - _comment: used default IPCC 2014 value of 0.0
       datetime: '2021-01-01'
       source: Electricity Maps, 2021 zone average
-      value: 397.14
-    - _comment: used storage values equal to zero.
+      value: 0.0
+    - _comment: used default IPCC 2014 value of 0.0
       datetime: '2022-01-01'
       source: Electricity Maps, 2022 zone average
-      value: 359.96
-    - _comment: used storage values equal to zero.
+      value: 0.0
+    - _comment: used default IPCC 2014 value of 0.0
       datetime: '2023-01-01'
       source: Electricity Maps, 2023 zone average
-      value: 385.59
-    - _comment: used storage values equal to zero.
+      value: 0.0
+    - _comment: used default IPCC 2014 value of 0.0
       datetime: '2025-01-01'
       source: Electricity Maps, 2025 zone average
-      value: 417.3
+      value: 0.0
   lifecycle:
     hydro discharge:
-    - _comment: used storage values equal to zero.
+    - _comment: used default IPCC 2014 value of 24.0
       datetime: '2020-01-01'
-      source: Electricity Maps, 2020 zone average
-      value: 385.74
-    - _comment: used storage values equal to zero.
+      source: Electricity Maps, 2020 zone average; IPCC 2014
+      value: 24.0
+    - _comment: used default IPCC 2014 value of 24.0
       datetime: '2021-01-01'
-      source: Electricity Maps, 2021 zone average
-      value: 459.34
-    - _comment: used storage values equal to zero.
+      source: Electricity Maps, 2021 zone average; IPCC 2014
+      value: 24.0
+    - _comment: used default IPCC 2014 value of 24.0
       datetime: '2022-01-01'
-      source: Electricity Maps, 2022 zone average
-      value: 419.07
-    - _comment: used storage values equal to zero.
+      source: Electricity Maps, 2022 zone average; IPCC 2014
+      value: 24.0
+    - _comment: used default IPCC 2014 value of 24.0
       datetime: '2023-01-01'
-      source: Electricity Maps, 2023 zone average
-      value: 443.42
-    - _comment: used storage values equal to zero.
+      source: Electricity Maps, 2023 zone average; IPCC 2014
+      value: 24.0
+    - _comment: used default IPCC 2014 value of 24.0
       datetime: '2025-01-01'
-      source: Electricity Maps, 2025 zone average
-      value: 479.21
+      source: Electricity Maps, 2025 zone average; IPCC 2014
+      value: 24.0
     unknown:
       _comment: calculated 20% nuclear, 80% thermal (coal)
       source: Souther Regional Load Dispatch Center Allocation Limits 2018-2019; SRLDC

--- a/config/zones/IT-CNO.yaml
+++ b/config/zones/IT-CNO.yaml
@@ -77,7 +77,7 @@ emissionFactors:
     - _comment: used storage values greater than zero.
       datetime: '2025-01-01'
       source: Electricity Maps, 2025 zone average
-      value: 175.24
+      value: 176.18
     biomass:
       datetime: '2021-01-01'
       source: BEIS 2021
@@ -130,12 +130,12 @@ emissionFactors:
     battery discharge:
     - _comment: used storage values greater than zero.
       datetime: '2024-01-01'
-      source: Electricity Maps, 2024 zone average
-      value: 357.3
+      source: Electricity Maps, 2024 zone average; National Laboratory of the Rockies
+      value: 307.34
     - _comment: used storage values greater than zero.
       datetime: '2025-01-01'
-      source: Electricity Maps, 2025 zone average
-      value: 238.55
+      source: Electricity Maps, 2025 zone average; National Laboratory of the Rockies
+      value: 209.18
     biomass:
       datetime: '2014-01-01'
       source: BEIS 2021; IPCC 2014
@@ -175,8 +175,8 @@ emissionFactors:
     hydro discharge:
     - _comment: used storage values greater than zero.
       datetime: '2024-01-01'
-      source: Electricity Maps, 2024 zone average
-      value: 358.46
+      source: Electricity Maps, 2024 zone average; IPCC 2014
+      value: 299.15
     nuclear:
       datetime: '2020-01-01'
       source: UNECE 2022

--- a/config/zones/IT-CNO.yaml
+++ b/config/zones/IT-CNO.yaml
@@ -73,7 +73,7 @@ emissionFactors:
     - _comment: used storage values greater than zero.
       datetime: '2024-01-01'
       source: Electricity Maps, 2024 zone average
-      value: 271.19
+      value: 274.34
     - _comment: used storage values greater than zero.
       datetime: '2025-01-01'
       source: Electricity Maps, 2025 zone average
@@ -112,7 +112,7 @@ emissionFactors:
     - _comment: used storage values greater than zero.
       datetime: '2024-01-01'
       source: Electricity Maps, 2024 zone average
-      value: 272.82
+      value: 275.15
     oil:
     - datetime: '2021-01-01'
       source: EU-ETS, ENTSO-E 2021
@@ -131,7 +131,7 @@ emissionFactors:
     - _comment: used storage values greater than zero.
       datetime: '2024-01-01'
       source: Electricity Maps, 2024 zone average
-      value: 353.19
+      value: 357.3
     - _comment: used storage values greater than zero.
       datetime: '2025-01-01'
       source: Electricity Maps, 2025 zone average
@@ -176,7 +176,7 @@ emissionFactors:
     - _comment: used storage values greater than zero.
       datetime: '2024-01-01'
       source: Electricity Maps, 2024 zone average
-      value: 355.42
+      value: 358.46
     nuclear:
       datetime: '2020-01-01'
       source: UNECE 2022

--- a/config/zones/IT-CSO.yaml
+++ b/config/zones/IT-CSO.yaml
@@ -111,10 +111,14 @@ delays:
 emissionFactors:
   direct:
     battery discharge:
+    - _comment: used non-null storage values
+      datetime: '2024-01-01'
+      source: Electricity Maps, 2024 zone average
+      value: 364.12
     - _comment: used storage values greater than zero.
       datetime: '2025-01-01'
       source: Electricity Maps, 2025 zone average
-      value: 213.62
+      value: 215.35
     biomass:
       datetime: '2021-01-01'
       source: BEIS 2021
@@ -149,19 +153,19 @@ emissionFactors:
     - _comment: used storage values greater than zero.
       datetime: '2020-01-01'
       source: Electricity Maps, 2020 zone average
-      value: 334.26
+      value: 334.44
     - _comment: used storage values greater than zero.
       datetime: '2021-01-01'
       source: Electricity Maps, 2021 zone average
-      value: 340.53
+      value: 340.85
     - _comment: used storage values greater than zero.
       datetime: '2022-01-01'
       source: Electricity Maps, 2022 zone average
-      value: 366.29
+      value: 366.48
     - _comment: used storage values greater than zero.
       datetime: '2023-01-01'
       source: Electricity Maps, 2023 zone average
-      value: 280.3
+      value: 280.76
     - _comment: used storage values greater than zero.
       datetime: '2024-01-01'
       source: Electricity Maps, 2024 zone average
@@ -169,7 +173,7 @@ emissionFactors:
     - _comment: used storage values greater than zero.
       datetime: '2025-01-01'
       source: Electricity Maps, 2025 zone average
-      value: 204.25
+      value: 204.7
     oil:
     - datetime: '2021-01-01'
       source: EU-ETS, ENTSO-E 2021
@@ -185,10 +189,14 @@ emissionFactors:
       value: 905.42
   lifecycle:
     battery discharge:
+    - _comment: used non-null storage values
+      datetime: '2024-01-01'
+      source: Electricity Maps, 2024 zone average; National Laboratory of the Rockies
+      value: 397.12
     - _comment: used storage values greater than zero.
       datetime: '2025-01-01'
-      source: Electricity Maps, 2025 zone average
-      value: 283.3
+      source: Electricity Maps, 2025 zone average; National Laboratory of the Rockies
+      value: 248.35
     biomass:
       datetime: '2014-01-01'
       source: BEIS 2021; IPCC 2014
@@ -228,28 +236,28 @@ emissionFactors:
     hydro discharge:
     - _comment: used storage values greater than zero.
       datetime: '2020-01-01'
-      source: Electricity Maps, 2020 zone average
-      value: 413.38
+      source: Electricity Maps, 2020 zone average; IPCC 2014
+      value: 358.44
     - _comment: used storage values greater than zero.
       datetime: '2021-01-01'
-      source: Electricity Maps, 2021 zone average
-      value: 418.45
+      source: Electricity Maps, 2021 zone average; IPCC 2014
+      value: 364.85
     - _comment: used storage values greater than zero.
       datetime: '2022-01-01'
-      source: Electricity Maps, 2022 zone average
-      value: 442.8
+      source: Electricity Maps, 2022 zone average; IPCC 2014
+      value: 390.48
     - _comment: used storage values greater than zero.
       datetime: '2023-01-01'
-      source: Electricity Maps, 2023 zone average
-      value: 342.2
+      source: Electricity Maps, 2023 zone average; IPCC 2014
+      value: 304.76
     - _comment: used storage values greater than zero.
       datetime: '2024-01-01'
-      source: Electricity Maps, 2024 zone average
-      value: 303.07
+      source: Electricity Maps, 2024 zone average; IPCC 2014
+      value: 255.45
     - _comment: used storage values greater than zero.
       datetime: '2025-01-01'
-      source: Electricity Maps, 2025 zone average
-      value: 272.72
+      source: Electricity Maps, 2025 zone average; IPCC 2014
+      value: 228.7
     nuclear:
       datetime: '2020-01-01'
       source: UNECE 2022

--- a/config/zones/IT-CSO.yaml
+++ b/config/zones/IT-CSO.yaml
@@ -165,7 +165,7 @@ emissionFactors:
     - _comment: used storage values greater than zero.
       datetime: '2024-01-01'
       source: Electricity Maps, 2024 zone average
-      value: 230.84
+      value: 231.45
     - _comment: used storage values greater than zero.
       datetime: '2025-01-01'
       source: Electricity Maps, 2025 zone average
@@ -245,7 +245,7 @@ emissionFactors:
     - _comment: used storage values greater than zero.
       datetime: '2024-01-01'
       source: Electricity Maps, 2024 zone average
-      value: 302.26
+      value: 303.07
     - _comment: used storage values greater than zero.
       datetime: '2025-01-01'
       source: Electricity Maps, 2025 zone average

--- a/config/zones/IT-NO.yaml
+++ b/config/zones/IT-NO.yaml
@@ -154,7 +154,7 @@ emissionFactors:
     - _comment: used storage values greater than zero.
       datetime: '2024-01-01'
       source: Electricity Maps, 2024 zone average
-      value: 185.87
+      value: 186.05
     - _comment: used storage values greater than zero.
       datetime: '2025-01-01'
       source: Electricity Maps, 2025 zone average
@@ -234,7 +234,7 @@ emissionFactors:
     - _comment: used storage values greater than zero.
       datetime: '2024-01-01'
       source: Electricity Maps, 2024 zone average
-      value: 246.27
+      value: 246.51
     - _comment: used storage values greater than zero.
       datetime: '2025-01-01'
       source: Electricity Maps, 2025 zone average

--- a/config/zones/IT-NO.yaml
+++ b/config/zones/IT-NO.yaml
@@ -100,10 +100,14 @@ delays:
 emissionFactors:
   direct:
     battery discharge:
+    - _comment: used non-null storage values
+      datetime: '2024-01-01'
+      source: Electricity Maps, 2024 zone average
+      value: 320.6
     - _comment: used storage values greater than zero.
       datetime: '2025-01-01'
       source: Electricity Maps, 2025 zone average
-      value: 211.36
+      value: 212.65
     biomass:
       datetime: '2021-01-01'
       source: BEIS 2021
@@ -138,19 +142,19 @@ emissionFactors:
     - _comment: used storage values greater than zero.
       datetime: '2020-01-01'
       source: Electricity Maps, 2020 zone average
-      value: 235.81
+      value: 236.12
     - _comment: used storage values greater than zero.
       datetime: '2021-01-01'
       source: Electricity Maps, 2021 zone average
-      value: 257.83
+      value: 258.09
     - _comment: used storage values greater than zero.
       datetime: '2022-01-01'
       source: Electricity Maps, 2022 zone average
-      value: 286.72
+      value: 287.0
     - _comment: used storage values greater than zero.
       datetime: '2023-01-01'
       source: Electricity Maps, 2023 zone average
-      value: 232.52
+      value: 232.81
     - _comment: used storage values greater than zero.
       datetime: '2024-01-01'
       source: Electricity Maps, 2024 zone average
@@ -158,7 +162,7 @@ emissionFactors:
     - _comment: used storage values greater than zero.
       datetime: '2025-01-01'
       source: Electricity Maps, 2025 zone average
-      value: 208.53
+      value: 209.13
     oil:
     - datetime: '2021-01-01'
       source: EU-ETS, ENTSO-E 2021
@@ -174,10 +178,14 @@ emissionFactors:
       value: 905.42
   lifecycle:
     battery discharge:
+    - _comment: used non-null storage values
+      datetime: '2024-01-01'
+      source: Electricity Maps, 2024 zone average; National Laboratory of the Rockies
+      value: 353.6
     - _comment: used storage values greater than zero.
       datetime: '2025-01-01'
-      source: Electricity Maps, 2025 zone average
-      value: 276.6
+      source: Electricity Maps, 2025 zone average; National Laboratory of the Rockies
+      value: 245.65
     biomass:
       datetime: '2014-01-01'
       source: BEIS 2021; IPCC 2014
@@ -217,28 +225,28 @@ emissionFactors:
     hydro discharge:
     - _comment: used storage values greater than zero.
       datetime: '2020-01-01'
-      source: Electricity Maps, 2020 zone average
-      value: 305.45
+      source: Electricity Maps, 2020 zone average; IPCC 2014
+      value: 260.12
     - _comment: used storage values greater than zero.
       datetime: '2021-01-01'
-      source: Electricity Maps, 2021 zone average
-      value: 331.63
+      source: Electricity Maps, 2021 zone average; IPCC 2014
+      value: 282.09
     - _comment: used storage values greater than zero.
       datetime: '2022-01-01'
-      source: Electricity Maps, 2022 zone average
-      value: 364.25
+      source: Electricity Maps, 2022 zone average; IPCC 2014
+      value: 311.0
     - _comment: used storage values greater than zero.
       datetime: '2023-01-01'
-      source: Electricity Maps, 2023 zone average
-      value: 299.02
+      source: Electricity Maps, 2023 zone average; IPCC 2014
+      value: 256.81
     - _comment: used storage values greater than zero.
       datetime: '2024-01-01'
-      source: Electricity Maps, 2024 zone average
-      value: 246.51
+      source: Electricity Maps, 2024 zone average; IPCC 2014
+      value: 210.05
     - _comment: used storage values greater than zero.
       datetime: '2025-01-01'
-      source: Electricity Maps, 2025 zone average
-      value: 274.48
+      source: Electricity Maps, 2025 zone average; IPCC 2014
+      value: 233.13
     nuclear:
       datetime: '2020-01-01'
       source: UNECE 2022

--- a/config/zones/IT-SAR.yaml
+++ b/config/zones/IT-SAR.yaml
@@ -75,14 +75,14 @@ delays:
 emissionFactors:
   direct:
     battery discharge:
-    - _comment: used storage values equal to zero.
+    - _comment: used non-null storage values
       datetime: '2024-01-01'
       source: Electricity Maps, 2024 zone average
       value: 426.4
     - _comment: used storage values greater than zero.
       datetime: '2025-01-01'
       source: Electricity Maps, 2025 zone average
-      value: 390.31
+      value: 394.54
     biomass:
       datetime: '2021-01-01'
       source: BEIS 2021
@@ -117,19 +117,19 @@ emissionFactors:
     - _comment: used storage values greater than zero.
       datetime: '2020-01-01'
       source: Electricity Maps, 2020 zone average
-      value: 528.53
+      value: 528.85
     - _comment: used storage values greater than zero.
       datetime: '2021-01-01'
       source: Electricity Maps, 2021 zone average
-      value: 479.87
+      value: 480.15
     - _comment: used storage values greater than zero.
       datetime: '2022-01-01'
       source: Electricity Maps, 2022 zone average
-      value: 486.58
+      value: 486.68
     - _comment: used storage values greater than zero.
       datetime: '2023-01-01'
       source: Electricity Maps, 2023 zone average
-      value: 438.1
+      value: 438.32
     - _comment: used storage values greater than zero.
       datetime: '2024-01-01'
       source: Electricity Maps, 2024 zone average
@@ -137,7 +137,7 @@ emissionFactors:
     - _comment: used storage values greater than zero.
       datetime: '2025-01-01'
       source: Electricity Maps, 2025 zone average
-      value: 387.44
+      value: 393.88
     oil:
     - datetime: '2021-01-01'
       source: EU-ETS, ENTSO-E 2021
@@ -153,14 +153,14 @@ emissionFactors:
       value: 905.42
   lifecycle:
     battery discharge:
-    - _comment: used storage values equal to zero.
+    - _comment: used non-null storage values
       datetime: '2024-01-01'
-      source: Electricity Maps, 2024 zone average
-      value: 558.15
+      source: Electricity Maps, 2024 zone average; National Laboratory of the Rockies
+      value: 459.4
     - _comment: used storage values greater than zero.
       datetime: '2025-01-01'
-      source: Electricity Maps, 2025 zone average
-      value: 468.76
+      source: Electricity Maps, 2025 zone average; National Laboratory of the Rockies
+      value: 427.54
     biomass:
       datetime: '2014-01-01'
       source: BEIS 2021; IPCC 2014
@@ -200,28 +200,28 @@ emissionFactors:
     hydro discharge:
     - _comment: used storage values greater than zero.
       datetime: '2020-01-01'
-      source: Electricity Maps, 2020 zone average
-      value: 620.11
+      source: Electricity Maps, 2020 zone average; IPCC 2014
+      value: 552.85
     - _comment: used storage values greater than zero.
       datetime: '2021-01-01'
-      source: Electricity Maps, 2021 zone average
-      value: 569.0
+      source: Electricity Maps, 2021 zone average; IPCC 2014
+      value: 504.15
     - _comment: used storage values greater than zero.
       datetime: '2022-01-01'
-      source: Electricity Maps, 2022 zone average
-      value: 574.65
+      source: Electricity Maps, 2022 zone average; IPCC 2014
+      value: 510.68
     - _comment: used storage values greater than zero.
       datetime: '2023-01-01'
-      source: Electricity Maps, 2023 zone average
-      value: 514.99
+      source: Electricity Maps, 2023 zone average; IPCC 2014
+      value: 462.32
     - _comment: used storage values greater than zero.
       datetime: '2024-01-01'
-      source: Electricity Maps, 2024 zone average
-      value: 506.08
+      source: Electricity Maps, 2024 zone average; IPCC 2014
+      value: 452.79
     - _comment: used storage values greater than zero.
       datetime: '2025-01-01'
-      source: Electricity Maps, 2025 zone average
-      value: 471.41
+      source: Electricity Maps, 2025 zone average; IPCC 2014
+      value: 417.88
     nuclear:
       datetime: '2020-01-01'
       source: UNECE 2022

--- a/config/zones/IT-SAR.yaml
+++ b/config/zones/IT-SAR.yaml
@@ -78,7 +78,7 @@ emissionFactors:
     - _comment: used storage values equal to zero.
       datetime: '2024-01-01'
       source: Electricity Maps, 2024 zone average
-      value: 425.68
+      value: 426.4
     - _comment: used storage values greater than zero.
       datetime: '2025-01-01'
       source: Electricity Maps, 2025 zone average
@@ -133,7 +133,7 @@ emissionFactors:
     - _comment: used storage values greater than zero.
       datetime: '2024-01-01'
       source: Electricity Maps, 2024 zone average
-      value: 428.5
+      value: 428.79
     - _comment: used storage values greater than zero.
       datetime: '2025-01-01'
       source: Electricity Maps, 2025 zone average
@@ -156,7 +156,7 @@ emissionFactors:
     - _comment: used storage values equal to zero.
       datetime: '2024-01-01'
       source: Electricity Maps, 2024 zone average
-      value: 557.2
+      value: 558.15
     - _comment: used storage values greater than zero.
       datetime: '2025-01-01'
       source: Electricity Maps, 2025 zone average
@@ -217,7 +217,7 @@ emissionFactors:
     - _comment: used storage values greater than zero.
       datetime: '2024-01-01'
       source: Electricity Maps, 2024 zone average
-      value: 505.74
+      value: 506.08
     - _comment: used storage values greater than zero.
       datetime: '2025-01-01'
       source: Electricity Maps, 2025 zone average

--- a/config/zones/IT-SIC.yaml
+++ b/config/zones/IT-SIC.yaml
@@ -80,14 +80,14 @@ delays:
 emissionFactors:
   direct:
     battery discharge:
-    - _comment: used storage values equal to zero.
+    - _comment: used non-null storage values
       datetime: '2024-01-01'
       source: Electricity Maps, 2024 zone average
       value: 287.88
     - _comment: used storage values greater than zero.
       datetime: '2025-01-01'
       source: Electricity Maps, 2025 zone average
-      value: 212.05
+      value: 213.59
     biomass:
       datetime: '2021-01-01'
       source: BEIS 2021
@@ -126,7 +126,7 @@ emissionFactors:
     - _comment: used storage values greater than zero.
       datetime: '2021-01-01'
       source: Electricity Maps, 2021 zone average
-      value: 288.1
+      value: 288.12
     - _comment: used storage values greater than zero.
       datetime: '2022-01-01'
       source: Electricity Maps, 2022 zone average
@@ -134,7 +134,7 @@ emissionFactors:
     - _comment: used storage values greater than zero.
       datetime: '2023-01-01'
       source: Electricity Maps, 2023 zone average
-      value: 244.25
+      value: 244.26
     - _comment: used storage values greater than zero.
       datetime: '2024-01-01'
       source: Electricity Maps, 2024 zone average
@@ -142,7 +142,7 @@ emissionFactors:
     - _comment: used storage values greater than zero.
       datetime: '2025-01-01'
       source: Electricity Maps, 2025 zone average
-      value: 203.2
+      value: 203.27
     oil:
     - datetime: '2021-01-01'
       source: EU-ETS, ENTSO-E 2021
@@ -158,14 +158,14 @@ emissionFactors:
       value: 905.42
   lifecycle:
     battery discharge:
-    - _comment: used storage values equal to zero.
+    - _comment: used non-null storage values
       datetime: '2024-01-01'
-      source: Electricity Maps, 2024 zone average
-      value: 440.43
+      source: Electricity Maps, 2024 zone average; National Laboratory of the Rockies
+      value: 320.88
     - _comment: used storage values greater than zero.
       datetime: '2025-01-01'
-      source: Electricity Maps, 2025 zone average
-      value: 284.79
+      source: Electricity Maps, 2025 zone average; National Laboratory of the Rockies
+      value: 246.59
     biomass:
       datetime: '2014-01-01'
       source: BEIS 2021; IPCC 2014
@@ -205,28 +205,28 @@ emissionFactors:
     hydro discharge:
     - _comment: used storage values greater than zero.
       datetime: '2020-01-01'
-      source: Electricity Maps, 2020 zone average
-      value: 387.21
+      source: Electricity Maps, 2020 zone average; IPCC 2014
+      value: 322.15
     - _comment: used storage values greater than zero.
       datetime: '2021-01-01'
-      source: Electricity Maps, 2021 zone average
-      value: 375.15
+      source: Electricity Maps, 2021 zone average; IPCC 2014
+      value: 312.12
     - _comment: used storage values greater than zero.
       datetime: '2022-01-01'
-      source: Electricity Maps, 2022 zone average
-      value: 422.63
+      source: Electricity Maps, 2022 zone average; IPCC 2014
+      value: 349.82
     - _comment: used storage values greater than zero.
       datetime: '2023-01-01'
-      source: Electricity Maps, 2023 zone average
-      value: 323.69
+      source: Electricity Maps, 2023 zone average; IPCC 2014
+      value: 268.26
     - _comment: used storage values greater than zero.
       datetime: '2024-01-01'
-      source: Electricity Maps, 2024 zone average
-      value: 253.61
+      source: Electricity Maps, 2024 zone average; IPCC 2014
+      value: 210.76
     - _comment: used storage values greater than zero.
       datetime: '2025-01-01'
-      source: Electricity Maps, 2025 zone average
-      value: 274.23
+      source: Electricity Maps, 2025 zone average; IPCC 2014
+      value: 227.27
     nuclear:
       datetime: '2020-01-01'
       source: UNECE 2022

--- a/config/zones/IT-SIC.yaml
+++ b/config/zones/IT-SIC.yaml
@@ -83,7 +83,7 @@ emissionFactors:
     - _comment: used storage values equal to zero.
       datetime: '2024-01-01'
       source: Electricity Maps, 2024 zone average
-      value: 260.95
+      value: 287.88
     - _comment: used storage values greater than zero.
       datetime: '2025-01-01'
       source: Electricity Maps, 2025 zone average
@@ -161,7 +161,7 @@ emissionFactors:
     - _comment: used storage values equal to zero.
       datetime: '2024-01-01'
       source: Electricity Maps, 2024 zone average
-      value: 399.22
+      value: 440.43
     - _comment: used storage values greater than zero.
       datetime: '2025-01-01'
       source: Electricity Maps, 2025 zone average
@@ -222,7 +222,7 @@ emissionFactors:
     - _comment: used storage values greater than zero.
       datetime: '2024-01-01'
       source: Electricity Maps, 2024 zone average
-      value: 253.6
+      value: 253.61
     - _comment: used storage values greater than zero.
       datetime: '2025-01-01'
       source: Electricity Maps, 2025 zone average

--- a/config/zones/IT.yaml
+++ b/config/zones/IT.yaml
@@ -25,7 +25,7 @@ emissionFactors:
     - _comment: used storage values greater than zero.
       datetime: '2024-01-01'
       source: Electricity Maps, 2024 zone average
-      value: 281.73
+      value: 288.15
     - _comment: used storage values greater than zero.
       datetime: '2025-01-01'
       source: Electricity Maps, 2025 zone average
@@ -80,7 +80,7 @@ emissionFactors:
     - _comment: used storage values greater than zero.
       datetime: '2024-01-01'
       source: Electricity Maps, 2024 zone average
-      value: 193.24
+      value: 193.69
     - _comment: used storage values greater than zero.
       datetime: '2025-01-01'
       source: Electricity Maps, 2025 zone average
@@ -103,7 +103,7 @@ emissionFactors:
     - _comment: used storage values greater than zero.
       datetime: '2024-01-01'
       source: Electricity Maps, 2024 zone average
-      value: 366.15
+      value: 374.48
     - _comment: used storage values greater than zero.
       datetime: '2025-01-01'
       source: Electricity Maps, 2025 zone average
@@ -164,7 +164,7 @@ emissionFactors:
     - _comment: used storage values greater than zero.
       datetime: '2024-01-01'
       source: Electricity Maps, 2024 zone average
-      value: 256.14
+      value: 256.75
     - _comment: used storage values greater than zero.
       datetime: '2025-01-01'
       source: Electricity Maps, 2025 zone average

--- a/config/zones/IT.yaml
+++ b/config/zones/IT.yaml
@@ -29,7 +29,7 @@ emissionFactors:
     - _comment: used storage values greater than zero.
       datetime: '2025-01-01'
       source: Electricity Maps, 2025 zone average
-      value: 210.83
+      value: 212.07
     biomass:
       datetime: '2021-01-01'
       source: BEIS 2021
@@ -64,19 +64,19 @@ emissionFactors:
     - _comment: used storage values greater than zero.
       datetime: '2020-01-01'
       source: Electricity Maps, 2020 zone average
-      value: 264.02
+      value: 264.71
     - _comment: used storage values greater than zero.
       datetime: '2021-01-01'
       source: Electricity Maps, 2021 zone average
-      value: 279.09
+      value: 279.69
     - _comment: used storage values greater than zero.
       datetime: '2022-01-01'
       source: Electricity Maps, 2022 zone average
-      value: 316.76
+      value: 317.15
     - _comment: used storage values greater than zero.
       datetime: '2023-01-01'
       source: Electricity Maps, 2023 zone average
-      value: 241.98
+      value: 242.48
     - _comment: used storage values greater than zero.
       datetime: '2024-01-01'
       source: Electricity Maps, 2024 zone average
@@ -84,7 +84,7 @@ emissionFactors:
     - _comment: used storage values greater than zero.
       datetime: '2025-01-01'
       source: Electricity Maps, 2025 zone average
-      value: 205.81
+      value: 206.38
     oil:
     - datetime: '2021-01-01'
       source: EU-ETS, ENTSO-E 2021
@@ -102,12 +102,12 @@ emissionFactors:
     battery discharge:
     - _comment: used storage values greater than zero.
       datetime: '2024-01-01'
-      source: Electricity Maps, 2024 zone average
-      value: 374.48
+      source: Electricity Maps, 2024 zone average; National Laboratory of the Rockies
+      value: 321.15
     - _comment: used storage values greater than zero.
       datetime: '2025-01-01'
-      source: Electricity Maps, 2025 zone average
-      value: 278.37
+      source: Electricity Maps, 2025 zone average; National Laboratory of the Rockies
+      value: 245.07
     biomass:
       datetime: '2014-01-01'
       source: BEIS 2021; IPCC 2014
@@ -147,28 +147,28 @@ emissionFactors:
     hydro discharge:
     - _comment: used storage values greater than zero.
       datetime: '2020-01-01'
-      source: Electricity Maps, 2020 zone average
-      value: 337.15
+      source: Electricity Maps, 2020 zone average; IPCC 2014
+      value: 288.71
     - _comment: used storage values greater than zero.
       datetime: '2021-01-01'
-      source: Electricity Maps, 2021 zone average
-      value: 354.62
+      source: Electricity Maps, 2021 zone average; IPCC 2014
+      value: 303.69
     - _comment: used storage values greater than zero.
       datetime: '2022-01-01'
-      source: Electricity Maps, 2022 zone average
-      value: 395.78
+      source: Electricity Maps, 2022 zone average; IPCC 2014
+      value: 341.15
     - _comment: used storage values greater than zero.
       datetime: '2023-01-01'
-      source: Electricity Maps, 2023 zone average
-      value: 308.33
+      source: Electricity Maps, 2023 zone average; IPCC 2014
+      value: 266.48
     - _comment: used storage values greater than zero.
       datetime: '2024-01-01'
-      source: Electricity Maps, 2024 zone average
-      value: 256.75
+      source: Electricity Maps, 2024 zone average; IPCC 2014
+      value: 217.69
     - _comment: used storage values greater than zero.
       datetime: '2025-01-01'
-      source: Electricity Maps, 2025 zone average
-      value: 273.25
+      source: Electricity Maps, 2025 zone average; IPCC 2014
+      value: 230.38
     nuclear:
       datetime: '2020-01-01'
       source: UNECE 2022

--- a/config/zones/JP-CB.yaml
+++ b/config/zones/JP-CB.yaml
@@ -29,6 +29,11 @@ disclaimer: The data provided for solar power production is suspected to be too 
   (source; Chubu Electric Power Co.,Inc.).
 emissionFactors:
   direct:
+    hydro discharge:
+    - _comment: used default IPCC 2014 value of 0.0
+      datetime: '2025-01-01'
+      source: Electricity Maps, 2025 zone average
+      value: 0.0
     unknown:
       _comment: 'Source: Derived from 2016-2019 Chubu area supply statistics and 2017-2018
         Chubu Electric report'
@@ -38,7 +43,12 @@ emissionFactors:
       source: Chubu Electric Power 2022; assumes 26.3% coal, 2.2% oil, 62.5% gas,
         9% hydro and wind
       value: 440.062
-  lifecycle: {}
+  lifecycle:
+    hydro discharge:
+    - _comment: used default IPCC 2014 value of 24.0
+      datetime: '2025-01-01'
+      source: Electricity Maps, 2025 zone average; IPCC 2014
+      value: 24.0
 fallbackZoneMixes:
   powerOriginRatios:
   - _source: Electricity Maps, 2017 average

--- a/config/zones/JP-CG.yaml
+++ b/config/zones/JP-CG.yaml
@@ -27,16 +27,16 @@ delays:
 emissionFactors:
   direct:
     hydro discharge:
-    - _comment: used storage values equal to zero.
+    - _comment: used default IPCC 2014 value of 0.0
       datetime: '2020-01-01'
       source: Electricity Maps, 2020 zone average
-      value: 419.3
+      value: 0.0
   lifecycle:
     hydro discharge:
-    - _comment: used storage values equal to zero.
+    - _comment: used default IPCC 2014 value of 24.0
       datetime: '2020-01-01'
-      source: Electricity Maps, 2020 zone average
-      value: 509.85
+      source: Electricity Maps, 2020 zone average; IPCC 2014
+      value: 24.0
 fallbackZoneMixes:
   powerOriginRatios:
   - _source: Electricity Maps, 2017 average

--- a/config/zones/JP-HKD.yaml
+++ b/config/zones/JP-HKD.yaml
@@ -30,16 +30,16 @@ delays:
 emissionFactors:
   direct:
     hydro discharge:
-    - _comment: used storage values equal to zero.
+    - _comment: used default IPCC 2014 value of 0.0
       datetime: '2020-01-01'
       source: Electricity Maps, 2020 zone average
-      value: 436.29
+      value: 0.0
   lifecycle:
     hydro discharge:
-    - _comment: used storage values equal to zero.
+    - _comment: used default IPCC 2014 value of 24.0
       datetime: '2020-01-01'
-      source: Electricity Maps, 2020 zone average
-      value: 523.63
+      source: Electricity Maps, 2020 zone average; IPCC 2014
+      value: 24.0
 fallbackZoneMixes:
   powerOriginRatios:
   - _source: Electricity Maps, 2017 average

--- a/config/zones/JP-HR.yaml
+++ b/config/zones/JP-HR.yaml
@@ -30,24 +30,24 @@ disclaimer: The data provider (Hokuriku Electric Power Co.,Inc.) provides live d
 emissionFactors:
   direct:
     hydro discharge:
-    - _comment: used storage values equal to zero.
+    - _comment: used default IPCC 2014 value of 0.0
       datetime: '2020-01-01'
       source: Electricity Maps, 2020 zone average
-      value: 365.09
-    - _comment: used storage values equal to zero.
+      value: 0.0
+    - _comment: used default IPCC 2014 value of 0.0
       datetime: '2025-01-01'
       source: Electricity Maps, 2025 zone average
-      value: 402.51
+      value: 0.0
   lifecycle:
     hydro discharge:
-    - _comment: used storage values equal to zero.
+    - _comment: used default IPCC 2014 value of 24.0
       datetime: '2020-01-01'
-      source: Electricity Maps, 2020 zone average
-      value: 445.61
-    - _comment: used storage values equal to zero.
+      source: Electricity Maps, 2020 zone average; IPCC 2014
+      value: 24.0
+    - _comment: used default IPCC 2014 value of 24.0
       datetime: '2025-01-01'
-      source: Electricity Maps, 2025 zone average
-      value: 488.19
+      source: Electricity Maps, 2025 zone average; IPCC 2014
+      value: 24.0
 fallbackZoneMixes:
   powerOriginRatios:
   - _source: Electricity Maps, 2017 average

--- a/config/zones/JP-KN.yaml
+++ b/config/zones/JP-KN.yaml
@@ -26,24 +26,32 @@ delays:
 emissionFactors:
   direct:
     hydro discharge:
-    - _comment: used storage values equal to zero.
+    - _comment: used default IPCC 2014 value of 0.0
       datetime: '2020-01-01'
       source: Electricity Maps, 2020 zone average
-      value: 427.8
-    - _comment: used storage values equal to zero.
+      value: 0.0
+    - _comment: used default IPCC 2014 value of 0.0
+      datetime: '2021-01-01'
+      source: Electricity Maps, 2021 zone average
+      value: 0.0
+    - _comment: used default IPCC 2014 value of 0.0
       datetime: '2023-01-01'
       source: Electricity Maps, 2023 zone average
-      value: 334.51
+      value: 0.0
   lifecycle:
     hydro discharge:
-    - _comment: used storage values equal to zero.
+    - _comment: used default IPCC 2014 value of 24.0
       datetime: '2020-01-01'
-      source: Electricity Maps, 2020 zone average
-      value: 513.87
-    - _comment: used storage values equal to zero.
+      source: Electricity Maps, 2020 zone average; IPCC 2014
+      value: 24.0
+    - _comment: used default IPCC 2014 value of 24.0
+      datetime: '2021-01-01'
+      source: Electricity Maps, 2021 zone average; IPCC 2014
+      value: 24.0
+    - _comment: used default IPCC 2014 value of 24.0
       datetime: '2023-01-01'
-      source: Electricity Maps, 2023 zone average
-      value: 405.39
+      source: Electricity Maps, 2023 zone average; IPCC 2014
+      value: 24.0
 fallbackZoneMixes:
   powerOriginRatios:
   - _source: Electricity Maps, 2015 average

--- a/config/zones/JP-KY.yaml
+++ b/config/zones/JP-KY.yaml
@@ -20,6 +20,27 @@ country_name: Japan
 currency: JPY
 delays:
   production: 5
+emissionFactors:
+  direct:
+    hydro discharge:
+    - _comment: used default IPCC 2014 value of 0.0
+      datetime: '2023-01-01'
+      source: Electricity Maps, 2023 zone average
+      value: 0.0
+    - _comment: used default IPCC 2014 value of 0.0
+      datetime: '2025-01-01'
+      source: Electricity Maps, 2025 zone average
+      value: 0.0
+  lifecycle:
+    hydro discharge:
+    - _comment: used default IPCC 2014 value of 24.0
+      datetime: '2023-01-01'
+      source: Electricity Maps, 2023 zone average; IPCC 2014
+      value: 24.0
+    - _comment: used default IPCC 2014 value of 24.0
+      datetime: '2025-01-01'
+      source: Electricity Maps, 2025 zone average; IPCC 2014
+      value: 24.0
 fallbackZoneMixes:
   powerOriginRatios:
   - _source: Electricity Maps, 2017 average

--- a/config/zones/JP-ON.yaml
+++ b/config/zones/JP-ON.yaml
@@ -25,24 +25,24 @@ delays:
 emissionFactors:
   direct:
     hydro discharge:
-    - _comment: used storage values equal to zero.
+    - _comment: used default IPCC 2014 value of 0.0
       datetime: '2020-01-01'
       source: Electricity Maps, 2020 zone average
-      value: 500.06
-    - _comment: used storage values equal to zero.
+      value: 0.0
+    - _comment: used default IPCC 2014 value of 0.0
       datetime: '2021-01-01'
       source: Electricity Maps, 2021 zone average
-      value: 492.75
+      value: 0.0
   lifecycle:
     hydro discharge:
-    - _comment: used storage values equal to zero.
+    - _comment: used default IPCC 2014 value of 24.0
       datetime: '2020-01-01'
-      source: Electricity Maps, 2020 zone average
-      value: 597.17
-    - _comment: used storage values equal to zero.
+      source: Electricity Maps, 2020 zone average; IPCC 2014
+      value: 24.0
+    - _comment: used default IPCC 2014 value of 24.0
       datetime: '2021-01-01'
-      source: Electricity Maps, 2021 zone average
-      value: 589.1
+      source: Electricity Maps, 2021 zone average; IPCC 2014
+      value: 24.0
 fallbackZoneMixes:
   powerOriginRatios:
   - _source: Electricity Maps, 2017 average

--- a/config/zones/JP-SK.yaml
+++ b/config/zones/JP-SK.yaml
@@ -29,7 +29,18 @@ disclaimer: The data provider (Yonden Shikoku Electric Power Co.,Inc.) provides 
   data only for solar and unknown. We are working on improving the data quality for
   this zone.
 emissionFactors:
-  lifecycle: {}
+  direct:
+    hydro discharge:
+    - _comment: used default IPCC 2014 value of 0.0
+      datetime: '2025-01-01'
+      source: Electricity Maps, 2025 zone average
+      value: 0.0
+  lifecycle:
+    hydro discharge:
+    - _comment: used default IPCC 2014 value of 24.0
+      datetime: '2025-01-01'
+      source: Electricity Maps, 2025 zone average; IPCC 2014
+      value: 24.0
 fallbackZoneMixes:
   powerOriginRatios:
   - _source: Electricity Maps, 2016 average

--- a/config/zones/JP-TK.yaml
+++ b/config/zones/JP-TK.yaml
@@ -25,16 +25,16 @@ delays:
 emissionFactors:
   direct:
     hydro discharge:
-    - _comment: used storage values equal to zero.
+    - _comment: used default IPCC 2014 value of 0.0
       datetime: '2025-01-01'
       source: Electricity Maps, 2025 zone average
-      value: 497.47
+      value: 0.0
   lifecycle:
     hydro discharge:
-    - _comment: used storage values equal to zero.
+    - _comment: used default IPCC 2014 value of 24.0
       datetime: '2025-01-01'
-      source: Electricity Maps, 2025 zone average
-      value: 592.73
+      source: Electricity Maps, 2025 zone average; IPCC 2014
+      value: 24.0
 fallbackZoneMixes:
   powerOriginRatios:
   - _source: Electricity Maps, 2015 average

--- a/config/zones/JP.yaml
+++ b/config/zones/JP.yaml
@@ -30,16 +30,40 @@ currency: JPY
 emissionFactors:
   direct:
     hydro discharge:
-    - _comment: used storage values equal to zero.
+    - _comment: used default IPCC 2014 value of 0.0
       datetime: '2020-01-01'
       source: Electricity Maps, 2020 zone average
-      value: 440.73
+      value: 0.0
+    - _comment: used default IPCC 2014 value of 0.0
+      datetime: '2021-01-01'
+      source: Electricity Maps, 2021 zone average
+      value: 0.0
+    - _comment: used default IPCC 2014 value of 0.0
+      datetime: '2023-01-01'
+      source: Electricity Maps, 2023 zone average
+      value: 0.0
+    - _comment: used default IPCC 2014 value of 0.0
+      datetime: '2025-01-01'
+      source: Electricity Maps, 2025 zone average
+      value: 0.0
   lifecycle:
     hydro discharge:
-    - _comment: used storage values equal to zero.
+    - _comment: used default IPCC 2014 value of 24.0
       datetime: '2020-01-01'
-      source: Electricity Maps, 2020 zone average
-      value: 530.94
+      source: Electricity Maps, 2020 zone average; IPCC 2014
+      value: 24.0
+    - _comment: used default IPCC 2014 value of 24.0
+      datetime: '2021-01-01'
+      source: Electricity Maps, 2021 zone average; IPCC 2014
+      value: 24.0
+    - _comment: used default IPCC 2014 value of 24.0
+      datetime: '2023-01-01'
+      source: Electricity Maps, 2023 zone average; IPCC 2014
+      value: 24.0
+    - _comment: used default IPCC 2014 value of 24.0
+      datetime: '2025-01-01'
+      source: Electricity Maps, 2025 zone average; IPCC 2014
+      value: 24.0
 fallbackZoneMixes:
   powerOriginRatios:
   - _source: Electricity Maps, 2017 average

--- a/config/zones/KR.yaml
+++ b/config/zones/KR.yaml
@@ -197,15 +197,15 @@ emissionFactors:
     - _comment: used storage values greater than zero.
       datetime: '2021-01-01'
       source: Electricity Maps, 2021 zone average
-      value: 395.22
+      value: 395.23
     - _comment: used storage values greater than zero.
       datetime: '2022-01-01'
       source: Electricity Maps, 2022 zone average
-      value: 388.11
+      value: 388.14
     - _comment: used storage values greater than zero.
       datetime: '2023-01-01'
       source: Electricity Maps, 2023 zone average
-      value: 373.6
+      value: 373.62
     - _comment: used storage values greater than zero.
       datetime: '2024-01-01'
       source: Electricity Maps, 2024 zone average
@@ -213,29 +213,29 @@ emissionFactors:
     - _comment: used storage values greater than zero.
       datetime: '2025-01-01'
       source: Electricity Maps, 2025 zone average
-      value: 353.4
+      value: 353.41
   lifecycle:
     hydro discharge:
     - _comment: used storage values greater than zero.
       datetime: '2021-01-01'
-      source: Electricity Maps, 2021 zone average
-      value: 456.44
+      source: Electricity Maps, 2021 zone average; IPCC 2014
+      value: 419.23
     - _comment: used storage values greater than zero.
       datetime: '2022-01-01'
-      source: Electricity Maps, 2022 zone average
-      value: 449.4
+      source: Electricity Maps, 2022 zone average; IPCC 2014
+      value: 412.14
     - _comment: used storage values greater than zero.
       datetime: '2023-01-01'
-      source: Electricity Maps, 2023 zone average
-      value: 434.01
+      source: Electricity Maps, 2023 zone average; IPCC 2014
+      value: 397.62
     - _comment: used storage values greater than zero.
       datetime: '2024-01-01'
-      source: Electricity Maps, 2024 zone average
-      value: 412.07
+      source: Electricity Maps, 2024 zone average; IPCC 2014
+      value: 375.52
     - _comment: used storage values greater than zero.
       datetime: '2025-01-01'
-      source: Electricity Maps, 2025 zone average
-      value: 413.44
+      source: Electricity Maps, 2025 zone average; IPCC 2014
+      value: 377.41
     unknown:
       _comment: 'Source: 2020 annual electricity production by IEA'
       _url: https://www.iea.org/fuels-and-technologies/electricity

--- a/config/zones/KR.yaml
+++ b/config/zones/KR.yaml
@@ -209,7 +209,7 @@ emissionFactors:
     - _comment: used storage values greater than zero.
       datetime: '2024-01-01'
       source: Electricity Maps, 2024 zone average
-      value: 351.5
+      value: 351.52
     - _comment: used storage values greater than zero.
       datetime: '2025-01-01'
       source: Electricity Maps, 2025 zone average
@@ -231,7 +231,7 @@ emissionFactors:
     - _comment: used storage values greater than zero.
       datetime: '2024-01-01'
       source: Electricity Maps, 2024 zone average
-      value: 412.05
+      value: 412.07
     - _comment: used storage values greater than zero.
       datetime: '2025-01-01'
       source: Electricity Maps, 2025 zone average

--- a/config/zones/LT.yaml
+++ b/config/zones/LT.yaml
@@ -180,7 +180,7 @@ emissionFactors:
     - _comment: used storage values greater than zero.
       datetime: '2025-01-01'
       source: Electricity Maps, 2025 zone average
-      value: 105.31
+      value: 116.19
     biomass:
       datetime: '2021-01-01'
       source: BEIS 2021
@@ -212,22 +212,22 @@ emissionFactors:
       source: EU-ETS, ENTSO-E 2024
       value: 370.92
     hydro discharge:
-    - _comment: used storage values equal to zero.
+    - _comment: used default IPCC 2014 value of 0.0
       datetime: '2020-01-01'
       source: Electricity Maps, 2020 zone average
-      value: 199.17
+      value: 0.0
     - _comment: used storage values greater than zero.
       datetime: '2021-01-01'
       source: Electricity Maps, 2021 zone average
-      value: 186.94
+      value: 186.95
     - _comment: used storage values greater than zero.
       datetime: '2022-01-01'
       source: Electricity Maps, 2022 zone average
-      value: 185.13
+      value: 185.15
     - _comment: used storage values greater than zero.
       datetime: '2023-01-01'
       source: Electricity Maps, 2023 zone average
-      value: 133.53
+      value: 133.56
     - _comment: used storage values greater than zero.
       datetime: '2024-01-01'
       source: Electricity Maps, 2024 zone average
@@ -235,7 +235,7 @@ emissionFactors:
     - _comment: used storage values greater than zero.
       datetime: '2025-01-01'
       source: Electricity Maps, 2025 zone average
-      value: 85.97
+      value: 86.07
     oil:
     - datetime: '2021-01-01'
       source: EU-ETS, ENTSO-E 2021
@@ -247,8 +247,8 @@ emissionFactors:
     battery discharge:
     - _comment: used storage values greater than zero.
       datetime: '2025-01-01'
-      source: Electricity Maps, 2025 zone average
-      value: 164.66
+      source: Electricity Maps, 2025 zone average; National Laboratory of the Rockies
+      value: 149.19
     biomass:
       datetime: '2014-01-01'
       source: BEIS 2021; IPCC 2014
@@ -284,30 +284,30 @@ emissionFactors:
       source: UNECE 2022
       value: 10.7
     hydro discharge:
-    - _comment: used storage values equal to zero.
+    - _comment: used default IPCC 2014 value of 24.0
       datetime: '2020-01-01'
-      source: Electricity Maps, 2020 zone average
-      value: 268.03
+      source: Electricity Maps, 2020 zone average; IPCC 2014
+      value: 24.0
     - _comment: used storage values greater than zero.
       datetime: '2021-01-01'
-      source: Electricity Maps, 2021 zone average
-      value: 254.2
+      source: Electricity Maps, 2021 zone average; IPCC 2014
+      value: 210.95
     - _comment: used storage values greater than zero.
       datetime: '2022-01-01'
-      source: Electricity Maps, 2022 zone average
-      value: 241.71
+      source: Electricity Maps, 2022 zone average; IPCC 2014
+      value: 209.15
     - _comment: used storage values greater than zero.
       datetime: '2023-01-01'
-      source: Electricity Maps, 2023 zone average
-      value: 180.76
+      source: Electricity Maps, 2023 zone average; IPCC 2014
+      value: 157.56
     - _comment: used storage values greater than zero.
       datetime: '2024-01-01'
-      source: Electricity Maps, 2024 zone average
-      value: 158.48
+      source: Electricity Maps, 2024 zone average; IPCC 2014
+      value: 136.85
     - _comment: used storage values greater than zero.
       datetime: '2025-01-01'
-      source: Electricity Maps, 2025 zone average
-      value: 135.35
+      source: Electricity Maps, 2025 zone average; IPCC 2014
+      value: 110.07
     nuclear:
       datetime: '2020-01-01'
       source: UNECE 2022

--- a/config/zones/LT.yaml
+++ b/config/zones/LT.yaml
@@ -231,7 +231,7 @@ emissionFactors:
     - _comment: used storage values greater than zero.
       datetime: '2024-01-01'
       source: Electricity Maps, 2024 zone average
-      value: 112.82
+      value: 112.85
     - _comment: used storage values greater than zero.
       datetime: '2025-01-01'
       source: Electricity Maps, 2025 zone average
@@ -303,7 +303,7 @@ emissionFactors:
     - _comment: used storage values greater than zero.
       datetime: '2024-01-01'
       source: Electricity Maps, 2024 zone average
-      value: 158.44
+      value: 158.48
     - _comment: used storage values greater than zero.
       datetime: '2025-01-01'
       source: Electricity Maps, 2025 zone average

--- a/config/zones/LV.yaml
+++ b/config/zones/LV.yaml
@@ -130,10 +130,10 @@ delays:
 emissionFactors:
   direct:
     battery discharge:
-    - _comment: used storage values equal to zero.
+    - _comment: used non-null storage values
       datetime: '2025-01-01'
       source: Electricity Maps, 2025 zone average
-      value: 102.01
+      value: 87.74
     biomass:
       datetime: '2021-01-01'
       source: BEIS 2021
@@ -179,10 +179,10 @@ emissionFactors:
       value: 889.87
   lifecycle:
     battery discharge:
-    - _comment: used storage values equal to zero.
+    - _comment: used non-null storage values
       datetime: '2025-01-01'
-      source: Electricity Maps, 2025 zone average
-      value: 155.5
+      source: Electricity Maps, 2025 zone average; National Laboratory of the Rockies
+      value: 120.74
     biomass:
       datetime: '2014-01-01'
       source: BEIS 2021; IPCC 2014

--- a/config/zones/NO-NO2.yaml
+++ b/config/zones/NO-NO2.yaml
@@ -94,26 +94,30 @@ emissionFactors:
       source: EU-ETS 2021
       value: 0.0
     hydro discharge:
-    - _comment: used storage values equal to zero.
+    - _comment: used default IPCC 2014 value of 0.0
+      datetime: '2020-01-01'
+      source: Electricity Maps, 2020 zone average
+      value: 0.0
+    - _comment: used default IPCC 2014 value of 0.0
       datetime: '2021-01-01'
       source: Electricity Maps, 2021 zone average
-      value: 15.52
-    - _comment: used storage values equal to zero.
+      value: 0.0
+    - _comment: used default IPCC 2014 value of 0.0
       datetime: '2022-01-01'
       source: Electricity Maps, 2022 zone average
-      value: 26.36
+      value: 0.0
     - _comment: used storage values greater than zero.
       datetime: '2023-01-01'
       source: Electricity Maps, 2023 zone average
       value: 51.77
-    - _comment: used storage values equal to zero.
+    - _comment: used default IPCC 2014 value of 0.0
       datetime: '2024-01-01'
       source: Electricity Maps, 2024 zone average
-      value: 10.23
+      value: 0.0
     - _comment: used storage values greater than zero.
       datetime: '2025-01-01'
       source: Electricity Maps, 2025 zone average
-      value: 5.58
+      value: 5.59
   lifecycle:
     biomass:
       datetime: '2014-01-01'
@@ -124,26 +128,30 @@ emissionFactors:
       source: IPCC 2014
       value: 490.0
     hydro discharge:
-    - _comment: used storage values equal to zero.
+    - _comment: used default IPCC 2014 value of 24.0
+      datetime: '2020-01-01'
+      source: Electricity Maps, 2020 zone average; IPCC 2014
+      value: 24.0
+    - _comment: used default IPCC 2014 value of 24.0
       datetime: '2021-01-01'
-      source: Electricity Maps, 2021 zone average
-      value: 40.82
-    - _comment: used storage values equal to zero.
+      source: Electricity Maps, 2021 zone average; IPCC 2014
+      value: 24.0
+    - _comment: used default IPCC 2014 value of 24.0
       datetime: '2022-01-01'
-      source: Electricity Maps, 2022 zone average
-      value: 53.9
+      source: Electricity Maps, 2022 zone average; IPCC 2014
+      value: 24.0
     - _comment: used storage values greater than zero.
       datetime: '2023-01-01'
-      source: Electricity Maps, 2023 zone average
-      value: 84.4
-    - _comment: used storage values equal to zero.
+      source: Electricity Maps, 2023 zone average; IPCC 2014
+      value: 75.77
+    - _comment: used default IPCC 2014 value of 24.0
       datetime: '2024-01-01'
-      source: Electricity Maps, 2024 zone average
-      value: 36.02
+      source: Electricity Maps, 2024 zone average; IPCC 2014
+      value: 24.0
     - _comment: used storage values greater than zero.
       datetime: '2025-01-01'
-      source: Electricity Maps, 2025 zone average
-      value: 29.36
+      source: Electricity Maps, 2025 zone average; IPCC 2014
+      value: 29.59
     oil:
       datetime: '2014-01-01'
       source: EIA 2020/BEIS 2021; IPCC 2014

--- a/config/zones/NO-NO2.yaml
+++ b/config/zones/NO-NO2.yaml
@@ -139,7 +139,7 @@ emissionFactors:
     - _comment: used storage values equal to zero.
       datetime: '2024-01-01'
       source: Electricity Maps, 2024 zone average
-      value: 36.0
+      value: 36.02
     - _comment: used storage values greater than zero.
       datetime: '2025-01-01'
       source: Electricity Maps, 2025 zone average

--- a/config/zones/NO-NO3.yaml
+++ b/config/zones/NO-NO3.yaml
@@ -100,26 +100,26 @@ emissionFactors:
       source: EU-ETS 2021
       value: 0.0
     hydro discharge:
-    - _comment: used storage values equal to zero.
+    - _comment: used default IPCC 2014 value of 0.0
       datetime: '2020-01-01'
       source: Electricity Maps, 2020 zone average
-      value: 6.47
-    - _comment: used storage values equal to zero.
+      value: 0.0
+    - _comment: used default IPCC 2014 value of 0.0
       datetime: '2021-01-01'
       source: Electricity Maps, 2021 zone average
-      value: 4.0
-    - _comment: used storage values equal to zero.
+      value: 0.0
+    - _comment: used default IPCC 2014 value of 0.0
       datetime: '2022-01-01'
       source: Electricity Maps, 2022 zone average
-      value: 5.04
-    - _comment: used storage values equal to zero.
+      value: 0.0
+    - _comment: used default IPCC 2014 value of 0.0
       datetime: '2023-01-01'
       source: Electricity Maps, 2023 zone average
-      value: 5.99
-    - _comment: used storage values equal to zero.
+      value: 0.0
+    - _comment: used default IPCC 2014 value of 0.0
       datetime: '2024-01-01'
       source: Electricity Maps, 2024 zone average
-      value: 7.53
+      value: 0.0
     - _comment: used storage values greater than zero.
       datetime: '2025-01-01'
       source: Electricity Maps, 2025 zone average
@@ -134,30 +134,30 @@ emissionFactors:
       source: IPCC 2014
       value: 490.0
     hydro discharge:
-    - _comment: used storage values equal to zero.
+    - _comment: used default IPCC 2014 value of 24.0
       datetime: '2020-01-01'
-      source: Electricity Maps, 2020 zone average
-      value: 29.13
-    - _comment: used storage values equal to zero.
+      source: Electricity Maps, 2020 zone average; IPCC 2014
+      value: 24.0
+    - _comment: used default IPCC 2014 value of 24.0
       datetime: '2021-01-01'
-      source: Electricity Maps, 2021 zone average
-      value: 25.87
-    - _comment: used storage values equal to zero.
+      source: Electricity Maps, 2021 zone average; IPCC 2014
+      value: 24.0
+    - _comment: used default IPCC 2014 value of 24.0
       datetime: '2022-01-01'
-      source: Electricity Maps, 2022 zone average
-      value: 27.13
-    - _comment: used storage values equal to zero.
+      source: Electricity Maps, 2022 zone average; IPCC 2014
+      value: 24.0
+    - _comment: used default IPCC 2014 value of 24.0
       datetime: '2023-01-01'
-      source: Electricity Maps, 2023 zone average
-      value: 28.11
-    - _comment: used storage values equal to zero.
+      source: Electricity Maps, 2023 zone average; IPCC 2014
+      value: 24.0
+    - _comment: used default IPCC 2014 value of 24.0
       datetime: '2024-01-01'
-      source: Electricity Maps, 2024 zone average
-      value: 29.85
+      source: Electricity Maps, 2024 zone average; IPCC 2014
+      value: 24.0
     - _comment: used storage values greater than zero.
       datetime: '2025-01-01'
-      source: Electricity Maps, 2025 zone average
-      value: 28.99
+      source: Electricity Maps, 2025 zone average; IPCC 2014
+      value: 31.54
     oil:
       datetime: '2014-01-01'
       source: EIA 2020/BEIS 2021; IPCC 2014

--- a/config/zones/NO-NO5.yaml
+++ b/config/zones/NO-NO5.yaml
@@ -79,26 +79,26 @@ emissionFactors:
       source: EU-ETS 2021
       value: 0.0
     hydro discharge:
-    - _comment: used storage values equal to zero.
+    - _comment: used default IPCC 2014 value of 0.0
       datetime: '2020-01-01'
       source: Electricity Maps, 2020 zone average
-      value: 10.07
-    - _comment: used storage values equal to zero.
+      value: 0.0
+    - _comment: used default IPCC 2014 value of 0.0
       datetime: '2021-01-01'
       source: Electricity Maps, 2021 zone average
-      value: 12.82
-    - _comment: used storage values equal to zero.
+      value: 0.0
+    - _comment: used default IPCC 2014 value of 0.0
       datetime: '2022-01-01'
       source: Electricity Maps, 2022 zone average
-      value: 1.94
-    - _comment: used storage values equal to zero.
+      value: 0.0
+    - _comment: used default IPCC 2014 value of 0.0
       datetime: '2023-01-01'
       source: Electricity Maps, 2023 zone average
-      value: 0.64
-    - _comment: used storage values equal to zero.
+      value: 0.0
+    - _comment: used default IPCC 2014 value of 0.0
       datetime: '2024-01-01'
       source: Electricity Maps, 2024 zone average
-      value: 0.82
+      value: 0.0
     - _comment: used storage values greater than zero.
       datetime: '2025-01-01'
       source: Electricity Maps, 2025 zone average
@@ -113,30 +113,30 @@ emissionFactors:
       source: IPCC 2014
       value: 490.0
     hydro discharge:
-    - _comment: used storage values equal to zero.
+    - _comment: used default IPCC 2014 value of 24.0
       datetime: '2020-01-01'
-      source: Electricity Maps, 2020 zone average
-      value: 37.42
-    - _comment: used storage values equal to zero.
+      source: Electricity Maps, 2020 zone average; IPCC 2014
+      value: 24.0
+    - _comment: used default IPCC 2014 value of 24.0
       datetime: '2021-01-01'
-      source: Electricity Maps, 2021 zone average
-      value: 41.44
-    - _comment: used storage values equal to zero.
+      source: Electricity Maps, 2021 zone average; IPCC 2014
+      value: 24.0
+    - _comment: used default IPCC 2014 value of 24.0
       datetime: '2022-01-01'
-      source: Electricity Maps, 2022 zone average
-      value: 27.09
-    - _comment: used storage values equal to zero.
+      source: Electricity Maps, 2022 zone average; IPCC 2014
+      value: 24.0
+    - _comment: used default IPCC 2014 value of 24.0
       datetime: '2023-01-01'
-      source: Electricity Maps, 2023 zone average
-      value: 25.87
-    - _comment: used storage values equal to zero.
+      source: Electricity Maps, 2023 zone average; IPCC 2014
+      value: 24.0
+    - _comment: used default IPCC 2014 value of 24.0
       datetime: '2024-01-01'
-      source: Electricity Maps, 2024 zone average
-      value: 25.97
+      source: Electricity Maps, 2024 zone average; IPCC 2014
+      value: 24.0
     - _comment: used storage values greater than zero.
       datetime: '2025-01-01'
-      source: Electricity Maps, 2025 zone average
-      value: 26.01
+      source: Electricity Maps, 2025 zone average; IPCC 2014
+      value: 25.21
     oil:
       datetime: '2014-01-01'
       source: EIA 2020/BEIS 2021; IPCC 2014

--- a/config/zones/NO.yaml
+++ b/config/zones/NO.yaml
@@ -27,26 +27,30 @@ emissionFactors:
       source: EU-ETS 2021
       value: 0
     hydro discharge:
-    - _comment: used storage values equal to zero.
+    - _comment: used default IPCC 2014 value of 0.0
+      datetime: '2020-01-01'
+      source: Electricity Maps, 2020 zone average
+      value: 0.0
+    - _comment: used default IPCC 2014 value of 0.0
       datetime: '2021-01-01'
       source: Electricity Maps, 2021 zone average
-      value: 11.2
-    - _comment: used storage values equal to zero.
+      value: 0.0
+    - _comment: used default IPCC 2014 value of 0.0
       datetime: '2022-01-01'
       source: Electricity Maps, 2022 zone average
-      value: 12.03
-    - _comment: used storage values equal to zero.
+      value: 0.0
+    - _comment: used default IPCC 2014 value of 0.0
       datetime: '2023-01-01'
       source: Electricity Maps, 2023 zone average
-      value: 7.74
-    - _comment: used storage values equal to zero.
+      value: 0.0
+    - _comment: used default IPCC 2014 value of 0.0
       datetime: '2024-01-01'
       source: Electricity Maps, 2024 zone average
-      value: 10.95
+      value: 0.0
     - _comment: used storage values greater than zero.
       datetime: '2025-01-01'
       source: Electricity Maps, 2025 zone average
-      value: 9.42
+      value: 9.43
   lifecycle:
     biomass:
       datetime: '2014-01-01'
@@ -57,26 +61,30 @@ emissionFactors:
       source: IPCC 2014
       value: 490
     hydro discharge:
-    - _comment: used storage values equal to zero.
+    - _comment: used default IPCC 2014 value of 24.0
+      datetime: '2020-01-01'
+      source: Electricity Maps, 2020 zone average; IPCC 2014
+      value: 24.0
+    - _comment: used default IPCC 2014 value of 24.0
       datetime: '2021-01-01'
-      source: Electricity Maps, 2021 zone average
-      value: 35.78
-    - _comment: used storage values equal to zero.
+      source: Electricity Maps, 2021 zone average; IPCC 2014
+      value: 24.0
+    - _comment: used default IPCC 2014 value of 24.0
       datetime: '2022-01-01'
-      source: Electricity Maps, 2022 zone average
-      value: 36.24
-    - _comment: used storage values equal to zero.
+      source: Electricity Maps, 2022 zone average; IPCC 2014
+      value: 24.0
+    - _comment: used default IPCC 2014 value of 24.0
       datetime: '2023-01-01'
-      source: Electricity Maps, 2023 zone average
-      value: 32.63
-    - _comment: used storage values equal to zero.
+      source: Electricity Maps, 2023 zone average; IPCC 2014
+      value: 24.0
+    - _comment: used default IPCC 2014 value of 24.0
       datetime: '2024-01-01'
-      source: Electricity Maps, 2024 zone average
-      value: 36.77
+      source: Electricity Maps, 2024 zone average; IPCC 2014
+      value: 24.0
     - _comment: used storage values greater than zero.
       datetime: '2025-01-01'
-      source: Electricity Maps, 2025 zone average
-      value: 33.27
+      source: Electricity Maps, 2025 zone average; IPCC 2014
+      value: 33.43
     oil:
       datetime: '2014-01-01'
       source: EIA 2020/BEIS 2021; IPCC 2014

--- a/config/zones/NZ.yaml
+++ b/config/zones/NZ.yaml
@@ -130,28 +130,28 @@ emissionFactors:
     battery discharge:
     - _comment: used storage values greater than zero.
       datetime: '2020-01-01'
-      source: Electricity Maps, 2020 zone average
-      value: 156.51
+      source: Electricity Maps, 2020 zone average; National Laboratory of the Rockies
+      value: 146.84
     - _comment: used storage values greater than zero.
       datetime: '2021-01-01'
-      source: Electricity Maps, 2021 zone average
-      value: 119.92
+      source: Electricity Maps, 2021 zone average; National Laboratory of the Rockies
+      value: 114.61
     - _comment: used storage values greater than zero.
       datetime: '2022-01-01'
-      source: Electricity Maps, 2022 zone average
-      value: 125.34
+      source: Electricity Maps, 2022 zone average; National Laboratory of the Rockies
+      value: 118.21
     - _comment: used storage values greater than zero.
       datetime: '2023-01-01'
-      source: Electricity Maps, 2023 zone average
-      value: 117.58
+      source: Electricity Maps, 2023 zone average; National Laboratory of the Rockies
+      value: 116.63
     - _comment: used storage values greater than zero.
       datetime: '2024-01-01'
-      source: Electricity Maps, 2024 zone average
-      value: 120.96
+      source: Electricity Maps, 2024 zone average; National Laboratory of the Rockies
+      value: 115.49
     - _comment: used storage values greater than zero.
       datetime: '2025-01-01'
-      source: Electricity Maps, 2025 zone average
-      value: 87.93
+      source: Electricity Maps, 2025 zone average; National Laboratory of the Rockies
+      value: 85.93
 fallbackZoneMixes:
   powerOriginRatios:
   - _source: Electricity Maps, 2015 average

--- a/config/zones/PH-LU.yaml
+++ b/config/zones/PH-LU.yaml
@@ -48,7 +48,7 @@ emissionFactors:
     - _comment: used storage values greater than zero.
       datetime: '2024-01-01'
       source: Electricity Maps, 2024 zone average
-      value: 548.1
+      value: 556.53
     - _comment: used storage values greater than zero.
       datetime: '2025-01-01'
       source: Electricity Maps, 2025 zone average
@@ -73,7 +73,7 @@ emissionFactors:
     - _comment: used storage values greater than zero.
       datetime: '2024-01-01'
       source: Electricity Maps, 2024 zone average
-      value: 579.61
+      value: 579.66
     - _comment: used storage values greater than zero.
       datetime: '2025-01-01'
       source: Electricity Maps, 2025 zone average
@@ -99,7 +99,7 @@ emissionFactors:
     - _comment: used storage values greater than zero.
       datetime: '2024-01-01'
       source: Electricity Maps, 2024 zone average
-      value: 620.93
+      value: 630.48
     - _comment: used storage values greater than zero.
       datetime: '2025-01-01'
       source: Electricity Maps, 2025 zone average
@@ -124,7 +124,7 @@ emissionFactors:
     - _comment: used storage values greater than zero.
       datetime: '2024-01-01'
       source: Electricity Maps, 2024 zone average
-      value: 653.54
+      value: 653.59
     - _comment: used storage values greater than zero.
       datetime: '2025-01-01'
       source: Electricity Maps, 2025 zone average

--- a/config/zones/PH-LU.yaml
+++ b/config/zones/PH-LU.yaml
@@ -32,19 +32,19 @@ emissionFactors:
     - _comment: used storage values greater than zero.
       datetime: '2020-01-01'
       source: Electricity Maps, 2020 zone average
-      value: 556.98
+      value: 562.65
     - _comment: used storage values greater than zero.
       datetime: '2021-01-01'
       source: Electricity Maps, 2021 zone average
-      value: 562.21
+      value: 567.84
     - _comment: used storage values greater than zero.
       datetime: '2022-01-01'
       source: Electricity Maps, 2022 zone average
-      value: 562.21
+      value: 567.84
     - _comment: used storage values greater than zero.
       datetime: '2023-01-01'
       source: Electricity Maps, 2023 zone average
-      value: 560.81
+      value: 567.85
     - _comment: used storage values greater than zero.
       datetime: '2024-01-01'
       source: Electricity Maps, 2024 zone average
@@ -52,7 +52,7 @@ emissionFactors:
     - _comment: used storage values greater than zero.
       datetime: '2025-01-01'
       source: Electricity Maps, 2025 zone average
-      value: 542.01
+      value: 549.56
     hydro discharge:
     - _comment: used storage values greater than zero.
       datetime: '2020-01-01'
@@ -69,7 +69,7 @@ emissionFactors:
     - _comment: used storage values greater than zero.
       datetime: '2023-01-01'
       source: Electricity Maps, 2023 zone average
-      value: 572.74
+      value: 572.75
     - _comment: used storage values greater than zero.
       datetime: '2024-01-01'
       source: Electricity Maps, 2024 zone average
@@ -77,58 +77,58 @@ emissionFactors:
     - _comment: used storage values greater than zero.
       datetime: '2025-01-01'
       source: Electricity Maps, 2025 zone average
-      value: 566.98
+      value: 567.03
   lifecycle:
     battery discharge:
     - _comment: used storage values greater than zero.
       datetime: '2020-01-01'
-      source: Electricity Maps, 2020 zone average
-      value: 631.27
+      source: Electricity Maps, 2020 zone average; National Laboratory of the Rockies
+      value: 595.65
     - _comment: used storage values greater than zero.
       datetime: '2021-01-01'
-      source: Electricity Maps, 2021 zone average
-      value: 635.82
+      source: Electricity Maps, 2021 zone average; National Laboratory of the Rockies
+      value: 600.84
     - _comment: used storage values greater than zero.
       datetime: '2022-01-01'
-      source: Electricity Maps, 2022 zone average
-      value: 635.82
+      source: Electricity Maps, 2022 zone average; National Laboratory of the Rockies
+      value: 600.84
     - _comment: used storage values greater than zero.
       datetime: '2023-01-01'
-      source: Electricity Maps, 2023 zone average
-      value: 632.64
+      source: Electricity Maps, 2023 zone average; National Laboratory of the Rockies
+      value: 600.85
     - _comment: used storage values greater than zero.
       datetime: '2024-01-01'
-      source: Electricity Maps, 2024 zone average
-      value: 630.48
+      source: Electricity Maps, 2024 zone average; National Laboratory of the Rockies
+      value: 589.53
     - _comment: used storage values greater than zero.
       datetime: '2025-01-01'
-      source: Electricity Maps, 2025 zone average
-      value: 618.48
+      source: Electricity Maps, 2025 zone average; National Laboratory of the Rockies
+      value: 582.56
     hydro discharge:
     - _comment: used storage values greater than zero.
       datetime: '2020-01-01'
-      source: Electricity Maps, 2020 zone average
-      value: 654.12
+      source: Electricity Maps, 2020 zone average; IPCC 2014
+      value: 602.8
     - _comment: used storage values greater than zero.
       datetime: '2021-01-01'
-      source: Electricity Maps, 2021 zone average
-      value: 658.55
+      source: Electricity Maps, 2021 zone average; IPCC 2014
+      value: 607.75
     - _comment: used storage values greater than zero.
       datetime: '2022-01-01'
-      source: Electricity Maps, 2022 zone average
-      value: 658.56
+      source: Electricity Maps, 2022 zone average; IPCC 2014
+      value: 607.76
     - _comment: used storage values greater than zero.
       datetime: '2023-01-01'
-      source: Electricity Maps, 2023 zone average
-      value: 646.01
+      source: Electricity Maps, 2023 zone average; IPCC 2014
+      value: 596.75
     - _comment: used storage values greater than zero.
       datetime: '2024-01-01'
-      source: Electricity Maps, 2024 zone average
-      value: 653.59
+      source: Electricity Maps, 2024 zone average; IPCC 2014
+      value: 603.66
     - _comment: used storage values greater than zero.
       datetime: '2025-01-01'
-      source: Electricity Maps, 2025 zone average
-      value: 644.03
+      source: Electricity Maps, 2025 zone average; IPCC 2014
+      value: 591.03
 fallbackZoneMixes:
   powerOriginRatios:
   - _source: Electricity Maps, 2017 average

--- a/config/zones/PH-MI.yaml
+++ b/config/zones/PH-MI.yaml
@@ -46,7 +46,7 @@ emissionFactors:
     - _comment: used storage values greater than zero.
       datetime: '2024-01-01'
       source: Electricity Maps, 2024 zone average
-      value: 489.77
+      value: 489.78
     - _comment: used storage values greater than zero.
       datetime: '2025-01-01'
       source: Electricity Maps, 2025 zone average
@@ -72,7 +72,7 @@ emissionFactors:
     - _comment: used storage values greater than zero.
       datetime: '2024-01-01'
       source: Electricity Maps, 2024 zone average
-      value: 549.42
+      value: 549.43
     - _comment: used storage values greater than zero.
       datetime: '2025-01-01'
       source: Electricity Maps, 2025 zone average

--- a/config/zones/PH-MI.yaml
+++ b/config/zones/PH-MI.yaml
@@ -50,33 +50,33 @@ emissionFactors:
     - _comment: used storage values greater than zero.
       datetime: '2025-01-01'
       source: Electricity Maps, 2025 zone average
-      value: 463.6
+      value: 463.63
   lifecycle:
     battery discharge:
     - _comment: used storage values greater than zero.
       datetime: '2020-01-01'
-      source: Electricity Maps, 2020 zone average
-      value: 534.14
+      source: Electricity Maps, 2020 zone average; National Laboratory of the Rockies
+      value: 508.45
     - _comment: used storage values greater than zero.
       datetime: '2021-01-01'
-      source: Electricity Maps, 2021 zone average
-      value: 543.04
+      source: Electricity Maps, 2021 zone average; National Laboratory of the Rockies
+      value: 516.32
     - _comment: used storage values greater than zero.
       datetime: '2022-01-01'
-      source: Electricity Maps, 2022 zone average
-      value: 543.04
+      source: Electricity Maps, 2022 zone average; National Laboratory of the Rockies
+      value: 516.32
     - _comment: used storage values greater than zero.
       datetime: '2023-01-01'
-      source: Electricity Maps, 2023 zone average
-      value: 517.16
+      source: Electricity Maps, 2023 zone average; National Laboratory of the Rockies
+      value: 490.32
     - _comment: used storage values greater than zero.
       datetime: '2024-01-01'
-      source: Electricity Maps, 2024 zone average
-      value: 549.43
+      source: Electricity Maps, 2024 zone average; National Laboratory of the Rockies
+      value: 522.78
     - _comment: used storage values greater than zero.
       datetime: '2025-01-01'
-      source: Electricity Maps, 2025 zone average
-      value: 521.68
+      source: Electricity Maps, 2025 zone average; National Laboratory of the Rockies
+      value: 496.63
 fallbackZoneMixes:
   powerOriginRatios:
   - _source: Electricity Maps, 2017 average

--- a/config/zones/PH-VI.yaml
+++ b/config/zones/PH-VI.yaml
@@ -43,7 +43,7 @@ emissionFactors:
     - _comment: used storage values greater than zero.
       datetime: '2023-01-01'
       source: Electricity Maps, 2023 zone average
-      value: 532.35
+      value: 532.37
     - _comment: used storage values greater than zero.
       datetime: '2024-01-01'
       source: Electricity Maps, 2024 zone average
@@ -51,33 +51,33 @@ emissionFactors:
     - _comment: used storage values greater than zero.
       datetime: '2025-01-01'
       source: Electricity Maps, 2025 zone average
-      value: 511.79
+      value: 512.14
   lifecycle:
     battery discharge:
     - _comment: used storage values greater than zero.
       datetime: '2020-01-01'
-      source: Electricity Maps, 2020 zone average
-      value: 576.19
+      source: Electricity Maps, 2020 zone average; National Laboratory of the Rockies
+      value: 538.25
     - _comment: used storage values greater than zero.
       datetime: '2021-01-01'
-      source: Electricity Maps, 2021 zone average
-      value: 568.82
+      source: Electricity Maps, 2021 zone average; National Laboratory of the Rockies
+      value: 531.23
     - _comment: used storage values greater than zero.
       datetime: '2022-01-01'
-      source: Electricity Maps, 2022 zone average
-      value: 568.82
+      source: Electricity Maps, 2022 zone average; National Laboratory of the Rockies
+      value: 531.23
     - _comment: used storage values greater than zero.
       datetime: '2023-01-01'
-      source: Electricity Maps, 2023 zone average
-      value: 601.74
+      source: Electricity Maps, 2023 zone average; National Laboratory of the Rockies
+      value: 565.37
     - _comment: used storage values greater than zero.
       datetime: '2024-01-01'
-      source: Electricity Maps, 2024 zone average
-      value: 591.57
+      source: Electricity Maps, 2024 zone average; National Laboratory of the Rockies
+      value: 549.89
     - _comment: used storage values greater than zero.
       datetime: '2025-01-01'
-      source: Electricity Maps, 2025 zone average
-      value: 583.54
+      source: Electricity Maps, 2025 zone average; National Laboratory of the Rockies
+      value: 545.14
 fallbackZoneMixes:
   powerOriginRatios:
   - _source: Electricity Maps, 2017 average

--- a/config/zones/PH-VI.yaml
+++ b/config/zones/PH-VI.yaml
@@ -47,7 +47,7 @@ emissionFactors:
     - _comment: used storage values greater than zero.
       datetime: '2024-01-01'
       source: Electricity Maps, 2024 zone average
-      value: 516.32
+      value: 516.89
     - _comment: used storage values greater than zero.
       datetime: '2025-01-01'
       source: Electricity Maps, 2025 zone average
@@ -73,7 +73,7 @@ emissionFactors:
     - _comment: used storage values greater than zero.
       datetime: '2024-01-01'
       source: Electricity Maps, 2024 zone average
-      value: 590.91
+      value: 591.57
     - _comment: used storage values greater than zero.
       datetime: '2025-01-01'
       source: Electricity Maps, 2025 zone average

--- a/config/zones/PH.yaml
+++ b/config/zones/PH.yaml
@@ -42,7 +42,7 @@ emissionFactors:
     - _comment: used storage values greater than zero.
       datetime: '2024-01-01'
       source: Electricity Maps, 2024 zone average
-      value: 537.05
+      value: 542.93
     - _comment: used storage values greater than zero.
       datetime: '2025-01-01'
       source: Electricity Maps, 2025 zone average
@@ -67,7 +67,7 @@ emissionFactors:
     - _comment: used storage values greater than zero.
       datetime: '2024-01-01'
       source: Electricity Maps, 2024 zone average
-      value: 559.47
+      value: 559.51
     - _comment: used storage values greater than zero.
       datetime: '2025-01-01'
       source: Electricity Maps, 2025 zone average
@@ -93,7 +93,7 @@ emissionFactors:
     - _comment: used storage values greater than zero.
       datetime: '2024-01-01'
       source: Electricity Maps, 2024 zone average
-      value: 607.67
+      value: 614.33
     - _comment: used storage values greater than zero.
       datetime: '2025-01-01'
       source: Electricity Maps, 2025 zone average
@@ -118,7 +118,7 @@ emissionFactors:
     - _comment: used storage values greater than zero.
       datetime: '2024-01-01'
       source: Electricity Maps, 2024 zone average
-      value: 630.74
+      value: 630.79
     - _comment: used storage values greater than zero.
       datetime: '2025-01-01'
       source: Electricity Maps, 2025 zone average

--- a/config/zones/PH.yaml
+++ b/config/zones/PH.yaml
@@ -26,19 +26,19 @@ emissionFactors:
     - _comment: used storage values greater than zero.
       datetime: '2020-01-01'
       source: Electricity Maps, 2020 zone average
-      value: 541.34
+      value: 544.55
     - _comment: used storage values greater than zero.
       datetime: '2021-01-01'
       source: Electricity Maps, 2021 zone average
-      value: 544.67
+      value: 548.21
     - _comment: used storage values greater than zero.
       datetime: '2022-01-01'
       source: Electricity Maps, 2022 zone average
-      value: 544.67
+      value: 548.21
     - _comment: used storage values greater than zero.
       datetime: '2023-01-01'
       source: Electricity Maps, 2023 zone average
-      value: 543.05
+      value: 547.8
     - _comment: used storage values greater than zero.
       datetime: '2024-01-01'
       source: Electricity Maps, 2024 zone average
@@ -46,16 +46,16 @@ emissionFactors:
     - _comment: used storage values greater than zero.
       datetime: '2025-01-01'
       source: Electricity Maps, 2025 zone average
-      value: 528.69
+      value: 533.9
     hydro discharge:
     - _comment: used storage values greater than zero.
       datetime: '2020-01-01'
       source: Electricity Maps, 2020 zone average
-      value: 556.06
+      value: 556.07
     - _comment: used storage values greater than zero.
       datetime: '2021-01-01'
       source: Electricity Maps, 2021 zone average
-      value: 559.71
+      value: 559.72
     - _comment: used storage values greater than zero.
       datetime: '2022-01-01'
       source: Electricity Maps, 2022 zone average
@@ -63,7 +63,7 @@ emissionFactors:
     - _comment: used storage values greater than zero.
       datetime: '2023-01-01'
       source: Electricity Maps, 2023 zone average
-      value: 550.04
+      value: 550.05
     - _comment: used storage values greater than zero.
       datetime: '2024-01-01'
       source: Electricity Maps, 2024 zone average
@@ -71,58 +71,58 @@ emissionFactors:
     - _comment: used storage values greater than zero.
       datetime: '2025-01-01'
       source: Electricity Maps, 2025 zone average
-      value: 545.39
+      value: 545.43
   lifecycle:
     battery discharge:
     - _comment: used storage values greater than zero.
       datetime: '2020-01-01'
-      source: Electricity Maps, 2020 zone average
-      value: 613.02
+      source: Electricity Maps, 2020 zone average; National Laboratory of the Rockies
+      value: 577.55
     - _comment: used storage values greater than zero.
       datetime: '2021-01-01'
-      source: Electricity Maps, 2021 zone average
-      value: 615.87
+      source: Electricity Maps, 2021 zone average; National Laboratory of the Rockies
+      value: 581.21
     - _comment: used storage values greater than zero.
       datetime: '2022-01-01'
-      source: Electricity Maps, 2022 zone average
-      value: 615.87
+      source: Electricity Maps, 2022 zone average; National Laboratory of the Rockies
+      value: 581.21
     - _comment: used storage values greater than zero.
       datetime: '2023-01-01'
-      source: Electricity Maps, 2023 zone average
-      value: 612.91
+      source: Electricity Maps, 2023 zone average; National Laboratory of the Rockies
+      value: 580.8
     - _comment: used storage values greater than zero.
       datetime: '2024-01-01'
-      source: Electricity Maps, 2024 zone average
-      value: 614.33
+      source: Electricity Maps, 2024 zone average; National Laboratory of the Rockies
+      value: 575.93
     - _comment: used storage values greater than zero.
       datetime: '2025-01-01'
-      source: Electricity Maps, 2025 zone average
-      value: 601.6
+      source: Electricity Maps, 2025 zone average; National Laboratory of the Rockies
+      value: 566.9
     hydro discharge:
     - _comment: used storage values greater than zero.
       datetime: '2020-01-01'
-      source: Electricity Maps, 2020 zone average
-      value: 628.15
+      source: Electricity Maps, 2020 zone average; IPCC 2014
+      value: 580.07
     - _comment: used storage values greater than zero.
       datetime: '2021-01-01'
-      source: Electricity Maps, 2021 zone average
-      value: 631.52
+      source: Electricity Maps, 2021 zone average; IPCC 2014
+      value: 583.72
     - _comment: used storage values greater than zero.
       datetime: '2022-01-01'
-      source: Electricity Maps, 2022 zone average
-      value: 631.52
+      source: Electricity Maps, 2022 zone average; IPCC 2014
+      value: 583.72
     - _comment: used storage values greater than zero.
       datetime: '2023-01-01'
-      source: Electricity Maps, 2023 zone average
-      value: 620.72
+      source: Electricity Maps, 2023 zone average; IPCC 2014
+      value: 574.05
     - _comment: used storage values greater than zero.
       datetime: '2024-01-01'
-      source: Electricity Maps, 2024 zone average
-      value: 630.79
+      source: Electricity Maps, 2024 zone average; IPCC 2014
+      value: 583.51
     - _comment: used storage values greater than zero.
       datetime: '2025-01-01'
-      source: Electricity Maps, 2025 zone average
-      value: 618.56
+      source: Electricity Maps, 2025 zone average; IPCC 2014
+      value: 569.43
 fallbackZoneMixes:
   powerOriginRatios:
   - _source: Electricity Maps, 2017 average

--- a/config/zones/PL.yaml
+++ b/config/zones/PL.yaml
@@ -261,22 +261,22 @@ emissionFactors:
       source: EU-ETS, ENTSO-E 2024
       value: 415.69
     hydro discharge:
-    - _comment: used storage values equal to zero.
+    - _comment: used default IPCC 2014 value of 0.0
       datetime: '2020-01-01'
       source: Electricity Maps, 2020 zone average
-      value: 739.76
-    - _comment: used storage values equal to zero.
+      value: 0.0
+    - _comment: used default IPCC 2014 value of 0.0
       datetime: '2021-01-01'
       source: Electricity Maps, 2021 zone average
-      value: 768.54
-    - _comment: used storage values equal to zero.
+      value: 0.0
+    - _comment: used default IPCC 2014 value of 0.0
       datetime: '2022-01-01'
       source: Electricity Maps, 2022 zone average
-      value: 782.09
-    - _comment: used storage values equal to zero.
+      value: 0.0
+    - _comment: used default IPCC 2014 value of 0.0
       datetime: '2023-01-01'
       source: Electricity Maps, 2023 zone average
-      value: 658.6
+      value: 0.0
     - _comment: used storage values greater than zero.
       datetime: '2024-01-01'
       source: Electricity Maps, 2024 zone average
@@ -284,7 +284,7 @@ emissionFactors:
     - _comment: used storage values greater than zero.
       datetime: '2025-01-01'
       source: Electricity Maps, 2025 zone average
-      value: 559.61
+      value: 559.9
     oil:
     - datetime: '2021-01-01'
       source: EU-ETS, ENTSO-E 2021
@@ -336,30 +336,30 @@ emissionFactors:
       source: UNECE 2022
       value: 10.7
     hydro discharge:
-    - _comment: used storage values equal to zero.
+    - _comment: used default IPCC 2014 value of 24.0
       datetime: '2020-01-01'
-      source: Electricity Maps, 2020 zone average
-      value: 823.87
-    - _comment: used storage values equal to zero.
+      source: Electricity Maps, 2020 zone average; IPCC 2014
+      value: 24.0
+    - _comment: used default IPCC 2014 value of 24.0
       datetime: '2021-01-01'
-      source: Electricity Maps, 2021 zone average
-      value: 853.53
-    - _comment: used storage values equal to zero.
+      source: Electricity Maps, 2021 zone average; IPCC 2014
+      value: 24.0
+    - _comment: used default IPCC 2014 value of 24.0
       datetime: '2022-01-01'
-      source: Electricity Maps, 2022 zone average
-      value: 861.79
-    - _comment: used storage values equal to zero.
+      source: Electricity Maps, 2022 zone average; IPCC 2014
+      value: 24.0
+    - _comment: used default IPCC 2014 value of 24.0
       datetime: '2023-01-01'
-      source: Electricity Maps, 2023 zone average
-      value: 717.1
+      source: Electricity Maps, 2023 zone average; IPCC 2014
+      value: 24.0
     - _comment: used storage values greater than zero.
       datetime: '2024-01-01'
-      source: Electricity Maps, 2024 zone average
-      value: 530.99
+      source: Electricity Maps, 2024 zone average; IPCC 2014
+      value: 500.34
     - _comment: used storage values greater than zero.
       datetime: '2025-01-01'
-      source: Electricity Maps, 2025 zone average
-      value: 622.09
+      source: Electricity Maps, 2025 zone average; IPCC 2014
+      value: 583.9
     nuclear:
       datetime: '2020-01-01'
       source: UNECE 2022

--- a/config/zones/PL.yaml
+++ b/config/zones/PL.yaml
@@ -280,7 +280,7 @@ emissionFactors:
     - _comment: used storage values greater than zero.
       datetime: '2024-01-01'
       source: Electricity Maps, 2024 zone average
-      value: 476.33
+      value: 476.34
     - _comment: used storage values greater than zero.
       datetime: '2025-01-01'
       source: Electricity Maps, 2025 zone average
@@ -355,7 +355,7 @@ emissionFactors:
     - _comment: used storage values greater than zero.
       datetime: '2024-01-01'
       source: Electricity Maps, 2024 zone average
-      value: 530.98
+      value: 530.99
     - _comment: used storage values greater than zero.
       datetime: '2025-01-01'
       source: Electricity Maps, 2025 zone average

--- a/config/zones/PT.yaml
+++ b/config/zones/PT.yaml
@@ -254,15 +254,15 @@ emissionFactors:
     - _comment: used storage values greater than zero.
       datetime: '2021-01-01'
       source: Electricity Maps, 2021 zone average
-      value: 127.79
+      value: 127.8
     - _comment: used storage values greater than zero.
       datetime: '2022-01-01'
       source: Electricity Maps, 2022 zone average
-      value: 149.32
+      value: 149.33
     - _comment: used storage values greater than zero.
       datetime: '2023-01-01'
       source: Electricity Maps, 2023 zone average
-      value: 92.23
+      value: 92.36
     - _comment: used storage values greater than zero.
       datetime: '2024-01-01'
       source: Electricity Maps, 2024 zone average
@@ -270,7 +270,7 @@ emissionFactors:
     - _comment: used storage values greater than zero.
       datetime: '2025-01-01'
       source: Electricity Maps, 2025 zone average
-      value: 66.85
+      value: 66.92
     oil:
     - datetime: '2021-01-01'
       source: EU-ETS, ENTSO-E 2021
@@ -312,28 +312,28 @@ emissionFactors:
     hydro discharge:
     - _comment: used storage values greater than zero.
       datetime: '2020-01-01'
-      source: Electricity Maps, 2020 zone average
-      value: 231.23
+      source: Electricity Maps, 2020 zone average; IPCC 2014
+      value: 190.7
     - _comment: used storage values greater than zero.
       datetime: '2021-01-01'
-      source: Electricity Maps, 2021 zone average
-      value: 189.38
+      source: Electricity Maps, 2021 zone average; IPCC 2014
+      value: 151.8
     - _comment: used storage values greater than zero.
       datetime: '2022-01-01'
-      source: Electricity Maps, 2022 zone average
-      value: 218.18
+      source: Electricity Maps, 2022 zone average; IPCC 2014
+      value: 173.33
     - _comment: used storage values greater than zero.
       datetime: '2023-01-01'
-      source: Electricity Maps, 2023 zone average
-      value: 144.22
+      source: Electricity Maps, 2023 zone average; IPCC 2014
+      value: 116.36
     - _comment: used storage values greater than zero.
       datetime: '2024-01-01'
-      source: Electricity Maps, 2024 zone average
-      value: 94.48
+      source: Electricity Maps, 2024 zone average; IPCC 2014
+      value: 76.74
     - _comment: used storage values greater than zero.
       datetime: '2025-01-01'
-      source: Electricity Maps, 2025 zone average
-      value: 111.77
+      source: Electricity Maps, 2025 zone average; IPCC 2014
+      value: 90.92
     nuclear:
       datetime: '2020-01-01'
       source: UNECE 2022

--- a/config/zones/PT.yaml
+++ b/config/zones/PT.yaml
@@ -266,7 +266,7 @@ emissionFactors:
     - _comment: used storage values greater than zero.
       datetime: '2024-01-01'
       source: Electricity Maps, 2024 zone average
-      value: 52.69
+      value: 52.74
     - _comment: used storage values greater than zero.
       datetime: '2025-01-01'
       source: Electricity Maps, 2025 zone average
@@ -329,7 +329,7 @@ emissionFactors:
     - _comment: used storage values greater than zero.
       datetime: '2024-01-01'
       source: Electricity Maps, 2024 zone average
-      value: 94.39
+      value: 94.48
     - _comment: used storage values greater than zero.
       datetime: '2025-01-01'
       source: Electricity Maps, 2025 zone average

--- a/config/zones/RE.yaml
+++ b/config/zones/RE.yaml
@@ -102,7 +102,7 @@ emissionFactors:
     - _comment: used storage values greater than zero.
       datetime: '2024-01-01'
       source: Electricity Maps, 2024 zone average
-      value: 468.03
+      value: 468.04
     - _comment: used storage values greater than zero.
       datetime: '2025-01-01'
       source: Electricity Maps, 2025 zone average

--- a/config/zones/RE.yaml
+++ b/config/zones/RE.yaml
@@ -81,37 +81,37 @@ emissionFactors:
       source: Electricity Maps, 2025 zone average
       value: 70.33
     hydro discharge:
-    - _comment: used storage values equal to zero.
+    - _comment: used default IPCC 2014 value of 0.0
       datetime: '2025-01-01'
       source: Electricity Maps, 2025 zone average
-      value: 235.01
+      value: 0.0
   lifecycle:
     battery discharge:
     - _comment: used storage values greater than zero.
       datetime: '2020-01-01'
-      source: Electricity Maps, 2020 zone average
-      value: 560.41
+      source: Electricity Maps, 2020 zone average; National Laboratory of the Rockies
+      value: 457.87
     - _comment: used storage values greater than zero.
       datetime: '2022-01-01'
-      source: Electricity Maps, 2022 zone average
-      value: 560.5
+      source: Electricity Maps, 2022 zone average; National Laboratory of the Rockies
+      value: 443.42
     - _comment: used storage values greater than zero.
       datetime: '2023-01-01'
-      source: Electricity Maps, 2023 zone average
-      value: 490.81
+      source: Electricity Maps, 2023 zone average; National Laboratory of the Rockies
+      value: 366.46
     - _comment: used storage values greater than zero.
       datetime: '2024-01-01'
-      source: Electricity Maps, 2024 zone average
-      value: 468.04
+      source: Electricity Maps, 2024 zone average; National Laboratory of the Rockies
+      value: 349.62
     - _comment: used storage values greater than zero.
       datetime: '2025-01-01'
-      source: Electricity Maps, 2025 zone average
-      value: 260.76
+      source: Electricity Maps, 2025 zone average; National Laboratory of the Rockies
+      value: 103.33
     hydro discharge:
-    - _comment: used storage values equal to zero.
+    - _comment: used default IPCC 2014 value of 24.0
       datetime: '2025-01-01'
-      source: Electricity Maps, 2025 zone average
-      value: 413.65
+      source: Electricity Maps, 2025 zone average; IPCC 2014
+      value: 24.0
 fallbackZoneMixes:
   powerOriginRatios:
   - _source: Electricity Maps, 2016 average

--- a/config/zones/RO.yaml
+++ b/config/zones/RO.yaml
@@ -180,7 +180,7 @@ emissionFactors:
     - _comment: used storage values greater than zero.
       datetime: '2025-01-01'
       source: Electricity Maps, 2025 zone average
-      value: 287.45
+      value: 276.54
     biomass:
       datetime: '2021-01-01'
       source: BEIS 2021
@@ -228,8 +228,8 @@ emissionFactors:
     battery discharge:
     - _comment: used storage values greater than zero.
       datetime: '2025-01-01'
-      source: Electricity Maps, 2025 zone average
-      value: 330.15
+      source: Electricity Maps, 2025 zone average; National Laboratory of the Rockies
+      value: 309.54
     biomass:
       datetime: '2014-01-01'
       source: BEIS 2021; IPCC 2014

--- a/config/zones/RS.yaml
+++ b/config/zones/RS.yaml
@@ -177,7 +177,7 @@ emissionFactors:
     - _comment: used storage values greater than zero.
       datetime: '2024-01-01'
       source: Electricity Maps, 2024 zone average
-      value: 453.93
+      value: 453.97
     - _comment: used storage values greater than zero.
       datetime: '2025-01-01'
       source: Electricity Maps, 2025 zone average
@@ -207,7 +207,7 @@ emissionFactors:
     - _comment: used storage values greater than zero.
       datetime: '2024-01-01'
       source: Electricity Maps, 2024 zone average
-      value: 501.46
+      value: 501.5
     - _comment: used storage values greater than zero.
       datetime: '2025-01-01'
       source: Electricity Maps, 2025 zone average

--- a/config/zones/RS.yaml
+++ b/config/zones/RS.yaml
@@ -158,18 +158,18 @@ delays:
 emissionFactors:
   direct:
     hydro discharge:
-    - _comment: used storage values equal to zero.
+    - _comment: used default IPCC 2014 value of 0.0
       datetime: '2020-01-01'
       source: Electricity Maps, 2020 zone average
-      value: 529.46
-    - _comment: used storage values equal to zero.
+      value: 0.0
+    - _comment: used default IPCC 2014 value of 0.0
       datetime: '2021-01-01'
       source: Electricity Maps, 2021 zone average
-      value: 479.07
+      value: 0.0
     - _comment: used storage values greater than zero.
       datetime: '2022-01-01'
       source: Electricity Maps, 2022 zone average
-      value: 529.49
+      value: 529.5
     - _comment: used storage values greater than zero.
       datetime: '2023-01-01'
       source: Electricity Maps, 2023 zone average
@@ -181,37 +181,37 @@ emissionFactors:
     - _comment: used storage values greater than zero.
       datetime: '2025-01-01'
       source: Electricity Maps, 2025 zone average
-      value: 469.89
+      value: 478.63
   lifecycle:
     hydro:
       datetime: '2020-01-01'
       source: UNECE 2022
       value: 10.7
     hydro discharge:
-    - _comment: used storage values equal to zero.
+    - _comment: used default IPCC 2014 value of 24.0
       datetime: '2020-01-01'
-      source: Electricity Maps, 2020 zone average
-      value: 578.2
-    - _comment: used storage values equal to zero.
+      source: Electricity Maps, 2020 zone average; IPCC 2014
+      value: 24.0
+    - _comment: used default IPCC 2014 value of 24.0
       datetime: '2021-01-01'
-      source: Electricity Maps, 2021 zone average
-      value: 525.56
+      source: Electricity Maps, 2021 zone average; IPCC 2014
+      value: 24.0
     - _comment: used storage values greater than zero.
       datetime: '2022-01-01'
-      source: Electricity Maps, 2022 zone average
-      value: 577.93
+      source: Electricity Maps, 2022 zone average; IPCC 2014
+      value: 553.5
     - _comment: used storage values greater than zero.
       datetime: '2023-01-01'
-      source: Electricity Maps, 2023 zone average
-      value: 487.64
+      source: Electricity Maps, 2023 zone average; IPCC 2014
+      value: 466.29
     - _comment: used storage values greater than zero.
       datetime: '2024-01-01'
-      source: Electricity Maps, 2024 zone average
-      value: 501.5
+      source: Electricity Maps, 2024 zone average; IPCC 2014
+      value: 477.97
     - _comment: used storage values greater than zero.
       datetime: '2025-01-01'
-      source: Electricity Maps, 2025 zone average
-      value: 521.39
+      source: Electricity Maps, 2025 zone average; IPCC 2014
+      value: 502.63
     nuclear:
       datetime: '2020-01-01'
       source: UNECE 2022

--- a/config/zones/SI.yaml
+++ b/config/zones/SI.yaml
@@ -194,30 +194,30 @@ emissionFactors:
       source: EU-ETS, ENTSO-E 2024
       value: 415.69
     hydro discharge:
-    - _comment: used storage values equal to zero.
+    - _comment: used default IPCC 2014 value of 0.0
       datetime: '2020-01-01'
       source: Electricity Maps, 2020 zone average
-      value: 239.97
-    - _comment: used storage values equal to zero.
+      value: 0.0
+    - _comment: used default IPCC 2014 value of 0.0
       datetime: '2021-01-01'
       source: Electricity Maps, 2021 zone average
-      value: 253.41
-    - _comment: used storage values equal to zero.
+      value: 0.0
+    - _comment: used default IPCC 2014 value of 0.0
       datetime: '2022-01-01'
       source: Electricity Maps, 2022 zone average
-      value: 256.47
+      value: 0.0
     - _comment: used storage values greater than zero.
       datetime: '2023-01-01'
       source: Electricity Maps, 2023 zone average
       value: 281.03
-    - _comment: used storage values equal to zero.
+    - _comment: used default IPCC 2014 value of 0.0
       datetime: '2024-01-01'
       source: Electricity Maps, 2024 zone average
-      value: 200.9
-    - _comment: used storage values equal to zero.
+      value: 0.0
+    - _comment: used default IPCC 2014 value of 0.0
       datetime: '2025-01-01'
       source: Electricity Maps, 2025 zone average
-      value: 172.81
+      value: 0.0
     oil:
     - datetime: '2021-01-01'
       source: EU-ETS, ENTSO-E 2021
@@ -269,30 +269,30 @@ emissionFactors:
       source: UNECE 2022
       value: 10.7
     hydro discharge:
-    - _comment: used storage values equal to zero.
+    - _comment: used default IPCC 2014 value of 24.0
       datetime: '2020-01-01'
-      source: Electricity Maps, 2020 zone average
-      value: 261.08
-    - _comment: used storage values equal to zero.
+      source: Electricity Maps, 2020 zone average; IPCC 2014
+      value: 24.0
+    - _comment: used default IPCC 2014 value of 24.0
       datetime: '2021-01-01'
-      source: Electricity Maps, 2021 zone average
-      value: 275.32
-    - _comment: used storage values equal to zero.
+      source: Electricity Maps, 2021 zone average; IPCC 2014
+      value: 24.0
+    - _comment: used default IPCC 2014 value of 24.0
       datetime: '2022-01-01'
-      source: Electricity Maps, 2022 zone average
-      value: 282.55
+      source: Electricity Maps, 2022 zone average; IPCC 2014
+      value: 24.0
     - _comment: used storage values greater than zero.
       datetime: '2023-01-01'
-      source: Electricity Maps, 2023 zone average
-      value: 320.88
-    - _comment: used storage values equal to zero.
+      source: Electricity Maps, 2023 zone average; IPCC 2014
+      value: 305.03
+    - _comment: used default IPCC 2014 value of 24.0
       datetime: '2024-01-01'
-      source: Electricity Maps, 2024 zone average
-      value: 231.43
-    - _comment: used storage values equal to zero.
+      source: Electricity Maps, 2024 zone average; IPCC 2014
+      value: 24.0
+    - _comment: used default IPCC 2014 value of 24.0
       datetime: '2025-01-01'
-      source: Electricity Maps, 2025 zone average
-      value: 206.73
+      source: Electricity Maps, 2025 zone average; IPCC 2014
+      value: 24.0
     nuclear:
       datetime: '2020-01-01'
       source: UNECE 2022

--- a/config/zones/SI.yaml
+++ b/config/zones/SI.yaml
@@ -213,7 +213,7 @@ emissionFactors:
     - _comment: used storage values equal to zero.
       datetime: '2024-01-01'
       source: Electricity Maps, 2024 zone average
-      value: 198.73
+      value: 200.9
     - _comment: used storage values equal to zero.
       datetime: '2025-01-01'
       source: Electricity Maps, 2025 zone average
@@ -288,7 +288,7 @@ emissionFactors:
     - _comment: used storage values equal to zero.
       datetime: '2024-01-01'
       source: Electricity Maps, 2024 zone average
-      value: 228.93
+      value: 231.43
     - _comment: used storage values equal to zero.
       datetime: '2025-01-01'
       source: Electricity Maps, 2025 zone average

--- a/config/zones/SK.yaml
+++ b/config/zones/SK.yaml
@@ -176,7 +176,7 @@ emissionFactors:
     - _comment: used storage values greater than zero.
       datetime: '2024-01-01'
       source: Electricity Maps, 2024 zone average
-      value: 147.1
+      value: 147.17
     - _comment: used storage values greater than zero.
       datetime: '2025-01-01'
       source: Electricity Maps, 2025 zone average
@@ -251,7 +251,7 @@ emissionFactors:
     - _comment: used storage values greater than zero.
       datetime: '2024-01-01'
       source: Electricity Maps, 2024 zone average
-      value: 182.72
+      value: 182.81
     - _comment: used storage values greater than zero.
       datetime: '2025-01-01'
       source: Electricity Maps, 2025 zone average

--- a/config/zones/SK.yaml
+++ b/config/zones/SK.yaml
@@ -160,19 +160,19 @@ emissionFactors:
     - _comment: used storage values greater than zero.
       datetime: '2020-01-01'
       source: Electricity Maps, 2020 zone average
-      value: 280.31
+      value: 280.95
     - _comment: used storage values greater than zero.
       datetime: '2021-01-01'
       source: Electricity Maps, 2021 zone average
-      value: 309.29
+      value: 309.49
     - _comment: used storage values greater than zero.
       datetime: '2022-01-01'
       source: Electricity Maps, 2022 zone average
-      value: 367.72
+      value: 368.11
     - _comment: used storage values greater than zero.
       datetime: '2023-01-01'
       source: Electricity Maps, 2023 zone average
-      value: 193.67
+      value: 193.78
     - _comment: used storage values greater than zero.
       datetime: '2024-01-01'
       source: Electricity Maps, 2024 zone average
@@ -180,7 +180,7 @@ emissionFactors:
     - _comment: used storage values greater than zero.
       datetime: '2025-01-01'
       source: Electricity Maps, 2025 zone average
-      value: 165.68
+      value: 165.93
     oil:
     - datetime: '2021-01-01'
       source: EU-ETS, ENTSO-E 2021
@@ -234,28 +234,28 @@ emissionFactors:
     hydro discharge:
     - _comment: used storage values greater than zero.
       datetime: '2020-01-01'
-      source: Electricity Maps, 2020 zone average
-      value: 314.51
+      source: Electricity Maps, 2020 zone average; IPCC 2014
+      value: 304.95
     - _comment: used storage values greater than zero.
       datetime: '2021-01-01'
-      source: Electricity Maps, 2021 zone average
-      value: 344.57
+      source: Electricity Maps, 2021 zone average; IPCC 2014
+      value: 333.49
     - _comment: used storage values greater than zero.
       datetime: '2022-01-01'
-      source: Electricity Maps, 2022 zone average
-      value: 396.34
+      source: Electricity Maps, 2022 zone average; IPCC 2014
+      value: 392.11
     - _comment: used storage values greater than zero.
       datetime: '2023-01-01'
-      source: Electricity Maps, 2023 zone average
-      value: 228.45
+      source: Electricity Maps, 2023 zone average; IPCC 2014
+      value: 217.78
     - _comment: used storage values greater than zero.
       datetime: '2024-01-01'
-      source: Electricity Maps, 2024 zone average
-      value: 182.81
+      source: Electricity Maps, 2024 zone average; IPCC 2014
+      value: 171.17
     - _comment: used storage values greater than zero.
       datetime: '2025-01-01'
-      source: Electricity Maps, 2025 zone average
-      value: 203.58
+      source: Electricity Maps, 2025 zone average; IPCC 2014
+      value: 189.93
     nuclear:
       datetime: '2020-01-01'
       source: UNECE 2022

--- a/config/zones/TW.yaml
+++ b/config/zones/TW.yaml
@@ -189,7 +189,7 @@ emissionFactors:
     - _comment: used storage values greater than zero.
       datetime: '2024-01-01'
       source: Electricity Maps, 2024 zone average
-      value: 388.71
+      value: 389.0
     - _comment: used storage values greater than zero.
       datetime: '2025-01-01'
       source: Electricity Maps, 2025 zone average
@@ -214,7 +214,7 @@ emissionFactors:
     - _comment: used storage values greater than zero.
       datetime: '2024-01-01'
       source: Electricity Maps, 2024 zone average
-      value: 400.95
+      value: 401.03
     - _comment: used storage values greater than zero.
       datetime: '2025-01-01'
       source: Electricity Maps, 2025 zone average
@@ -240,7 +240,7 @@ emissionFactors:
     - _comment: used storage values greater than zero.
       datetime: '2024-01-01'
       source: Electricity Maps, 2024 zone average
-      value: 476.41
+      value: 476.76
     - _comment: used storage values greater than zero.
       datetime: '2025-01-01'
       source: Electricity Maps, 2025 zone average
@@ -265,7 +265,7 @@ emissionFactors:
     - _comment: used storage values greater than zero.
       datetime: '2024-01-01'
       source: Electricity Maps, 2024 zone average
-      value: 484.65
+      value: 484.75
     - _comment: used storage values greater than zero.
       datetime: '2025-01-01'
       source: Electricity Maps, 2025 zone average

--- a/config/zones/TW.yaml
+++ b/config/zones/TW.yaml
@@ -173,19 +173,19 @@ emissionFactors:
     - _comment: used storage values greater than zero.
       datetime: '2020-01-01'
       source: Electricity Maps, 2020 zone average
-      value: 458.0
+      value: 458.44
     - _comment: used storage values greater than zero.
       datetime: '2021-01-01'
       source: Electricity Maps, 2021 zone average
-      value: 427.53
+      value: 430.5
     - _comment: used storage values greater than zero.
       datetime: '2022-01-01'
       source: Electricity Maps, 2022 zone average
-      value: 423.38
+      value: 425.23
     - _comment: used storage values greater than zero.
       datetime: '2023-01-01'
       source: Electricity Maps, 2023 zone average
-      value: 414.33
+      value: 416.16
     - _comment: used storage values greater than zero.
       datetime: '2024-01-01'
       source: Electricity Maps, 2024 zone average
@@ -193,24 +193,24 @@ emissionFactors:
     - _comment: used storage values greater than zero.
       datetime: '2025-01-01'
       source: Electricity Maps, 2025 zone average
-      value: 428.17
+      value: 430.45
     hydro discharge:
     - _comment: used storage values greater than zero.
       datetime: '2020-01-01'
       source: Electricity Maps, 2020 zone average
-      value: 465.63
+      value: 465.73
     - _comment: used storage values greater than zero.
       datetime: '2021-01-01'
       source: Electricity Maps, 2021 zone average
-      value: 460.04
+      value: 460.14
     - _comment: used storage values greater than zero.
       datetime: '2022-01-01'
       source: Electricity Maps, 2022 zone average
-      value: 453.57
+      value: 453.79
     - _comment: used storage values greater than zero.
       datetime: '2023-01-01'
       source: Electricity Maps, 2023 zone average
-      value: 446.33
+      value: 446.47
     - _comment: used storage values greater than zero.
       datetime: '2024-01-01'
       source: Electricity Maps, 2024 zone average
@@ -218,58 +218,58 @@ emissionFactors:
     - _comment: used storage values greater than zero.
       datetime: '2025-01-01'
       source: Electricity Maps, 2025 zone average
-      value: 429.36
+      value: 429.6
   lifecycle:
     battery discharge:
     - _comment: used storage values greater than zero.
       datetime: '2020-01-01'
-      source: Electricity Maps, 2020 zone average
-      value: 535.03
+      source: Electricity Maps, 2020 zone average; National Laboratory of the Rockies
+      value: 491.44
     - _comment: used storage values greater than zero.
       datetime: '2021-01-01'
-      source: Electricity Maps, 2021 zone average
-      value: 512.18
+      source: Electricity Maps, 2021 zone average; National Laboratory of the Rockies
+      value: 463.5
     - _comment: used storage values greater than zero.
       datetime: '2022-01-01'
-      source: Electricity Maps, 2022 zone average
-      value: 507.89
+      source: Electricity Maps, 2022 zone average; National Laboratory of the Rockies
+      value: 458.23
     - _comment: used storage values greater than zero.
       datetime: '2023-01-01'
-      source: Electricity Maps, 2023 zone average
-      value: 498.12
+      source: Electricity Maps, 2023 zone average; National Laboratory of the Rockies
+      value: 449.16
     - _comment: used storage values greater than zero.
       datetime: '2024-01-01'
-      source: Electricity Maps, 2024 zone average
-      value: 476.76
+      source: Electricity Maps, 2024 zone average; National Laboratory of the Rockies
+      value: 422.0
     - _comment: used storage values greater than zero.
       datetime: '2025-01-01'
-      source: Electricity Maps, 2025 zone average
-      value: 520.95
+      source: Electricity Maps, 2025 zone average; National Laboratory of the Rockies
+      value: 463.45
     hydro discharge:
     - _comment: used storage values greater than zero.
       datetime: '2020-01-01'
-      source: Electricity Maps, 2020 zone average
-      value: 545.12
+      source: Electricity Maps, 2020 zone average; IPCC 2014
+      value: 489.73
     - _comment: used storage values greater than zero.
       datetime: '2021-01-01'
-      source: Electricity Maps, 2021 zone average
-      value: 542.22
+      source: Electricity Maps, 2021 zone average; IPCC 2014
+      value: 484.14
     - _comment: used storage values greater than zero.
       datetime: '2022-01-01'
-      source: Electricity Maps, 2022 zone average
-      value: 536.04
+      source: Electricity Maps, 2022 zone average; IPCC 2014
+      value: 477.79
     - _comment: used storage values greater than zero.
       datetime: '2023-01-01'
-      source: Electricity Maps, 2023 zone average
-      value: 530.4
+      source: Electricity Maps, 2023 zone average; IPCC 2014
+      value: 470.47
     - _comment: used storage values greater than zero.
       datetime: '2024-01-01'
-      source: Electricity Maps, 2024 zone average
-      value: 484.75
+      source: Electricity Maps, 2024 zone average; IPCC 2014
+      value: 425.03
     - _comment: used storage values greater than zero.
       datetime: '2025-01-01'
-      source: Electricity Maps, 2025 zone average
-      value: 522.38
+      source: Electricity Maps, 2025 zone average; IPCC 2014
+      value: 453.6
 fallbackZoneMixes:
   powerOriginRatios:
   - _source: Electricity Maps, 2015 average

--- a/config/zones/UA.yaml
+++ b/config/zones/UA.yaml
@@ -28,7 +28,7 @@ emissionFactors:
     - _comment: used storage values greater than zero.
       datetime: '2020-01-01'
       source: Electricity Maps, 2020 zone average
-      value: 231.06
+      value: 231.08
     - _comment: used storage values greater than zero.
       datetime: '2021-01-01'
       source: Electricity Maps, 2021 zone average
@@ -48,16 +48,16 @@ emissionFactors:
     hydro discharge:
     - _comment: used storage values greater than zero.
       datetime: '2020-01-01'
-      source: Electricity Maps, 2020 zone average
-      value: 267.26
+      source: Electricity Maps, 2020 zone average; IPCC 2014
+      value: 255.08
     - _comment: used storage values greater than zero.
       datetime: '2021-01-01'
-      source: Electricity Maps, 2021 zone average
-      value: 229.23
+      source: Electricity Maps, 2021 zone average; IPCC 2014
+      value: 221.61
     - _comment: used storage values greater than zero.
       datetime: '2022-01-01'
-      source: Electricity Maps, 2022 zone average
-      value: 220.79
+      source: Electricity Maps, 2022 zone average; IPCC 2014
+      value: 212.55
     unknown:
       _comment: estimated yearly share of solar & wind in this mixed renewable category
         based on installed capacity in Y2018; assumes 50% solar, 50% wind renewable

--- a/config/zones/US-CAL-CISO.yaml
+++ b/config/zones/US-CAL-CISO.yaml
@@ -1014,19 +1014,19 @@ emissionFactors:
     - _comment: used storage values greater than zero.
       datetime: '2020-01-01'
       source: Electricity Maps, 2020 zone average
-      value: 187.52
+      value: 187.55
     - _comment: used storage values greater than zero.
       datetime: '2021-01-01'
       source: Electricity Maps, 2021 zone average
-      value: 179.27
+      value: 179.31
     - _comment: used storage values greater than zero.
       datetime: '2022-01-01'
       source: Electricity Maps, 2022 zone average
-      value: 163.0
+      value: 163.06
     - _comment: used storage values greater than zero.
       datetime: '2023-01-01'
       source: Electricity Maps, 2023 zone average
-      value: 164.89
+      value: 164.97
     - _comment: used storage values greater than zero.
       datetime: '2024-01-01'
       source: Electricity Maps, 2024 zone average
@@ -1034,7 +1034,7 @@ emissionFactors:
     - _comment: used storage values greater than zero.
       datetime: '2025-01-01'
       source: Electricity Maps, 2025 zone average
-      value: 105.16
+      value: 105.31
     biomass:
     - datetime: '2020-01-01'
       source: BEIS 2021
@@ -1091,15 +1091,15 @@ emissionFactors:
     - _comment: used storage values greater than zero.
       datetime: '2020-01-01'
       source: Electricity Maps, 2020 zone average
-      value: 168.62
+      value: 168.68
     - _comment: used storage values greater than zero.
       datetime: '2021-01-01'
       source: Electricity Maps, 2021 zone average
-      value: 133.09
+      value: 133.14
     - _comment: used storage values greater than zero.
       datetime: '2022-01-01'
       source: Electricity Maps, 2022 zone average
-      value: 165.53
+      value: 165.82
     - _comment: used storage values greater than zero.
       datetime: '2023-01-01'
       source: Electricity Maps, 2023 zone average
@@ -1111,7 +1111,7 @@ emissionFactors:
     - _comment: used storage values greater than zero.
       datetime: '2025-01-01'
       source: Electricity Maps, 2025 zone average
-      value: 70.32
+      value: 70.37
     oil:
     - datetime: '2020-01-01'
       source: eGrid 2020
@@ -1129,28 +1129,28 @@ emissionFactors:
     battery discharge:
     - _comment: used storage values greater than zero.
       datetime: '2020-01-01'
-      source: Electricity Maps, 2020 zone average
-      value: 255.9
+      source: Electricity Maps, 2020 zone average; National Laboratory of the Rockies
+      value: 220.55
     - _comment: used storage values greater than zero.
       datetime: '2021-01-01'
-      source: Electricity Maps, 2021 zone average
-      value: 246.51
+      source: Electricity Maps, 2021 zone average; National Laboratory of the Rockies
+      value: 212.31
     - _comment: used storage values greater than zero.
       datetime: '2022-01-01'
-      source: Electricity Maps, 2022 zone average
-      value: 227.3
+      source: Electricity Maps, 2022 zone average; National Laboratory of the Rockies
+      value: 196.06
     - _comment: used storage values greater than zero.
       datetime: '2023-01-01'
-      source: Electricity Maps, 2023 zone average
-      value: 229.61
+      source: Electricity Maps, 2023 zone average; National Laboratory of the Rockies
+      value: 197.97
     - _comment: used storage values greater than zero.
       datetime: '2024-01-01'
-      source: Electricity Maps, 2024 zone average
-      value: 185.49
+      source: Electricity Maps, 2024 zone average; National Laboratory of the Rockies
+      value: 162.51
     - _comment: used storage values greater than zero.
       datetime: '2025-01-01'
-      source: Electricity Maps, 2025 zone average
-      value: 155.17
+      source: Electricity Maps, 2025 zone average; National Laboratory of the Rockies
+      value: 138.31
     biomass:
     - _comment: Mean of all US zones
       datetime: '2020-01-01'
@@ -1210,28 +1210,28 @@ emissionFactors:
     hydro discharge:
     - _comment: used storage values greater than zero.
       datetime: '2020-01-01'
-      source: Electricity Maps, 2020 zone average
-      value: 233.53
+      source: Electricity Maps, 2020 zone average; IPCC 2014
+      value: 192.68
     - _comment: used storage values greater than zero.
       datetime: '2021-01-01'
-      source: Electricity Maps, 2021 zone average
-      value: 190.75
+      source: Electricity Maps, 2021 zone average; IPCC 2014
+      value: 157.14
     - _comment: used storage values greater than zero.
       datetime: '2022-01-01'
-      source: Electricity Maps, 2022 zone average
-      value: 231.07
+      source: Electricity Maps, 2022 zone average; IPCC 2014
+      value: 189.82
     - _comment: used storage values greater than zero.
       datetime: '2023-01-01'
-      source: Electricity Maps, 2023 zone average
-      value: 220.06
+      source: Electricity Maps, 2023 zone average; IPCC 2014
+      value: 180.65
     - _comment: used storage values greater than zero.
       datetime: '2024-01-01'
-      source: Electricity Maps, 2024 zone average
-      value: 118.64
+      source: Electricity Maps, 2024 zone average; IPCC 2014
+      value: 98.59
     - _comment: used storage values greater than zero.
       datetime: '2025-01-01'
-      source: Electricity Maps, 2025 zone average
-      value: 113.18
+      source: Electricity Maps, 2025 zone average; IPCC 2014
+      value: 94.37
     oil:
     - datetime: '2020-01-01'
       source: eGrid 2020; IPCC 2014

--- a/config/zones/US-CAL-CISO.yaml
+++ b/config/zones/US-CAL-CISO.yaml
@@ -1030,7 +1030,7 @@ emissionFactors:
     - _comment: used storage values greater than zero.
       datetime: '2024-01-01'
       source: Electricity Maps, 2024 zone average
-      value: 129.4
+      value: 129.51
     - _comment: used storage values greater than zero.
       datetime: '2025-01-01'
       source: Electricity Maps, 2025 zone average
@@ -1107,7 +1107,7 @@ emissionFactors:
     - _comment: used storage values greater than zero.
       datetime: '2024-01-01'
       source: Electricity Maps, 2024 zone average
-      value: 74.58
+      value: 74.59
     - _comment: used storage values greater than zero.
       datetime: '2025-01-01'
       source: Electricity Maps, 2025 zone average
@@ -1146,7 +1146,7 @@ emissionFactors:
     - _comment: used storage values greater than zero.
       datetime: '2024-01-01'
       source: Electricity Maps, 2024 zone average
-      value: 185.35
+      value: 185.49
     - _comment: used storage values greater than zero.
       datetime: '2025-01-01'
       source: Electricity Maps, 2025 zone average
@@ -1227,7 +1227,7 @@ emissionFactors:
     - _comment: used storage values greater than zero.
       datetime: '2024-01-01'
       source: Electricity Maps, 2024 zone average
-      value: 118.63
+      value: 118.64
     - _comment: used storage values greater than zero.
       datetime: '2025-01-01'
       source: Electricity Maps, 2025 zone average

--- a/config/zones/US-CAL-IID.yaml
+++ b/config/zones/US-CAL-IID.yaml
@@ -147,7 +147,7 @@ emissionFactors:
     - _comment: used storage values greater than zero.
       datetime: '2025-01-01'
       source: Electricity Maps, 2025 zone average
-      value: 98.98
+      value: 99.04
     biomass:
     - datetime: '2020-01-01'
       source: BEIS 2021
@@ -212,7 +212,7 @@ emissionFactors:
     - _comment: used storage values greater than zero.
       datetime: '2025-01-01'
       source: Electricity Maps, 2025 zone average
-      value: 86.51
+      value: 86.52
     oil:
     - _comment: Mean of all US zones
       datetime: '2020-01-01'
@@ -234,8 +234,8 @@ emissionFactors:
     battery discharge:
     - _comment: used storage values greater than zero.
       datetime: '2025-01-01'
-      source: Electricity Maps, 2025 zone average
-      value: 146.43
+      source: Electricity Maps, 2025 zone average; National Laboratory of the Rockies
+      value: 132.04
     biomass:
     - _comment: Mean of all US zones
       datetime: '2020-01-01'
@@ -299,12 +299,12 @@ emissionFactors:
     hydro discharge:
     - _comment: used storage values greater than zero.
       datetime: '2024-01-01'
-      source: Electricity Maps, 2024 zone average
-      value: 368.42
+      source: Electricity Maps, 2024 zone average; IPCC 2014
+      value: 315.91
     - _comment: used storage values greater than zero.
       datetime: '2025-01-01'
-      source: Electricity Maps, 2025 zone average
-      value: 126.06
+      source: Electricity Maps, 2025 zone average; IPCC 2014
+      value: 110.52
     oil:
     - _comment: Mean of all US zones
       datetime: '2020-01-01'

--- a/config/zones/US-CAL-LDWP.yaml
+++ b/config/zones/US-CAL-LDWP.yaml
@@ -228,14 +228,14 @@ delays:
 emissionFactors:
   direct:
     battery discharge:
-    - _comment: used storage values equal to zero.
+    - _comment: used non-null storage values
       datetime: '2022-01-01'
       source: Electricity Maps, 2022 zone average
-      value: 425.63
-    - _comment: used storage values equal to zero.
+      value: 428.13
+    - _comment: used non-null storage values
       datetime: '2025-01-01'
       source: Electricity Maps, 2025 zone average
-      value: 279.85
+      value: 288.75
     biomass:
     - datetime: '2020-01-01'
       source: BEIS 2021
@@ -300,15 +300,15 @@ emissionFactors:
     - _comment: used storage values greater than zero.
       datetime: '2021-01-01'
       source: Electricity Maps, 2021 zone average
-      value: 343.4
-    - _comment: used storage values equal to zero.
+      value: 343.42
+    - _comment: used default IPCC 2014 value of 0.0
       datetime: '2022-01-01'
       source: Electricity Maps, 2022 zone average
-      value: 355.09
-    - _comment: used storage values equal to zero.
+      value: 0.0
+    - _comment: used default IPCC 2014 value of 0.0
       datetime: '2025-01-01'
       source: Electricity Maps, 2025 zone average
-      value: 278.98
+      value: 0.0
     oil:
     - _comment: Mean of all US zones
       datetime: '2020-01-01'
@@ -328,14 +328,14 @@ emissionFactors:
       value: 692.2365799135232
   lifecycle:
     battery discharge:
-    - _comment: used storage values equal to zero.
+    - _comment: used non-null storage values
       datetime: '2022-01-01'
-      source: Electricity Maps, 2022 zone average
-      value: 504.22
-    - _comment: used storage values equal to zero.
+      source: Electricity Maps, 2022 zone average; National Laboratory of the Rockies
+      value: 461.13
+    - _comment: used non-null storage values
       datetime: '2025-01-01'
-      source: Electricity Maps, 2025 zone average
-      value: 340.66
+      source: Electricity Maps, 2025 zone average; National Laboratory of the Rockies
+      value: 321.75
     biomass:
     - _comment: Mean of all US zones
       datetime: '2020-01-01'
@@ -399,20 +399,20 @@ emissionFactors:
     hydro discharge:
     - _comment: used storage values greater than zero.
       datetime: '2020-01-01'
-      source: Electricity Maps, 2020 zone average
-      value: 463.34
+      source: Electricity Maps, 2020 zone average; IPCC 2014
+      value: 414.51
     - _comment: used storage values greater than zero.
       datetime: '2021-01-01'
-      source: Electricity Maps, 2021 zone average
-      value: 407.05
-    - _comment: used storage values equal to zero.
+      source: Electricity Maps, 2021 zone average; IPCC 2014
+      value: 367.42
+    - _comment: used default IPCC 2014 value of 24.0
       datetime: '2022-01-01'
-      source: Electricity Maps, 2022 zone average
-      value: 424.04
-    - _comment: used storage values equal to zero.
+      source: Electricity Maps, 2022 zone average; IPCC 2014
+      value: 24.0
+    - _comment: used default IPCC 2014 value of 24.0
       datetime: '2025-01-01'
-      source: Electricity Maps, 2025 zone average
-      value: 340.25
+      source: Electricity Maps, 2025 zone average; IPCC 2014
+      value: 24.0
     oil:
     - _comment: Mean of all US zones
       datetime: '2020-01-01'

--- a/config/zones/US-CAL-TIDC.yaml
+++ b/config/zones/US-CAL-TIDC.yaml
@@ -132,10 +132,10 @@ emissionFactors:
       source: eGrid 2023
       value: 28.739435464835893
     hydro discharge:
-    - _comment: used storage values equal to zero.
+    - _comment: used default IPCC 2014 value of 0.0
       datetime: '2022-01-01'
       source: Electricity Maps, 2022 zone average
-      value: 354.28
+      value: 0.0
     oil:
     - _comment: Mean of all US zones
       datetime: '2020-01-01'
@@ -219,10 +219,10 @@ emissionFactors:
       source: eGrid 2023; IPCC 2014
       value: 66.73943546483589
     hydro discharge:
-    - _comment: used storage values equal to zero.
+    - _comment: used default IPCC 2014 value of 24.0
       datetime: '2022-01-01'
-      source: Electricity Maps, 2022 zone average
-      value: 449.6
+      source: Electricity Maps, 2022 zone average; IPCC 2014
+      value: 24.0
     oil:
     - _comment: Mean of all US zones
       datetime: '2020-01-01'

--- a/config/zones/US-CAR-CPLE.yaml
+++ b/config/zones/US-CAR-CPLE.yaml
@@ -264,7 +264,7 @@ emissionFactors:
     - _comment: used storage values greater than zero.
       datetime: '2025-01-01'
       source: Electricity Maps, 2025 zone average
-      value: 304.52
+      value: 304.72
     biomass:
     - datetime: '2020-01-01'
       source: BEIS 2021
@@ -363,8 +363,8 @@ emissionFactors:
     battery discharge:
     - _comment: used storage values greater than zero.
       datetime: '2025-01-01'
-      source: Electricity Maps, 2025 zone average
-      value: 360.03
+      source: Electricity Maps, 2025 zone average; National Laboratory of the Rockies
+      value: 337.72
     biomass:
     - _comment: Mean of all US zones
       datetime: '2020-01-01'
@@ -428,24 +428,24 @@ emissionFactors:
     hydro discharge:
     - _comment: used storage values greater than zero.
       datetime: '2020-01-01'
-      source: Electricity Maps, 2020 zone average
-      value: 296.98
+      source: Electricity Maps, 2020 zone average; IPCC 2014
+      value: 267.81
     - _comment: used storage values greater than zero.
       datetime: '2021-01-01'
-      source: Electricity Maps, 2021 zone average
-      value: 179.95
+      source: Electricity Maps, 2021 zone average; IPCC 2014
+      value: 166.98
     - _comment: used storage values greater than zero.
       datetime: '2022-01-01'
-      source: Electricity Maps, 2022 zone average
-      value: 250.69
+      source: Electricity Maps, 2022 zone average; IPCC 2014
+      value: 219.85
     - _comment: used storage values greater than zero.
       datetime: '2023-01-01'
-      source: Electricity Maps, 2023 zone average
-      value: 282.74
+      source: Electricity Maps, 2023 zone average; IPCC 2014
+      value: 252.69
     - _comment: used storage values greater than zero.
       datetime: '2025-01-01'
-      source: Electricity Maps, 2025 zone average
-      value: 339.85
+      source: Electricity Maps, 2025 zone average; IPCC 2014
+      value: 307.85
     oil:
     - _comment: Mean of all US zones
       datetime: '2020-01-01'

--- a/config/zones/US-CAR-CPLW.yaml
+++ b/config/zones/US-CAR-CPLW.yaml
@@ -267,28 +267,28 @@ emissionFactors:
     hydro discharge:
     - _comment: used storage values greater than zero.
       datetime: '2020-01-01'
-      source: Electricity Maps, 2020 zone average
-      value: 376.73
+      source: Electricity Maps, 2020 zone average; IPCC 2014
+      value: 322.58
     - _comment: used storage values greater than zero.
       datetime: '2021-01-01'
-      source: Electricity Maps, 2021 zone average
-      value: 527.09
+      source: Electricity Maps, 2021 zone average; IPCC 2014
+      value: 442.32
     - _comment: used storage values greater than zero.
       datetime: '2022-01-01'
-      source: Electricity Maps, 2022 zone average
-      value: 522.09
+      source: Electricity Maps, 2022 zone average; IPCC 2014
+      value: 442.59
     - _comment: used storage values greater than zero.
       datetime: '2023-01-01'
-      source: Electricity Maps, 2023 zone average
-      value: 569.47
+      source: Electricity Maps, 2023 zone average; IPCC 2014
+      value: 473.0
     - _comment: used storage values greater than zero.
       datetime: '2024-01-01'
-      source: Electricity Maps, 2024 zone average
-      value: 506.29
+      source: Electricity Maps, 2024 zone average; IPCC 2014
+      value: 428.87
     - _comment: used storage values greater than zero.
       datetime: '2025-01-01'
-      source: Electricity Maps, 2025 zone average
-      value: 541.5
+      source: Electricity Maps, 2025 zone average; IPCC 2014
+      value: 459.05
     oil:
     - _comment: Mean of all US zones
       datetime: '2020-01-01'

--- a/config/zones/US-CAR-DUK.yaml
+++ b/config/zones/US-CAR-DUK.yaml
@@ -354,7 +354,7 @@ emissionFactors:
     - _comment: used storage values greater than zero.
       datetime: '2025-01-01'
       source: Electricity Maps, 2025 zone average
-      value: 248.3
+      value: 253.49
     biomass:
     - datetime: '2020-01-01'
       source: BEIS 2021
@@ -416,11 +416,11 @@ emissionFactors:
     - _comment: used storage values greater than zero.
       datetime: '2020-01-01'
       source: Electricity Maps, 2020 zone average
-      value: 214.4
+      value: 214.41
     - _comment: used storage values greater than zero.
       datetime: '2021-01-01'
       source: Electricity Maps, 2021 zone average
-      value: 225.36
+      value: 225.37
     - _comment: used storage values greater than zero.
       datetime: '2022-01-01'
       source: Electricity Maps, 2022 zone average
@@ -432,7 +432,7 @@ emissionFactors:
     - _comment: used storage values greater than zero.
       datetime: '2025-01-01'
       source: Electricity Maps, 2025 zone average
-      value: 248.69
+      value: 248.78
     oil:
     - _comment: Mean of all US zones
       datetime: '2020-01-01'
@@ -453,8 +453,8 @@ emissionFactors:
     battery discharge:
     - _comment: used storage values greater than zero.
       datetime: '2025-01-01'
-      source: Electricity Maps, 2025 zone average
-      value: 294.71
+      source: Electricity Maps, 2025 zone average; National Laboratory of the Rockies
+      value: 286.49
     biomass:
     - _comment: Mean of all US zones
       datetime: '2020-01-01'
@@ -519,24 +519,24 @@ emissionFactors:
     hydro discharge:
     - _comment: used storage values greater than zero.
       datetime: '2020-01-01'
-      source: Electricity Maps, 2020 zone average
-      value: 257.66
+      source: Electricity Maps, 2020 zone average; IPCC 2014
+      value: 238.41
     - _comment: used storage values greater than zero.
       datetime: '2021-01-01'
-      source: Electricity Maps, 2021 zone average
-      value: 270.01
+      source: Electricity Maps, 2021 zone average; IPCC 2014
+      value: 249.37
     - _comment: used storage values greater than zero.
       datetime: '2022-01-01'
-      source: Electricity Maps, 2022 zone average
-      value: 345.44
+      source: Electricity Maps, 2022 zone average; IPCC 2014
+      value: 323.81
     - _comment: used storage values greater than zero.
       datetime: '2023-01-01'
-      source: Electricity Maps, 2023 zone average
-      value: 293.24
+      source: Electricity Maps, 2023 zone average; IPCC 2014
+      value: 271.62
     - _comment: used storage values greater than zero.
       datetime: '2025-01-01'
-      source: Electricity Maps, 2025 zone average
-      value: 294.9
+      source: Electricity Maps, 2025 zone average; IPCC 2014
+      value: 272.78
     oil:
     - _comment: Mean of all US zones
       datetime: '2020-01-01'

--- a/config/zones/US-CAR-SC.yaml
+++ b/config/zones/US-CAR-SC.yaml
@@ -283,7 +283,7 @@ emissionFactors:
     - _comment: used storage values greater than zero.
       datetime: '2024-01-01'
       source: Electricity Maps, 2024 zone average
-      value: 661.48
+      value: 661.49
     - _comment: used storage values greater than zero.
       datetime: '2025-01-01'
       source: Electricity Maps, 2025 zone average

--- a/config/zones/US-CAR-SC.yaml
+++ b/config/zones/US-CAR-SC.yaml
@@ -177,7 +177,7 @@ emissionFactors:
     - _comment: used storage values greater than zero.
       datetime: '2022-01-01'
       source: Electricity Maps, 2022 zone average
-      value: 587.15
+      value: 587.16
     - _comment: used storage values greater than zero.
       datetime: '2023-01-01'
       source: Electricity Maps, 2023 zone average
@@ -189,7 +189,7 @@ emissionFactors:
     - _comment: used storage values greater than zero.
       datetime: '2025-01-01'
       source: Electricity Maps, 2025 zone average
-      value: 626.98
+      value: 627.12
     oil:
     - _comment: Mean of all US zones
       datetime: '2020-01-01'
@@ -270,24 +270,24 @@ emissionFactors:
     hydro discharge:
     - _comment: used storage values greater than zero.
       datetime: '2021-01-01'
-      source: Electricity Maps, 2021 zone average
-      value: 737.5
+      source: Electricity Maps, 2021 zone average; IPCC 2014
+      value: 691.34
     - _comment: used storage values greater than zero.
       datetime: '2022-01-01'
-      source: Electricity Maps, 2022 zone average
-      value: 651.62
+      source: Electricity Maps, 2022 zone average; IPCC 2014
+      value: 611.16
     - _comment: used storage values greater than zero.
       datetime: '2023-01-01'
-      source: Electricity Maps, 2023 zone average
-      value: 633.24
+      source: Electricity Maps, 2023 zone average; IPCC 2014
+      value: 586.85
     - _comment: used storage values greater than zero.
       datetime: '2024-01-01'
-      source: Electricity Maps, 2024 zone average
-      value: 661.49
+      source: Electricity Maps, 2024 zone average; IPCC 2014
+      value: 615.74
     - _comment: used storage values greater than zero.
       datetime: '2025-01-01'
-      source: Electricity Maps, 2025 zone average
-      value: 697.02
+      source: Electricity Maps, 2025 zone average; IPCC 2014
+      value: 651.12
     oil:
     - _comment: Mean of all US zones
       datetime: '2020-01-01'

--- a/config/zones/US-CAR-SCEG.yaml
+++ b/config/zones/US-CAR-SCEG.yaml
@@ -264,10 +264,10 @@ emissionFactors:
       source: eGrid 2023
       value: 28.739435464835893
     hydro discharge:
-    - _comment: used storage values equal to zero.
+    - _comment: used default IPCC 2014 value of 0.0
       datetime: '2022-01-01'
       source: Electricity Maps, 2022 zone average
-      value: 385.11
+      value: 0.0
     oil:
     - _comment: Mean of all US zones
       datetime: '2020-01-01'
@@ -346,10 +346,10 @@ emissionFactors:
       source: eGrid 2023; IPCC 2014
       value: 66.73943546483589
     hydro discharge:
-    - _comment: used storage values equal to zero.
+    - _comment: used default IPCC 2014 value of 24.0
       datetime: '2022-01-01'
-      source: Electricity Maps, 2022 zone average
-      value: 469.49
+      source: Electricity Maps, 2022 zone average; IPCC 2014
+      value: 24.0
     oil:
     - _comment: Mean of all US zones
       datetime: '2020-01-01'

--- a/config/zones/US-FLA-FPC.yaml
+++ b/config/zones/US-FLA-FPC.yaml
@@ -220,7 +220,7 @@ emissionFactors:
     - _comment: used storage values greater than zero.
       datetime: '2025-01-01'
       source: Electricity Maps, 2025 zone average
-      value: 464.7
+      value: 464.73
     biomass:
     - datetime: '2020-01-01'
       source: BEIS 2021
@@ -279,10 +279,10 @@ emissionFactors:
       source: eGrid 2023
       value: 28.739435464835893
     hydro discharge:
-    - _comment: used storage values equal to zero.
+    - _comment: used default IPCC 2014 value of 0.0
       datetime: '2022-01-01'
       source: Electricity Maps, 2022 zone average
-      value: 421.29
+      value: 0.0
     oil:
     - datetime: '2020-01-01'
       source: eGrid 2020
@@ -300,12 +300,12 @@ emissionFactors:
     battery discharge:
     - _comment: used storage values greater than zero.
       datetime: '2022-01-01'
-      source: Electricity Maps, 2022 zone average
-      value: 538.03
+      source: Electricity Maps, 2022 zone average; National Laboratory of the Rockies
+      value: 463.87
     - _comment: used storage values greater than zero.
       datetime: '2025-01-01'
-      source: Electricity Maps, 2025 zone average
-      value: 569.79
+      source: Electricity Maps, 2025 zone average; National Laboratory of the Rockies
+      value: 497.73
     biomass:
     - _comment: Mean of all US zones
       datetime: '2020-01-01'
@@ -368,10 +368,10 @@ emissionFactors:
       source: eGrid 2023; IPCC 2014
       value: 66.73943546483589
     hydro discharge:
-    - _comment: used storage values equal to zero.
+    - _comment: used default IPCC 2014 value of 24.0
       datetime: '2022-01-01'
-      source: Electricity Maps, 2022 zone average
-      value: 526.92
+      source: Electricity Maps, 2022 zone average; IPCC 2014
+      value: 24.0
     oil:
     - datetime: '2020-01-01'
       source: eGrid 2020; IPCC 2014

--- a/config/zones/US-FLA-FPL.yaml
+++ b/config/zones/US-FLA-FPL.yaml
@@ -216,7 +216,7 @@ emissionFactors:
     - _comment: used storage values greater than zero.
       datetime: '2025-01-01'
       source: Electricity Maps, 2025 zone average
-      value: 248.93
+      value: 248.88
     biomass:
     - datetime: '2020-01-01'
       source: BEIS 2021
@@ -294,8 +294,8 @@ emissionFactors:
     battery discharge:
     - _comment: used storage values greater than zero.
       datetime: '2025-01-01'
-      source: Electricity Maps, 2025 zone average
-      value: 330.33
+      source: Electricity Maps, 2025 zone average; National Laboratory of the Rockies
+      value: 281.88
     biomass:
     - _comment: Mean of all US zones
       datetime: '2020-01-01'

--- a/config/zones/US-MIDA-PJM.yaml
+++ b/config/zones/US-MIDA-PJM.yaml
@@ -1148,15 +1148,15 @@ delays:
 emissionFactors:
   direct:
     battery discharge:
-    - _comment: used storage values equal to zero.
+    - _comment: used non-null storage values
       datetime: '2020-01-01'
       source: Electricity Maps, 2020 zone average
       value: 353.73
-    - _comment: used storage values equal to zero.
+    - _comment: used non-null storage values
       datetime: '2021-01-01'
       source: Electricity Maps, 2021 zone average
       value: 373.76
-    - _comment: used storage values equal to zero.
+    - _comment: used non-null storage values
       datetime: '2022-01-01'
       source: Electricity Maps, 2022 zone average
       value: 367.08
@@ -1243,30 +1243,30 @@ emissionFactors:
       value: 860.2336465682306
   lifecycle:
     battery discharge:
-    - _comment: used storage values equal to zero.
+    - _comment: used non-null storage values
       datetime: '2020-01-01'
-      source: Electricity Maps, 2020 zone average
-      value: 419.64
-    - _comment: used storage values equal to zero.
+      source: Electricity Maps, 2020 zone average; National Laboratory of the Rockies
+      value: 386.73
+    - _comment: used non-null storage values
       datetime: '2021-01-01'
-      source: Electricity Maps, 2021 zone average
-      value: 439.08
-    - _comment: used storage values equal to zero.
+      source: Electricity Maps, 2021 zone average; National Laboratory of the Rockies
+      value: 406.76
+    - _comment: used non-null storage values
       datetime: '2022-01-01'
-      source: Electricity Maps, 2022 zone average
-      value: 433.68
+      source: Electricity Maps, 2022 zone average; National Laboratory of the Rockies
+      value: 400.08
     - _comment: used storage values greater than zero.
       datetime: '2023-01-01'
-      source: Electricity Maps, 2023 zone average
-      value: 397.57
+      source: Electricity Maps, 2023 zone average; National Laboratory of the Rockies
+      value: 362.11
     - _comment: used storage values greater than zero.
       datetime: '2024-01-01'
-      source: Electricity Maps, 2024 zone average
-      value: 407.87
+      source: Electricity Maps, 2024 zone average; National Laboratory of the Rockies
+      value: 370.04
     - _comment: used storage values greater than zero.
       datetime: '2025-01-01'
-      source: Electricity Maps, 2025 zone average
-      value: 456.74
+      source: Electricity Maps, 2025 zone average; National Laboratory of the Rockies
+      value: 420.65
     biomass:
     - _comment: Mean of all US zones
       datetime: '2020-01-01'

--- a/config/zones/US-MIDW-LGEE.yaml
+++ b/config/zones/US-MIDW-LGEE.yaml
@@ -164,22 +164,22 @@ emissionFactors:
       source: eGrid 2023
       value: 28.739435464835893
     hydro discharge:
-    - _comment: used storage values equal to zero.
+    - _comment: used default IPCC 2014 value of 0.0
       datetime: '2020-01-01'
       source: Electricity Maps, 2020 zone average
-      value: 806.88
-    - _comment: used storage values equal to zero.
+      value: 0.0
+    - _comment: used default IPCC 2014 value of 0.0
       datetime: '2021-01-01'
       source: Electricity Maps, 2021 zone average
-      value: 754.05
-    - _comment: used storage values equal to zero.
+      value: 0.0
+    - _comment: used default IPCC 2014 value of 0.0
       datetime: '2022-01-01'
       source: Electricity Maps, 2022 zone average
-      value: 746.14
+      value: 0.0
     - _comment: used storage values greater than zero.
       datetime: '2025-01-01'
       source: Electricity Maps, 2025 zone average
-      value: 771.27
+      value: 771.69
     oil:
     - _comment: Mean of all US zones
       datetime: '2020-01-01'
@@ -259,22 +259,22 @@ emissionFactors:
       source: eGrid 2023; IPCC 2014
       value: 66.73943546483589
     hydro discharge:
-    - _comment: used storage values equal to zero.
+    - _comment: used default IPCC 2014 value of 24.0
       datetime: '2020-01-01'
-      source: Electricity Maps, 2020 zone average
-      value: 868.17
-    - _comment: used storage values equal to zero.
+      source: Electricity Maps, 2020 zone average; IPCC 2014
+      value: 24.0
+    - _comment: used default IPCC 2014 value of 24.0
       datetime: '2021-01-01'
-      source: Electricity Maps, 2021 zone average
-      value: 824.96
-    - _comment: used storage values equal to zero.
+      source: Electricity Maps, 2021 zone average; IPCC 2014
+      value: 24.0
+    - _comment: used default IPCC 2014 value of 24.0
       datetime: '2022-01-01'
-      source: Electricity Maps, 2022 zone average
-      value: 818.49
+      source: Electricity Maps, 2022 zone average; IPCC 2014
+      value: 24.0
     - _comment: used storage values greater than zero.
       datetime: '2025-01-01'
-      source: Electricity Maps, 2025 zone average
-      value: 840.66
+      source: Electricity Maps, 2025 zone average; IPCC 2014
+      value: 795.69
     oil:
     - _comment: Mean of all US zones
       datetime: '2020-01-01'

--- a/config/zones/US-MIDW-MISO.yaml
+++ b/config/zones/US-MIDW-MISO.yaml
@@ -1232,7 +1232,7 @@ emissionFactors:
     - _comment: used storage values greater than zero.
       datetime: '2025-01-01'
       source: Electricity Maps, 2025 zone average
-      value: 419.96
+      value: 419.95
     biomass:
     - datetime: '2020-01-01'
       source: BEIS 2021
@@ -1306,8 +1306,8 @@ emissionFactors:
     battery discharge:
     - _comment: used storage values greater than zero.
       datetime: '2025-01-01'
-      source: Electricity Maps, 2025 zone average
-      value: 484.08
+      source: Electricity Maps, 2025 zone average; National Laboratory of the Rockies
+      value: 452.95
     biomass:
     - _comment: Mean of all US zones
       datetime: '2020-01-01'

--- a/config/zones/US-NE-ISNE.yaml
+++ b/config/zones/US-NE-ISNE.yaml
@@ -852,30 +852,30 @@ delays:
 emissionFactors:
   direct:
     battery discharge:
-    - _comment: used storage values equal to zero.
+    - _comment: used non-null storage values
       datetime: '2020-01-01'
       source: Electricity Maps, 2020 zone average
-      value: 168.07
-    - _comment: used storage values equal to zero.
+      value: 183.0
+    - _comment: used non-null storage values
       datetime: '2021-01-01'
       source: Electricity Maps, 2021 zone average
-      value: 165.04
-    - _comment: used storage values equal to zero.
+      value: 193.17
+    - _comment: used non-null storage values
       datetime: '2022-01-01'
       source: Electricity Maps, 2022 zone average
-      value: 164.74
-    - _comment: used storage values equal to zero.
+      value: 202.41
+    - _comment: used non-null storage values
       datetime: '2023-01-01'
       source: Electricity Maps, 2023 zone average
-      value: 182.77
-    - _comment: used storage values equal to zero.
+      value: 204.17
+    - _comment: used non-null storage values
       datetime: '2024-01-01'
       source: Electricity Maps, 2024 zone average
-      value: 205.61
-    - _comment: used storage values equal to zero.
+      value: 214.78
+    - _comment: used non-null storage values
       datetime: '2025-01-01'
       source: Electricity Maps, 2025 zone average
-      value: 208.79
+      value: 223.34
     biomass:
     - datetime: '2020-01-01'
       source: BEIS 2021
@@ -947,30 +947,30 @@ emissionFactors:
       value: 976.0253449225385
   lifecycle:
     battery discharge:
-    - _comment: used storage values equal to zero.
+    - _comment: used non-null storage values
       datetime: '2020-01-01'
-      source: Electricity Maps, 2020 zone average
-      value: 243.49
-    - _comment: used storage values equal to zero.
+      source: Electricity Maps, 2020 zone average; National Laboratory of the Rockies
+      value: 216.0
+    - _comment: used non-null storage values
       datetime: '2021-01-01'
-      source: Electricity Maps, 2021 zone average
-      value: 238.98
-    - _comment: used storage values equal to zero.
+      source: Electricity Maps, 2021 zone average; National Laboratory of the Rockies
+      value: 226.17
+    - _comment: used non-null storage values
       datetime: '2022-01-01'
-      source: Electricity Maps, 2022 zone average
-      value: 236.75
-    - _comment: used storage values equal to zero.
+      source: Electricity Maps, 2022 zone average; National Laboratory of the Rockies
+      value: 235.41
+    - _comment: used non-null storage values
       datetime: '2023-01-01'
-      source: Electricity Maps, 2023 zone average
-      value: 260.59
-    - _comment: used storage values equal to zero.
+      source: Electricity Maps, 2023 zone average; National Laboratory of the Rockies
+      value: 237.17
+    - _comment: used non-null storage values
       datetime: '2024-01-01'
-      source: Electricity Maps, 2024 zone average
-      value: 288.12
-    - _comment: used storage values equal to zero.
+      source: Electricity Maps, 2024 zone average; National Laboratory of the Rockies
+      value: 247.78
+    - _comment: used non-null storage values
       datetime: '2025-01-01'
-      source: Electricity Maps, 2025 zone average
-      value: 289.85
+      source: Electricity Maps, 2025 zone average; National Laboratory of the Rockies
+      value: 256.34
     biomass:
     - _comment: Mean of all US zones
       datetime: '2020-01-01'

--- a/config/zones/US-NW-AVA.yaml
+++ b/config/zones/US-NW-AVA.yaml
@@ -242,8 +242,8 @@ emissionFactors:
     hydro discharge:
     - _comment: used storage values greater than zero.
       datetime: '2025-01-01'
-      source: Electricity Maps, 2025 zone average
-      value: 238.74
+      source: Electricity Maps, 2025 zone average; IPCC 2014
+      value: 207.93
     oil:
     - _comment: Mean of all US zones
       datetime: '2020-01-01'

--- a/config/zones/US-NW-IPCO.yaml
+++ b/config/zones/US-NW-IPCO.yaml
@@ -207,7 +207,7 @@ emissionFactors:
     - _comment: used storage values greater than zero.
       datetime: '2025-01-01'
       source: Electricity Maps, 2025 zone average
-      value: 246.67
+      value: 246.68
     biomass:
     - datetime: '2020-01-01'
       source: BEIS 2021
@@ -285,8 +285,8 @@ emissionFactors:
     battery discharge:
     - _comment: used storage values greater than zero.
       datetime: '2025-01-01'
-      source: Electricity Maps, 2025 zone average
-      value: 296.75
+      source: Electricity Maps, 2025 zone average; National Laboratory of the Rockies
+      value: 279.68
     biomass:
     - _comment: Mean of all US zones
       datetime: '2020-01-01'

--- a/config/zones/US-NW-NEVP.yaml
+++ b/config/zones/US-NW-NEVP.yaml
@@ -322,10 +322,10 @@ emissionFactors:
       source: eGrid 2023
       value: 1.183420260702788
     hydro discharge:
-    - _comment: used storage values equal to zero.
+    - _comment: used default IPCC 2014 value of 0.0
       datetime: '2022-01-01'
       source: Electricity Maps, 2022 zone average
-      value: 436.76
+      value: 0.0
     oil:
     - _comment: Mean of all US zones
       datetime: '2020-01-01'
@@ -401,10 +401,10 @@ emissionFactors:
       source: eGrid 2023; IPCC 2014
       value: 39.18342026070279
     hydro discharge:
-    - _comment: used storage values equal to zero.
+    - _comment: used default IPCC 2014 value of 24.0
       datetime: '2022-01-01'
-      source: Electricity Maps, 2022 zone average
-      value: 527.18
+      source: Electricity Maps, 2022 zone average; IPCC 2014
+      value: 24.0
     oil:
     - _comment: Mean of all US zones
       datetime: '2020-01-01'

--- a/config/zones/US-NW-NWMT.yaml
+++ b/config/zones/US-NW-NWMT.yaml
@@ -224,7 +224,7 @@ emissionFactors:
     - _comment: used storage values greater than zero.
       datetime: '2024-01-01'
       source: Electricity Maps, 2024 zone average
-      value: 867.14
+      value: 867.13
     oil:
     - datetime: '2020-01-01'
       source: eGrid 2020
@@ -303,7 +303,7 @@ emissionFactors:
     - _comment: used storage values greater than zero.
       datetime: '2024-01-01'
       source: Electricity Maps, 2024 zone average
-      value: 927.68
+      value: 927.67
     oil:
     - datetime: '2020-01-01'
       source: eGrid 2020; IPCC 2014

--- a/config/zones/US-NW-NWMT.yaml
+++ b/config/zones/US-NW-NWMT.yaml
@@ -302,8 +302,8 @@ emissionFactors:
     hydro discharge:
     - _comment: used storage values greater than zero.
       datetime: '2024-01-01'
-      source: Electricity Maps, 2024 zone average
-      value: 927.67
+      source: Electricity Maps, 2024 zone average; IPCC 2014
+      value: 891.13
     oil:
     - datetime: '2020-01-01'
       source: eGrid 2020; IPCC 2014

--- a/config/zones/US-NW-PACW.yaml
+++ b/config/zones/US-NW-PACW.yaml
@@ -263,7 +263,7 @@ emissionFactors:
     - _comment: used storage values greater than zero.
       datetime: '2021-01-01'
       source: Electricity Maps, 2021 zone average
-      value: 395.8
+      value: 395.79
     oil:
     - _comment: Mean of all US zones
       datetime: '2020-01-01'
@@ -349,12 +349,12 @@ emissionFactors:
     hydro discharge:
     - _comment: used storage values greater than zero.
       datetime: '2020-01-01'
-      source: Electricity Maps, 2020 zone average
-      value: 219.99
+      source: Electricity Maps, 2020 zone average; IPCC 2014
+      value: 211.81
     - _comment: used storage values greater than zero.
       datetime: '2021-01-01'
-      source: Electricity Maps, 2021 zone average
-      value: 447.07
+      source: Electricity Maps, 2021 zone average; IPCC 2014
+      value: 419.79
     oil:
     - _comment: Mean of all US zones
       datetime: '2020-01-01'

--- a/config/zones/US-NW-PGE.yaml
+++ b/config/zones/US-NW-PGE.yaml
@@ -189,7 +189,7 @@ emissionFactors:
     - _comment: used storage values greater than zero.
       datetime: '2025-01-01'
       source: Electricity Maps, 2025 zone average
-      value: 213.1
+      value: 213.12
     biomass:
     - datetime: '2020-01-01'
       source: BEIS 2021
@@ -270,8 +270,8 @@ emissionFactors:
     battery discharge:
     - _comment: used storage values greater than zero.
       datetime: '2025-01-01'
-      source: Electricity Maps, 2025 zone average
-      value: 274.46
+      source: Electricity Maps, 2025 zone average; National Laboratory of the Rockies
+      value: 246.12
     biomass:
     - _comment: Mean of all US zones
       datetime: '2020-01-01'

--- a/config/zones/US-NW-PSCO.yaml
+++ b/config/zones/US-NW-PSCO.yaml
@@ -312,7 +312,7 @@ emissionFactors:
     - _comment: used storage values greater than zero.
       datetime: '2025-01-01'
       source: Electricity Maps, 2025 zone average
-      value: 324.03
+      value: 324.14
     biomass:
     - datetime: '2020-01-01'
       source: BEIS 2021
@@ -390,8 +390,8 @@ emissionFactors:
     battery discharge:
     - _comment: used storage values greater than zero.
       datetime: '2025-01-01'
-      source: Electricity Maps, 2025 zone average
-      value: 379.35
+      source: Electricity Maps, 2025 zone average; National Laboratory of the Rockies
+      value: 357.14
     biomass:
     - _comment: Mean of all US zones
       datetime: '2020-01-01'

--- a/config/zones/US-NW-WACM.yaml
+++ b/config/zones/US-NW-WACM.yaml
@@ -431,8 +431,8 @@ emissionFactors:
     hydro discharge:
     - _comment: used storage values greater than zero.
       datetime: '2025-01-01'
-      source: Electricity Maps, 2025 zone average
-      value: 723.56
+      source: Electricity Maps, 2025 zone average; IPCC 2014
+      value: 695.46
     oil:
     - datetime: '2020-01-01'
       source: eGrid 2020; IPCC 2014

--- a/config/zones/US-SE-SOCO.yaml
+++ b/config/zones/US-SE-SOCO.yaml
@@ -469,7 +469,7 @@ emissionFactors:
     - _comment: used storage values greater than zero.
       datetime: '2025-01-01'
       source: Electricity Maps, 2025 zone average
-      value: 385.89
+      value: 387.51
     biomass:
     - datetime: '2020-01-01'
       source: BEIS 2021
@@ -530,7 +530,7 @@ emissionFactors:
     - _comment: used storage values greater than zero.
       datetime: '2025-01-01'
       source: Electricity Maps, 2025 zone average
-      value: 388.09
+      value: 388.17
     oil:
     - datetime: '2020-01-01'
       source: eGrid 2020
@@ -548,8 +548,8 @@ emissionFactors:
     battery discharge:
     - _comment: used storage values greater than zero.
       datetime: '2025-01-01'
-      source: Electricity Maps, 2025 zone average
-      value: 459.84
+      source: Electricity Maps, 2025 zone average; National Laboratory of the Rockies
+      value: 420.51
     biomass:
     - _comment: Mean of all US zones
       datetime: '2020-01-01'
@@ -613,8 +613,8 @@ emissionFactors:
     hydro discharge:
     - _comment: used storage values greater than zero.
       datetime: '2025-01-01'
-      source: Electricity Maps, 2025 zone average
-      value: 461.86
+      source: Electricity Maps, 2025 zone average; IPCC 2014
+      value: 412.17
     oil:
     - datetime: '2020-01-01'
       source: eGrid 2020; IPCC 2014

--- a/config/zones/US-SW-AZPS.yaml
+++ b/config/zones/US-SW-AZPS.yaml
@@ -193,7 +193,7 @@ emissionFactors:
     - _comment: used storage values greater than zero.
       datetime: '2025-01-01'
       source: Electricity Maps, 2025 zone average
-      value: 261.31
+      value: 261.44
     biomass:
     - datetime: '2020-01-01'
       source: BEIS 2021
@@ -271,8 +271,8 @@ emissionFactors:
     battery discharge:
     - _comment: used storage values greater than zero.
       datetime: '2025-01-01'
-      source: Electricity Maps, 2025 zone average
-      value: 314.3
+      source: Electricity Maps, 2025 zone average; National Laboratory of the Rockies
+      value: 294.44
     biomass:
     - _comment: Mean of all US zones
       datetime: '2020-01-01'

--- a/config/zones/US-SW-PNM.yaml
+++ b/config/zones/US-SW-PNM.yaml
@@ -270,7 +270,7 @@ emissionFactors:
     - _comment: used storage values greater than zero.
       datetime: '2025-01-01'
       source: Electricity Maps, 2025 zone average
-      value: 185.38
+      value: 185.62
     biomass:
     - datetime: '2020-01-01'
       source: BEIS 2021
@@ -336,7 +336,7 @@ emissionFactors:
     - _comment: used storage values greater than zero.
       datetime: '2023-01-01'
       source: Electricity Maps, 2023 zone average
-      value: 353.13
+      value: 356.66
     - _comment: used storage values greater than zero.
       datetime: '2024-01-01'
       source: Electricity Maps, 2024 zone average
@@ -362,16 +362,16 @@ emissionFactors:
     battery discharge:
     - _comment: used storage values greater than zero.
       datetime: '2023-01-01'
-      source: Electricity Maps, 2023 zone average
-      value: 406.83
+      source: Electricity Maps, 2023 zone average; National Laboratory of the Rockies
+      value: 383.94
     - _comment: used storage values greater than zero.
       datetime: '2024-01-01'
-      source: Electricity Maps, 2024 zone average
-      value: 337.44
+      source: Electricity Maps, 2024 zone average; National Laboratory of the Rockies
+      value: 314.11
     - _comment: used storage values greater than zero.
       datetime: '2025-01-01'
-      source: Electricity Maps, 2025 zone average
-      value: 224.72
+      source: Electricity Maps, 2025 zone average; National Laboratory of the Rockies
+      value: 218.62
     biomass:
     - _comment: Mean of all US zones
       datetime: '2020-01-01'
@@ -436,16 +436,16 @@ emissionFactors:
     hydro discharge:
     - _comment: used storage values greater than zero.
       datetime: '2022-01-01'
-      source: Electricity Maps, 2022 zone average
-      value: 685.96
+      source: Electricity Maps, 2022 zone average; IPCC 2014
+      value: 643.21
     - _comment: used storage values greater than zero.
       datetime: '2023-01-01'
-      source: Electricity Maps, 2023 zone average
-      value: 410.18
+      source: Electricity Maps, 2023 zone average; IPCC 2014
+      value: 380.66
     - _comment: used storage values greater than zero.
       datetime: '2024-01-01'
-      source: Electricity Maps, 2024 zone average
-      value: 197.36
+      source: Electricity Maps, 2024 zone average; IPCC 2014
+      value: 185.54
     oil:
     - _comment: Mean of all US zones
       datetime: '2020-01-01'

--- a/config/zones/US-SW-SRP.yaml
+++ b/config/zones/US-SW-SRP.yaml
@@ -179,7 +179,7 @@ emissionFactors:
     - _comment: used storage values greater than zero.
       datetime: '2025-01-01'
       source: Electricity Maps, 2025 zone average
-      value: 241.8
+      value: 241.85
     biomass:
     - datetime: '2020-01-01'
       source: BEIS 2021
@@ -252,7 +252,7 @@ emissionFactors:
     - _comment: used storage values greater than zero.
       datetime: '2023-01-01'
       source: Electricity Maps, 2023 zone average
-      value: 267.03
+      value: 267.21
     - _comment: used storage values greater than zero.
       datetime: '2024-01-01'
       source: Electricity Maps, 2024 zone average
@@ -260,7 +260,7 @@ emissionFactors:
     - _comment: used storage values greater than zero.
       datetime: '2025-01-01'
       source: Electricity Maps, 2025 zone average
-      value: 241.52
+      value: 242.98
     oil:
     - _comment: Mean of all US zones
       datetime: '2020-01-01'
@@ -282,16 +282,16 @@ emissionFactors:
     battery discharge:
     - _comment: used storage values greater than zero.
       datetime: '2023-01-01'
-      source: Electricity Maps, 2023 zone average
-      value: 305.97
+      source: Electricity Maps, 2023 zone average; National Laboratory of the Rockies
+      value: 283.01
     - _comment: used storage values greater than zero.
       datetime: '2024-01-01'
-      source: Electricity Maps, 2024 zone average
-      value: 293.07
+      source: Electricity Maps, 2024 zone average; National Laboratory of the Rockies
+      value: 275.56
     - _comment: used storage values greater than zero.
       datetime: '2025-01-01'
-      source: Electricity Maps, 2025 zone average
-      value: 299.15
+      source: Electricity Maps, 2025 zone average; National Laboratory of the Rockies
+      value: 274.85
     biomass:
     - _comment: Mean of all US zones
       datetime: '2020-01-01'
@@ -355,28 +355,28 @@ emissionFactors:
     hydro discharge:
     - _comment: used storage values greater than zero.
       datetime: '2020-01-01'
-      source: Electricity Maps, 2020 zone average
-      value: 303.47
+      source: Electricity Maps, 2020 zone average; IPCC 2014
+      value: 261.84
     - _comment: used storage values greater than zero.
       datetime: '2021-01-01'
-      source: Electricity Maps, 2021 zone average
-      value: 269.32
+      source: Electricity Maps, 2021 zone average; IPCC 2014
+      value: 238.07
     - _comment: used storage values greater than zero.
       datetime: '2022-01-01'
-      source: Electricity Maps, 2022 zone average
-      value: 259.64
+      source: Electricity Maps, 2022 zone average; IPCC 2014
+      value: 230.8
     - _comment: used storage values greater than zero.
       datetime: '2023-01-01'
-      source: Electricity Maps, 2023 zone average
-      value: 326.86
+      source: Electricity Maps, 2023 zone average; IPCC 2014
+      value: 291.21
     - _comment: used storage values greater than zero.
       datetime: '2024-01-01'
-      source: Electricity Maps, 2024 zone average
-      value: 286.85
+      source: Electricity Maps, 2024 zone average; IPCC 2014
+      value: 259.1
     - _comment: used storage values greater than zero.
       datetime: '2025-01-01'
-      source: Electricity Maps, 2025 zone average
-      value: 292.35
+      source: Electricity Maps, 2025 zone average; IPCC 2014
+      value: 266.98
     oil:
     - _comment: Mean of all US zones
       datetime: '2020-01-01'

--- a/config/zones/US-SW-SRP.yaml
+++ b/config/zones/US-SW-SRP.yaml
@@ -256,7 +256,7 @@ emissionFactors:
     - _comment: used storage values greater than zero.
       datetime: '2024-01-01'
       source: Electricity Maps, 2024 zone average
-      value: 234.07
+      value: 235.1
     - _comment: used storage values greater than zero.
       datetime: '2025-01-01'
       source: Electricity Maps, 2025 zone average
@@ -372,7 +372,7 @@ emissionFactors:
     - _comment: used storage values greater than zero.
       datetime: '2024-01-01'
       source: Electricity Maps, 2024 zone average
-      value: 285.6
+      value: 286.85
     - _comment: used storage values greater than zero.
       datetime: '2025-01-01'
       source: Electricity Maps, 2025 zone average

--- a/config/zones/US-SW-TEPC.yaml
+++ b/config/zones/US-SW-TEPC.yaml
@@ -138,7 +138,7 @@ emissionFactors:
     - _comment: used storage values greater than zero.
       datetime: '2025-01-01'
       source: Electricity Maps, 2025 zone average
-      value: 405.46
+      value: 406.82
     biomass:
     - datetime: '2020-01-01'
       source: BEIS 2021
@@ -216,8 +216,8 @@ emissionFactors:
     battery discharge:
     - _comment: used storage values greater than zero.
       datetime: '2025-01-01'
-      source: Electricity Maps, 2025 zone average
-      value: 486.89
+      source: Electricity Maps, 2025 zone average; National Laboratory of the Rockies
+      value: 439.82
     biomass:
     - _comment: Mean of all US zones
       datetime: '2020-01-01'

--- a/config/zones/US-SW-WALC.yaml
+++ b/config/zones/US-SW-WALC.yaml
@@ -288,12 +288,12 @@ emissionFactors:
     hydro discharge:
     - _comment: used storage values greater than zero.
       datetime: '2024-01-01'
-      source: Electricity Maps, 2024 zone average
-      value: 321.72
+      source: Electricity Maps, 2024 zone average; IPCC 2014
+      value: 274.74
     - _comment: used storage values greater than zero.
       datetime: '2025-01-01'
-      source: Electricity Maps, 2025 zone average
-      value: 597.93
+      source: Electricity Maps, 2025 zone average; IPCC 2014
+      value: 562.35
     oil:
     - _comment: Mean of all US zones
       datetime: '2020-01-01'

--- a/config/zones/US-TEN-TVA.yaml
+++ b/config/zones/US-TEN-TVA.yaml
@@ -276,7 +276,7 @@ emissionFactors:
     - _comment: used storage values equal to zero.
       datetime: '2024-01-01'
       source: Electricity Maps, 2024 zone average
-      value: 366.23
+      value: 366.24
     - _comment: used storage values equal to zero.
       datetime: '2025-01-01'
       source: Electricity Maps, 2025 zone average
@@ -379,7 +379,7 @@ emissionFactors:
     - _comment: used storage values equal to zero.
       datetime: '2024-01-01'
       source: Electricity Maps, 2024 zone average
-      value: 433.69
+      value: 433.7
     - _comment: used storage values equal to zero.
       datetime: '2025-01-01'
       source: Electricity Maps, 2025 zone average

--- a/config/zones/US-TEN-TVA.yaml
+++ b/config/zones/US-TEN-TVA.yaml
@@ -273,14 +273,14 @@ delays:
 emissionFactors:
   direct:
     battery discharge:
-    - _comment: used storage values equal to zero.
+    - _comment: used non-null storage values
       datetime: '2024-01-01'
       source: Electricity Maps, 2024 zone average
       value: 366.24
-    - _comment: used storage values equal to zero.
+    - _comment: used non-null storage values
       datetime: '2025-01-01'
       source: Electricity Maps, 2025 zone average
-      value: 337.49
+      value: 342.17
     biomass:
     - datetime: '2020-01-01'
       source: BEIS 2021
@@ -338,6 +338,10 @@ emissionFactors:
       source: eGrid 2023
       value: 28.739435464835893
     hydro discharge:
+    - _comment: used default IPCC 2014 value of 0.0
+      datetime: '2020-01-01'
+      source: Electricity Maps, 2020 zone average
+      value: 0.0
     - _comment: used storage values greater than zero.
       datetime: '2021-01-01'
       source: Electricity Maps, 2021 zone average
@@ -357,7 +361,7 @@ emissionFactors:
     - _comment: used storage values greater than zero.
       datetime: '2025-01-01'
       source: Electricity Maps, 2025 zone average
-      value: 341.49
+      value: 341.53
     oil:
     - datetime: '2020-01-01'
       source: eGrid 2020
@@ -376,14 +380,14 @@ emissionFactors:
       value: 692.2365799135232
   lifecycle:
     battery discharge:
-    - _comment: used storage values equal to zero.
+    - _comment: used non-null storage values
       datetime: '2024-01-01'
-      source: Electricity Maps, 2024 zone average
-      value: 433.7
-    - _comment: used storage values equal to zero.
+      source: Electricity Maps, 2024 zone average; National Laboratory of the Rockies
+      value: 399.24
+    - _comment: used non-null storage values
       datetime: '2025-01-01'
-      source: Electricity Maps, 2025 zone average
-      value: 394.99
+      source: Electricity Maps, 2025 zone average; National Laboratory of the Rockies
+      value: 375.17
     biomass:
     - _comment: Mean of all US zones
       datetime: '2020-01-01'
@@ -445,26 +449,30 @@ emissionFactors:
       source: eGrid 2023; IPCC 2014
       value: 66.73943546483589
     hydro discharge:
+    - _comment: used default IPCC 2014 value of 24.0
+      datetime: '2020-01-01'
+      source: Electricity Maps, 2020 zone average; IPCC 2014
+      value: 24.0
     - _comment: used storage values greater than zero.
       datetime: '2021-01-01'
-      source: Electricity Maps, 2021 zone average
-      value: 386.34
+      source: Electricity Maps, 2021 zone average; IPCC 2014
+      value: 355.87
     - _comment: used storage values greater than zero.
       datetime: '2022-01-01'
-      source: Electricity Maps, 2022 zone average
-      value: 423.24
+      source: Electricity Maps, 2022 zone average; IPCC 2014
+      value: 388.52
     - _comment: used storage values greater than zero.
       datetime: '2023-01-01'
-      source: Electricity Maps, 2023 zone average
-      value: 380.26
+      source: Electricity Maps, 2023 zone average; IPCC 2014
+      value: 349.56
     - _comment: used storage values greater than zero.
       datetime: '2024-01-01'
-      source: Electricity Maps, 2024 zone average
-      value: 431.93
+      source: Electricity Maps, 2024 zone average; IPCC 2014
+      value: 389.26
     - _comment: used storage values greater than zero.
       datetime: '2025-01-01'
-      source: Electricity Maps, 2025 zone average
-      value: 399.24
+      source: Electricity Maps, 2025 zone average; IPCC 2014
+      value: 365.53
     oil:
     - datetime: '2020-01-01'
       source: eGrid 2020; IPCC 2014

--- a/config/zones/US-TEX-ERCO.yaml
+++ b/config/zones/US-TEX-ERCO.yaml
@@ -845,7 +845,7 @@ emissionFactors:
     - _comment: used storage values greater than zero.
       datetime: '2025-01-01'
       source: Electricity Maps, 2025 zone average
-      value: 268.51
+      value: 268.58
     biomass:
     - datetime: '2020-01-01'
       source: BEIS 2021
@@ -919,8 +919,8 @@ emissionFactors:
     battery discharge:
     - _comment: used storage values greater than zero.
       datetime: '2025-01-01'
-      source: Electricity Maps, 2025 zone average
-      value: 326.64
+      source: Electricity Maps, 2025 zone average; National Laboratory of the Rockies
+      value: 301.58
     biomass:
     - _comment: Mean of all US zones
       datetime: '2020-01-01'

--- a/config/zones/US.yaml
+++ b/config/zones/US.yaml
@@ -226,19 +226,19 @@ emissionFactors:
     - _comment: used storage values greater than zero.
       datetime: '2020-01-01'
       source: Electricity Maps, 2020 zone average
-      value: 359.31
+      value: 359.36
     - _comment: used storage values greater than zero.
       datetime: '2021-01-01'
       source: Electricity Maps, 2021 zone average
-      value: 381.24
+      value: 381.29
     - _comment: used storage values greater than zero.
       datetime: '2022-01-01'
       source: Electricity Maps, 2022 zone average
-      value: 363.25
+      value: 363.26
     - _comment: used storage values greater than zero.
       datetime: '2023-01-01'
       source: Electricity Maps, 2023 zone average
-      value: 340.6
+      value: 340.62
     - _comment: used storage values greater than zero.
       datetime: '2024-01-01'
       source: Electricity Maps, 2024 zone average
@@ -246,7 +246,7 @@ emissionFactors:
     - _comment: used storage values greater than zero.
       datetime: '2025-01-01'
       source: Electricity Maps, 2025 zone average
-      value: 329.91
+      value: 330.63
     biomass:
       datetime: '2020-01-01'
       source: eGrid 2020
@@ -267,19 +267,19 @@ emissionFactors:
     - _comment: used storage values greater than zero.
       datetime: '2020-01-01'
       source: Electricity Maps, 2020 zone average
-      value: 353.37
+      value: 353.42
     - _comment: used storage values greater than zero.
       datetime: '2021-01-01'
       source: Electricity Maps, 2021 zone average
-      value: 378.73
+      value: 378.82
     - _comment: used storage values greater than zero.
       datetime: '2022-01-01'
       source: Electricity Maps, 2022 zone average
-      value: 360.46
+      value: 360.64
     - _comment: used storage values greater than zero.
       datetime: '2023-01-01'
       source: Electricity Maps, 2023 zone average
-      value: 343.43
+      value: 343.72
     - _comment: used storage values greater than zero.
       datetime: '2024-01-01'
       source: Electricity Maps, 2024 zone average
@@ -287,7 +287,7 @@ emissionFactors:
     - _comment: used storage values greater than zero.
       datetime: '2025-01-01'
       source: Electricity Maps, 2025 zone average
-      value: 334.05
+      value: 335.24
     oil:
       datetime: '2021-01-01'
       source: eGrid 2020
@@ -296,28 +296,28 @@ emissionFactors:
     battery discharge:
     - _comment: used storage values greater than zero.
       datetime: '2020-01-01'
-      source: Electricity Maps, 2020 zone average
-      value: 426.43
+      source: Electricity Maps, 2020 zone average; National Laboratory of the Rockies
+      value: 392.36
     - _comment: used storage values greater than zero.
       datetime: '2021-01-01'
-      source: Electricity Maps, 2021 zone average
-      value: 447.58
+      source: Electricity Maps, 2021 zone average; National Laboratory of the Rockies
+      value: 414.29
     - _comment: used storage values greater than zero.
       datetime: '2022-01-01'
-      source: Electricity Maps, 2022 zone average
-      value: 429.61
+      source: Electricity Maps, 2022 zone average; National Laboratory of the Rockies
+      value: 396.26
     - _comment: used storage values greater than zero.
       datetime: '2023-01-01'
-      source: Electricity Maps, 2023 zone average
-      value: 408.68
+      source: Electricity Maps, 2023 zone average; National Laboratory of the Rockies
+      value: 373.62
     - _comment: used storage values greater than zero.
       datetime: '2024-01-01'
-      source: Electricity Maps, 2024 zone average
-      value: 396.98
+      source: Electricity Maps, 2024 zone average; National Laboratory of the Rockies
+      value: 362.42
     - _comment: used storage values greater than zero.
       datetime: '2025-01-01'
-      source: Electricity Maps, 2025 zone average
-      value: 395.16
+      source: Electricity Maps, 2025 zone average; National Laboratory of the Rockies
+      value: 363.63
     biomass:
       datetime: '2020-01-01'
       source: eGrid 2020
@@ -337,28 +337,28 @@ emissionFactors:
     hydro discharge:
     - _comment: used storage values greater than zero.
       datetime: '2020-01-01'
-      source: Electricity Maps, 2020 zone average
-      value: 419.16
+      source: Electricity Maps, 2020 zone average; IPCC 2014
+      value: 377.42
     - _comment: used storage values greater than zero.
       datetime: '2021-01-01'
-      source: Electricity Maps, 2021 zone average
-      value: 443.53
+      source: Electricity Maps, 2021 zone average; IPCC 2014
+      value: 402.82
     - _comment: used storage values greater than zero.
       datetime: '2022-01-01'
-      source: Electricity Maps, 2022 zone average
-      value: 425.47
+      source: Electricity Maps, 2022 zone average; IPCC 2014
+      value: 384.64
     - _comment: used storage values greater than zero.
       datetime: '2023-01-01'
-      source: Electricity Maps, 2023 zone average
-      value: 411.47
+      source: Electricity Maps, 2023 zone average; IPCC 2014
+      value: 367.72
     - _comment: used storage values greater than zero.
       datetime: '2024-01-01'
-      source: Electricity Maps, 2024 zone average
-      value: 399.82
+      source: Electricity Maps, 2024 zone average; IPCC 2014
+      value: 356.64
     - _comment: used storage values greater than zero.
       datetime: '2025-01-01'
-      source: Electricity Maps, 2025 zone average
-      value: 398.97
+      source: Electricity Maps, 2025 zone average; IPCC 2014
+      value: 359.24
     oil:
       datetime: '2021-01-01'
       source: eGrid 2020; IPCC 2014

--- a/config/zones/US.yaml
+++ b/config/zones/US.yaml
@@ -242,7 +242,7 @@ emissionFactors:
     - _comment: used storage values greater than zero.
       datetime: '2024-01-01'
       source: Electricity Maps, 2024 zone average
-      value: 329.4
+      value: 329.42
     - _comment: used storage values greater than zero.
       datetime: '2025-01-01'
       source: Electricity Maps, 2025 zone average
@@ -283,7 +283,7 @@ emissionFactors:
     - _comment: used storage values greater than zero.
       datetime: '2024-01-01'
       source: Electricity Maps, 2024 zone average
-      value: 332.02
+      value: 332.64
     - _comment: used storage values greater than zero.
       datetime: '2025-01-01'
       source: Electricity Maps, 2025 zone average
@@ -313,7 +313,7 @@ emissionFactors:
     - _comment: used storage values greater than zero.
       datetime: '2024-01-01'
       source: Electricity Maps, 2024 zone average
-      value: 396.95
+      value: 396.98
     - _comment: used storage values greater than zero.
       datetime: '2025-01-01'
       source: Electricity Maps, 2025 zone average
@@ -354,7 +354,7 @@ emissionFactors:
     - _comment: used storage values greater than zero.
       datetime: '2024-01-01'
       source: Electricity Maps, 2024 zone average
-      value: 399.08
+      value: 399.82
     - _comment: used storage values greater than zero.
       datetime: '2025-01-01'
       source: Electricity Maps, 2025 zone average

--- a/config/zones/ZA.yaml
+++ b/config/zones/ZA.yaml
@@ -129,33 +129,33 @@ emissionFactors:
     - _comment: used storage values greater than zero.
       datetime: '2025-01-01'
       source: Electricity Maps, 2025 zone average
-      value: 644.75
+      value: 644.62
   lifecycle:
     hydro discharge:
     - _comment: used storage values greater than zero.
       datetime: '2020-01-01'
-      source: Electricity Maps, 2020 zone average
-      value: 713.76
+      source: Electricity Maps, 2020 zone average; IPCC 2014
+      value: 680.24
     - _comment: used storage values greater than zero.
       datetime: '2021-01-01'
-      source: Electricity Maps, 2021 zone average
-      value: 699.36
+      source: Electricity Maps, 2021 zone average; IPCC 2014
+      value: 665.08
     - _comment: used storage values greater than zero.
       datetime: '2022-01-01'
-      source: Electricity Maps, 2022 zone average
-      value: 696.33
+      source: Electricity Maps, 2022 zone average; IPCC 2014
+      value: 661.55
     - _comment: used storage values greater than zero.
       datetime: '2023-01-01'
-      source: Electricity Maps, 2023 zone average
-      value: 692.44
+      source: Electricity Maps, 2023 zone average; IPCC 2014
+      value: 655.99
     - _comment: used storage values greater than zero.
       datetime: '2024-01-01'
-      source: Electricity Maps, 2024 zone average
-      value: 715.53
+      source: Electricity Maps, 2024 zone average; IPCC 2014
+      value: 682.28
     - _comment: used storage values greater than zero.
       datetime: '2025-01-01'
-      source: Electricity Maps, 2025 zone average
-      value: 701.24
+      source: Electricity Maps, 2025 zone average; IPCC 2014
+      value: 668.62
 fallbackZoneMixes:
   powerOriginRatios:
   - _source: Electricity Maps, 2015 average


### PR DESCRIPTION
Note from emission factor meeting:
* Denominator for the calculation of emission factor of discharging: Need to remove consumption of Battery and hydro discharge from total_consumption (need to sum up to 1)
* Default of hydro_discharge should be hydro (if hydro_discharge always positive , i.e. never charging).
* Default of battery_discharge should be the grid emission


Question in suspense: (Maybe of lesser importance)
* Lifecycle emission of battery and hydro_storage: Should we have the grid_emission + the infrastructure emission factors? So for hydro discharge it should be at least hydro.