### PR TITLE
feat(emission-factors): remove us-fla-fpl powerplant that has low oil factor

### DIFF
--- a/config/zones/US-AK-SEAPA.yaml
+++ b/config/zones/US-AK-SEAPA.yaml
@@ -91,7 +91,7 @@ emissionFactors:
       - _comment: Mean of all US zones
         datetime: '2023-01-01'
         source: eGrid 2023
-        value: 757.3688858307635
+        value: 757.4527012126907
   lifecycle:
     biomass:
       - _comment: Mean of all US zones
@@ -177,7 +177,7 @@ emissionFactors:
       - _comment: Mean of all US zones
         datetime: '2023-01-01'
         source: eGrid 2023; IPCC 2014
-        value: 1001.3688858307635
+        value: 1001.4527012126907
 fallbackZoneMixes:
   powerOriginRatios:
     - _source: Electricity Maps, 2024 average

--- a/config/zones/US-CAL-BANC.yaml
+++ b/config/zones/US-CAL-BANC.yaml
@@ -216,7 +216,7 @@ emissionFactors:
       - _comment: Mean of all US zones
         datetime: '2023-01-01'
         source: eGrid 2023
-        value: 757.3688858307635
+        value: 757.4527012126907
   lifecycle:
     biomass:
       - _comment: Mean of all US zones
@@ -298,7 +298,7 @@ emissionFactors:
       - _comment: Mean of all US zones
         datetime: '2023-01-01'
         source: eGrid 2023; IPCC 2014
-        value: 1001.3688858307635
+        value: 1001.4527012126907
     solar:
       datetime: '2021-01-01'
       source: INCER ACV

--- a/config/zones/US-CAL-IID.yaml
+++ b/config/zones/US-CAL-IID.yaml
@@ -229,7 +229,7 @@ emissionFactors:
       - _comment: Mean of all US zones
         datetime: '2023-01-01'
         source: eGrid 2023
-        value: 757.3688858307635
+        value: 757.4527012126907
   lifecycle:
     battery discharge:
       - _comment: used storage values greater than zero.
@@ -321,7 +321,7 @@ emissionFactors:
       - _comment: Mean of all US zones
         datetime: '2023-01-01'
         source: eGrid 2023; IPCC 2014
-        value: 1001.3688858307635
+        value: 1001.4527012126907
     solar:
       datetime: '2021-01-01'
       source: INCER ACV

--- a/config/zones/US-CAL-LDWP.yaml
+++ b/config/zones/US-CAL-LDWP.yaml
@@ -325,7 +325,7 @@ emissionFactors:
       - _comment: Mean of all US zones
         datetime: '2023-01-01'
         source: eGrid 2023
-        value: 757.3688858307635
+        value: 757.4527012126907
   lifecycle:
     battery discharge:
       - _comment: used non-null storage values
@@ -429,7 +429,7 @@ emissionFactors:
       - _comment: Mean of all US zones
         datetime: '2023-01-01'
         source: eGrid 2023; IPCC 2014
-        value: 1001.3688858307635
+        value: 1001.4527012126907
     solar:
       datetime: '2021-01-01'
       source: INCER ACV

--- a/config/zones/US-CAL-TIDC.yaml
+++ b/config/zones/US-CAL-TIDC.yaml
@@ -152,7 +152,7 @@ emissionFactors:
       - _comment: Mean of all US zones
         datetime: '2023-01-01'
         source: eGrid 2023
-        value: 757.3688858307635
+        value: 757.4527012126907
   lifecycle:
     biomass:
       - _comment: Mean of all US zones
@@ -239,7 +239,7 @@ emissionFactors:
       - _comment: Mean of all US zones
         datetime: '2023-01-01'
         source: eGrid 2023; IPCC 2014
-        value: 1001.3688858307635
+        value: 1001.4527012126907
 fallbackZoneMixes:
   powerOriginRatios:
     - _source: Electricity Maps, 2015 average

--- a/config/zones/US-CAR-CPLE.yaml
+++ b/config/zones/US-CAR-CPLE.yaml
@@ -358,7 +358,7 @@ emissionFactors:
       - _comment: Mean of all US zones
         datetime: '2023-01-01'
         source: eGrid 2023
-        value: 757.3688858307635
+        value: 757.4527012126907
   lifecycle:
     battery discharge:
       - _comment: used storage values greater than zero.
@@ -462,7 +462,7 @@ emissionFactors:
       - _comment: Mean of all US zones
         datetime: '2023-01-01'
         source: eGrid 2023; IPCC 2014
-        value: 1001.3688858307635
+        value: 1001.4527012126907
     solar:
       datetime: '2021-01-01'
       source: INCER ACV

--- a/config/zones/US-CAR-CPLW.yaml
+++ b/config/zones/US-CAR-CPLW.yaml
@@ -191,7 +191,7 @@ emissionFactors:
       - _comment: Mean of all US zones
         datetime: '2023-01-01'
         source: eGrid 2023
-        value: 757.3688858307635
+        value: 757.4527012126907
   lifecycle:
     biomass:
       - _comment: Mean of all US zones
@@ -305,7 +305,7 @@ emissionFactors:
       - _comment: Mean of all US zones
         datetime: '2023-01-01'
         source: eGrid 2023; IPCC 2014
-        value: 1001.3688858307635
+        value: 1001.4527012126907
     solar:
       datetime: '2021-01-01'
       source: INCER ACV

--- a/config/zones/US-CAR-DUK.yaml
+++ b/config/zones/US-CAR-DUK.yaml
@@ -448,7 +448,7 @@ emissionFactors:
       - _comment: Mean of all US zones
         datetime: '2023-01-01'
         source: eGrid 2023
-        value: 757.3688858307635
+        value: 757.4527012126907
   lifecycle:
     battery discharge:
       - _comment: used storage values greater than zero.
@@ -552,7 +552,7 @@ emissionFactors:
       - _comment: Mean of all US zones
         datetime: '2023-01-01'
         source: eGrid 2023; IPCC 2014
-        value: 1001.3688858307635
+        value: 1001.4527012126907
     solar:
       datetime: '2021-01-01'
       source: INCER ACV

--- a/config/zones/US-CAR-SC.yaml
+++ b/config/zones/US-CAR-SC.yaml
@@ -205,7 +205,7 @@ emissionFactors:
       - _comment: Mean of all US zones
         datetime: '2023-01-01'
         source: eGrid 2023
-        value: 757.3688858307635
+        value: 757.4527012126907
   lifecycle:
     biomass:
       - _comment: Mean of all US zones
@@ -303,7 +303,7 @@ emissionFactors:
       - _comment: Mean of all US zones
         datetime: '2023-01-01'
         source: eGrid 2023; IPCC 2014
-        value: 1001.3688858307635
+        value: 1001.4527012126907
     solar:
       datetime: '2021-01-01'
       source: INCER ACV

--- a/config/zones/US-CAR-SCEG.yaml
+++ b/config/zones/US-CAR-SCEG.yaml
@@ -283,7 +283,7 @@ emissionFactors:
       - _comment: Mean of all US zones
         datetime: '2023-01-01'
         source: eGrid 2023
-        value: 757.3688858307635
+        value: 757.4527012126907
   lifecycle:
     biomass:
       - _comment: Mean of all US zones
@@ -365,7 +365,7 @@ emissionFactors:
       - _comment: Mean of all US zones
         datetime: '2023-01-01'
         source: eGrid 2023; IPCC 2014
-        value: 1001.3688858307635
+        value: 1001.4527012126907
     solar:
       datetime: '2021-01-01'
       source: INCER ACV

--- a/config/zones/US-CAR-YAD.yaml
+++ b/config/zones/US-CAR-YAD.yaml
@@ -143,7 +143,7 @@ emissionFactors:
       - _comment: Mean of all US zones
         datetime: '2023-01-01'
         source: eGrid 2023
-        value: 757.3688858307635
+        value: 757.4527012126907
   lifecycle:
     biomass:
       - _comment: Mean of all US zones
@@ -232,7 +232,7 @@ emissionFactors:
       - _comment: Mean of all US zones
         datetime: '2023-01-01'
         source: eGrid 2023; IPCC 2014
-        value: 1001.3688858307635
+        value: 1001.4527012126907
 fallbackZoneMixes:
   powerOriginRatios:
     - _source: Electricity Maps, 2015 average

--- a/config/zones/US-CENT-SPA.yaml
+++ b/config/zones/US-CENT-SPA.yaml
@@ -189,7 +189,7 @@ emissionFactors:
       - _comment: Mean of all US zones
         datetime: '2023-01-01'
         source: eGrid 2023
-        value: 757.3688858307635
+        value: 757.4527012126907
   lifecycle:
     biomass:
       - _comment: Mean of all US zones
@@ -274,7 +274,7 @@ emissionFactors:
       - _comment: Mean of all US zones
         datetime: '2023-01-01'
         source: eGrid 2023; IPCC 2014
-        value: 1001.3688858307635
+        value: 1001.4527012126907
 fallbackZoneMixes:
   powerOriginRatios:
     - _source: Electricity Maps, 2015 average

--- a/config/zones/US-FLA-FMPP.yaml
+++ b/config/zones/US-FLA-FMPP.yaml
@@ -176,7 +176,7 @@ emissionFactors:
       - _comment: Mean of all US zones
         datetime: '2023-01-01'
         source: eGrid 2023
-        value: 757.3688858307635
+        value: 757.4527012126907
   lifecycle:
     biomass:
       - _comment: Mean of all US zones
@@ -253,7 +253,7 @@ emissionFactors:
       - _comment: Mean of all US zones
         datetime: '2023-01-01'
         source: eGrid 2023; IPCC 2014
-        value: 1001.3688858307635
+        value: 1001.4527012126907
     solar:
       datetime: '2021-01-01'
       source: INCER ACV

--- a/config/zones/US-FLA-FPL.yaml
+++ b/config/zones/US-FLA-FPL.yaml
@@ -287,9 +287,10 @@ emissionFactors:
       - datetime: '2022-01-01'
         source: eGrid 2022
         value: 289.96851114965034
-      - datetime: '2023-01-01'
+      - _comment: Mean of all US zones
+        datetime: '2023-01-01'
         source: eGrid 2023
-        value: 175.09320207293555
+        value: 757.4527012126907
   lifecycle:
     battery discharge:
       - _comment: used storage values greater than zero.
@@ -370,9 +371,10 @@ emissionFactors:
       - datetime: '2022-01-01'
         source: eGrid 2022; IPCC 2014
         value: 533.9685111496503
-      - datetime: '2023-01-01'
+      - _comment: Mean of all US zones
+        datetime: '2023-01-01'
         source: eGrid 2023; IPCC 2014
-        value: 419.0932020729356
+        value: 1001.4527012126907
     solar:
       datetime: '2021-01-01'
       source: INCER ACV

--- a/config/zones/US-FLA-GVL.yaml
+++ b/config/zones/US-FLA-GVL.yaml
@@ -163,7 +163,7 @@ emissionFactors:
       - _comment: Mean of all US zones
         datetime: '2023-01-01'
         source: eGrid 2023
-        value: 757.3688858307635
+        value: 757.4527012126907
   lifecycle:
     biomass:
       - _comment: Mean of all US zones
@@ -243,7 +243,7 @@ emissionFactors:
       - _comment: Mean of all US zones
         datetime: '2023-01-01'
         source: eGrid 2023; IPCC 2014
-        value: 1001.3688858307635
+        value: 1001.4527012126907
     solar:
       datetime: '2021-01-01'
       source: INCER ACV

--- a/config/zones/US-FLA-HST.yaml
+++ b/config/zones/US-FLA-HST.yaml
@@ -157,7 +157,7 @@ emissionFactors:
       - _comment: Mean of all US zones
         datetime: '2023-01-01'
         source: eGrid 2023
-        value: 757.3688858307635
+        value: 757.4527012126907
   lifecycle:
     biomass:
       - _comment: Mean of all US zones
@@ -246,7 +246,7 @@ emissionFactors:
       - _comment: Mean of all US zones
         datetime: '2023-01-01'
         source: eGrid 2023; IPCC 2014
-        value: 1001.3688858307635
+        value: 1001.4527012126907
 fallbackZoneMixes:
   powerOriginRatios:
     - _source: Electricity Maps, 2017 average

--- a/config/zones/US-FLA-JEA.yaml
+++ b/config/zones/US-FLA-JEA.yaml
@@ -173,7 +173,7 @@ emissionFactors:
       - _comment: Mean of all US zones
         datetime: '2023-01-01'
         source: eGrid 2023
-        value: 757.3688858307635
+        value: 757.4527012126907
   lifecycle:
     biomass:
       - _comment: Mean of all US zones
@@ -255,7 +255,7 @@ emissionFactors:
       - _comment: Mean of all US zones
         datetime: '2023-01-01'
         source: eGrid 2023; IPCC 2014
-        value: 1001.3688858307635
+        value: 1001.4527012126907
     solar:
       datetime: '2021-01-01'
       source: INCER ACV

--- a/config/zones/US-FLA-SEC.yaml
+++ b/config/zones/US-FLA-SEC.yaml
@@ -155,7 +155,7 @@ emissionFactors:
       - _comment: Mean of all US zones
         datetime: '2023-01-01'
         source: eGrid 2023
-        value: 757.3688858307635
+        value: 757.4527012126907
   lifecycle:
     biomass:
       - _comment: Mean of all US zones
@@ -233,7 +233,7 @@ emissionFactors:
       - _comment: Mean of all US zones
         datetime: '2023-01-01'
         source: eGrid 2023; IPCC 2014
-        value: 1001.3688858307635
+        value: 1001.4527012126907
     solar:
       datetime: '2021-01-01'
       source: INCER ACV

--- a/config/zones/US-FLA-TAL.yaml
+++ b/config/zones/US-FLA-TAL.yaml
@@ -165,7 +165,7 @@ emissionFactors:
       - _comment: Mean of all US zones
         datetime: '2023-01-01'
         source: eGrid 2023
-        value: 757.3688858307635
+        value: 757.4527012126907
   lifecycle:
     biomass:
       - _comment: Mean of all US zones
@@ -247,7 +247,7 @@ emissionFactors:
       - _comment: Mean of all US zones
         datetime: '2023-01-01'
         source: eGrid 2023; IPCC 2014
-        value: 1001.3688858307635
+        value: 1001.4527012126907
 fallbackZoneMixes:
   powerOriginRatios:
     - _source: Electricity Maps, 2015 average

--- a/config/zones/US-FLA-TEC.yaml
+++ b/config/zones/US-FLA-TEC.yaml
@@ -263,7 +263,7 @@ emissionFactors:
       - _comment: Mean of all US zones
         datetime: '2023-01-01'
         source: eGrid 2023
-        value: 757.3688858307635
+        value: 757.4527012126907
   lifecycle:
     biomass:
       - _comment: Mean of all US zones
@@ -343,7 +343,7 @@ emissionFactors:
       - _comment: Mean of all US zones
         datetime: '2023-01-01'
         source: eGrid 2023; IPCC 2014
-        value: 1001.3688858307635
+        value: 1001.4527012126907
     solar:
       datetime: '2021-01-01'
       source: INCER ACV

--- a/config/zones/US-MIDW-AECI.yaml
+++ b/config/zones/US-MIDW-AECI.yaml
@@ -169,7 +169,7 @@ emissionFactors:
       - _comment: Mean of all US zones
         datetime: '2023-01-01'
         source: eGrid 2023
-        value: 757.3688858307635
+        value: 757.4527012126907
   lifecycle:
     biomass:
       - _comment: Mean of all US zones
@@ -246,7 +246,7 @@ emissionFactors:
       - _comment: Mean of all US zones
         datetime: '2023-01-01'
         source: eGrid 2023; IPCC 2014
-        value: 1001.3688858307635
+        value: 1001.4527012126907
     solar:
       datetime: '2021-01-01'
       source: INCER ACV

--- a/config/zones/US-MIDW-LGEE.yaml
+++ b/config/zones/US-MIDW-LGEE.yaml
@@ -196,7 +196,7 @@ emissionFactors:
       - _comment: Mean of all US zones
         datetime: '2023-01-01'
         source: eGrid 2023
-        value: 757.3688858307635
+        value: 757.4527012126907
   lifecycle:
     biomass:
       - _comment: Mean of all US zones
@@ -291,7 +291,7 @@ emissionFactors:
       - _comment: Mean of all US zones
         datetime: '2023-01-01'
         source: eGrid 2023; IPCC 2014
-        value: 1001.3688858307635
+        value: 1001.4527012126907
 fallbackZoneMixes:
   powerOriginRatios:
     - _source: Electricity Maps, 2015 average

--- a/config/zones/US-NW-AVA.yaml
+++ b/config/zones/US-NW-AVA.yaml
@@ -173,7 +173,7 @@ emissionFactors:
       - _comment: Mean of all US zones
         datetime: '2023-01-01'
         source: eGrid 2023
-        value: 757.3688858307635
+        value: 757.4527012126907
   lifecycle:
     biomass:
       - _comment: Mean of all US zones
@@ -260,7 +260,7 @@ emissionFactors:
       - _comment: Mean of all US zones
         datetime: '2023-01-01'
         source: eGrid 2023; IPCC 2014
-        value: 1001.3688858307635
+        value: 1001.4527012126907
 fallbackZoneMixes:
   powerOriginRatios:
     - _source: Electricity Maps, 2015 average

--- a/config/zones/US-NW-BPAT.yaml
+++ b/config/zones/US-NW-BPAT.yaml
@@ -266,7 +266,7 @@ emissionFactors:
       - _comment: Mean of all US zones
         datetime: '2023-01-01'
         source: eGrid 2023
-        value: 757.3688858307635
+        value: 757.4527012126907
   lifecycle:
     biomass:
       - _comment: Mean of all US zones
@@ -343,7 +343,7 @@ emissionFactors:
       - _comment: Mean of all US zones
         datetime: '2023-01-01'
         source: eGrid 2023; IPCC 2014
-        value: 1001.3688858307635
+        value: 1001.4527012126907
     solar:
       datetime: '2021-01-01'
       source: INCER ACV

--- a/config/zones/US-NW-CHPD.yaml
+++ b/config/zones/US-NW-CHPD.yaml
@@ -166,7 +166,7 @@ emissionFactors:
       - _comment: Mean of all US zones
         datetime: '2023-01-01'
         source: eGrid 2023
-        value: 757.3688858307635
+        value: 757.4527012126907
   lifecycle:
     biomass:
       - _comment: Mean of all US zones
@@ -255,7 +255,7 @@ emissionFactors:
       - _comment: Mean of all US zones
         datetime: '2023-01-01'
         source: eGrid 2023; IPCC 2014
-        value: 1001.3688858307635
+        value: 1001.4527012126907
 fallbackZoneMixes:
   powerOriginRatios:
     - _source: Electricity Maps, 2015 average

--- a/config/zones/US-NW-DOPD.yaml
+++ b/config/zones/US-NW-DOPD.yaml
@@ -157,7 +157,7 @@ emissionFactors:
       - _comment: Mean of all US zones
         datetime: '2023-01-01'
         source: eGrid 2023
-        value: 757.3688858307635
+        value: 757.4527012126907
   lifecycle:
     biomass:
       - _comment: Mean of all US zones
@@ -246,7 +246,7 @@ emissionFactors:
       - _comment: Mean of all US zones
         datetime: '2023-01-01'
         source: eGrid 2023; IPCC 2014
-        value: 1001.3688858307635
+        value: 1001.4527012126907
 fallbackZoneMixes:
   powerOriginRatios:
     - _source: Electricity Maps, 2015 average

--- a/config/zones/US-NW-GCPD.yaml
+++ b/config/zones/US-NW-GCPD.yaml
@@ -157,7 +157,7 @@ emissionFactors:
       - _comment: Mean of all US zones
         datetime: '2023-01-01'
         source: eGrid 2023
-        value: 757.3688858307635
+        value: 757.4527012126907
   lifecycle:
     biomass:
       - _comment: Mean of all US zones
@@ -246,7 +246,7 @@ emissionFactors:
       - _comment: Mean of all US zones
         datetime: '2023-01-01'
         source: eGrid 2023; IPCC 2014
-        value: 1001.3688858307635
+        value: 1001.4527012126907
 fallbackZoneMixes:
   powerOriginRatios:
     - _source: Electricity Maps, 2015 average

--- a/config/zones/US-NW-GRID.yaml
+++ b/config/zones/US-NW-GRID.yaml
@@ -139,7 +139,7 @@ emissionFactors:
       - _comment: Mean of all US zones
         datetime: '2023-01-01'
         source: eGrid 2023
-        value: 757.3688858307635
+        value: 757.4527012126907
   lifecycle:
     biomass:
       - _comment: Mean of all US zones
@@ -222,7 +222,7 @@ emissionFactors:
       - _comment: Mean of all US zones
         datetime: '2023-01-01'
         source: eGrid 2023; IPCC 2014
-        value: 1001.3688858307635
+        value: 1001.4527012126907
 fallbackZoneMixes:
   powerOriginRatios:
     - _source: Electricity Maps, 2015 average

--- a/config/zones/US-NW-IPCO.yaml
+++ b/config/zones/US-NW-IPCO.yaml
@@ -280,7 +280,7 @@ emissionFactors:
       - _comment: Mean of all US zones
         datetime: '2023-01-01'
         source: eGrid 2023
-        value: 757.3688858307635
+        value: 757.4527012126907
   lifecycle:
     battery discharge:
       - _comment: used storage values greater than zero.
@@ -363,7 +363,7 @@ emissionFactors:
       - _comment: Mean of all US zones
         datetime: '2023-01-01'
         source: eGrid 2023; IPCC 2014
-        value: 1001.3688858307635
+        value: 1001.4527012126907
     solar:
       datetime: '2021-01-01'
       source: INCER ACV

--- a/config/zones/US-NW-NEVP.yaml
+++ b/config/zones/US-NW-NEVP.yaml
@@ -342,7 +342,7 @@ emissionFactors:
       - _comment: Mean of all US zones
         datetime: '2023-01-01'
         source: eGrid 2023
-        value: 757.3688858307635
+        value: 757.4527012126907
   lifecycle:
     biomass:
       - _comment: Mean of all US zones
@@ -421,7 +421,7 @@ emissionFactors:
       - _comment: Mean of all US zones
         datetime: '2023-01-01'
         source: eGrid 2023; IPCC 2014
-        value: 1001.3688858307635
+        value: 1001.4527012126907
     solar:
       datetime: '2021-01-01'
       source: INCER ACV

--- a/config/zones/US-NW-PACE.yaml
+++ b/config/zones/US-NW-PACE.yaml
@@ -347,7 +347,7 @@ emissionFactors:
       - _comment: Mean of all US zones
         datetime: '2023-01-01'
         source: eGrid 2023
-        value: 757.3688858307635
+        value: 757.4527012126907
   lifecycle:
     biomass:
       - _comment: Mean of all US zones
@@ -421,7 +421,7 @@ emissionFactors:
       - _comment: Mean of all US zones
         datetime: '2023-01-01'
         source: eGrid 2023; IPCC 2014
-        value: 1001.3688858307635
+        value: 1001.4527012126907
     solar:
       datetime: '2021-01-01'
       source: INCER ACV

--- a/config/zones/US-NW-PACW.yaml
+++ b/config/zones/US-NW-PACW.yaml
@@ -280,7 +280,7 @@ emissionFactors:
       - _comment: Mean of all US zones
         datetime: '2023-01-01'
         source: eGrid 2023
-        value: 757.3688858307635
+        value: 757.4527012126907
   lifecycle:
     biomass:
       - _comment: Mean of all US zones
@@ -371,7 +371,7 @@ emissionFactors:
       - _comment: Mean of all US zones
         datetime: '2023-01-01'
         source: eGrid 2023; IPCC 2014
-        value: 1001.3688858307635
+        value: 1001.4527012126907
     solar:
       datetime: '2021-01-01'
       source: INCER ACV

--- a/config/zones/US-NW-PGE.yaml
+++ b/config/zones/US-NW-PGE.yaml
@@ -265,7 +265,7 @@ emissionFactors:
       - _comment: Mean of all US zones
         datetime: '2023-01-01'
         source: eGrid 2023
-        value: 757.3688858307635
+        value: 757.4527012126907
   lifecycle:
     battery discharge:
       - _comment: used storage values greater than zero.
@@ -351,7 +351,7 @@ emissionFactors:
       - _comment: Mean of all US zones
         datetime: '2023-01-01'
         source: eGrid 2023; IPCC 2014
-        value: 1001.3688858307635
+        value: 1001.4527012126907
     solar:
       datetime: '2021-01-01'
       source: INCER ACV

--- a/config/zones/US-NW-PSCO.yaml
+++ b/config/zones/US-NW-PSCO.yaml
@@ -385,7 +385,7 @@ emissionFactors:
       - _comment: Mean of all US zones
         datetime: '2023-01-01'
         source: eGrid 2023
-        value: 757.3688858307635
+        value: 757.4527012126907
   lifecycle:
     battery discharge:
       - _comment: used storage values greater than zero.
@@ -468,7 +468,7 @@ emissionFactors:
       - _comment: Mean of all US zones
         datetime: '2023-01-01'
         source: eGrid 2023; IPCC 2014
-        value: 1001.3688858307635
+        value: 1001.4527012126907
     solar:
       datetime: '2021-01-01'
       source: INCER ACV

--- a/config/zones/US-NW-PSEI.yaml
+++ b/config/zones/US-NW-PSEI.yaml
@@ -172,7 +172,7 @@ emissionFactors:
       - _comment: Mean of all US zones
         datetime: '2023-01-01'
         source: eGrid 2023
-        value: 757.3688858307635
+        value: 757.4527012126907
   lifecycle:
     biomass:
       - _comment: Mean of all US zones
@@ -254,7 +254,7 @@ emissionFactors:
       - _comment: Mean of all US zones
         datetime: '2023-01-01'
         source: eGrid 2023; IPCC 2014
-        value: 1001.3688858307635
+        value: 1001.4527012126907
 fallbackZoneMixes:
   powerOriginRatios:
     - _source: Electricity Maps, 2015 average

--- a/config/zones/US-NW-SCL.yaml
+++ b/config/zones/US-NW-SCL.yaml
@@ -163,7 +163,7 @@ emissionFactors:
       - _comment: Mean of all US zones
         datetime: '2023-01-01'
         source: eGrid 2023
-        value: 757.3688858307635
+        value: 757.4527012126907
   lifecycle:
     biomass:
       - _comment: Mean of all US zones
@@ -252,7 +252,7 @@ emissionFactors:
       - _comment: Mean of all US zones
         datetime: '2023-01-01'
         source: eGrid 2023; IPCC 2014
-        value: 1001.3688858307635
+        value: 1001.4527012126907
 fallbackZoneMixes:
   powerOriginRatios:
     - _source: Electricity Maps, 2015 average

--- a/config/zones/US-NW-TPWR.yaml
+++ b/config/zones/US-NW-TPWR.yaml
@@ -148,7 +148,7 @@ emissionFactors:
       - _comment: Mean of all US zones
         datetime: '2023-01-01'
         source: eGrid 2023
-        value: 757.3688858307635
+        value: 757.4527012126907
   lifecycle:
     biomass:
       - _comment: Mean of all US zones
@@ -237,7 +237,7 @@ emissionFactors:
       - _comment: Mean of all US zones
         datetime: '2023-01-01'
         source: eGrid 2023; IPCC 2014
-        value: 1001.3688858307635
+        value: 1001.4527012126907
 fallbackZoneMixes:
   powerOriginRatios:
     - _source: Electricity Maps, 2015 average

--- a/config/zones/US-NW-WAUW.yaml
+++ b/config/zones/US-NW-WAUW.yaml
@@ -169,7 +169,7 @@ emissionFactors:
       - _comment: Mean of all US zones
         datetime: '2023-01-01'
         source: eGrid 2023
-        value: 757.3688858307635
+        value: 757.4527012126907
   lifecycle:
     biomass:
       - _comment: Mean of all US zones
@@ -258,7 +258,7 @@ emissionFactors:
       - _comment: Mean of all US zones
         datetime: '2023-01-01'
         source: eGrid 2023; IPCC 2014
-        value: 1001.3688858307635
+        value: 1001.4527012126907
 fallbackZoneMixes:
   powerOriginRatios:
     - _source: Electricity Maps, 2015 average

--- a/config/zones/US-SE-SEPA.yaml
+++ b/config/zones/US-SE-SEPA.yaml
@@ -167,7 +167,7 @@ emissionFactors:
       - _comment: Mean of all US zones
         datetime: '2023-01-01'
         source: eGrid 2023
-        value: 757.3688858307635
+        value: 757.4527012126907
   lifecycle:
     biomass:
       - _comment: Mean of all US zones
@@ -256,7 +256,7 @@ emissionFactors:
       - _comment: Mean of all US zones
         datetime: '2023-01-01'
         source: eGrid 2023; IPCC 2014
-        value: 1001.3688858307635
+        value: 1001.4527012126907
 fallbackZoneMixes:
   powerOriginRatios:
     - _source: Electricity Maps, 2017 average

--- a/config/zones/US-SW-AZPS.yaml
+++ b/config/zones/US-SW-AZPS.yaml
@@ -266,7 +266,7 @@ emissionFactors:
       - _comment: Mean of all US zones
         datetime: '2023-01-01'
         source: eGrid 2023
-        value: 757.3688858307635
+        value: 757.4527012126907
   lifecycle:
     battery discharge:
       - _comment: used storage values greater than zero.
@@ -349,7 +349,7 @@ emissionFactors:
       - _comment: Mean of all US zones
         datetime: '2023-01-01'
         source: eGrid 2023; IPCC 2014
-        value: 1001.3688858307635
+        value: 1001.4527012126907
     solar:
       datetime: '2021-01-01'
       source: INCER ACV

--- a/config/zones/US-SW-EPE.yaml
+++ b/config/zones/US-SW-EPE.yaml
@@ -189,7 +189,7 @@ emissionFactors:
       - _comment: Mean of all US zones
         datetime: '2023-01-01'
         source: eGrid 2023
-        value: 757.3688858307635
+        value: 757.4527012126907
   lifecycle:
     biomass:
       - _comment: Mean of all US zones
@@ -271,7 +271,7 @@ emissionFactors:
       - _comment: Mean of all US zones
         datetime: '2023-01-01'
         source: eGrid 2023; IPCC 2014
-        value: 1001.3688858307635
+        value: 1001.4527012126907
     solar:
       datetime: '2021-01-01'
       source: INCER ACV

--- a/config/zones/US-SW-PNM.yaml
+++ b/config/zones/US-SW-PNM.yaml
@@ -357,7 +357,7 @@ emissionFactors:
       - _comment: Mean of all US zones
         datetime: '2023-01-01'
         source: eGrid 2023
-        value: 757.3688858307635
+        value: 757.4527012126907
   lifecycle:
     battery discharge:
       - _comment: used storage values greater than zero.
@@ -462,7 +462,7 @@ emissionFactors:
       - _comment: Mean of all US zones
         datetime: '2023-01-01'
         source: eGrid 2023; IPCC 2014
-        value: 1001.3688858307635
+        value: 1001.4527012126907
     solar:
       datetime: '2021-01-01'
       source: INCER ACV

--- a/config/zones/US-SW-SRP.yaml
+++ b/config/zones/US-SW-SRP.yaml
@@ -277,7 +277,7 @@ emissionFactors:
       - _comment: Mean of all US zones
         datetime: '2023-01-01'
         source: eGrid 2023
-        value: 757.3688858307635
+        value: 757.4527012126907
   lifecycle:
     battery discharge:
       - _comment: used storage values greater than zero.
@@ -393,7 +393,7 @@ emissionFactors:
       - _comment: Mean of all US zones
         datetime: '2023-01-01'
         source: eGrid 2023; IPCC 2014
-        value: 1001.3688858307635
+        value: 1001.4527012126907
     solar:
       datetime: '2021-01-01'
       source: INCER ACV

--- a/config/zones/US-SW-TEPC.yaml
+++ b/config/zones/US-SW-TEPC.yaml
@@ -211,7 +211,7 @@ emissionFactors:
       - _comment: Mean of all US zones
         datetime: '2023-01-01'
         source: eGrid 2023
-        value: 757.3688858307635
+        value: 757.4527012126907
   lifecycle:
     battery discharge:
       - _comment: used storage values greater than zero.
@@ -294,7 +294,7 @@ emissionFactors:
       - _comment: Mean of all US zones
         datetime: '2023-01-01'
         source: eGrid 2023; IPCC 2014
-        value: 1001.3688858307635
+        value: 1001.4527012126907
     solar:
       datetime: '2021-01-01'
       source: INCER ACV

--- a/config/zones/US-SW-WALC.yaml
+++ b/config/zones/US-SW-WALC.yaml
@@ -222,7 +222,7 @@ emissionFactors:
       - _comment: Mean of all US zones
         datetime: '2023-01-01'
         source: eGrid 2023
-        value: 757.3688858307635
+        value: 757.4527012126907
   lifecycle:
     biomass:
       - _comment: Mean of all US zones
@@ -310,7 +310,7 @@ emissionFactors:
       - _comment: Mean of all US zones
         datetime: '2023-01-01'
         source: eGrid 2023; IPCC 2014
-        value: 1001.3688858307635
+        value: 1001.4527012126907
 fallbackZoneMixes:
   powerOriginRatios:
     - _source: Electricity Maps, 2015 average

--- a/config/zones/US-TEN-TVA.yaml
+++ b/config/zones/US-TEN-TVA.yaml
@@ -377,7 +377,7 @@ emissionFactors:
       - _comment: Mean of all US zones
         datetime: '2023-01-01'
         source: eGrid 2023
-        value: 757.3688858307635
+        value: 757.4527012126907
   lifecycle:
     battery discharge:
       - _comment: used non-null storage values
@@ -488,7 +488,7 @@ emissionFactors:
       - _comment: Mean of all US zones
         datetime: '2023-01-01'
         source: eGrid 2023; IPCC 2014
-        value: 1001.3688858307635
+        value: 1001.4527012126907
     solar:
       datetime: '2021-01-01'
       source: INCER ACV


### PR DESCRIPTION
main change is in `config/zones/US-FLA-FPL.yaml`
this zone has a single oil power plant that's been producing less and less co2 over the years, 2023 it's at 175 direct. has very little effect on final carbon intensity so we decided to keep it in. This way the zone keeps a downward then with it's oil emission factor.

In short, not going to merge this, but going to keep it here for posterity if anyone comes looking.