### PR TITLE
fix publish workflow

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "electricitymap-contrib"
-version = "2.0.0"
+version = "1.2.0"
 description = ""
 authors = [{ name = "Electricity Maps", email = "app@electricitymaps.com" }]
 requires-python = ">= 3.10, < 3.14"

--- a/uv.lock
+++ b/uv.lock
@@ -283,7 +283,7 @@ sdist = { url = "https://files.pythonhosted.org/packages/f7/d2/6a81a9b5311d50542
 
 [[package]]
 name = "electricitymap-contrib"
-version = "2.0.0"
+version = "1.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "electricitymap-contrib-types" },
@@ -364,7 +364,7 @@ scripts = [{ name = "xmltodict", specifier = ">=0.13.0,<0.14" }]
 
 [[package]]
 name = "electricitymap-contrib-types"
-version = "0.1.1"
+version = "0.1.0"
 source = { editable = "libs/types" }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Issue

This pushed changes even though the publish part changed 😬 

## Description
- Simplifies the publishing workflow by removing steps we don't need by directly bumping the package with the `--package` parameter.
- Uses UV to install python.
- Ensures that the changes are not pushed until the package is published.
- Ensure that all changed files are added (both pyproject and lockfiles).

### Double check

- [x] I have run `pnpx prettier@2 --write .` and `uv run format` in the top level directory to format my changes.
