### PR TITLE
feat(parser): add latest Interconnector to CA-QC->US-NE-ISNE exchange

### DIFF
--- a/electricitymap/contrib/parsers/US_NEISO.py
+++ b/electricitymap/contrib/parsers/US_NEISO.py
@@ -192,6 +192,7 @@ def fetch_exchange(
         postdata = {
             "_nstmp_zone0": "4012",  # ".I.HQ_P1_P2345 5"
             "_nstmp_zone1": "4013",  # ".I.HQHIGATE120 2"
+            "_nstmp_zone2": "4018",  # ".I.HQMRL_RD345 1"
         }
 
     elif sorted_zone_keys == "US-NE-ISNE->US-NY-NYIS":


### PR DESCRIPTION
## Issue

A new interconnector opened up that should be part of the CA-QC->US-NE-ISNE exchange.
Closes: GMM-1453

## Description

Added the new interconnector and double checked the ID from the CSV on their dashboard which can be found [here](https://www.iso-ne.com/isoexpress/charts?p_p_id=FiveMinuteLMPPriceList_WAR_isoneportlet_INSTANCE_XzYdsNb59szm&p_p_lifecycle=0&p_p_state=pop_up&p_p_mode=view).  (Full dashboard [here](https://www.iso-ne.com/isoexpress/))

Downloaded CSV: [fiveminlmplist.csv](https://github.com/user-attachments/files/24858161/fiveminlmplist.csv)


### Double check

- [x] I have tested my parser changes locally with `uv run test_parser "zone_key"`
- [x] I have run `pnpx prettier@2 --write .` and `uv run format` in the top level directory to format my changes.
