### PR TITLE
feat(emission-factors): isRenewable and isLowCarbon battery and hydro discharge

### DIFF
--- a/config/zones/AR.yaml
+++ b/config/zones/AR.yaml
@@ -336,10 +336,14 @@ isLowCarbon:
   hydro discharge:
     - datetime: '2020-01-01'
       value: 0.3527
+    - datetime: '2021-01-01'
+      value: 0.2992
 isRenewable:
   hydro discharge:
     - datetime: '2020-01-01'
       value: 0.2751
+    - datetime: '2021-01-01'
+      value: 0.2268
 parsers:
   production: CAMMESA.fetch_production
   productionCapacity: EMBER.fetch_production_capacity

--- a/config/zones/AR.yaml
+++ b/config/zones/AR.yaml
@@ -169,11 +169,11 @@ emissionFactors:
       - _comment: used storage values greater than zero.
         datetime: '2020-01-01'
         source: Electricity Maps, 2020 zone average
-        value: 255.55
+        value: 255.5
       - _comment: used storage values greater than zero.
         datetime: '2021-01-01'
         source: Electricity Maps, 2021 zone average
-        value: 278.69
+        value: 246.81
       - _comment: used default IPCC 2014 value of 0.0
         datetime: '2022-01-01'
         source: Electricity Maps, 2022 zone average
@@ -191,11 +191,11 @@ emissionFactors:
       - _comment: used storage values greater than zero.
         datetime: '2020-01-01'
         source: Electricity Maps, 2020 zone average; IPCC 2014
-        value: 279.55
+        value: 279.5
       - _comment: used storage values greater than zero.
         datetime: '2021-01-01'
         source: Electricity Maps, 2021 zone average; IPCC 2014
-        value: 302.69
+        value: 270.81
       - _comment: used default IPCC 2014 value of 24.0
         datetime: '2022-01-01'
         source: Electricity Maps, 2022 zone average; IPCC 2014
@@ -335,9 +335,9 @@ hide_day_ahead_price: false
 isLowCarbon:
   hydro discharge:
     - datetime: '2020-01-01'
-      value: 0.3527
+      value: 0.3529
     - datetime: '2021-01-01'
-      value: 0.2992
+      value: 0.3697
     - datetime: '2022-01-01'
       value: 1.0
     - datetime: '2023-01-01'
@@ -347,9 +347,9 @@ isLowCarbon:
 isRenewable:
   hydro discharge:
     - datetime: '2020-01-01'
-      value: 0.2751
+      value: 0.2752
     - datetime: '2021-01-01'
-      value: 0.2268
+      value: 0.2892
     - datetime: '2022-01-01'
       value: 1.0
     - datetime: '2023-01-01'

--- a/config/zones/AR.yaml
+++ b/config/zones/AR.yaml
@@ -330,16 +330,24 @@ fallbackZoneMixes:
         solar: 0.02698552858936858
         unknown: 0.5265037188143048
         wind: 0.11199192793014612
-has_day_ahead_price_license: False
-hide_day_ahead_price: False
+has_day_ahead_price_license: false
+hide_day_ahead_price: false
+isLowCarbon:
+  hydro discharge:
+    - datetime: '2020-01-01'
+      value: 0.3527
+isRenewable:
+  hydro discharge:
+    - datetime: '2020-01-01'
+      value: 0.2751
 parsers:
   production: CAMMESA.fetch_production
   productionCapacity: EMBER.fetch_production_capacity
 region: Americas
-timezone: America/Argentina/Buenos_Aires
-zone_name: Argentina
 sources:
   IPCC 2014:
     link: https://www.ipcc.ch/site/assets/uploads/2018/02/ipcc_wg3_ar5_annex-iii.pdf#page=7
   National Laboratory of the Rockies:
     link: https://docs.nrel.gov/docs/fy21osti/80580.pdf
+timezone: America/Argentina/Buenos_Aires
+zone_name: Argentina

--- a/config/zones/AR.yaml
+++ b/config/zones/AR.yaml
@@ -338,12 +338,16 @@ isLowCarbon:
       value: 0.3527
     - datetime: '2021-01-01'
       value: 0.2992
+    - datetime: '2022-01-01'
+      value: 1.0
 isRenewable:
   hydro discharge:
     - datetime: '2020-01-01'
       value: 0.2751
     - datetime: '2021-01-01'
       value: 0.2268
+    - datetime: '2022-01-01'
+      value: 1.0
 parsers:
   production: CAMMESA.fetch_production
   productionCapacity: EMBER.fetch_production_capacity

--- a/config/zones/AR.yaml
+++ b/config/zones/AR.yaml
@@ -340,6 +340,10 @@ isLowCarbon:
       value: 0.2992
     - datetime: '2022-01-01'
       value: 1.0
+    - datetime: '2023-01-01'
+      value: 1.0
+    - datetime: '2025-01-01'
+      value: 1.0
 isRenewable:
   hydro discharge:
     - datetime: '2020-01-01'
@@ -347,6 +351,10 @@ isRenewable:
     - datetime: '2021-01-01'
       value: 0.2268
     - datetime: '2022-01-01'
+      value: 1.0
+    - datetime: '2023-01-01'
+      value: 1.0
+    - datetime: '2025-01-01'
       value: 1.0
 parsers:
   production: CAMMESA.fetch_production

--- a/config/zones/AT.yaml
+++ b/config/zones/AT.yaml
@@ -539,12 +539,16 @@ isLowCarbon:
       value: 0.7783
     - datetime: '2021-01-01'
       value: 0.7329
+    - datetime: '2022-01-01'
+      value: 0.7323
 isRenewable:
   hydro discharge:
     - datetime: '2020-01-01'
       value: 0.707
     - datetime: '2021-01-01'
       value: 0.6466
+    - datetime: '2022-01-01'
+      value: 0.6487
 parsers:
   consumption: ENTSOE.fetch_consumption
   consumptionForecast: ENTSOE.fetch_consumption_forecast

--- a/config/zones/AT.yaml
+++ b/config/zones/AT.yaml
@@ -263,7 +263,7 @@ emissionFactors:
       - _comment: used storage values greater than zero.
         datetime: '2020-01-01'
         source: Electricity Maps, 2020 zone average
-        value: 151.07
+        value: 151.02
       - _comment: used storage values greater than zero.
         datetime: '2021-01-01'
         source: Electricity Maps, 2021 zone average
@@ -283,7 +283,7 @@ emissionFactors:
       - _comment: used storage values greater than zero.
         datetime: '2025-01-01'
         source: Electricity Maps, 2025 zone average
-        value: 108.31
+        value: 110.12
     oil:
       - datetime: '2021-01-01'
         source: EU-ETS, ENTSO-E 2021
@@ -332,7 +332,7 @@ emissionFactors:
       - _comment: used storage values greater than zero.
         datetime: '2020-01-01'
         source: Electricity Maps, 2020 zone average; UNECE 2022
-        value: 161.77
+        value: 161.72
       - _comment: used storage values greater than zero.
         datetime: '2021-01-01'
         source: Electricity Maps, 2021 zone average; UNECE 2022
@@ -352,7 +352,7 @@ emissionFactors:
       - _comment: used storage values greater than zero.
         datetime: '2025-01-01'
         source: Electricity Maps, 2025 zone average; UNECE 2022
-        value: 119.01
+        value: 120.82
     nuclear:
       datetime: '2020-01-01'
       source: UNECE 2022
@@ -536,7 +536,7 @@ hide_day_ahead_price: false
 isLowCarbon:
   hydro discharge:
     - datetime: '2020-01-01'
-      value: 0.7783
+      value: 0.7784
     - datetime: '2021-01-01'
       value: 0.7329
     - datetime: '2022-01-01'
@@ -546,11 +546,11 @@ isLowCarbon:
     - datetime: '2024-01-01'
       value: 0.8784
     - datetime: '2025-01-01'
-      value: 0.8312
+      value: 0.8286
 isRenewable:
   hydro discharge:
     - datetime: '2020-01-01'
-      value: 0.707
+      value: 0.7071
     - datetime: '2021-01-01'
       value: 0.6466
     - datetime: '2022-01-01'
@@ -560,7 +560,7 @@ isRenewable:
     - datetime: '2024-01-01'
       value: 0.8394
     - datetime: '2025-01-01'
-      value: 0.7742
+      value: 0.771
 parsers:
   consumption: ENTSOE.fetch_consumption
   consumptionForecast: ENTSOE.fetch_consumption_forecast

--- a/config/zones/AT.yaml
+++ b/config/zones/AT.yaml
@@ -263,7 +263,7 @@ emissionFactors:
       - _comment: used storage values greater than zero.
         datetime: '2020-01-01'
         source: Electricity Maps, 2020 zone average
-        value: 151.02
+        value: 151.07
       - _comment: used storage values greater than zero.
         datetime: '2021-01-01'
         source: Electricity Maps, 2021 zone average
@@ -332,7 +332,7 @@ emissionFactors:
       - _comment: used storage values greater than zero.
         datetime: '2020-01-01'
         source: Electricity Maps, 2020 zone average; UNECE 2022
-        value: 161.72
+        value: 161.77
       - _comment: used storage values greater than zero.
         datetime: '2021-01-01'
         source: Electricity Maps, 2021 zone average; UNECE 2022
@@ -533,6 +533,14 @@ fallbackZoneMixes:
         wind: 0.14425013699561962
 has_day_ahead_price_license: true
 hide_day_ahead_price: false
+isLowCarbon:
+  hydro discharge:
+    - datetime: '2020-01-01'
+      value: 0.7783
+isRenewable:
+  hydro discharge:
+    - datetime: '2020-01-01'
+      value: 0.707
 parsers:
   consumption: ENTSOE.fetch_consumption
   consumptionForecast: ENTSOE.fetch_consumption_forecast

--- a/config/zones/AT.yaml
+++ b/config/zones/AT.yaml
@@ -537,10 +537,14 @@ isLowCarbon:
   hydro discharge:
     - datetime: '2020-01-01'
       value: 0.7783
+    - datetime: '2021-01-01'
+      value: 0.7329
 isRenewable:
   hydro discharge:
     - datetime: '2020-01-01'
       value: 0.707
+    - datetime: '2021-01-01'
+      value: 0.6466
 parsers:
   consumption: ENTSOE.fetch_consumption
   consumptionForecast: ENTSOE.fetch_consumption_forecast

--- a/config/zones/AT.yaml
+++ b/config/zones/AT.yaml
@@ -275,15 +275,15 @@ emissionFactors:
       - _comment: used storage values greater than zero.
         datetime: '2023-01-01'
         source: Electricity Maps, 2023 zone average
-        value: 113.25
+        value: 109.66
       - _comment: used storage values greater than zero.
         datetime: '2024-01-01'
         source: Electricity Maps, 2024 zone average
-        value: 77.83
+        value: 77.02
       - _comment: used storage values greater than zero.
         datetime: '2025-01-01'
         source: Electricity Maps, 2025 zone average
-        value: 109.4
+        value: 108.31
     oil:
       - datetime: '2021-01-01'
         source: EU-ETS, ENTSO-E 2021
@@ -344,15 +344,15 @@ emissionFactors:
       - _comment: used storage values greater than zero.
         datetime: '2023-01-01'
         source: Electricity Maps, 2023 zone average; UNECE 2022
-        value: 123.95
+        value: 120.36
       - _comment: used storage values greater than zero.
         datetime: '2024-01-01'
         source: Electricity Maps, 2024 zone average; UNECE 2022
-        value: 88.53
+        value: 87.72
       - _comment: used storage values greater than zero.
         datetime: '2025-01-01'
         source: Electricity Maps, 2025 zone average; UNECE 2022
-        value: 120.1
+        value: 119.01
     nuclear:
       datetime: '2020-01-01'
       source: UNECE 2022
@@ -541,6 +541,12 @@ isLowCarbon:
       value: 0.7329
     - datetime: '2022-01-01'
       value: 0.7323
+    - datetime: '2023-01-01'
+      value: 0.8431
+    - datetime: '2024-01-01'
+      value: 0.8784
+    - datetime: '2025-01-01'
+      value: 0.8312
 isRenewable:
   hydro discharge:
     - datetime: '2020-01-01'
@@ -549,6 +555,12 @@ isRenewable:
       value: 0.6466
     - datetime: '2022-01-01'
       value: 0.6487
+    - datetime: '2023-01-01'
+      value: 0.7817
+    - datetime: '2024-01-01'
+      value: 0.8394
+    - datetime: '2025-01-01'
+      value: 0.7742
 parsers:
   consumption: ENTSOE.fetch_consumption
   consumptionForecast: ENTSOE.fetch_consumption_forecast

--- a/config/zones/AU-NSW.yaml
+++ b/config/zones/AU-NSW.yaml
@@ -117,7 +117,7 @@ emissionFactors:
       - _comment: used storage values greater than zero.
         datetime: '2025-01-01'
         source: Electricity Maps, 2025 zone average
-        value: 451.2
+        value: 450.42
     hydro discharge:
       - _comment: used storage values greater than zero.
         datetime: '2020-01-01'
@@ -142,7 +142,7 @@ emissionFactors:
       - _comment: used storage values greater than zero.
         datetime: '2025-01-01'
         source: Electricity Maps, 2025 zone average
-        value: 345.48
+        value: 344.54
   lifecycle:
     battery discharge:
       - _comment: used storage values greater than zero.
@@ -164,7 +164,7 @@ emissionFactors:
       - _comment: used storage values greater than zero.
         datetime: '2025-01-01'
         source: Electricity Maps, 2025 zone average; National Laboratory of the Rockies
-        value: 484.2
+        value: 483.42
     hydro discharge:
       - _comment: used storage values greater than zero.
         datetime: '2020-01-01'
@@ -189,7 +189,7 @@ emissionFactors:
       - _comment: used storage values greater than zero.
         datetime: '2025-01-01'
         source: Electricity Maps, 2025 zone average; IPCC 2014
-        value: 369.48
+        value: 368.54
 fallbackZoneMixes:
   powerOriginRatios:
     - _source: Electricity Maps, 2015 average
@@ -350,6 +350,12 @@ isLowCarbon:
       value: 0.4608
     - datetime: '2022-01-01'
       value: 0.2954
+    - datetime: '2023-01-01'
+      value: 0.3927
+    - datetime: '2024-01-01'
+      value: 0.3744
+    - datetime: '2025-01-01'
+      value: 0.3977
   hydro discharge:
     - datetime: '2020-01-01'
       value: 0.1798
@@ -357,12 +363,24 @@ isLowCarbon:
       value: 0.2579
     - datetime: '2022-01-01'
       value: 0.39
+    - datetime: '2023-01-01'
+      value: 0.497
+    - datetime: '2024-01-01'
+      value: 0.486
+    - datetime: '2025-01-01'
+      value: 0.5417
 isRenewable:
   battery discharge:
     - datetime: '2021-01-01'
       value: 0.4608
     - datetime: '2022-01-01'
       value: 0.2954
+    - datetime: '2023-01-01'
+      value: 0.3927
+    - datetime: '2024-01-01'
+      value: 0.3744
+    - datetime: '2025-01-01'
+      value: 0.3977
   hydro discharge:
     - datetime: '2020-01-01'
       value: 0.1798
@@ -370,6 +388,12 @@ isRenewable:
       value: 0.2579
     - datetime: '2022-01-01'
       value: 0.39
+    - datetime: '2023-01-01'
+      value: 0.497
+    - datetime: '2024-01-01'
+      value: 0.486
+    - datetime: '2025-01-01'
+      value: 0.5417
 parsers:
   consumptionForecast: AEMO.fetch_consumption_forecast
   price: OPENNEM.fetch_price

--- a/config/zones/AU-NSW.yaml
+++ b/config/zones/AU-NSW.yaml
@@ -101,7 +101,7 @@ emissionFactors:
       - _comment: used storage values greater than zero.
         datetime: '2021-01-01'
         source: Electricity Maps, 2021 zone average
-        value: 397.37
+        value: 397.36
       - _comment: used storage values greater than zero.
         datetime: '2022-01-01'
         source: Electricity Maps, 2022 zone average
@@ -113,11 +113,11 @@ emissionFactors:
       - _comment: used storage values greater than zero.
         datetime: '2024-01-01'
         source: Electricity Maps, 2024 zone average
-        value: 469.96
+        value: 470.0
       - _comment: used storage values greater than zero.
         datetime: '2025-01-01'
         source: Electricity Maps, 2025 zone average
-        value: 450.42
+        value: 449.78
     hydro discharge:
       - _comment: used storage values greater than zero.
         datetime: '2020-01-01'
@@ -126,7 +126,7 @@ emissionFactors:
       - _comment: used storage values greater than zero.
         datetime: '2021-01-01'
         source: Electricity Maps, 2021 zone average
-        value: 561.75
+        value: 559.46
       - _comment: used storage values greater than zero.
         datetime: '2022-01-01'
         source: Electricity Maps, 2022 zone average
@@ -138,7 +138,7 @@ emissionFactors:
       - _comment: used storage values greater than zero.
         datetime: '2024-01-01'
         source: Electricity Maps, 2024 zone average
-        value: 387.66
+        value: 387.68
       - _comment: used storage values greater than zero.
         datetime: '2025-01-01'
         source: Electricity Maps, 2025 zone average
@@ -148,7 +148,7 @@ emissionFactors:
       - _comment: used storage values greater than zero.
         datetime: '2021-01-01'
         source: Electricity Maps, 2021 zone average; National Laboratory of the Rockies
-        value: 430.37
+        value: 430.36
       - _comment: used storage values greater than zero.
         datetime: '2022-01-01'
         source: Electricity Maps, 2022 zone average; National Laboratory of the Rockies
@@ -160,11 +160,11 @@ emissionFactors:
       - _comment: used storage values greater than zero.
         datetime: '2024-01-01'
         source: Electricity Maps, 2024 zone average; National Laboratory of the Rockies
-        value: 502.96
+        value: 503.0
       - _comment: used storage values greater than zero.
         datetime: '2025-01-01'
         source: Electricity Maps, 2025 zone average; National Laboratory of the Rockies
-        value: 483.42
+        value: 482.78
     hydro discharge:
       - _comment: used storage values greater than zero.
         datetime: '2020-01-01'
@@ -173,7 +173,7 @@ emissionFactors:
       - _comment: used storage values greater than zero.
         datetime: '2021-01-01'
         source: Electricity Maps, 2021 zone average; IPCC 2014
-        value: 585.75
+        value: 583.46
       - _comment: used storage values greater than zero.
         datetime: '2022-01-01'
         source: Electricity Maps, 2022 zone average; IPCC 2014
@@ -185,7 +185,7 @@ emissionFactors:
       - _comment: used storage values greater than zero.
         datetime: '2024-01-01'
         source: Electricity Maps, 2024 zone average; IPCC 2014
-        value: 411.66
+        value: 411.68
       - _comment: used storage values greater than zero.
         datetime: '2025-01-01'
         source: Electricity Maps, 2025 zone average; IPCC 2014
@@ -355,20 +355,20 @@ isLowCarbon:
     - datetime: '2024-01-01'
       value: 0.3744
     - datetime: '2025-01-01'
-      value: 0.3977
+      value: 0.3986
   hydro discharge:
     - datetime: '2020-01-01'
       value: 0.1798
     - datetime: '2021-01-01'
-      value: 0.2579
+      value: 0.2609
     - datetime: '2022-01-01'
       value: 0.39
     - datetime: '2023-01-01'
       value: 0.497
     - datetime: '2024-01-01'
-      value: 0.486
+      value: 0.4859
     - datetime: '2025-01-01'
-      value: 0.5417
+      value: 0.5418
 isRenewable:
   battery discharge:
     - datetime: '2021-01-01'
@@ -380,20 +380,20 @@ isRenewable:
     - datetime: '2024-01-01'
       value: 0.3744
     - datetime: '2025-01-01'
-      value: 0.3977
+      value: 0.3986
   hydro discharge:
     - datetime: '2020-01-01'
       value: 0.1798
     - datetime: '2021-01-01'
-      value: 0.2579
+      value: 0.2609
     - datetime: '2022-01-01'
       value: 0.39
     - datetime: '2023-01-01'
       value: 0.497
     - datetime: '2024-01-01'
-      value: 0.486
+      value: 0.4859
     - datetime: '2025-01-01'
-      value: 0.5417
+      value: 0.5418
 parsers:
   consumptionForecast: AEMO.fetch_consumption_forecast
   price: OPENNEM.fetch_price

--- a/config/zones/AU-NSW.yaml
+++ b/config/zones/AU-NSW.yaml
@@ -342,8 +342,16 @@ fallbackZoneMixes:
         solar: 0.2085011484047794
         unknown: 0.0
         wind: 0.09586177067488971
-has_day_ahead_price_license: False
-hide_day_ahead_price: False
+has_day_ahead_price_license: false
+hide_day_ahead_price: false
+isLowCarbon:
+  hydro discharge:
+    - datetime: '2020-01-01'
+      value: 0.1798
+isRenewable:
+  hydro discharge:
+    - datetime: '2020-01-01'
+      value: 0.1798
 parsers:
   consumptionForecast: AEMO.fetch_consumption_forecast
   price: OPENNEM.fetch_price

--- a/config/zones/AU-NSW.yaml
+++ b/config/zones/AU-NSW.yaml
@@ -345,13 +345,23 @@ fallbackZoneMixes:
 has_day_ahead_price_license: false
 hide_day_ahead_price: false
 isLowCarbon:
+  battery discharge:
+    - datetime: '2021-01-01'
+      value: 0.4608
   hydro discharge:
     - datetime: '2020-01-01'
       value: 0.1798
+    - datetime: '2021-01-01'
+      value: 0.2579
 isRenewable:
+  battery discharge:
+    - datetime: '2021-01-01'
+      value: 0.4608
   hydro discharge:
     - datetime: '2020-01-01'
       value: 0.1798
+    - datetime: '2021-01-01'
+      value: 0.2579
 parsers:
   consumptionForecast: AEMO.fetch_consumption_forecast
   price: OPENNEM.fetch_price

--- a/config/zones/AU-NSW.yaml
+++ b/config/zones/AU-NSW.yaml
@@ -348,20 +348,28 @@ isLowCarbon:
   battery discharge:
     - datetime: '2021-01-01'
       value: 0.4608
+    - datetime: '2022-01-01'
+      value: 0.2954
   hydro discharge:
     - datetime: '2020-01-01'
       value: 0.1798
     - datetime: '2021-01-01'
       value: 0.2579
+    - datetime: '2022-01-01'
+      value: 0.39
 isRenewable:
   battery discharge:
     - datetime: '2021-01-01'
       value: 0.4608
+    - datetime: '2022-01-01'
+      value: 0.2954
   hydro discharge:
     - datetime: '2020-01-01'
       value: 0.1798
     - datetime: '2021-01-01'
       value: 0.2579
+    - datetime: '2022-01-01'
+      value: 0.39
 parsers:
   consumptionForecast: AEMO.fetch_consumption_forecast
   price: OPENNEM.fetch_price

--- a/config/zones/AU-QLD.yaml
+++ b/config/zones/AU-QLD.yaml
@@ -333,13 +333,23 @@ fallbackZoneMixes:
 has_day_ahead_price_license: false
 hide_day_ahead_price: false
 isLowCarbon:
+  battery discharge:
+    - datetime: '2021-01-01'
+      value: 0.2759
   hydro discharge:
     - datetime: '2020-01-01'
       value: 0.1962
+    - datetime: '2021-01-01'
+      value: 0.2673
 isRenewable:
+  battery discharge:
+    - datetime: '2021-01-01'
+      value: 0.2759
   hydro discharge:
     - datetime: '2020-01-01'
       value: 0.1962
+    - datetime: '2021-01-01'
+      value: 0.2673
 parsers:
   consumptionForecast: AEMO.fetch_consumption_forecast
   price: OPENNEM.fetch_price

--- a/config/zones/AU-QLD.yaml
+++ b/config/zones/AU-QLD.yaml
@@ -330,18 +330,26 @@ fallbackZoneMixes:
         solar: 0.20730753084217618
         unknown: 0.0
         wind: 0.04511033753549817
-has_day_ahead_price_license: False
-hide_day_ahead_price: False
+has_day_ahead_price_license: false
+hide_day_ahead_price: false
+isLowCarbon:
+  hydro discharge:
+    - datetime: '2020-01-01'
+      value: 0.1962
+isRenewable:
+  hydro discharge:
+    - datetime: '2020-01-01'
+      value: 0.1962
 parsers:
   consumptionForecast: AEMO.fetch_consumption_forecast
   price: OPENNEM.fetch_price
   production: OPENNEM.fetch_production
   productionCapacity: OPENELECTRICITY.fetch_production_capacity
 region: Oceania
-timezone: Australia/Brisbane
-zone_name: Queensland
 sources:
   IPCC 2014:
     link: https://www.ipcc.ch/site/assets/uploads/2018/02/ipcc_wg3_ar5_annex-iii.pdf#page=7
   National Laboratory of the Rockies:
     link: https://docs.nrel.gov/docs/fy21osti/80580.pdf
+timezone: Australia/Brisbane
+zone_name: Queensland

--- a/config/zones/AU-QLD.yaml
+++ b/config/zones/AU-QLD.yaml
@@ -105,7 +105,7 @@ emissionFactors:
       - _comment: used storage values greater than zero.
         datetime: '2025-01-01'
         source: Electricity Maps, 2025 zone average
-        value: 485.31
+        value: 484.54
     hydro discharge:
       - _comment: used storage values greater than zero.
         datetime: '2020-01-01'
@@ -130,7 +130,7 @@ emissionFactors:
       - _comment: used storage values greater than zero.
         datetime: '2025-01-01'
         source: Electricity Maps, 2025 zone average
-        value: 391.96
+        value: 391.31
   lifecycle:
     battery discharge:
       - _comment: used storage values greater than zero.
@@ -152,7 +152,7 @@ emissionFactors:
       - _comment: used storage values greater than zero.
         datetime: '2025-01-01'
         source: Electricity Maps, 2025 zone average; National Laboratory of the Rockies
-        value: 518.31
+        value: 517.54
     hydro discharge:
       - _comment: used storage values greater than zero.
         datetime: '2020-01-01'
@@ -177,7 +177,7 @@ emissionFactors:
       - _comment: used storage values greater than zero.
         datetime: '2025-01-01'
         source: Electricity Maps, 2025 zone average; IPCC 2014
-        value: 415.96
+        value: 415.31
 fallbackZoneMixes:
   powerOriginRatios:
     - _source: Electricity Maps, 2015 average
@@ -338,6 +338,12 @@ isLowCarbon:
       value: 0.2759
     - datetime: '2022-01-01'
       value: 0.2276
+    - datetime: '2023-01-01'
+      value: 0.3365
+    - datetime: '2024-01-01'
+      value: 0.3307
+    - datetime: '2025-01-01'
+      value: 0.3457
   hydro discharge:
     - datetime: '2020-01-01'
       value: 0.1962
@@ -345,12 +351,24 @@ isLowCarbon:
       value: 0.2673
     - datetime: '2022-01-01'
       value: 0.3105
+    - datetime: '2023-01-01'
+      value: 0.4868
+    - datetime: '2024-01-01'
+      value: 0.5019
+    - datetime: '2025-01-01'
+      value: 0.473
 isRenewable:
   battery discharge:
     - datetime: '2021-01-01'
       value: 0.2759
     - datetime: '2022-01-01'
       value: 0.2276
+    - datetime: '2023-01-01'
+      value: 0.3365
+    - datetime: '2024-01-01'
+      value: 0.3307
+    - datetime: '2025-01-01'
+      value: 0.3457
   hydro discharge:
     - datetime: '2020-01-01'
       value: 0.1962
@@ -358,6 +376,12 @@ isRenewable:
       value: 0.2673
     - datetime: '2022-01-01'
       value: 0.3105
+    - datetime: '2023-01-01'
+      value: 0.4868
+    - datetime: '2024-01-01'
+      value: 0.5019
+    - datetime: '2025-01-01'
+      value: 0.473
 parsers:
   consumptionForecast: AEMO.fetch_consumption_forecast
   price: OPENNEM.fetch_price

--- a/config/zones/AU-QLD.yaml
+++ b/config/zones/AU-QLD.yaml
@@ -336,20 +336,28 @@ isLowCarbon:
   battery discharge:
     - datetime: '2021-01-01'
       value: 0.2759
+    - datetime: '2022-01-01'
+      value: 0.2276
   hydro discharge:
     - datetime: '2020-01-01'
       value: 0.1962
     - datetime: '2021-01-01'
       value: 0.2673
+    - datetime: '2022-01-01'
+      value: 0.3105
 isRenewable:
   battery discharge:
     - datetime: '2021-01-01'
       value: 0.2759
+    - datetime: '2022-01-01'
+      value: 0.2276
   hydro discharge:
     - datetime: '2020-01-01'
       value: 0.1962
     - datetime: '2021-01-01'
       value: 0.2673
+    - datetime: '2022-01-01'
+      value: 0.3105
 parsers:
   consumptionForecast: AEMO.fetch_consumption_forecast
   price: OPENNEM.fetch_price

--- a/config/zones/AU-QLD.yaml
+++ b/config/zones/AU-QLD.yaml
@@ -89,23 +89,23 @@ emissionFactors:
       - _comment: used storage values greater than zero.
         datetime: '2021-01-01'
         source: Electricity Maps, 2021 zone average
-        value: 524.81
+        value: 509.87
       - _comment: used storage values greater than zero.
         datetime: '2022-01-01'
         source: Electricity Maps, 2022 zone average
-        value: 558.86
+        value: 559.06
       - _comment: used storage values greater than zero.
         datetime: '2023-01-01'
         source: Electricity Maps, 2023 zone average
-        value: 487.73
+        value: 486.99
       - _comment: used storage values greater than zero.
         datetime: '2024-01-01'
         source: Electricity Maps, 2024 zone average
-        value: 493.04
+        value: 493.14
       - _comment: used storage values greater than zero.
         datetime: '2025-01-01'
         source: Electricity Maps, 2025 zone average
-        value: 484.54
+        value: 484.79
     hydro discharge:
       - _comment: used storage values greater than zero.
         datetime: '2020-01-01'
@@ -114,45 +114,45 @@ emissionFactors:
       - _comment: used storage values greater than zero.
         datetime: '2021-01-01'
         source: Electricity Maps, 2021 zone average
-        value: 540.25
+        value: 532.82
       - _comment: used storage values greater than zero.
         datetime: '2022-01-01'
         source: Electricity Maps, 2022 zone average
-        value: 505.58
+        value: 507.06
       - _comment: used storage values greater than zero.
         datetime: '2023-01-01'
         source: Electricity Maps, 2023 zone average
-        value: 380.51
+        value: 382.64
       - _comment: used storage values greater than zero.
         datetime: '2024-01-01'
         source: Electricity Maps, 2024 zone average
-        value: 369.27
+        value: 369.82
       - _comment: used storage values greater than zero.
         datetime: '2025-01-01'
         source: Electricity Maps, 2025 zone average
-        value: 391.31
+        value: 392.55
   lifecycle:
     battery discharge:
       - _comment: used storage values greater than zero.
         datetime: '2021-01-01'
         source: Electricity Maps, 2021 zone average; National Laboratory of the Rockies
-        value: 557.81
+        value: 542.87
       - _comment: used storage values greater than zero.
         datetime: '2022-01-01'
         source: Electricity Maps, 2022 zone average; National Laboratory of the Rockies
-        value: 591.86
+        value: 592.06
       - _comment: used storage values greater than zero.
         datetime: '2023-01-01'
         source: Electricity Maps, 2023 zone average; National Laboratory of the Rockies
-        value: 520.73
+        value: 519.99
       - _comment: used storage values greater than zero.
         datetime: '2024-01-01'
         source: Electricity Maps, 2024 zone average; National Laboratory of the Rockies
-        value: 526.04
+        value: 526.14
       - _comment: used storage values greater than zero.
         datetime: '2025-01-01'
         source: Electricity Maps, 2025 zone average; National Laboratory of the Rockies
-        value: 517.54
+        value: 517.79
     hydro discharge:
       - _comment: used storage values greater than zero.
         datetime: '2020-01-01'
@@ -161,23 +161,23 @@ emissionFactors:
       - _comment: used storage values greater than zero.
         datetime: '2021-01-01'
         source: Electricity Maps, 2021 zone average; IPCC 2014
-        value: 564.25
+        value: 556.82
       - _comment: used storage values greater than zero.
         datetime: '2022-01-01'
         source: Electricity Maps, 2022 zone average; IPCC 2014
-        value: 529.58
+        value: 531.06
       - _comment: used storage values greater than zero.
         datetime: '2023-01-01'
         source: Electricity Maps, 2023 zone average; IPCC 2014
-        value: 404.51
+        value: 406.64
       - _comment: used storage values greater than zero.
         datetime: '2024-01-01'
         source: Electricity Maps, 2024 zone average; IPCC 2014
-        value: 393.27
+        value: 393.82
       - _comment: used storage values greater than zero.
         datetime: '2025-01-01'
         source: Electricity Maps, 2025 zone average; IPCC 2014
-        value: 415.31
+        value: 416.55
 fallbackZoneMixes:
   powerOriginRatios:
     - _source: Electricity Maps, 2015 average
@@ -335,53 +335,53 @@ hide_day_ahead_price: false
 isLowCarbon:
   battery discharge:
     - datetime: '2021-01-01'
-      value: 0.2759
+      value: 0.2964
     - datetime: '2022-01-01'
-      value: 0.2276
+      value: 0.2272
     - datetime: '2023-01-01'
-      value: 0.3365
+      value: 0.3377
     - datetime: '2024-01-01'
-      value: 0.3307
+      value: 0.3306
     - datetime: '2025-01-01'
-      value: 0.3457
+      value: 0.3453
   hydro discharge:
     - datetime: '2020-01-01'
       value: 0.1962
     - datetime: '2021-01-01'
-      value: 0.2673
+      value: 0.2773
     - datetime: '2022-01-01'
-      value: 0.3105
+      value: 0.3084
     - datetime: '2023-01-01'
-      value: 0.4868
+      value: 0.484
     - datetime: '2024-01-01'
-      value: 0.5019
+      value: 0.501
     - datetime: '2025-01-01'
-      value: 0.473
+      value: 0.4713
 isRenewable:
   battery discharge:
     - datetime: '2021-01-01'
-      value: 0.2759
+      value: 0.2964
     - datetime: '2022-01-01'
-      value: 0.2276
+      value: 0.2272
     - datetime: '2023-01-01'
-      value: 0.3365
+      value: 0.3377
     - datetime: '2024-01-01'
-      value: 0.3307
+      value: 0.3306
     - datetime: '2025-01-01'
-      value: 0.3457
+      value: 0.3453
   hydro discharge:
     - datetime: '2020-01-01'
       value: 0.1962
     - datetime: '2021-01-01'
-      value: 0.2673
+      value: 0.2773
     - datetime: '2022-01-01'
-      value: 0.3105
+      value: 0.3084
     - datetime: '2023-01-01'
-      value: 0.4868
+      value: 0.484
     - datetime: '2024-01-01'
-      value: 0.5019
+      value: 0.501
     - datetime: '2025-01-01'
-      value: 0.473
+      value: 0.4713
 parsers:
   consumptionForecast: AEMO.fetch_consumption_forecast
   price: OPENNEM.fetch_price

--- a/config/zones/AU-SA.yaml
+++ b/config/zones/AU-SA.yaml
@@ -91,23 +91,23 @@ emissionFactors:
       - _comment: used storage values greater than zero.
         datetime: '2021-01-01'
         source: Electricity Maps, 2021 zone average
-        value: 127.38
+        value: 125.83
       - _comment: used storage values greater than zero.
         datetime: '2022-01-01'
         source: Electricity Maps, 2022 zone average
-        value: 96.37
+        value: 96.16
       - _comment: used storage values greater than zero.
         datetime: '2023-01-01'
         source: Electricity Maps, 2023 zone average
-        value: 105.57
+        value: 105.59
       - _comment: used storage values greater than zero.
         datetime: '2024-01-01'
         source: Electricity Maps, 2024 zone average
-        value: 115.74
+        value: 114.28
       - _comment: used storage values greater than zero.
         datetime: '2025-01-01'
         source: Electricity Maps, 2025 zone average
-        value: 89.23
+        value: 92.12
   lifecycle:
     battery discharge:
       - _comment: used storage values greater than zero.
@@ -117,23 +117,23 @@ emissionFactors:
       - _comment: used storage values greater than zero.
         datetime: '2021-01-01'
         source: Electricity Maps, 2021 zone average; National Laboratory of the Rockies
-        value: 160.38
+        value: 158.83
       - _comment: used storage values greater than zero.
         datetime: '2022-01-01'
         source: Electricity Maps, 2022 zone average; National Laboratory of the Rockies
-        value: 129.37
+        value: 129.16
       - _comment: used storage values greater than zero.
         datetime: '2023-01-01'
         source: Electricity Maps, 2023 zone average; National Laboratory of the Rockies
-        value: 138.57
+        value: 138.59
       - _comment: used storage values greater than zero.
         datetime: '2024-01-01'
         source: Electricity Maps, 2024 zone average; National Laboratory of the Rockies
-        value: 148.74
+        value: 147.28
       - _comment: used storage values greater than zero.
         datetime: '2025-01-01'
         source: Electricity Maps, 2025 zone average; National Laboratory of the Rockies
-        value: 122.23
+        value: 125.12
 fallbackZoneMixes:
   powerOriginRatios:
     - _source: Electricity Maps, 2015 average
@@ -293,29 +293,29 @@ isLowCarbon:
     - datetime: '2020-01-01'
       value: 0.5635
     - datetime: '2021-01-01'
-      value: 0.6558
+      value: 0.66
     - datetime: '2022-01-01'
-      value: 0.7399
+      value: 0.7404
     - datetime: '2023-01-01'
       value: 0.7749
     - datetime: '2024-01-01'
-      value: 0.7499
+      value: 0.7532
     - datetime: '2025-01-01'
-      value: 0.7955
+      value: 0.7911
 isRenewable:
   battery discharge:
     - datetime: '2020-01-01'
       value: 0.5635
     - datetime: '2021-01-01'
-      value: 0.6558
+      value: 0.66
     - datetime: '2022-01-01'
-      value: 0.7399
+      value: 0.7404
     - datetime: '2023-01-01'
       value: 0.7749
     - datetime: '2024-01-01'
-      value: 0.7499
+      value: 0.7532
     - datetime: '2025-01-01'
-      value: 0.7955
+      value: 0.7911
 parsers:
   consumptionForecast: AEMO.fetch_consumption_forecast
   price: OPENNEM.fetch_price

--- a/config/zones/AU-SA.yaml
+++ b/config/zones/AU-SA.yaml
@@ -286,18 +286,26 @@ fallbackZoneMixes:
         solar: 0.2668651967564851
         unknown: 0.0
         wind: 0.42456316091004337
-has_day_ahead_price_license: False
-hide_day_ahead_price: False
+has_day_ahead_price_license: false
+hide_day_ahead_price: false
+isLowCarbon:
+  battery discharge:
+    - datetime: '2020-01-01'
+      value: 0.5635
+isRenewable:
+  battery discharge:
+    - datetime: '2020-01-01'
+      value: 0.5635
 parsers:
   consumptionForecast: AEMO.fetch_consumption_forecast
   price: OPENNEM.fetch_price
   production: OPENNEM.fetch_production
   productionCapacity: OPENELECTRICITY.fetch_production_capacity
 region: Oceania
-timezone: Australia/Adelaide
-zone_name: South Australia
 sources:
   IPCC 2014:
     link: https://www.ipcc.ch/site/assets/uploads/2018/02/ipcc_wg3_ar5_annex-iii.pdf#page=7
   National Laboratory of the Rockies:
     link: https://docs.nrel.gov/docs/fy21osti/80580.pdf
+timezone: Australia/Adelaide
+zone_name: South Australia

--- a/config/zones/AU-SA.yaml
+++ b/config/zones/AU-SA.yaml
@@ -107,7 +107,7 @@ emissionFactors:
       - _comment: used storage values greater than zero.
         datetime: '2025-01-01'
         source: Electricity Maps, 2025 zone average
-        value: 89.97
+        value: 89.23
   lifecycle:
     battery discharge:
       - _comment: used storage values greater than zero.
@@ -133,7 +133,7 @@ emissionFactors:
       - _comment: used storage values greater than zero.
         datetime: '2025-01-01'
         source: Electricity Maps, 2025 zone average; National Laboratory of the Rockies
-        value: 122.97
+        value: 122.23
 fallbackZoneMixes:
   powerOriginRatios:
     - _source: Electricity Maps, 2015 average
@@ -296,6 +296,12 @@ isLowCarbon:
       value: 0.6558
     - datetime: '2022-01-01'
       value: 0.7399
+    - datetime: '2023-01-01'
+      value: 0.7749
+    - datetime: '2024-01-01'
+      value: 0.7499
+    - datetime: '2025-01-01'
+      value: 0.7955
 isRenewable:
   battery discharge:
     - datetime: '2020-01-01'
@@ -304,6 +310,12 @@ isRenewable:
       value: 0.6558
     - datetime: '2022-01-01'
       value: 0.7399
+    - datetime: '2023-01-01'
+      value: 0.7749
+    - datetime: '2024-01-01'
+      value: 0.7499
+    - datetime: '2025-01-01'
+      value: 0.7955
 parsers:
   consumptionForecast: AEMO.fetch_consumption_forecast
   price: OPENNEM.fetch_price

--- a/config/zones/AU-SA.yaml
+++ b/config/zones/AU-SA.yaml
@@ -292,10 +292,14 @@ isLowCarbon:
   battery discharge:
     - datetime: '2020-01-01'
       value: 0.5635
+    - datetime: '2021-01-01'
+      value: 0.6558
 isRenewable:
   battery discharge:
     - datetime: '2020-01-01'
       value: 0.5635
+    - datetime: '2021-01-01'
+      value: 0.6558
 parsers:
   consumptionForecast: AEMO.fetch_consumption_forecast
   price: OPENNEM.fetch_price

--- a/config/zones/AU-SA.yaml
+++ b/config/zones/AU-SA.yaml
@@ -294,12 +294,16 @@ isLowCarbon:
       value: 0.5635
     - datetime: '2021-01-01'
       value: 0.6558
+    - datetime: '2022-01-01'
+      value: 0.7399
 isRenewable:
   battery discharge:
     - datetime: '2020-01-01'
       value: 0.5635
     - datetime: '2021-01-01'
       value: 0.6558
+    - datetime: '2022-01-01'
+      value: 0.7399
 parsers:
   consumptionForecast: AEMO.fetch_consumption_forecast
   price: OPENNEM.fetch_price

--- a/config/zones/AU-TAS-FI.yaml
+++ b/config/zones/AU-TAS-FI.yaml
@@ -30,7 +30,7 @@ emissionFactors:
       - _comment: used storage values greater than zero.
         datetime: '2020-01-01'
         source: Electricity Maps, 2020 zone average
-        value: 151.28
+        value: 150.24
       - _comment: used storage values greater than zero.
         datetime: '2021-01-01'
         source: Electricity Maps, 2021 zone average
@@ -56,7 +56,7 @@ emissionFactors:
       - _comment: used storage values greater than zero.
         datetime: '2020-01-01'
         source: Electricity Maps, 2020 zone average; National Laboratory of the Rockies
-        value: 184.28
+        value: 183.24
       - _comment: used storage values greater than zero.
         datetime: '2021-01-01'
         source: Electricity Maps, 2021 zone average; National Laboratory of the Rockies
@@ -144,7 +144,7 @@ hide_day_ahead_price: false
 isLowCarbon:
   battery discharge:
     - datetime: '2020-01-01'
-      value: 0.6274
+      value: 0.6299
     - datetime: '2021-01-01'
       value: 0.647
     - datetime: '2022-01-01'
@@ -158,7 +158,7 @@ isLowCarbon:
 isRenewable:
   battery discharge:
     - datetime: '2020-01-01'
-      value: 0.6274
+      value: 0.6299
     - datetime: '2021-01-01'
       value: 0.647
     - datetime: '2022-01-01'

--- a/config/zones/AU-TAS-FI.yaml
+++ b/config/zones/AU-TAS-FI.yaml
@@ -147,12 +147,16 @@ isLowCarbon:
       value: 0.6274
     - datetime: '2021-01-01'
       value: 0.647
+    - datetime: '2022-01-01'
+      value: 0.5717
 isRenewable:
   battery discharge:
     - datetime: '2020-01-01'
       value: 0.6274
     - datetime: '2021-01-01'
       value: 0.647
+    - datetime: '2022-01-01'
+      value: 0.5717
 parsers:
   production: ajenti.fetch_production
 region: Oceania

--- a/config/zones/AU-TAS-FI.yaml
+++ b/config/zones/AU-TAS-FI.yaml
@@ -1,4 +1,6 @@
-_comment: 'Capacity data fetched from the test payload (capacity is sent in all payloads). Parsing for production is done on instantaneous measurements : this is not reliable at all. Battery storage is composed of 0.5 battery+0.2 of flywheel'
+_comment: 'Capacity data fetched from the test payload (capacity is sent in all payloads).
+  Parsing for production is done on instantaneous measurements : this is not reliable
+  at all. Battery storage is composed of 0.5 battery+0.2 of flywheel'
 bounding_box:
   - - 147.25766035200024
     - -40.770603122999844
@@ -137,15 +139,23 @@ fallbackZoneMixes:
         solar: 0.01938750199323187
         unknown: 0.0
         wind: 0.5865180749218949
-has_day_ahead_price_license: False
-hide_day_ahead_price: False
+has_day_ahead_price_license: false
+hide_day_ahead_price: false
+isLowCarbon:
+  battery discharge:
+    - datetime: '2020-01-01'
+      value: 0.6274
+isRenewable:
+  battery discharge:
+    - datetime: '2020-01-01'
+      value: 0.6274
 parsers:
   production: ajenti.fetch_production
 region: Oceania
-timezone: Australia/Hobart
-zone_name: Flinders Island
 sources:
   IPCC 2014:
     link: https://www.ipcc.ch/site/assets/uploads/2018/02/ipcc_wg3_ar5_annex-iii.pdf#page=7
   National Laboratory of the Rockies:
     link: https://docs.nrel.gov/docs/fy21osti/80580.pdf
+timezone: Australia/Hobart
+zone_name: Flinders Island

--- a/config/zones/AU-TAS-FI.yaml
+++ b/config/zones/AU-TAS-FI.yaml
@@ -149,6 +149,12 @@ isLowCarbon:
       value: 0.647
     - datetime: '2022-01-01'
       value: 0.5717
+    - datetime: '2023-01-01'
+      value: 0.5901
+    - datetime: '2024-01-01'
+      value: 0.6074
+    - datetime: '2025-01-01'
+      value: 0.5356
 isRenewable:
   battery discharge:
     - datetime: '2020-01-01'
@@ -157,6 +163,12 @@ isRenewable:
       value: 0.647
     - datetime: '2022-01-01'
       value: 0.5717
+    - datetime: '2023-01-01'
+      value: 0.5901
+    - datetime: '2024-01-01'
+      value: 0.6074
+    - datetime: '2025-01-01'
+      value: 0.5356
 parsers:
   production: ajenti.fetch_production
 region: Oceania

--- a/config/zones/AU-TAS-FI.yaml
+++ b/config/zones/AU-TAS-FI.yaml
@@ -145,10 +145,14 @@ isLowCarbon:
   battery discharge:
     - datetime: '2020-01-01'
       value: 0.6274
+    - datetime: '2021-01-01'
+      value: 0.647
 isRenewable:
   battery discharge:
     - datetime: '2020-01-01'
       value: 0.6274
+    - datetime: '2021-01-01'
+      value: 0.647
 parsers:
   production: ajenti.fetch_production
 region: Oceania

--- a/config/zones/AU-TAS-KI.yaml
+++ b/config/zones/AU-TAS-KI.yaml
@@ -51,7 +51,7 @@ emissionFactors:
       - _comment: used storage values greater than zero.
         datetime: '2025-01-01'
         source: Electricity Maps, 2025 zone average
-        value: 291.22
+        value: 291.23
   lifecycle:
     battery discharge:
       - _comment: used storage values greater than zero.
@@ -77,7 +77,7 @@ emissionFactors:
       - _comment: used storage values greater than zero.
         datetime: '2025-01-01'
         source: Electricity Maps, 2025 zone average; National Laboratory of the Rockies
-        value: 324.22
+        value: 324.23
 fallbackZoneMixes:
   powerOriginRatios:
     - _source: Electricity Maps, 2020 average
@@ -165,6 +165,12 @@ isLowCarbon:
       value: 0.5657
     - datetime: '2022-01-01'
       value: 0.449
+    - datetime: '2023-01-01'
+      value: 0.2468
+    - datetime: '2024-01-01'
+      value: 0.3118
+    - datetime: '2025-01-01'
+      value: 0.2827
 isRenewable:
   battery discharge:
     - datetime: '2020-01-01'
@@ -173,6 +179,12 @@ isRenewable:
       value: 0.5657
     - datetime: '2022-01-01'
       value: 0.449
+    - datetime: '2023-01-01'
+      value: 0.2468
+    - datetime: '2024-01-01'
+      value: 0.3118
+    - datetime: '2025-01-01'
+      value: 0.2827
 parsers:
   production: ajenti.fetch_production
 region: Oceania

--- a/config/zones/AU-TAS-KI.yaml
+++ b/config/zones/AU-TAS-KI.yaml
@@ -1,4 +1,8 @@
-_comment: 'Capacity data fetched from https://www.hydro.com.au/docs/default-source/clean-energy/hybrid-energy-solutions/king_island.pdf . Oil capacity is said to run with blended biodiesel : hense the diesel capacity is equal to the biomass capacity. Parsing for production is done on instantaneous measurements : this is not reliable at all'
+_comment:
+  'Capacity data fetched from https://www.hydro.com.au/docs/default-source/clean-energy/hybrid-energy-solutions/king_island.pdf
+  . Oil capacity is said to run with blended biodiesel : hense the diesel capacity
+  is equal to the biomass capacity. Parsing for production is done on instantaneous
+  measurements : this is not reliable at all'
 bounding_box:
   - - 143.33716881600026
     - -40.627373955999886
@@ -151,15 +155,23 @@ fallbackZoneMixes:
         solar: 0.1199307309665122
         unknown: 0.0
         wind: 0.2054531930390045
-has_day_ahead_price_license: False
-hide_day_ahead_price: False
+has_day_ahead_price_license: false
+hide_day_ahead_price: false
+isLowCarbon:
+  battery discharge:
+    - datetime: '2020-01-01'
+      value: 0.6608
+isRenewable:
+  battery discharge:
+    - datetime: '2020-01-01'
+      value: 0.6608
 parsers:
   production: ajenti.fetch_production
 region: Oceania
-timezone: Australia/Hobart
-zone_name: King Island
 sources:
   IPCC 2014:
     link: https://www.ipcc.ch/site/assets/uploads/2018/02/ipcc_wg3_ar5_annex-iii.pdf#page=7
   National Laboratory of the Rockies:
     link: https://docs.nrel.gov/docs/fy21osti/80580.pdf
+timezone: Australia/Hobart
+zone_name: King Island

--- a/config/zones/AU-TAS-KI.yaml
+++ b/config/zones/AU-TAS-KI.yaml
@@ -163,12 +163,16 @@ isLowCarbon:
       value: 0.6608
     - datetime: '2021-01-01'
       value: 0.5657
+    - datetime: '2022-01-01'
+      value: 0.449
 isRenewable:
   battery discharge:
     - datetime: '2020-01-01'
       value: 0.6608
     - datetime: '2021-01-01'
       value: 0.5657
+    - datetime: '2022-01-01'
+      value: 0.449
 parsers:
   production: ajenti.fetch_production
 region: Oceania

--- a/config/zones/AU-TAS-KI.yaml
+++ b/config/zones/AU-TAS-KI.yaml
@@ -161,10 +161,14 @@ isLowCarbon:
   battery discharge:
     - datetime: '2020-01-01'
       value: 0.6608
+    - datetime: '2021-01-01'
+      value: 0.5657
 isRenewable:
   battery discharge:
     - datetime: '2020-01-01'
       value: 0.6608
+    - datetime: '2021-01-01'
+      value: 0.5657
 parsers:
   production: ajenti.fetch_production
 region: Oceania

--- a/config/zones/AU-TAS-KI.yaml
+++ b/config/zones/AU-TAS-KI.yaml
@@ -35,23 +35,23 @@ emissionFactors:
       - _comment: used storage values greater than zero.
         datetime: '2021-01-01'
         source: Electricity Maps, 2021 zone average
-        value: 176.34
+        value: 173.94
       - _comment: used storage values greater than zero.
         datetime: '2022-01-01'
         source: Electricity Maps, 2022 zone average
-        value: 223.73
+        value: 222.92
       - _comment: used storage values greater than zero.
         datetime: '2023-01-01'
         source: Electricity Maps, 2023 zone average
-        value: 305.8
+        value: 305.96
       - _comment: used storage values greater than zero.
         datetime: '2024-01-01'
         source: Electricity Maps, 2024 zone average
-        value: 279.41
+        value: 280.75
       - _comment: used storage values greater than zero.
         datetime: '2025-01-01'
         source: Electricity Maps, 2025 zone average
-        value: 291.23
+        value: 291.34
   lifecycle:
     battery discharge:
       - _comment: used storage values greater than zero.
@@ -61,23 +61,23 @@ emissionFactors:
       - _comment: used storage values greater than zero.
         datetime: '2021-01-01'
         source: Electricity Maps, 2021 zone average; National Laboratory of the Rockies
-        value: 209.34
+        value: 206.94
       - _comment: used storage values greater than zero.
         datetime: '2022-01-01'
         source: Electricity Maps, 2022 zone average; National Laboratory of the Rockies
-        value: 256.73
+        value: 255.92
       - _comment: used storage values greater than zero.
         datetime: '2023-01-01'
         source: Electricity Maps, 2023 zone average; National Laboratory of the Rockies
-        value: 338.8
+        value: 338.96
       - _comment: used storage values greater than zero.
         datetime: '2024-01-01'
         source: Electricity Maps, 2024 zone average; National Laboratory of the Rockies
-        value: 312.41
+        value: 313.75
       - _comment: used storage values greater than zero.
         datetime: '2025-01-01'
         source: Electricity Maps, 2025 zone average; National Laboratory of the Rockies
-        value: 324.23
+        value: 324.34
 fallbackZoneMixes:
   powerOriginRatios:
     - _source: Electricity Maps, 2020 average
@@ -162,29 +162,29 @@ isLowCarbon:
     - datetime: '2020-01-01'
       value: 0.6608
     - datetime: '2021-01-01'
-      value: 0.5657
+      value: 0.5716
     - datetime: '2022-01-01'
-      value: 0.449
+      value: 0.4509
     - datetime: '2023-01-01'
-      value: 0.2468
+      value: 0.2464
     - datetime: '2024-01-01'
-      value: 0.3118
+      value: 0.3085
     - datetime: '2025-01-01'
-      value: 0.2827
+      value: 0.2824
 isRenewable:
   battery discharge:
     - datetime: '2020-01-01'
       value: 0.6608
     - datetime: '2021-01-01'
-      value: 0.5657
+      value: 0.5716
     - datetime: '2022-01-01'
-      value: 0.449
+      value: 0.4509
     - datetime: '2023-01-01'
-      value: 0.2468
+      value: 0.2464
     - datetime: '2024-01-01'
-      value: 0.3118
+      value: 0.3085
     - datetime: '2025-01-01'
-      value: 0.2827
+      value: 0.2824
 parsers:
   production: ajenti.fetch_production
 region: Oceania

--- a/config/zones/AU-TAS.yaml
+++ b/config/zones/AU-TAS.yaml
@@ -209,8 +209,16 @@ fallbackZoneMixes:
         solar: 0.07151092912874732
         unknown: 0.0
         wind: 0.2039048715577342
-has_day_ahead_price_license: False
-hide_day_ahead_price: False
+has_day_ahead_price_license: false
+hide_day_ahead_price: false
+isLowCarbon:
+  battery discharge:
+    - datetime: '2022-01-01'
+      value: 0.999
+isRenewable:
+  battery discharge:
+    - datetime: '2022-01-01'
+      value: 0.999
 parsers:
   consumptionForecast: AEMO.fetch_consumption_forecast
   price: OPENNEM.fetch_price

--- a/config/zones/AU-VIC.yaml
+++ b/config/zones/AU-VIC.yaml
@@ -293,12 +293,16 @@ isLowCarbon:
       value: 0.2055
     - datetime: '2021-01-01'
       value: 0.2809
+    - datetime: '2022-01-01'
+      value: 0.3439
 isRenewable:
   battery discharge:
     - datetime: '2020-01-01'
       value: 0.2055
     - datetime: '2021-01-01'
       value: 0.2809
+    - datetime: '2022-01-01'
+      value: 0.3439
 parsers:
   consumptionForecast: AEMO.fetch_consumption_forecast
   price: OPENNEM.fetch_price

--- a/config/zones/AU-VIC.yaml
+++ b/config/zones/AU-VIC.yaml
@@ -291,10 +291,14 @@ isLowCarbon:
   battery discharge:
     - datetime: '2020-01-01'
       value: 0.2055
+    - datetime: '2021-01-01'
+      value: 0.2809
 isRenewable:
   battery discharge:
     - datetime: '2020-01-01'
       value: 0.2055
+    - datetime: '2021-01-01'
+      value: 0.2809
 parsers:
   consumptionForecast: AEMO.fetch_consumption_forecast
   price: OPENNEM.fetch_price

--- a/config/zones/AU-VIC.yaml
+++ b/config/zones/AU-VIC.yaml
@@ -86,7 +86,7 @@ emissionFactors:
       - _comment: used storage values greater than zero.
         datetime: '2020-01-01'
         source: Electricity Maps, 2020 zone average
-        value: 595.22
+        value: 595.23
       - _comment: used storage values greater than zero.
         datetime: '2021-01-01'
         source: Electricity Maps, 2021 zone average
@@ -112,7 +112,7 @@ emissionFactors:
       - _comment: used storage values greater than zero.
         datetime: '2020-01-01'
         source: Electricity Maps, 2020 zone average; National Laboratory of the Rockies
-        value: 628.22
+        value: 628.23
       - _comment: used storage values greater than zero.
         datetime: '2021-01-01'
         source: Electricity Maps, 2021 zone average; National Laboratory of the Rockies
@@ -285,18 +285,26 @@ fallbackZoneMixes:
         solar: 0.1470457660916572
         unknown: 0.0
         wind: 0.18972740562986398
-has_day_ahead_price_license: False
-hide_day_ahead_price: False
+has_day_ahead_price_license: false
+hide_day_ahead_price: false
+isLowCarbon:
+  battery discharge:
+    - datetime: '2020-01-01'
+      value: 0.2055
+isRenewable:
+  battery discharge:
+    - datetime: '2020-01-01'
+      value: 0.2055
 parsers:
   consumptionForecast: AEMO.fetch_consumption_forecast
   price: OPENNEM.fetch_price
   production: OPENNEM.fetch_production
   productionCapacity: OPENELECTRICITY.fetch_production_capacity
 region: Oceania
-timezone: Australia/Melbourne
-zone_name: Victoria
 sources:
   IPCC 2014:
     link: https://www.ipcc.ch/site/assets/uploads/2018/02/ipcc_wg3_ar5_annex-iii.pdf#page=7
   National Laboratory of the Rockies:
     link: https://docs.nrel.gov/docs/fy21osti/80580.pdf
+timezone: Australia/Melbourne
+zone_name: Victoria

--- a/config/zones/AU-VIC.yaml
+++ b/config/zones/AU-VIC.yaml
@@ -86,11 +86,11 @@ emissionFactors:
       - _comment: used storage values greater than zero.
         datetime: '2020-01-01'
         source: Electricity Maps, 2020 zone average
-        value: 595.23
+        value: 595.22
       - _comment: used storage values greater than zero.
         datetime: '2021-01-01'
         source: Electricity Maps, 2021 zone average
-        value: 542.33
+        value: 539.83
       - _comment: used storage values greater than zero.
         datetime: '2022-01-01'
         source: Electricity Maps, 2022 zone average
@@ -102,21 +102,21 @@ emissionFactors:
       - _comment: used storage values greater than zero.
         datetime: '2024-01-01'
         source: Electricity Maps, 2024 zone average
-        value: 441.94
+        value: 441.97
       - _comment: used storage values greater than zero.
         datetime: '2025-01-01'
         source: Electricity Maps, 2025 zone average
-        value: 410.06
+        value: 408.53
   lifecycle:
     battery discharge:
       - _comment: used storage values greater than zero.
         datetime: '2020-01-01'
         source: Electricity Maps, 2020 zone average; National Laboratory of the Rockies
-        value: 628.23
+        value: 628.22
       - _comment: used storage values greater than zero.
         datetime: '2021-01-01'
         source: Electricity Maps, 2021 zone average; National Laboratory of the Rockies
-        value: 575.33
+        value: 572.83
       - _comment: used storage values greater than zero.
         datetime: '2022-01-01'
         source: Electricity Maps, 2022 zone average; National Laboratory of the Rockies
@@ -128,11 +128,11 @@ emissionFactors:
       - _comment: used storage values greater than zero.
         datetime: '2024-01-01'
         source: Electricity Maps, 2024 zone average; National Laboratory of the Rockies
-        value: 474.94
+        value: 474.97
       - _comment: used storage values greater than zero.
         datetime: '2025-01-01'
         source: Electricity Maps, 2025 zone average; National Laboratory of the Rockies
-        value: 443.06
+        value: 441.53
 fallbackZoneMixes:
   powerOriginRatios:
     - _source: Electricity Maps, 2015 average
@@ -292,7 +292,7 @@ isLowCarbon:
     - datetime: '2020-01-01'
       value: 0.2055
     - datetime: '2021-01-01'
-      value: 0.2809
+      value: 0.2842
     - datetime: '2022-01-01'
       value: 0.3439
     - datetime: '2023-01-01'
@@ -300,13 +300,13 @@ isLowCarbon:
     - datetime: '2024-01-01'
       value: 0.4085
     - datetime: '2025-01-01'
-      value: 0.4524
+      value: 0.4544
 isRenewable:
   battery discharge:
     - datetime: '2020-01-01'
       value: 0.2055
     - datetime: '2021-01-01'
-      value: 0.2809
+      value: 0.2842
     - datetime: '2022-01-01'
       value: 0.3439
     - datetime: '2023-01-01'
@@ -314,7 +314,7 @@ isRenewable:
     - datetime: '2024-01-01'
       value: 0.4085
     - datetime: '2025-01-01'
-      value: 0.4524
+      value: 0.4544
 parsers:
   consumptionForecast: AEMO.fetch_consumption_forecast
   price: OPENNEM.fetch_price

--- a/config/zones/AU-VIC.yaml
+++ b/config/zones/AU-VIC.yaml
@@ -106,7 +106,7 @@ emissionFactors:
       - _comment: used storage values greater than zero.
         datetime: '2025-01-01'
         source: Electricity Maps, 2025 zone average
-        value: 411.08
+        value: 410.06
   lifecycle:
     battery discharge:
       - _comment: used storage values greater than zero.
@@ -132,7 +132,7 @@ emissionFactors:
       - _comment: used storage values greater than zero.
         datetime: '2025-01-01'
         source: Electricity Maps, 2025 zone average; National Laboratory of the Rockies
-        value: 444.08
+        value: 443.06
 fallbackZoneMixes:
   powerOriginRatios:
     - _source: Electricity Maps, 2015 average
@@ -295,6 +295,12 @@ isLowCarbon:
       value: 0.2809
     - datetime: '2022-01-01'
       value: 0.3439
+    - datetime: '2023-01-01'
+      value: 0.4435
+    - datetime: '2024-01-01'
+      value: 0.4085
+    - datetime: '2025-01-01'
+      value: 0.4524
 isRenewable:
   battery discharge:
     - datetime: '2020-01-01'
@@ -303,6 +309,12 @@ isRenewable:
       value: 0.2809
     - datetime: '2022-01-01'
       value: 0.3439
+    - datetime: '2023-01-01'
+      value: 0.4435
+    - datetime: '2024-01-01'
+      value: 0.4085
+    - datetime: '2025-01-01'
+      value: 0.4524
 parsers:
   consumptionForecast: AEMO.fetch_consumption_forecast
   price: OPENNEM.fetch_price

--- a/config/zones/AU-WA-RI.yaml
+++ b/config/zones/AU-WA-RI.yaml
@@ -29,15 +29,15 @@ emissionFactors:
       - _comment: used non-null storage values
         datetime: '2020-01-01'
         source: Electricity Maps, 2020 zone average
-        value: 311.06
+        value: 310.86
       - _comment: used non-null storage values
         datetime: '2021-01-01'
         source: Electricity Maps, 2021 zone average
-        value: 310.93
+        value: 310.86
       - _comment: used non-null storage values
         datetime: '2022-01-01'
         source: Electricity Maps, 2022 zone average
-        value: 310.92
+        value: 310.86
       - _comment: used non-null storage values
         datetime: '2023-01-01'
         source: Electricity Maps, 2023 zone average
@@ -45,7 +45,7 @@ emissionFactors:
       - _comment: used non-null storage values
         datetime: '2024-01-01'
         source: Electricity Maps, 2024 zone average
-        value: 322.11
+        value: 321.42
       - _comment: used non-null storage values
         datetime: '2025-01-01'
         source: Electricity Maps, 2025 zone average
@@ -55,15 +55,15 @@ emissionFactors:
       - _comment: used non-null storage values
         datetime: '2020-01-01'
         source: Electricity Maps, 2020 zone average; National Laboratory of the Rockies
-        value: 344.06
+        value: 343.86
       - _comment: used non-null storage values
         datetime: '2021-01-01'
         source: Electricity Maps, 2021 zone average; National Laboratory of the Rockies
-        value: 343.93
+        value: 343.86
       - _comment: used non-null storage values
         datetime: '2022-01-01'
         source: Electricity Maps, 2022 zone average; National Laboratory of the Rockies
-        value: 343.92
+        value: 343.86
       - _comment: used non-null storage values
         datetime: '2023-01-01'
         source: Electricity Maps, 2023 zone average; National Laboratory of the Rockies
@@ -71,7 +71,7 @@ emissionFactors:
       - _comment: used non-null storage values
         datetime: '2024-01-01'
         source: Electricity Maps, 2024 zone average; National Laboratory of the Rockies
-        value: 355.11
+        value: 354.42
       - _comment: used non-null storage values
         datetime: '2025-01-01'
         source: Electricity Maps, 2025 zone average; National Laboratory of the Rockies
@@ -128,29 +128,29 @@ hide_day_ahead_price: false
 isLowCarbon:
   battery discharge:
     - datetime: '2020-01-01'
-      value: 0.2338
+      value: 0.2343
     - datetime: '2021-01-01'
-      value: 0.2342
+      value: 0.2343
     - datetime: '2022-01-01'
-      value: 0.2342
+      value: 0.2343
     - datetime: '2023-01-01'
       value: 0.25
     - datetime: '2024-01-01'
-      value: 0.2066
+      value: 0.2083
     - datetime: '2025-01-01'
       value: 0.2481
 isRenewable:
   battery discharge:
     - datetime: '2020-01-01'
-      value: 0.2338
+      value: 0.2343
     - datetime: '2021-01-01'
-      value: 0.2342
+      value: 0.2343
     - datetime: '2022-01-01'
-      value: 0.2342
+      value: 0.2343
     - datetime: '2023-01-01'
       value: 0.25
     - datetime: '2024-01-01'
-      value: 0.2066
+      value: 0.2083
     - datetime: '2025-01-01'
       value: 0.2481
 parsers:

--- a/config/zones/AU-WA-RI.yaml
+++ b/config/zones/AU-WA-RI.yaml
@@ -1,4 +1,6 @@
-_comment: 'Capacity data fetched from the test payload (capacity is sent in all payloads). Parsing for production is done on instantaneous measurements : this is not reliable at all'
+_comment: 'Capacity data fetched from the test payload (capacity is sent in all payloads).
+  Parsing for production is done on instantaneous measurements : this is not reliable
+  at all'
 bounding_box:
   - - 114.94014224400007
     - -32.52536222099991
@@ -121,15 +123,23 @@ fallbackZoneMixes:
         solar: 0.06026681890829423
         unknown: 0.0
         wind: 0.1463649654920588
-has_day_ahead_price_license: False
-hide_day_ahead_price: False
+has_day_ahead_price_license: false
+hide_day_ahead_price: false
+isLowCarbon:
+  battery discharge:
+    - datetime: '2020-01-01'
+      value: 0.2338
+isRenewable:
+  battery discharge:
+    - datetime: '2020-01-01'
+      value: 0.2338
 parsers:
   production: ajenti.fetch_production
 region: Oceania
-timezone: Australia/Perth
-zone_name: Rottnest Island
 sources:
   IPCC 2014:
     link: https://www.ipcc.ch/site/assets/uploads/2018/02/ipcc_wg3_ar5_annex-iii.pdf#page=7
   National Laboratory of the Rockies:
     link: https://docs.nrel.gov/docs/fy21osti/80580.pdf
+timezone: Australia/Perth
+zone_name: Rottnest Island

--- a/config/zones/AU-WA-RI.yaml
+++ b/config/zones/AU-WA-RI.yaml
@@ -131,11 +131,15 @@ isLowCarbon:
       value: 0.2338
     - datetime: '2021-01-01'
       value: 0.2342
+    - datetime: '2022-01-01'
+      value: 0.2342
 isRenewable:
   battery discharge:
     - datetime: '2020-01-01'
       value: 0.2338
     - datetime: '2021-01-01'
+      value: 0.2342
+    - datetime: '2022-01-01'
       value: 0.2342
 parsers:
   production: ajenti.fetch_production

--- a/config/zones/AU-WA-RI.yaml
+++ b/config/zones/AU-WA-RI.yaml
@@ -133,6 +133,12 @@ isLowCarbon:
       value: 0.2342
     - datetime: '2022-01-01'
       value: 0.2342
+    - datetime: '2023-01-01'
+      value: 0.25
+    - datetime: '2024-01-01'
+      value: 0.2066
+    - datetime: '2025-01-01'
+      value: 0.2481
 isRenewable:
   battery discharge:
     - datetime: '2020-01-01'
@@ -141,6 +147,12 @@ isRenewable:
       value: 0.2342
     - datetime: '2022-01-01'
       value: 0.2342
+    - datetime: '2023-01-01'
+      value: 0.25
+    - datetime: '2024-01-01'
+      value: 0.2066
+    - datetime: '2025-01-01'
+      value: 0.2481
 parsers:
   production: ajenti.fetch_production
 region: Oceania

--- a/config/zones/AU-WA-RI.yaml
+++ b/config/zones/AU-WA-RI.yaml
@@ -129,10 +129,14 @@ isLowCarbon:
   battery discharge:
     - datetime: '2020-01-01'
       value: 0.2338
+    - datetime: '2021-01-01'
+      value: 0.2342
 isRenewable:
   battery discharge:
     - datetime: '2020-01-01'
       value: 0.2338
+    - datetime: '2021-01-01'
+      value: 0.2342
 parsers:
   production: ajenti.fetch_production
 region: Oceania

--- a/config/zones/AU-WA.yaml
+++ b/config/zones/AU-WA.yaml
@@ -81,7 +81,7 @@ emissionFactors:
       - _comment: used storage values greater than zero.
         datetime: '2023-01-01'
         source: Electricity Maps, 2023 zone average
-        value: 311.0
+        value: 301.2
       - _comment: used storage values greater than zero.
         datetime: '2024-01-01'
         source: Electricity Maps, 2024 zone average
@@ -89,7 +89,7 @@ emissionFactors:
       - _comment: used storage values greater than zero.
         datetime: '2025-01-01'
         source: Electricity Maps, 2025 zone average
-        value: 281.95
+        value: 281.91
   lifecycle:
     battery discharge:
       - _comment: used storage values greater than zero.
@@ -99,7 +99,7 @@ emissionFactors:
       - _comment: used storage values greater than zero.
         datetime: '2023-01-01'
         source: Electricity Maps, 2023 zone average; National Laboratory of the Rockies
-        value: 344.0
+        value: 334.2
       - _comment: used storage values greater than zero.
         datetime: '2024-01-01'
         source: Electricity Maps, 2024 zone average; National Laboratory of the Rockies
@@ -107,7 +107,7 @@ emissionFactors:
       - _comment: used storage values greater than zero.
         datetime: '2025-01-01'
         source: Electricity Maps, 2025 zone average; National Laboratory of the Rockies
-        value: 314.95
+        value: 314.91
 fallbackZoneMixes:
   powerOriginRatios:
     - _source: Electricity Maps, 2015 average
@@ -267,21 +267,21 @@ isLowCarbon:
     - datetime: '2020-01-01'
       value: 0.4461
     - datetime: '2023-01-01'
-      value: 0.465
+      value: 0.4809
     - datetime: '2024-01-01'
       value: 0.4567
     - datetime: '2025-01-01'
-      value: 0.5079
+      value: 0.5084
 isRenewable:
   battery discharge:
     - datetime: '2020-01-01'
       value: 0.4461
     - datetime: '2023-01-01'
-      value: 0.465
+      value: 0.4809
     - datetime: '2024-01-01'
       value: 0.4567
     - datetime: '2025-01-01'
-      value: 0.5079
+      value: 0.5084
 parsers:
   price: OPENNEM.fetch_price
   production: OPENNEM.fetch_production

--- a/config/zones/AU-WA.yaml
+++ b/config/zones/AU-WA.yaml
@@ -69,7 +69,8 @@ country_name: Australia
 currency: AUD
 delays:
   production: 96
-disclaimer: Western Australia's power grid is not connected to the (Australian) National Electricity Market or the Northern Territory grid.
+disclaimer: Western Australia's power grid is not connected to the (Australian) National
+  Electricity Market or the Northern Territory grid.
 emissionFactors:
   direct:
     battery discharge:
@@ -259,17 +260,25 @@ fallbackZoneMixes:
         solar: 0.23467167868922628
         unknown: 0.0
         wind: 0.1699992813333499
-has_day_ahead_price_license: False
-hide_day_ahead_price: False
+has_day_ahead_price_license: false
+hide_day_ahead_price: false
+isLowCarbon:
+  battery discharge:
+    - datetime: '2020-01-01'
+      value: 0.4461
+isRenewable:
+  battery discharge:
+    - datetime: '2020-01-01'
+      value: 0.4461
 parsers:
   price: OPENNEM.fetch_price
   production: OPENNEM.fetch_production
   productionCapacity: OPENELECTRICITY.fetch_production_capacity
 region: Oceania
-timezone: Australia/Perth
-zone_name: Western Australia
 sources:
   IPCC 2014:
     link: https://www.ipcc.ch/site/assets/uploads/2018/02/ipcc_wg3_ar5_annex-iii.pdf#page=7
   National Laboratory of the Rockies:
     link: https://docs.nrel.gov/docs/fy21osti/80580.pdf
+timezone: Australia/Perth
+zone_name: Western Australia

--- a/config/zones/AU-WA.yaml
+++ b/config/zones/AU-WA.yaml
@@ -266,10 +266,22 @@ isLowCarbon:
   battery discharge:
     - datetime: '2020-01-01'
       value: 0.4461
+    - datetime: '2023-01-01'
+      value: 0.465
+    - datetime: '2024-01-01'
+      value: 0.4567
+    - datetime: '2025-01-01'
+      value: 0.5079
 isRenewable:
   battery discharge:
     - datetime: '2020-01-01'
       value: 0.4461
+    - datetime: '2023-01-01'
+      value: 0.465
+    - datetime: '2024-01-01'
+      value: 0.4567
+    - datetime: '2025-01-01'
+      value: 0.5079
 parsers:
   price: OPENNEM.fetch_price
   production: OPENNEM.fetch_production

--- a/config/zones/AU.yaml
+++ b/config/zones/AU.yaml
@@ -264,16 +264,24 @@ isLowCarbon:
   battery discharge:
     - datetime: '2020-01-01'
       value: 0.2325
+    - datetime: '2021-01-01'
+      value: 0.2942
   hydro discharge:
     - datetime: '2020-01-01'
       value: 0.2626
+    - datetime: '2021-01-01'
+      value: 0.3367
 isRenewable:
   battery discharge:
     - datetime: '2020-01-01'
       value: 0.2325
+    - datetime: '2021-01-01'
+      value: 0.2942
   hydro discharge:
     - datetime: '2020-01-01'
       value: 0.2626
+    - datetime: '2021-01-01'
+      value: 0.3367
 region: Oceania
 sources:
   IPCC 2014:

--- a/config/zones/AU.yaml
+++ b/config/zones/AU.yaml
@@ -59,7 +59,7 @@ emissionFactors:
       - _comment: used storage values greater than zero.
         datetime: '2025-01-01'
         source: Electricity Maps, 2025 zone average
-        value: 386.31
+        value: 385.78
     hydro discharge:
       - _comment: used storage values greater than zero.
         datetime: '2020-01-01'
@@ -84,7 +84,7 @@ emissionFactors:
       - _comment: used storage values greater than zero.
         datetime: '2025-01-01'
         source: Electricity Maps, 2025 zone average
-        value: 337.34
+        value: 336.74
   lifecycle:
     battery discharge:
       - _comment: used storage values greater than zero.
@@ -110,7 +110,7 @@ emissionFactors:
       - _comment: used storage values greater than zero.
         datetime: '2025-01-01'
         source: Electricity Maps, 2025 zone average; National Laboratory of the Rockies
-        value: 419.31
+        value: 418.78
     hydro discharge:
       - _comment: used storage values greater than zero.
         datetime: '2020-01-01'
@@ -135,7 +135,7 @@ emissionFactors:
       - _comment: used storage values greater than zero.
         datetime: '2025-01-01'
         source: Electricity Maps, 2025 zone average; IPCC 2014
-        value: 361.34
+        value: 360.74
 fallbackZoneMixes:
   powerOriginRatios:
     - _source: Electricity Maps, 2017 average
@@ -268,6 +268,12 @@ isLowCarbon:
       value: 0.2942
     - datetime: '2022-01-01'
       value: 0.3488
+    - datetime: '2023-01-01'
+      value: 0.447
+    - datetime: '2024-01-01'
+      value: 0.4335
+    - datetime: '2025-01-01'
+      value: 0.4632
   hydro discharge:
     - datetime: '2020-01-01'
       value: 0.2626
@@ -275,6 +281,12 @@ isLowCarbon:
       value: 0.3367
     - datetime: '2022-01-01'
       value: 0.4042
+    - datetime: '2023-01-01'
+      value: 0.5054
+    - datetime: '2024-01-01'
+      value: 0.4952
+    - datetime: '2025-01-01'
+      value: 0.5326
 isRenewable:
   battery discharge:
     - datetime: '2020-01-01'
@@ -283,6 +295,12 @@ isRenewable:
       value: 0.2942
     - datetime: '2022-01-01'
       value: 0.3488
+    - datetime: '2023-01-01'
+      value: 0.447
+    - datetime: '2024-01-01'
+      value: 0.4335
+    - datetime: '2025-01-01'
+      value: 0.4632
   hydro discharge:
     - datetime: '2020-01-01'
       value: 0.2626
@@ -290,6 +308,12 @@ isRenewable:
       value: 0.3367
     - datetime: '2022-01-01'
       value: 0.4042
+    - datetime: '2023-01-01'
+      value: 0.5054
+    - datetime: '2024-01-01'
+      value: 0.4952
+    - datetime: '2025-01-01'
+      value: 0.5326
 region: Oceania
 sources:
   IPCC 2014:

--- a/config/zones/AU.yaml
+++ b/config/zones/AU.yaml
@@ -39,7 +39,7 @@ emissionFactors:
       - _comment: used storage values greater than zero.
         datetime: '2020-01-01'
         source: Electricity Maps, 2020 zone average
-        value: 545.09
+        value: 545.1
       - _comment: used storage values greater than zero.
         datetime: '2021-01-01'
         source: Electricity Maps, 2021 zone average
@@ -90,7 +90,7 @@ emissionFactors:
       - _comment: used storage values greater than zero.
         datetime: '2020-01-01'
         source: Electricity Maps, 2020 zone average; National Laboratory of the Rockies
-        value: 578.09
+        value: 578.1
       - _comment: used storage values greater than zero.
         datetime: '2021-01-01'
         source: Electricity Maps, 2021 zone average; National Laboratory of the Rockies
@@ -258,9 +258,28 @@ fallbackZoneMixes:
         solar: 0.19323819121037497
         unknown: 0.00019039581980082146
         wind: 0.13259950282926702
-has_day_ahead_price_license: False
-hide_day_ahead_price: False
+has_day_ahead_price_license: false
+hide_day_ahead_price: false
+isLowCarbon:
+  battery discharge:
+    - datetime: '2020-01-01'
+      value: 0.2325
+  hydro discharge:
+    - datetime: '2020-01-01'
+      value: 0.2626
+isRenewable:
+  battery discharge:
+    - datetime: '2020-01-01'
+      value: 0.2325
+  hydro discharge:
+    - datetime: '2020-01-01'
+      value: 0.2626
 region: Oceania
+sources:
+  IPCC 2014:
+    link: https://www.ipcc.ch/site/assets/uploads/2018/02/ipcc_wg3_ar5_annex-iii.pdf#page=7
+  National Laboratory of the Rockies:
+    link: https://docs.nrel.gov/docs/fy21osti/80580.pdf
 subZoneNames:
   - AU-LH
   - AU-NSW
@@ -276,8 +295,3 @@ subZoneNames:
   - AU-WA-RI
 timezone: Australia/Sydney
 zone_name: Australia
-sources:
-  IPCC 2014:
-    link: https://www.ipcc.ch/site/assets/uploads/2018/02/ipcc_wg3_ar5_annex-iii.pdf#page=7
-  National Laboratory of the Rockies:
-    link: https://docs.nrel.gov/docs/fy21osti/80580.pdf

--- a/config/zones/AU.yaml
+++ b/config/zones/AU.yaml
@@ -39,27 +39,27 @@ emissionFactors:
       - _comment: used storage values greater than zero.
         datetime: '2020-01-01'
         source: Electricity Maps, 2020 zone average
-        value: 545.1
+        value: 545.09
       - _comment: used storage values greater than zero.
         datetime: '2021-01-01'
         source: Electricity Maps, 2021 zone average
-        value: 507.82
+        value: 504.14
       - _comment: used storage values greater than zero.
         datetime: '2022-01-01'
         source: Electricity Maps, 2022 zone average
-        value: 459.51
+        value: 459.41
       - _comment: used storage values greater than zero.
         datetime: '2023-01-01'
         source: Electricity Maps, 2023 zone average
-        value: 397.4
+        value: 397.33
       - _comment: used storage values greater than zero.
         datetime: '2024-01-01'
         source: Electricity Maps, 2024 zone average
-        value: 406.66
+        value: 408.12
       - _comment: used storage values greater than zero.
         datetime: '2025-01-01'
         source: Electricity Maps, 2025 zone average
-        value: 385.78
+        value: 373.33
     hydro discharge:
       - _comment: used storage values greater than zero.
         datetime: '2020-01-01'
@@ -68,49 +68,49 @@ emissionFactors:
       - _comment: used storage values greater than zero.
         datetime: '2021-01-01'
         source: Electricity Maps, 2021 zone average
-        value: 479.51
+        value: 475.05
       - _comment: used storage values greater than zero.
         datetime: '2022-01-01'
         source: Electricity Maps, 2022 zone average
-        value: 425.02
+        value: 425.59
       - _comment: used storage values greater than zero.
         datetime: '2023-01-01'
         source: Electricity Maps, 2023 zone average
-        value: 356.0
+        value: 357.1
       - _comment: used storage values greater than zero.
         datetime: '2024-01-01'
         source: Electricity Maps, 2024 zone average
-        value: 363.54
+        value: 363.62
       - _comment: used storage values greater than zero.
         datetime: '2025-01-01'
         source: Electricity Maps, 2025 zone average
-        value: 336.74
+        value: 337.53
   lifecycle:
     battery discharge:
       - _comment: used storage values greater than zero.
         datetime: '2020-01-01'
         source: Electricity Maps, 2020 zone average; National Laboratory of the Rockies
-        value: 578.1
+        value: 578.09
       - _comment: used storage values greater than zero.
         datetime: '2021-01-01'
         source: Electricity Maps, 2021 zone average; National Laboratory of the Rockies
-        value: 540.82
+        value: 537.14
       - _comment: used storage values greater than zero.
         datetime: '2022-01-01'
         source: Electricity Maps, 2022 zone average; National Laboratory of the Rockies
-        value: 492.51
+        value: 492.41
       - _comment: used storage values greater than zero.
         datetime: '2023-01-01'
         source: Electricity Maps, 2023 zone average; National Laboratory of the Rockies
-        value: 430.4
+        value: 430.33
       - _comment: used storage values greater than zero.
         datetime: '2024-01-01'
         source: Electricity Maps, 2024 zone average; National Laboratory of the Rockies
-        value: 439.66
+        value: 441.12
       - _comment: used storage values greater than zero.
         datetime: '2025-01-01'
         source: Electricity Maps, 2025 zone average; National Laboratory of the Rockies
-        value: 418.78
+        value: 406.33
     hydro discharge:
       - _comment: used storage values greater than zero.
         datetime: '2020-01-01'
@@ -119,23 +119,23 @@ emissionFactors:
       - _comment: used storage values greater than zero.
         datetime: '2021-01-01'
         source: Electricity Maps, 2021 zone average; IPCC 2014
-        value: 503.51
+        value: 499.05
       - _comment: used storage values greater than zero.
         datetime: '2022-01-01'
         source: Electricity Maps, 2022 zone average; IPCC 2014
-        value: 449.02
+        value: 449.59
       - _comment: used storage values greater than zero.
         datetime: '2023-01-01'
         source: Electricity Maps, 2023 zone average; IPCC 2014
-        value: 380.0
+        value: 381.1
       - _comment: used storage values greater than zero.
         datetime: '2024-01-01'
         source: Electricity Maps, 2024 zone average; IPCC 2014
-        value: 387.54
+        value: 387.62
       - _comment: used storage values greater than zero.
         datetime: '2025-01-01'
         source: Electricity Maps, 2025 zone average; IPCC 2014
-        value: 360.74
+        value: 361.53
 fallbackZoneMixes:
   powerOriginRatios:
     - _source: Electricity Maps, 2017 average
@@ -265,55 +265,55 @@ isLowCarbon:
     - datetime: '2020-01-01'
       value: 0.2325
     - datetime: '2021-01-01'
-      value: 0.2942
+      value: 0.2993
     - datetime: '2022-01-01'
-      value: 0.3488
+      value: 0.3489
     - datetime: '2023-01-01'
-      value: 0.447
+      value: 0.4472
     - datetime: '2024-01-01'
-      value: 0.4335
+      value: 0.432
     - datetime: '2025-01-01'
-      value: 0.4632
+      value: 0.4809
   hydro discharge:
     - datetime: '2020-01-01'
       value: 0.2626
     - datetime: '2021-01-01'
-      value: 0.3367
+      value: 0.3429
     - datetime: '2022-01-01'
-      value: 0.4042
+      value: 0.4032
     - datetime: '2023-01-01'
-      value: 0.5054
+      value: 0.5038
     - datetime: '2024-01-01'
-      value: 0.4952
+      value: 0.4949
     - datetime: '2025-01-01'
-      value: 0.5326
+      value: 0.5307
 isRenewable:
   battery discharge:
     - datetime: '2020-01-01'
       value: 0.2325
     - datetime: '2021-01-01'
-      value: 0.2942
+      value: 0.2993
     - datetime: '2022-01-01'
-      value: 0.3488
+      value: 0.3489
     - datetime: '2023-01-01'
-      value: 0.447
+      value: 0.4472
     - datetime: '2024-01-01'
-      value: 0.4335
+      value: 0.432
     - datetime: '2025-01-01'
-      value: 0.4632
+      value: 0.4809
   hydro discharge:
     - datetime: '2020-01-01'
       value: 0.2626
     - datetime: '2021-01-01'
-      value: 0.3367
+      value: 0.3429
     - datetime: '2022-01-01'
-      value: 0.4042
+      value: 0.4032
     - datetime: '2023-01-01'
-      value: 0.5054
+      value: 0.5038
     - datetime: '2024-01-01'
-      value: 0.4952
+      value: 0.4949
     - datetime: '2025-01-01'
-      value: 0.5326
+      value: 0.5307
 region: Oceania
 sources:
   IPCC 2014:

--- a/config/zones/AU.yaml
+++ b/config/zones/AU.yaml
@@ -266,22 +266,30 @@ isLowCarbon:
       value: 0.2325
     - datetime: '2021-01-01'
       value: 0.2942
+    - datetime: '2022-01-01'
+      value: 0.3488
   hydro discharge:
     - datetime: '2020-01-01'
       value: 0.2626
     - datetime: '2021-01-01'
       value: 0.3367
+    - datetime: '2022-01-01'
+      value: 0.4042
 isRenewable:
   battery discharge:
     - datetime: '2020-01-01'
       value: 0.2325
     - datetime: '2021-01-01'
       value: 0.2942
+    - datetime: '2022-01-01'
+      value: 0.3488
   hydro discharge:
     - datetime: '2020-01-01'
       value: 0.2626
     - datetime: '2021-01-01'
       value: 0.3367
+    - datetime: '2022-01-01'
+      value: 0.4042
 region: Oceania
 sources:
   IPCC 2014:

--- a/config/zones/BA.yaml
+++ b/config/zones/BA.yaml
@@ -241,8 +241,16 @@ fallbackZoneMixes:
         solar: 0.01565642226201501
         unknown: 0.0026649035309820757
         wind: 0.028774809119518137
-has_day_ahead_price_license: False
-hide_day_ahead_price: False
+has_day_ahead_price_license: false
+hide_day_ahead_price: false
+isLowCarbon:
+  hydro discharge:
+    - datetime: '2021-01-01'
+      value: 1.0
+isRenewable:
+  hydro discharge:
+    - datetime: '2021-01-01'
+      value: 1.0
 parsers:
   consumption: ENTSOE.fetch_consumption
   consumptionForecast: ENTSOE.fetch_consumption_forecast

--- a/config/zones/BA.yaml
+++ b/config/zones/BA.yaml
@@ -247,9 +247,13 @@ isLowCarbon:
   hydro discharge:
     - datetime: '2021-01-01'
       value: 1.0
+    - datetime: '2022-01-01'
+      value: 1.0
 isRenewable:
   hydro discharge:
     - datetime: '2021-01-01'
+      value: 1.0
+    - datetime: '2022-01-01'
       value: 1.0
 parsers:
   consumption: ENTSOE.fetch_consumption

--- a/config/zones/BA.yaml
+++ b/config/zones/BA.yaml
@@ -65,10 +65,10 @@ delays:
 emissionFactors:
   direct:
     hydro discharge:
-      - _comment: used default IPCC 2014 value of 0.0
+      - _comment: used storage values greater than zero.
         datetime: '2021-01-01'
         source: Electricity Maps, 2021 zone average
-        value: 0.0
+        value: 556.44
       - _comment: used default IPCC 2014 value of 0.0
         datetime: '2022-01-01'
         source: Electricity Maps, 2022 zone average
@@ -76,25 +76,25 @@ emissionFactors:
       - _comment: used storage values greater than zero.
         datetime: '2023-01-01'
         source: Electricity Maps, 2023 zone average
-        value: 606.56
+        value: 596.88
       - _comment: used storage values greater than zero.
         datetime: '2024-01-01'
         source: Electricity Maps, 2024 zone average
-        value: 421.24
+        value: 453.28
       - _comment: used storage values greater than zero.
         datetime: '2025-01-01'
         source: Electricity Maps, 2025 zone average
-        value: 481.19
+        value: 422.64
   lifecycle:
     hydro:
       datetime: '2020-01-01'
       source: UNECE 2022
       value: 10.7
     hydro discharge:
-      - _comment: used default IPCC 2014 value of 24.0
+      - _comment: used storage values greater than zero.
         datetime: '2021-01-01'
         source: Electricity Maps, 2021 zone average; UNECE 2022
-        value: 10.7
+        value: 567.14
       - _comment: used default IPCC 2014 value of 24.0
         datetime: '2022-01-01'
         source: Electricity Maps, 2022 zone average; UNECE 2022
@@ -102,15 +102,15 @@ emissionFactors:
       - _comment: used storage values greater than zero.
         datetime: '2023-01-01'
         source: Electricity Maps, 2023 zone average; UNECE 2022
-        value: 617.26
+        value: 607.58
       - _comment: used storage values greater than zero.
         datetime: '2024-01-01'
         source: Electricity Maps, 2024 zone average; UNECE 2022
-        value: 431.94
+        value: 463.98
       - _comment: used storage values greater than zero.
         datetime: '2025-01-01'
         source: Electricity Maps, 2025 zone average; UNECE 2022
-        value: 491.89
+        value: 433.34
     nuclear:
       datetime: '2020-01-01'
       source: UNECE 2022
@@ -246,27 +246,27 @@ hide_day_ahead_price: false
 isLowCarbon:
   hydro discharge:
     - datetime: '2021-01-01'
-      value: 1.0
+      value: 0.2599
     - datetime: '2022-01-01'
       value: 1.0
     - datetime: '2023-01-01'
-      value: 0.1965
+      value: 0.2086
     - datetime: '2024-01-01'
-      value: 0.4248
+      value: 0.3879
     - datetime: '2025-01-01'
-      value: 0.3669
+      value: 0.4357
 isRenewable:
   hydro discharge:
     - datetime: '2021-01-01'
-      value: 1.0
+      value: 0.2476
     - datetime: '2022-01-01'
       value: 1.0
     - datetime: '2023-01-01'
-      value: 0.1838
+      value: 0.1948
     - datetime: '2024-01-01'
-      value: 0.3718
+      value: 0.3443
     - datetime: '2025-01-01'
-      value: 0.3669
+      value: 0.4224
 parsers:
   consumption: ENTSOE.fetch_consumption
   consumptionForecast: ENTSOE.fetch_consumption_forecast

--- a/config/zones/BA.yaml
+++ b/config/zones/BA.yaml
@@ -80,7 +80,7 @@ emissionFactors:
       - _comment: used storage values greater than zero.
         datetime: '2024-01-01'
         source: Electricity Maps, 2024 zone average
-        value: 316.88
+        value: 421.24
       - _comment: used storage values greater than zero.
         datetime: '2025-01-01'
         source: Electricity Maps, 2025 zone average
@@ -106,7 +106,7 @@ emissionFactors:
       - _comment: used storage values greater than zero.
         datetime: '2024-01-01'
         source: Electricity Maps, 2024 zone average; UNECE 2022
-        value: 327.58
+        value: 431.94
       - _comment: used storage values greater than zero.
         datetime: '2025-01-01'
         source: Electricity Maps, 2025 zone average; UNECE 2022
@@ -249,12 +249,24 @@ isLowCarbon:
       value: 1.0
     - datetime: '2022-01-01'
       value: 1.0
+    - datetime: '2023-01-01'
+      value: 0.1965
+    - datetime: '2024-01-01'
+      value: 0.4248
+    - datetime: '2025-01-01'
+      value: 0.3669
 isRenewable:
   hydro discharge:
     - datetime: '2021-01-01'
       value: 1.0
     - datetime: '2022-01-01'
       value: 1.0
+    - datetime: '2023-01-01'
+      value: 0.1838
+    - datetime: '2024-01-01'
+      value: 0.3718
+    - datetime: '2025-01-01'
+      value: 0.3669
 parsers:
   consumption: ENTSOE.fetch_consumption
   consumptionForecast: ENTSOE.fetch_consumption_forecast

--- a/config/zones/BE.yaml
+++ b/config/zones/BE.yaml
@@ -215,7 +215,7 @@ emissionFactors:
       - _comment: used non-null storage values
         datetime: '2025-01-01'
         source: Electricity Maps, 2025 zone average
-        value: 130.9
+        value: 131.51
     biomass:
       datetime: '2021-01-01'
       source: BEIS 2021
@@ -254,23 +254,23 @@ emissionFactors:
       - _comment: used storage values greater than zero.
         datetime: '2021-01-01'
         source: Electricity Maps, 2021 zone average
-        value: 123.5
+        value: 120.58
       - _comment: used storage values greater than zero.
         datetime: '2022-01-01'
         source: Electricity Maps, 2022 zone average
-        value: 131.76
+        value: 129.86
       - _comment: used storage values greater than zero.
         datetime: '2023-01-01'
         source: Electricity Maps, 2023 zone average
-        value: 117.1
+        value: 116.34
       - _comment: used storage values greater than zero.
         datetime: '2024-01-01'
         source: Electricity Maps, 2024 zone average
-        value: 96.74
+        value: 96.76
       - _comment: used storage values greater than zero.
         datetime: '2025-01-01'
         source: Electricity Maps, 2025 zone average
-        value: 116.0
+        value: 117.54
     oil:
       - datetime: '2021-01-01'
         source: EU-ETS, ENTSO-E 2021
@@ -293,7 +293,7 @@ emissionFactors:
       - _comment: used non-null storage values
         datetime: '2025-01-01'
         source: Electricity Maps, 2025 zone average; National Laboratory of the Rockies
-        value: 163.9
+        value: 164.51
     biomass:
       datetime: '2014-01-01'
       source: BEIS 2021; IPCC 2014
@@ -338,23 +338,23 @@ emissionFactors:
       - _comment: used storage values greater than zero.
         datetime: '2021-01-01'
         source: Electricity Maps, 2021 zone average; UNECE 2022
-        value: 134.2
+        value: 131.28
       - _comment: used storage values greater than zero.
         datetime: '2022-01-01'
         source: Electricity Maps, 2022 zone average; UNECE 2022
-        value: 142.46
+        value: 140.56
       - _comment: used storage values greater than zero.
         datetime: '2023-01-01'
         source: Electricity Maps, 2023 zone average; UNECE 2022
-        value: 127.8
+        value: 127.04
       - _comment: used storage values greater than zero.
         datetime: '2024-01-01'
         source: Electricity Maps, 2024 zone average; UNECE 2022
-        value: 107.44
+        value: 107.46
       - _comment: used storage values greater than zero.
         datetime: '2025-01-01'
         source: Electricity Maps, 2025 zone average; UNECE 2022
-        value: 126.7
+        value: 128.24
     nuclear:
       datetime: '2020-01-01'
       source: UNECE 2022
@@ -540,39 +540,39 @@ isLowCarbon:
     - datetime: '2024-01-01'
       value: 0.8504
     - datetime: '2025-01-01'
-      value: 0.7185
+      value: 0.7178
   hydro discharge:
     - datetime: '2020-01-01'
       value: 0.6614
     - datetime: '2021-01-01'
-      value: 0.7364
+      value: 0.7439
     - datetime: '2022-01-01'
-      value: 0.7178
+      value: 0.7222
     - datetime: '2023-01-01'
-      value: 0.7472
+      value: 0.7489
     - datetime: '2024-01-01'
       value: 0.7944
     - datetime: '2025-01-01'
-      value: 0.7537
+      value: 0.7513
 isRenewable:
   battery discharge:
     - datetime: '2024-01-01'
       value: 0.4838
     - datetime: '2025-01-01'
-      value: 0.3798
+      value: 0.3794
   hydro discharge:
     - datetime: '2020-01-01'
       value: 0.2656
     - datetime: '2021-01-01'
-      value: 0.2415
+      value: 0.2448
     - datetime: '2022-01-01'
-      value: 0.2916
+      value: 0.297
     - datetime: '2023-01-01'
-      value: 0.3621
+      value: 0.3644
     - datetime: '2024-01-01'
-      value: 0.3862
+      value: 0.3864
     - datetime: '2025-01-01'
-      value: 0.4298
+      value: 0.4253
 parsers:
   consumption: ENTSOE.fetch_consumption
   consumptionForecast: ENTSOE.fetch_consumption_forecast

--- a/config/zones/BE.yaml
+++ b/config/zones/BE.yaml
@@ -541,12 +541,16 @@ isLowCarbon:
       value: 0.6614
     - datetime: '2021-01-01'
       value: 0.7364
+    - datetime: '2022-01-01'
+      value: 0.7178
 isRenewable:
   hydro discharge:
     - datetime: '2020-01-01'
       value: 0.2656
     - datetime: '2021-01-01'
       value: 0.2415
+    - datetime: '2022-01-01'
+      value: 0.2916
 parsers:
   consumption: ENTSOE.fetch_consumption
   consumptionForecast: ENTSOE.fetch_consumption_forecast

--- a/config/zones/BE.yaml
+++ b/config/zones/BE.yaml
@@ -535,6 +535,14 @@ fallbackZoneMixes:
         wind: 0.17896151273177904
 has_day_ahead_price_license: true
 hide_day_ahead_price: false
+isLowCarbon:
+  hydro discharge:
+    - datetime: '2020-01-01'
+      value: 0.6614
+isRenewable:
+  hydro discharge:
+    - datetime: '2020-01-01'
+      value: 0.2656
 parsers:
   consumption: ENTSOE.fetch_consumption
   consumptionForecast: ENTSOE.fetch_consumption_forecast
@@ -545,8 +553,6 @@ parsers:
   productionPerModeForecast: ENTSOE.fetch_wind_solar_forecasts
 region: Europe
 sources:
-  National Laboratory of the Rockies:
-    link: https://docs.nrel.gov/docs/fy21osti/80580.pdf
   EU-ETS, ENTSO-E 2021:
     link: https://drive.google.com/file/d/15UeUHyhcjVw8fGLc0Zx_HELSx20cw_-e/view?usp=share_link
   EU-ETS, ENTSO-E 2022:
@@ -559,6 +565,8 @@ sources:
     link: https://docs.google.com/spreadsheets/d/1w5DJ7sPen6axIHU8TCVcuzNCjlct4I6JAbhUlw-ZXu8/edit?usp=sharing
   IPCC 2014:
     link: https://www.ipcc.ch/site/assets/uploads/2018/02/ipcc_wg3_ar5_annex-iii.pdf#page=7
+  National Laboratory of the Rockies:
+    link: https://docs.nrel.gov/docs/fy21osti/80580.pdf
   UNECE 2022:
     link: https://unece.org/sites/default/files/2022-04/LCA_3_FINAL%20March%202022.pdf
   ? UNECE 2022, WindEurope "Wind energy in Europe, 2021 Statistics and the outlook

--- a/config/zones/BE.yaml
+++ b/config/zones/BE.yaml
@@ -211,11 +211,11 @@ emissionFactors:
       - _comment: used non-null storage values
         datetime: '2024-01-01'
         source: Electricity Maps, 2024 zone average
-        value: 77.27
+        value: 75.05
       - _comment: used non-null storage values
         datetime: '2025-01-01'
         source: Electricity Maps, 2025 zone average
-        value: 135.65
+        value: 130.9
     biomass:
       datetime: '2021-01-01'
       source: BEIS 2021
@@ -262,15 +262,15 @@ emissionFactors:
       - _comment: used storage values greater than zero.
         datetime: '2023-01-01'
         source: Electricity Maps, 2023 zone average
-        value: 118.89
+        value: 117.1
       - _comment: used storage values greater than zero.
         datetime: '2024-01-01'
         source: Electricity Maps, 2024 zone average
-        value: 101.16
+        value: 96.74
       - _comment: used storage values greater than zero.
         datetime: '2025-01-01'
         source: Electricity Maps, 2025 zone average
-        value: 120.07
+        value: 116.0
     oil:
       - datetime: '2021-01-01'
         source: EU-ETS, ENTSO-E 2021
@@ -289,11 +289,11 @@ emissionFactors:
       - _comment: used non-null storage values
         datetime: '2024-01-01'
         source: Electricity Maps, 2024 zone average; National Laboratory of the Rockies
-        value: 110.27
+        value: 108.05
       - _comment: used non-null storage values
         datetime: '2025-01-01'
         source: Electricity Maps, 2025 zone average; National Laboratory of the Rockies
-        value: 168.65
+        value: 163.9
     biomass:
       datetime: '2014-01-01'
       source: BEIS 2021; IPCC 2014
@@ -346,15 +346,15 @@ emissionFactors:
       - _comment: used storage values greater than zero.
         datetime: '2023-01-01'
         source: Electricity Maps, 2023 zone average; UNECE 2022
-        value: 129.59
+        value: 127.8
       - _comment: used storage values greater than zero.
         datetime: '2024-01-01'
         source: Electricity Maps, 2024 zone average; UNECE 2022
-        value: 111.86
+        value: 107.44
       - _comment: used storage values greater than zero.
         datetime: '2025-01-01'
         source: Electricity Maps, 2025 zone average; UNECE 2022
-        value: 130.77
+        value: 126.7
     nuclear:
       datetime: '2020-01-01'
       source: UNECE 2022
@@ -536,6 +536,11 @@ fallbackZoneMixes:
 has_day_ahead_price_license: true
 hide_day_ahead_price: false
 isLowCarbon:
+  battery discharge:
+    - datetime: '2024-01-01'
+      value: 0.8504
+    - datetime: '2025-01-01'
+      value: 0.7185
   hydro discharge:
     - datetime: '2020-01-01'
       value: 0.6614
@@ -543,7 +548,18 @@ isLowCarbon:
       value: 0.7364
     - datetime: '2022-01-01'
       value: 0.7178
+    - datetime: '2023-01-01'
+      value: 0.7472
+    - datetime: '2024-01-01'
+      value: 0.7944
+    - datetime: '2025-01-01'
+      value: 0.7537
 isRenewable:
+  battery discharge:
+    - datetime: '2024-01-01'
+      value: 0.4838
+    - datetime: '2025-01-01'
+      value: 0.3798
   hydro discharge:
     - datetime: '2020-01-01'
       value: 0.2656
@@ -551,6 +567,12 @@ isRenewable:
       value: 0.2415
     - datetime: '2022-01-01'
       value: 0.2916
+    - datetime: '2023-01-01'
+      value: 0.3621
+    - datetime: '2024-01-01'
+      value: 0.3862
+    - datetime: '2025-01-01'
+      value: 0.4298
 parsers:
   consumption: ENTSOE.fetch_consumption
   consumptionForecast: ENTSOE.fetch_consumption_forecast

--- a/config/zones/BE.yaml
+++ b/config/zones/BE.yaml
@@ -539,10 +539,14 @@ isLowCarbon:
   hydro discharge:
     - datetime: '2020-01-01'
       value: 0.6614
+    - datetime: '2021-01-01'
+      value: 0.7364
 isRenewable:
   hydro discharge:
     - datetime: '2020-01-01'
       value: 0.2656
+    - datetime: '2021-01-01'
+      value: 0.2415
 parsers:
   consumption: ENTSOE.fetch_consumption
   consumptionForecast: ENTSOE.fetch_consumption_forecast

--- a/config/zones/CA-AB.yaml
+++ b/config/zones/CA-AB.yaml
@@ -21,7 +21,7 @@ emissionFactors:
       - _comment: used storage values greater than zero.
         datetime: '2022-01-01'
         source: Electricity Maps, 2022 zone average
-        value: 354.9
+        value: 354.84
       - _comment: used storage values greater than zero.
         datetime: '2023-01-01'
         source: Electricity Maps, 2023 zone average
@@ -47,7 +47,7 @@ emissionFactors:
       - _comment: used storage values greater than zero.
         datetime: '2022-01-01'
         source: Electricity Maps, 2022 zone average; National Laboratory of the Rockies
-        value: 387.9
+        value: 387.84
       - _comment: used storage values greater than zero.
         datetime: '2023-01-01'
         source: Electricity Maps, 2023 zone average; National Laboratory of the Rockies
@@ -192,6 +192,8 @@ isLowCarbon:
   battery discharge:
     - datetime: '2021-01-01'
       value: 0.1578
+    - datetime: '2022-01-01'
+      value: 0.1597
   unknown:
     source: assumes 50% coal and 50% natural gas from Battle River dual fuel power
       plant
@@ -200,6 +202,8 @@ isRenewable:
   battery discharge:
     - datetime: '2021-01-01'
       value: 0.1577
+    - datetime: '2022-01-01'
+      value: 0.1596
   unknown:
     source: assumes 50% coal and 50% natural gas from Battle River dual fuel power
       plant

--- a/config/zones/CA-AB.yaml
+++ b/config/zones/CA-AB.yaml
@@ -25,11 +25,11 @@ emissionFactors:
       - _comment: used storage values greater than zero.
         datetime: '2023-01-01'
         source: Electricity Maps, 2023 zone average
-        value: 335.27
+        value: 334.83
       - _comment: used storage values greater than zero.
         datetime: '2024-01-01'
         source: Electricity Maps, 2024 zone average
-        value: 313.76
+        value: 313.56
       - _comment: used storage values greater than zero.
         datetime: '2025-01-01'
         source: Electricity Maps, 2025 zone average
@@ -51,11 +51,11 @@ emissionFactors:
       - _comment: used storage values greater than zero.
         datetime: '2023-01-01'
         source: Electricity Maps, 2023 zone average; National Laboratory of the Rockies
-        value: 368.27
+        value: 367.83
       - _comment: used storage values greater than zero.
         datetime: '2024-01-01'
         source: Electricity Maps, 2024 zone average; National Laboratory of the Rockies
-        value: 346.76
+        value: 346.56
       - _comment: used storage values greater than zero.
         datetime: '2025-01-01'
         source: Electricity Maps, 2025 zone average; National Laboratory of the Rockies
@@ -194,6 +194,12 @@ isLowCarbon:
       value: 0.1578
     - datetime: '2022-01-01'
       value: 0.1597
+    - datetime: '2023-01-01'
+      value: 0.1993
+    - datetime: '2024-01-01'
+      value: 0.1862
+    - datetime: '2025-01-01'
+      value: 0.2343
   unknown:
     source: assumes 50% coal and 50% natural gas from Battle River dual fuel power
       plant
@@ -204,6 +210,12 @@ isRenewable:
       value: 0.1577
     - datetime: '2022-01-01'
       value: 0.1596
+    - datetime: '2023-01-01'
+      value: 0.1992
+    - datetime: '2024-01-01'
+      value: 0.1861
+    - datetime: '2025-01-01'
+      value: 0.2343
   unknown:
     source: assumes 50% coal and 50% natural gas from Battle River dual fuel power
       plant

--- a/config/zones/CA-AB.yaml
+++ b/config/zones/CA-AB.yaml
@@ -17,7 +17,7 @@ emissionFactors:
       - _comment: used storage values greater than zero.
         datetime: '2021-01-01'
         source: Electricity Maps, 2021 zone average
-        value: 385.87
+        value: 385.61
       - _comment: used storage values greater than zero.
         datetime: '2022-01-01'
         source: Electricity Maps, 2022 zone average
@@ -35,14 +35,15 @@ emissionFactors:
         source: Electricity Maps, 2025 zone average
         value: 283.86
     unknown:
-      source: assumes 50% coal and 50% natural gas from Battle River dual fuel power plant
+      source: assumes 50% coal and 50% natural gas from Battle River dual fuel power
+        plant
       value: 565
   lifecycle:
     battery discharge:
       - _comment: used storage values greater than zero.
         datetime: '2021-01-01'
         source: Electricity Maps, 2021 zone average; National Laboratory of the Rockies
-        value: 418.87
+        value: 418.61
       - _comment: used storage values greater than zero.
         datetime: '2022-01-01'
         source: Electricity Maps, 2022 zone average; National Laboratory of the Rockies
@@ -60,7 +61,8 @@ emissionFactors:
         source: Electricity Maps, 2025 zone average; National Laboratory of the Rockies
         value: 316.86
     unknown:
-      source: assumes 50% coal and 50% natural gas from Battle River dual fuel power plant
+      source: assumes 50% coal and 50% natural gas from Battle River dual fuel power
+        plant
       value: 655
 fallbackZoneMixes:
   powerOriginRatios:
@@ -184,8 +186,24 @@ fallbackZoneMixes:
         solar: 0.03183536456739056
         unknown: 0.024948048115312323
         wind: 0.14374665671413908
-has_day_ahead_price_license: False
-hide_day_ahead_price: False
+has_day_ahead_price_license: false
+hide_day_ahead_price: false
+isLowCarbon:
+  battery discharge:
+    - datetime: '2021-01-01'
+      value: 0.1578
+  unknown:
+    source: assumes 50% coal and 50% natural gas from Battle River dual fuel power
+      plant
+    value: 0
+isRenewable:
+  battery discharge:
+    - datetime: '2021-01-01'
+      value: 0.1577
+  unknown:
+    source: assumes 50% coal and 50% natural gas from Battle River dual fuel power
+      plant
+    value: 0
 parsers:
   gridAlerts: CA_AB.fetch_grid_alerts
   price: CA_AB.fetch_price
@@ -197,11 +215,3 @@ sources:
     link: https://docs.nrel.gov/docs/fy21osti/80580.pdf
 timezone: America/Edmonton
 zone_name: Alberta
-isRenewable:
-  unknown:
-    source: assumes 50% coal and 50% natural gas from Battle River dual fuel power plant
-    value: 0
-isLowCarbon:
-  unknown:
-    source: assumes 50% coal and 50% natural gas from Battle River dual fuel power plant
-    value: 0

--- a/config/zones/CA-AB.yaml
+++ b/config/zones/CA-AB.yaml
@@ -29,11 +29,11 @@ emissionFactors:
       - _comment: used storage values greater than zero.
         datetime: '2024-01-01'
         source: Electricity Maps, 2024 zone average
-        value: 313.56
+        value: 313.55
       - _comment: used storage values greater than zero.
         datetime: '2025-01-01'
         source: Electricity Maps, 2025 zone average
-        value: 283.86
+        value: 285.67
     unknown:
       source: assumes 50% coal and 50% natural gas from Battle River dual fuel power
         plant
@@ -55,11 +55,11 @@ emissionFactors:
       - _comment: used storage values greater than zero.
         datetime: '2024-01-01'
         source: Electricity Maps, 2024 zone average; National Laboratory of the Rockies
-        value: 346.56
+        value: 346.55
       - _comment: used storage values greater than zero.
         datetime: '2025-01-01'
         source: Electricity Maps, 2025 zone average; National Laboratory of the Rockies
-        value: 316.86
+        value: 318.67
     unknown:
       source: assumes 50% coal and 50% natural gas from Battle River dual fuel power
         plant
@@ -197,9 +197,9 @@ isLowCarbon:
     - datetime: '2023-01-01'
       value: 0.1993
     - datetime: '2024-01-01'
-      value: 0.1862
+      value: 0.1861
     - datetime: '2025-01-01'
-      value: 0.2343
+      value: 0.2306
   unknown:
     source: assumes 50% coal and 50% natural gas from Battle River dual fuel power
       plant
@@ -213,9 +213,9 @@ isRenewable:
     - datetime: '2023-01-01'
       value: 0.1992
     - datetime: '2024-01-01'
-      value: 0.1861
+      value: 0.186
     - datetime: '2025-01-01'
-      value: 0.2343
+      value: 0.2306
   unknown:
     source: assumes 50% coal and 50% natural gas from Battle River dual fuel power
       plant

--- a/config/zones/CA.yaml
+++ b/config/zones/CA.yaml
@@ -199,10 +199,14 @@ isLowCarbon:
   battery discharge:
     - datetime: '2021-01-01'
       value: 0.7917
+    - datetime: '2022-01-01'
+      value: 0.7982
 isRenewable:
   battery discharge:
     - datetime: '2021-01-01'
       value: 0.6593
+    - datetime: '2022-01-01'
+      value: 0.6801
 parsers:
   productionCapacity: EMBER.fetch_production_capacity
 region: Americas

--- a/config/zones/CA.yaml
+++ b/config/zones/CA.yaml
@@ -158,11 +158,11 @@ emissionFactors:
       - _comment: used storage values greater than zero.
         datetime: '2022-01-01'
         source: Electricity Maps, 2022 zone average
-        value: 89.69
+        value: 89.7
       - _comment: used storage values greater than zero.
         datetime: '2023-01-01'
         source: Electricity Maps, 2023 zone average
-        value: 89.48
+        value: 89.49
       - _comment: used storage values greater than zero.
         datetime: '2024-01-01'
         source: Electricity Maps, 2024 zone average
@@ -170,7 +170,7 @@ emissionFactors:
       - _comment: used storage values greater than zero.
         datetime: '2025-01-01'
         source: Electricity Maps, 2025 zone average
-        value: 92.37
+        value: 93.25
   lifecycle:
     battery discharge:
       - _comment: used storage values greater than zero.
@@ -180,11 +180,11 @@ emissionFactors:
       - _comment: used storage values greater than zero.
         datetime: '2022-01-01'
         source: Electricity Maps, 2022 zone average; National Laboratory of the Rockies
-        value: 122.69
+        value: 122.7
       - _comment: used storage values greater than zero.
         datetime: '2023-01-01'
         source: Electricity Maps, 2023 zone average; National Laboratory of the Rockies
-        value: 122.48
+        value: 122.49
       - _comment: used storage values greater than zero.
         datetime: '2024-01-01'
         source: Electricity Maps, 2024 zone average; National Laboratory of the Rockies
@@ -192,7 +192,7 @@ emissionFactors:
       - _comment: used storage values greater than zero.
         datetime: '2025-01-01'
         source: Electricity Maps, 2025 zone average; National Laboratory of the Rockies
-        value: 125.37
+        value: 126.25
 has_day_ahead_price_license: false
 hide_day_ahead_price: false
 isLowCarbon:
@@ -206,19 +206,19 @@ isLowCarbon:
     - datetime: '2024-01-01'
       value: 0.7862
     - datetime: '2025-01-01'
-      value: 0.7738
+      value: 0.7715
 isRenewable:
   battery discharge:
     - datetime: '2021-01-01'
       value: 0.6593
     - datetime: '2022-01-01'
-      value: 0.6801
+      value: 0.68
     - datetime: '2023-01-01'
       value: 0.6714
     - datetime: '2024-01-01'
       value: 0.6593
     - datetime: '2025-01-01'
-      value: 0.6488
+      value: 0.6474
 parsers:
   productionCapacity: EMBER.fetch_production_capacity
 region: Americas

--- a/config/zones/CA.yaml
+++ b/config/zones/CA.yaml
@@ -193,11 +193,24 @@ emissionFactors:
         datetime: '2025-01-01'
         source: Electricity Maps, 2025 zone average; National Laboratory of the Rockies
         value: 125.35
-has_day_ahead_price_license: False
-hide_day_ahead_price: False
+has_day_ahead_price_license: false
+hide_day_ahead_price: false
+isLowCarbon:
+  battery discharge:
+    - datetime: '2021-01-01'
+      value: 0.7917
+isRenewable:
+  battery discharge:
+    - datetime: '2021-01-01'
+      value: 0.6593
 parsers:
   productionCapacity: EMBER.fetch_production_capacity
 region: Americas
+sources:
+  IPCC 2014:
+    link: https://www.ipcc.ch/site/assets/uploads/2018/02/ipcc_wg3_ar5_annex-iii.pdf#page=7
+  National Laboratory of the Rockies:
+    link: https://docs.nrel.gov/docs/fy21osti/80580.pdf
 subZoneNames:
   - CA-AB
   - CA-BC
@@ -214,8 +227,3 @@ subZoneNames:
   - CA-YT
 timezone: America/Toronto
 zone_name: Canada
-sources:
-  IPCC 2014:
-    link: https://www.ipcc.ch/site/assets/uploads/2018/02/ipcc_wg3_ar5_annex-iii.pdf#page=7
-  National Laboratory of the Rockies:
-    link: https://docs.nrel.gov/docs/fy21osti/80580.pdf

--- a/config/zones/CA.yaml
+++ b/config/zones/CA.yaml
@@ -170,7 +170,7 @@ emissionFactors:
       - _comment: used storage values greater than zero.
         datetime: '2025-01-01'
         source: Electricity Maps, 2025 zone average
-        value: 92.35
+        value: 92.37
   lifecycle:
     battery discharge:
       - _comment: used storage values greater than zero.
@@ -192,7 +192,7 @@ emissionFactors:
       - _comment: used storage values greater than zero.
         datetime: '2025-01-01'
         source: Electricity Maps, 2025 zone average; National Laboratory of the Rockies
-        value: 125.35
+        value: 125.37
 has_day_ahead_price_license: false
 hide_day_ahead_price: false
 isLowCarbon:
@@ -201,12 +201,24 @@ isLowCarbon:
       value: 0.7917
     - datetime: '2022-01-01'
       value: 0.7982
+    - datetime: '2023-01-01'
+      value: 0.7958
+    - datetime: '2024-01-01'
+      value: 0.7862
+    - datetime: '2025-01-01'
+      value: 0.7738
 isRenewable:
   battery discharge:
     - datetime: '2021-01-01'
       value: 0.6593
     - datetime: '2022-01-01'
       value: 0.6801
+    - datetime: '2023-01-01'
+      value: 0.6714
+    - datetime: '2024-01-01'
+      value: 0.6593
+    - datetime: '2025-01-01'
+      value: 0.6488
 parsers:
   productionCapacity: EMBER.fetch_production_capacity
 region: Americas

--- a/config/zones/CZ.yaml
+++ b/config/zones/CZ.yaml
@@ -454,12 +454,16 @@ isLowCarbon:
       value: 0.5331
     - datetime: '2021-01-01'
       value: 0.4839
+    - datetime: '2022-01-01'
+      value: 0.4938
 isRenewable:
   hydro discharge:
     - datetime: '2020-01-01'
       value: 0.1529
     - datetime: '2021-01-01'
       value: 0.1677
+    - datetime: '2022-01-01'
+      value: 0.1418
 parsers:
   consumption: ENTSOE.fetch_consumption
   consumptionForecast: ENTSOE.fetch_consumption_forecast

--- a/config/zones/CZ.yaml
+++ b/config/zones/CZ.yaml
@@ -448,6 +448,14 @@ fallbackZoneMixes:
         wind: 0.048488262214254355
 has_day_ahead_price_license: false
 hide_day_ahead_price: false
+isLowCarbon:
+  hydro discharge:
+    - datetime: '2020-01-01'
+      value: 0.5331
+isRenewable:
+  hydro discharge:
+    - datetime: '2020-01-01'
+      value: 0.1529
 parsers:
   consumption: ENTSOE.fetch_consumption
   consumptionForecast: ENTSOE.fetch_consumption_forecast

--- a/config/zones/CZ.yaml
+++ b/config/zones/CZ.yaml
@@ -204,7 +204,7 @@ emissionFactors:
       - _comment: used storage values greater than zero.
         datetime: '2025-01-01'
         source: Electricity Maps, 2025 zone average
-        value: 434.06
+        value: 434.09
     oil:
       - datetime: '2021-01-01'
         source: EU-ETS, ENTSO-E 2021
@@ -273,7 +273,7 @@ emissionFactors:
       - _comment: used storage values greater than zero.
         datetime: '2025-01-01'
         source: Electricity Maps, 2025 zone average; UNECE 2022
-        value: 444.76
+        value: 444.79
     nuclear:
       datetime: '2020-01-01'
       source: UNECE 2022

--- a/config/zones/CZ.yaml
+++ b/config/zones/CZ.yaml
@@ -204,7 +204,7 @@ emissionFactors:
       - _comment: used storage values greater than zero.
         datetime: '2025-01-01'
         source: Electricity Maps, 2025 zone average
-        value: 467.9
+        value: 434.06
     oil:
       - datetime: '2021-01-01'
         source: EU-ETS, ENTSO-E 2021
@@ -273,7 +273,7 @@ emissionFactors:
       - _comment: used storage values greater than zero.
         datetime: '2025-01-01'
         source: Electricity Maps, 2025 zone average; UNECE 2022
-        value: 478.6
+        value: 444.76
     nuclear:
       datetime: '2020-01-01'
       source: UNECE 2022
@@ -456,6 +456,12 @@ isLowCarbon:
       value: 0.4839
     - datetime: '2022-01-01'
       value: 0.4938
+    - datetime: '2023-01-01'
+      value: 1.0
+    - datetime: '2024-01-01'
+      value: 1.0
+    - datetime: '2025-01-01'
+      value: 0.5197
 isRenewable:
   hydro discharge:
     - datetime: '2020-01-01'
@@ -464,6 +470,12 @@ isRenewable:
       value: 0.1677
     - datetime: '2022-01-01'
       value: 0.1418
+    - datetime: '2023-01-01'
+      value: 1.0
+    - datetime: '2024-01-01'
+      value: 1.0
+    - datetime: '2025-01-01'
+      value: 0.1187
 parsers:
   consumption: ENTSOE.fetch_consumption
   consumptionForecast: ENTSOE.fetch_consumption_forecast

--- a/config/zones/CZ.yaml
+++ b/config/zones/CZ.yaml
@@ -452,10 +452,14 @@ isLowCarbon:
   hydro discharge:
     - datetime: '2020-01-01'
       value: 0.5331
+    - datetime: '2021-01-01'
+      value: 0.4839
 isRenewable:
   hydro discharge:
     - datetime: '2020-01-01'
       value: 0.1529
+    - datetime: '2021-01-01'
+      value: 0.1677
 parsers:
   consumption: ENTSOE.fetch_consumption
   consumptionForecast: ENTSOE.fetch_consumption_forecast

--- a/config/zones/DE.yaml
+++ b/config/zones/DE.yaml
@@ -598,6 +598,14 @@ fallbackZoneMixes:
         wind: 0.2921152749986025
 has_day_ahead_price_license: true
 hide_day_ahead_price: false
+isLowCarbon:
+  hydro discharge:
+    - datetime: '2020-01-01'
+      value: 0.6353
+isRenewable:
+  hydro discharge:
+    - datetime: '2020-01-01'
+      value: 0.4941
 parsers:
   consumption: ENTSOE.fetch_consumption
   consumptionForecast: ENTSOE.fetch_consumption_forecast

--- a/config/zones/DE.yaml
+++ b/config/zones/DE.yaml
@@ -602,10 +602,14 @@ isLowCarbon:
   hydro discharge:
     - datetime: '2020-01-01'
       value: 0.6353
+    - datetime: '2021-01-01'
+      value: 0.6219
 isRenewable:
   hydro discharge:
     - datetime: '2020-01-01'
       value: 0.4941
+    - datetime: '2021-01-01'
+      value: 0.4794
 parsers:
   consumption: ENTSOE.fetch_consumption
   consumptionForecast: ENTSOE.fetch_consumption_forecast

--- a/config/zones/DE.yaml
+++ b/config/zones/DE.yaml
@@ -604,12 +604,16 @@ isLowCarbon:
       value: 0.6353
     - datetime: '2021-01-01'
       value: 0.6219
+    - datetime: '2022-01-01'
+      value: 0.6031
 isRenewable:
   hydro discharge:
     - datetime: '2020-01-01'
       value: 0.4941
     - datetime: '2021-01-01'
       value: 0.4794
+    - datetime: '2022-01-01'
+      value: 0.5294
 parsers:
   consumption: ENTSOE.fetch_consumption
   consumptionForecast: ENTSOE.fetch_consumption_forecast

--- a/config/zones/DE.yaml
+++ b/config/zones/DE.yaml
@@ -326,11 +326,11 @@ emissionFactors:
       - _comment: used storage values greater than zero.
         datetime: '2021-01-01'
         source: Electricity Maps, 2021 zone average
-        value: 339.15
+        value: 339.07
       - _comment: used storage values greater than zero.
         datetime: '2022-01-01'
         source: Electricity Maps, 2022 zone average
-        value: 376.61
+        value: 376.56
       - _comment: used storage values greater than zero.
         datetime: '2023-01-01'
         source: Electricity Maps, 2023 zone average
@@ -342,7 +342,7 @@ emissionFactors:
       - _comment: used storage values greater than zero.
         datetime: '2025-01-01'
         source: Electricity Maps, 2025 zone average
-        value: 234.68
+        value: 235.59
     oil:
       - datetime: '2021-01-01'
         source: EU-ETS, ENTSO-E 2021
@@ -401,11 +401,11 @@ emissionFactors:
       - _comment: used storage values greater than zero.
         datetime: '2021-01-01'
         source: Electricity Maps, 2021 zone average; UNECE 2022
-        value: 349.85
+        value: 349.77
       - _comment: used storage values greater than zero.
         datetime: '2022-01-01'
         source: Electricity Maps, 2022 zone average; UNECE 2022
-        value: 387.31
+        value: 387.26
       - _comment: used storage values greater than zero.
         datetime: '2023-01-01'
         source: Electricity Maps, 2023 zone average; UNECE 2022
@@ -417,7 +417,7 @@ emissionFactors:
       - _comment: used storage values greater than zero.
         datetime: '2025-01-01'
         source: Electricity Maps, 2025 zone average; UNECE 2022
-        value: 245.38
+        value: 246.29
     nuclear:
       datetime: '2020-01-01'
       source: UNECE 2022
@@ -611,7 +611,7 @@ isLowCarbon:
     - datetime: '2024-01-01'
       value: 0.701
     - datetime: '2025-01-01'
-      value: 0.7014
+      value: 0.7002
 isRenewable:
   hydro discharge:
     - datetime: '2020-01-01'
@@ -619,13 +619,13 @@ isRenewable:
     - datetime: '2021-01-01'
       value: 0.4794
     - datetime: '2022-01-01'
-      value: 0.5294
+      value: 0.5295
     - datetime: '2023-01-01'
       value: 0.6292
     - datetime: '2024-01-01'
       value: 0.6621
     - datetime: '2025-01-01'
-      value: 0.6697
+      value: 0.6685
 parsers:
   consumption: ENTSOE.fetch_consumption
   consumptionForecast: ENTSOE.fetch_consumption_forecast

--- a/config/zones/DE.yaml
+++ b/config/zones/DE.yaml
@@ -334,15 +334,15 @@ emissionFactors:
       - _comment: used storage values greater than zero.
         datetime: '2023-01-01'
         source: Electricity Maps, 2023 zone average
-        value: 274.86
+        value: 277.92
       - _comment: used storage values greater than zero.
         datetime: '2024-01-01'
         source: Electricity Maps, 2024 zone average
-        value: 241.9
+        value: 240.15
       - _comment: used storage values greater than zero.
         datetime: '2025-01-01'
         source: Electricity Maps, 2025 zone average
-        value: 236.68
+        value: 234.68
     oil:
       - datetime: '2021-01-01'
         source: EU-ETS, ENTSO-E 2021
@@ -409,15 +409,15 @@ emissionFactors:
       - _comment: used storage values greater than zero.
         datetime: '2023-01-01'
         source: Electricity Maps, 2023 zone average; UNECE 2022
-        value: 285.56
+        value: 288.62
       - _comment: used storage values greater than zero.
         datetime: '2024-01-01'
         source: Electricity Maps, 2024 zone average; UNECE 2022
-        value: 252.6
+        value: 250.85
       - _comment: used storage values greater than zero.
         datetime: '2025-01-01'
         source: Electricity Maps, 2025 zone average; UNECE 2022
-        value: 247.38
+        value: 245.38
     nuclear:
       datetime: '2020-01-01'
       source: UNECE 2022
@@ -606,6 +606,12 @@ isLowCarbon:
       value: 0.6219
     - datetime: '2022-01-01'
       value: 0.6031
+    - datetime: '2023-01-01'
+      value: 0.6686
+    - datetime: '2024-01-01'
+      value: 0.701
+    - datetime: '2025-01-01'
+      value: 0.7014
 isRenewable:
   hydro discharge:
     - datetime: '2020-01-01'
@@ -614,6 +620,12 @@ isRenewable:
       value: 0.4794
     - datetime: '2022-01-01'
       value: 0.5294
+    - datetime: '2023-01-01'
+      value: 0.6292
+    - datetime: '2024-01-01'
+      value: 0.6621
+    - datetime: '2025-01-01'
+      value: 0.6697
 parsers:
   consumption: ENTSOE.fetch_consumption
   consumptionForecast: ENTSOE.fetch_consumption_forecast

--- a/config/zones/ES-CE.yaml
+++ b/config/zones/ES-CE.yaml
@@ -153,6 +153,12 @@ isLowCarbon:
       value: 0.0
     - datetime: '2022-01-01'
       value: 0.0
+    - datetime: '2023-01-01'
+      value: 0.0
+    - datetime: '2024-01-01'
+      value: 0.0
+    - datetime: '2025-01-01'
+      value: 0.0
   hydro discharge:
     - datetime: '2020-01-01'
       value: 1.0
@@ -167,6 +173,12 @@ isRenewable:
     - datetime: '2021-01-01'
       value: 0.0
     - datetime: '2022-01-01'
+      value: 0.0
+    - datetime: '2023-01-01'
+      value: 0.0
+    - datetime: '2024-01-01'
+      value: 0.0
+    - datetime: '2025-01-01'
       value: 0.0
   hydro discharge:
     - datetime: '2020-01-01'

--- a/config/zones/ES-CE.yaml
+++ b/config/zones/ES-CE.yaml
@@ -143,17 +143,31 @@ fallbackZoneMixes:
         solar: 0.0
         unknown: 0.0
         wind: 0.0
-has_day_ahead_price_license: True
-hide_day_ahead_price: False
+has_day_ahead_price_license: true
+hide_day_ahead_price: false
+isLowCarbon:
+  battery discharge:
+    - datetime: '2020-01-01'
+      value: 0.0
+  hydro discharge:
+    - datetime: '2020-01-01'
+      value: 1.0
+isRenewable:
+  battery discharge:
+    - datetime: '2020-01-01'
+      value: 0.0
+  hydro discharge:
+    - datetime: '2020-01-01'
+      value: 1.0
 parsers:
   consumption: ES.fetch_consumption
   production: ES.fetch_production
   productionCapacity: REE.fetch_production_capacity
 region: Europe
-timezone: Europe/Madrid
-zone_name: Ceuta
 sources:
   IPCC 2014:
     link: https://www.ipcc.ch/site/assets/uploads/2018/02/ipcc_wg3_ar5_annex-iii.pdf#page=7
   National Laboratory of the Rockies:
     link: https://docs.nrel.gov/docs/fy21osti/80580.pdf
+timezone: Europe/Madrid
+zone_name: Ceuta

--- a/config/zones/ES-CE.yaml
+++ b/config/zones/ES-CE.yaml
@@ -149,15 +149,23 @@ isLowCarbon:
   battery discharge:
     - datetime: '2020-01-01'
       value: 0.0
+    - datetime: '2021-01-01'
+      value: 0.0
   hydro discharge:
     - datetime: '2020-01-01'
+      value: 1.0
+    - datetime: '2021-01-01'
       value: 1.0
 isRenewable:
   battery discharge:
     - datetime: '2020-01-01'
       value: 0.0
+    - datetime: '2021-01-01'
+      value: 0.0
   hydro discharge:
     - datetime: '2020-01-01'
+      value: 1.0
+    - datetime: '2021-01-01'
       value: 1.0
 parsers:
   consumption: ES.fetch_consumption

--- a/config/zones/ES-CE.yaml
+++ b/config/zones/ES-CE.yaml
@@ -27,7 +27,7 @@ emissionFactors:
       - _comment: used non-null storage values
         datetime: '2021-01-01'
         source: Electricity Maps, 2021 zone average
-        value: 389.51
+        value: 405.89
       - _comment: used non-null storage values
         datetime: '2022-01-01'
         source: Electricity Maps, 2022 zone average
@@ -66,7 +66,7 @@ emissionFactors:
       - _comment: used non-null storage values
         datetime: '2021-01-01'
         source: Electricity Maps, 2021 zone average; National Laboratory of the Rockies
-        value: 422.51
+        value: 438.89
       - _comment: used non-null storage values
         datetime: '2022-01-01'
         source: Electricity Maps, 2022 zone average; National Laboratory of the Rockies

--- a/config/zones/ES-CE.yaml
+++ b/config/zones/ES-CE.yaml
@@ -151,10 +151,14 @@ isLowCarbon:
       value: 0.0
     - datetime: '2021-01-01'
       value: 0.0
+    - datetime: '2022-01-01'
+      value: 0.0
   hydro discharge:
     - datetime: '2020-01-01'
       value: 1.0
     - datetime: '2021-01-01'
+      value: 1.0
+    - datetime: '2022-01-01'
       value: 1.0
 isRenewable:
   battery discharge:
@@ -162,10 +166,14 @@ isRenewable:
       value: 0.0
     - datetime: '2021-01-01'
       value: 0.0
+    - datetime: '2022-01-01'
+      value: 0.0
   hydro discharge:
     - datetime: '2020-01-01'
       value: 1.0
     - datetime: '2021-01-01'
+      value: 1.0
+    - datetime: '2022-01-01'
       value: 1.0
 parsers:
   consumption: ES.fetch_consumption

--- a/config/zones/ES-CN-FV.yaml
+++ b/config/zones/ES-CN-FV.yaml
@@ -178,11 +178,15 @@ isLowCarbon:
       value: 1.0
     - datetime: '2021-01-01'
       value: 1.0
+    - datetime: '2022-01-01'
+      value: 1.0
 isRenewable:
   hydro discharge:
     - datetime: '2020-01-01'
       value: 1.0
     - datetime: '2021-01-01'
+      value: 1.0
+    - datetime: '2022-01-01'
       value: 1.0
 parsers:
   consumption: ES.fetch_consumption

--- a/config/zones/ES-CN-FV.yaml
+++ b/config/zones/ES-CN-FV.yaml
@@ -176,9 +176,13 @@ isLowCarbon:
   hydro discharge:
     - datetime: '2020-01-01'
       value: 1.0
+    - datetime: '2021-01-01'
+      value: 1.0
 isRenewable:
   hydro discharge:
     - datetime: '2020-01-01'
+      value: 1.0
+    - datetime: '2021-01-01'
       value: 1.0
 parsers:
   consumption: ES.fetch_consumption

--- a/config/zones/ES-CN-FV.yaml
+++ b/config/zones/ES-CN-FV.yaml
@@ -89,10 +89,12 @@ emissionFactors:
       value: 230
     coal:
       - datetime: '2021-01-01'
-        source: EU-ETS, ENTSO-E 2021; Oberschelp, Christopher, et al. "Global emission hotspots of coal power generation."
+        source: EU-ETS, ENTSO-E 2021; Oberschelp, Christopher, et al. "Global emission
+          hotspots of coal power generation."
         value: 1050.5643503
       - datetime: '2022-01-01'
-        source: EU-ETS, ENTSO-E 2022; Oberschelp, Christopher, et al. "Global emission hotspots of coal power generation."
+        source: EU-ETS, ENTSO-E 2022; Oberschelp, Christopher, et al. "Global emission
+          hotspots of coal power generation."
         value: 1235.586989
     gas:
       - datetime: '2021-01-01'
@@ -165,10 +167,19 @@ emissionFactors:
       value: 25.6
     wind:
       datetime: '2021-01-01'
-      source: UNECE 2022, WindEurope "Wind energy in Europe, 2021 Statistics and the outlook for 2022-2026" Wind Europe Proceedings (2021)
+      source: UNECE 2022, WindEurope "Wind energy in Europe, 2021 Statistics and the
+        outlook for 2022-2026" Wind Europe Proceedings (2021)
       value: 12.62
-has_day_ahead_price_license: True
-hide_day_ahead_price: False
+has_day_ahead_price_license: true
+hide_day_ahead_price: false
+isLowCarbon:
+  hydro discharge:
+    - datetime: '2020-01-01'
+      value: 1.0
+isRenewable:
+  hydro discharge:
+    - datetime: '2020-01-01'
+      value: 1.0
 parsers:
   consumption: ES.fetch_consumption
   production: ES.fetch_production
@@ -186,7 +197,10 @@ sources:
     link: https://www.ipcc.ch/site/assets/uploads/2018/02/ipcc_wg3_ar5_annex-iii.pdf#page=7
   UNECE 2022:
     link: https://unece.org/sites/default/files/2022-04/LCA_3_FINAL%20March%202022.pdf
-  UNECE 2022, WindEurope "Wind energy in Europe, 2021 Statistics and the outlook for 2022-2026" Wind Europe Proceedings (2021):
-    link: https://unece.org/sites/default/files/2022-04/LCA_3_FINAL%20March%202022.pdf#page=37, https://proceedings.windeurope.org/biplatform/rails/active_storage/disk/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdDRG9JYTJWNVNTSWhORFJ0ZDJJMWVUbG9OMll6TVRaaGEza3lkamgxZG1aM056WnZZZ1k2QmtWVU9oQmthWE53YjNOcGRHbHZia2tpQVk1cGJteHBibVU3SUdacGJHVnVZVzFsUFNKWGFXNWtaWFZ5YjNCbExWZHBibVF0Wlc1bGNtZDVMV2x1TFVWMWNtOXdaUzB5TURJeExYTjBZWFJwYzNScFkzTXVjR1JtSWpzZ1ptbHNaVzVoYldVcVBWVlVSaTA0SnlkWGFXNWtaWFZ5YjNCbExWZHBibVF0Wlc1bGNtZDVMV2x1TFVWMWNtOXdaUzB5TURJeExYTjBZWFJwYzNScFkzTXVjR1JtQmpzR1ZEb1JZMjl1ZEdWdWRGOTBlWEJsU1NJVVlYQndiR2xqWVhScGIyNHZjR1JtQmpzR1ZBPT0iLCJleHAiOiIyMDIyLTExLTAyVDE1OjU0OjAzLjEyNFoiLCJwdXIiOiJibG9iX2tleSJ9fQ==--c25280a7345257bd91bfaf6d64ddb75c55eef799/Windeurope-Wind-energy-in-Europe-2021-statistics.pdf?content_type=application%2Fpdf&disposition=inline%3B+filename%3D%22Windeurope-Wind-energy-in-Europe-2021-statistics.pdf%22%3B+filename%2A%3DUTF-8%27%27Windeurope-Wind-energy-in-Europe-2021-statistics.pdf
+  ? UNECE 2022, WindEurope "Wind energy in Europe, 2021 Statistics and the outlook
+    for 2022-2026" Wind Europe Proceedings (2021)
+  : link:
+      https://unece.org/sites/default/files/2022-04/LCA_3_FINAL%20March%202022.pdf#page=37,
+      https://proceedings.windeurope.org/biplatform/rails/active_storage/disk/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdDRG9JYTJWNVNTSWhORFJ0ZDJJMWVUbG9OMll6TVRaaGEza3lkamgxZG1aM056WnZZZ1k2QmtWVU9oQmthWE53YjNOcGRHbHZia2tpQVk1cGJteHBibVU3SUdacGJHVnVZVzFsUFNKWGFXNWtaWFZ5YjNCbExWZHBibVF0Wlc1bGNtZDVMV2x1TFVWMWNtOXdaUzB5TURJeExYTjBZWFJwYzNScFkzTXVjR1JtSWpzZ1ptbHNaVzVoYldVcVBWVlVSaTA0SnlkWGFXNWtaWFZ5YjNCbExWZHBibVF0Wlc1bGNtZDVMV2x1TFVWMWNtOXdaUzB5TURJeExYTjBZWFJwYzNScFkzTXVjR1JtQmpzR1ZEb1JZMjl1ZEdWdWRGOTBlWEJsU1NJVVlYQndiR2xqWVhScGIyNHZjR1JtQmpzR1ZBPT0iLCJleHAiOiIyMDIyLTExLTAyVDE1OjU0OjAzLjEyNFoiLCJwdXIiOiJibG9iX2tleSJ9fQ==--c25280a7345257bd91bfaf6d64ddb75c55eef799/Windeurope-Wind-energy-in-Europe-2021-statistics.pdf?content_type=application%2Fpdf&disposition=inline%3B+filename%3D%22Windeurope-Wind-energy-in-Europe-2021-statistics.pdf%22%3B+filename%2A%3DUTF-8%27%27Windeurope-Wind-energy-in-Europe-2021-statistics.pdf
 timezone: Atlantic/Canary
 zone_name: Fuerteventura

--- a/config/zones/ES-CN-FV.yaml
+++ b/config/zones/ES-CN-FV.yaml
@@ -180,6 +180,12 @@ isLowCarbon:
       value: 1.0
     - datetime: '2022-01-01'
       value: 1.0
+    - datetime: '2023-01-01'
+      value: 1.0
+    - datetime: '2024-01-01'
+      value: 1.0
+    - datetime: '2025-01-01'
+      value: 1.0
 isRenewable:
   hydro discharge:
     - datetime: '2020-01-01'
@@ -187,6 +193,12 @@ isRenewable:
     - datetime: '2021-01-01'
       value: 1.0
     - datetime: '2022-01-01'
+      value: 1.0
+    - datetime: '2023-01-01'
+      value: 1.0
+    - datetime: '2024-01-01'
+      value: 1.0
+    - datetime: '2025-01-01'
       value: 1.0
 parsers:
   consumption: ES.fetch_consumption

--- a/config/zones/ES-CN-GC.yaml
+++ b/config/zones/ES-CN-GC.yaml
@@ -87,10 +87,12 @@ emissionFactors:
       value: 230.0
     coal:
       - datetime: '2021-01-01'
-        source: EU-ETS, ENTSO-E 2021; Oberschelp, Christopher, et al. "Global emission hotspots of coal power generation."
+        source: EU-ETS, ENTSO-E 2021; Oberschelp, Christopher, et al. "Global emission
+          hotspots of coal power generation."
         value: 1050.5643503
       - datetime: '2022-01-01'
-        source: EU-ETS, ENTSO-E 2022; Oberschelp, Christopher, et al. "Global emission hotspots of coal power generation."
+        source: EU-ETS, ENTSO-E 2022; Oberschelp, Christopher, et al. "Global emission
+          hotspots of coal power generation."
         value: 1235.586989
     gas:
       - datetime: '2021-01-01'
@@ -163,7 +165,8 @@ emissionFactors:
       value: 25.95
     wind:
       datetime: '2021-01-01'
-      source: UNECE 2022, WindEurope "Wind energy in Europe, 2021 Statistics and the outlook for 2022-2026" Wind Europe Proceedings (2021)
+      source: UNECE 2022, WindEurope "Wind energy in Europe, 2021 Statistics and the
+        outlook for 2022-2026" Wind Europe Proceedings (2021)
       value: 12.62
 fallbackZoneMixes:
   powerOriginRatios:
@@ -272,8 +275,16 @@ fallbackZoneMixes:
         solar: 0.04889212064097191
         unknown: 0.0
         wind: 0.20833115421534318
-has_day_ahead_price_license: True
-hide_day_ahead_price: False
+has_day_ahead_price_license: true
+hide_day_ahead_price: false
+isLowCarbon:
+  hydro discharge:
+    - datetime: '2020-01-01'
+      value: 1.0
+isRenewable:
+  hydro discharge:
+    - datetime: '2020-01-01'
+      value: 1.0
 parsers:
   consumption: ES.fetch_consumption
   production: ES.fetch_production
@@ -291,7 +302,10 @@ sources:
     link: https://www.ipcc.ch/site/assets/uploads/2018/02/ipcc_wg3_ar5_annex-iii.pdf#page=7
   UNECE 2022:
     link: https://unece.org/sites/default/files/2022-04/LCA_3_FINAL%20March%202022.pdf
-  UNECE 2022, WindEurope "Wind energy in Europe, 2021 Statistics and the outlook for 2022-2026" Wind Europe Proceedings (2021):
-    link: https://unece.org/sites/default/files/2022-04/LCA_3_FINAL%20March%202022.pdf#page=37, https://proceedings.windeurope.org/biplatform/rails/active_storage/disk/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdDRG9JYTJWNVNTSWhORFJ0ZDJJMWVUbG9OMll6TVRaaGEza3lkamgxZG1aM056WnZZZ1k2QmtWVU9oQmthWE53YjNOcGRHbHZia2tpQVk1cGJteHBibVU3SUdacGJHVnVZVzFsUFNKWGFXNWtaWFZ5YjNCbExWZHBibVF0Wlc1bGNtZDVMV2x1TFVWMWNtOXdaUzB5TURJeExYTjBZWFJwYzNScFkzTXVjR1JtSWpzZ1ptbHNaVzVoYldVcVBWVlVSaTA0SnlkWGFXNWtaWFZ5YjNCbExWZHBibVF0Wlc1bGNtZDVMV2x1TFVWMWNtOXdaUzB5TURJeExYTjBZWFJwYzNScFkzTXVjR1JtQmpzR1ZEb1JZMjl1ZEdWdWRGOTBlWEJsU1NJVVlYQndiR2xqWVhScGIyNHZjR1JtQmpzR1ZBPT0iLCJleHAiOiIyMDIyLTExLTAyVDE1OjU0OjAzLjEyNFoiLCJwdXIiOiJibG9iX2tleSJ9fQ==--c25280a7345257bd91bfaf6d64ddb75c55eef799/Windeurope-Wind-energy-in-Europe-2021-statistics.pdf?content_type=application%2Fpdf&disposition=inline%3B+filename%3D%22Windeurope-Wind-energy-in-Europe-2021-statistics.pdf%22%3B+filename%2A%3DUTF-8%27%27Windeurope-Wind-energy-in-Europe-2021-statistics.pdf
+  ? UNECE 2022, WindEurope "Wind energy in Europe, 2021 Statistics and the outlook
+    for 2022-2026" Wind Europe Proceedings (2021)
+  : link:
+      https://unece.org/sites/default/files/2022-04/LCA_3_FINAL%20March%202022.pdf#page=37,
+      https://proceedings.windeurope.org/biplatform/rails/active_storage/disk/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdDRG9JYTJWNVNTSWhORFJ0ZDJJMWVUbG9OMll6TVRaaGEza3lkamgxZG1aM056WnZZZ1k2QmtWVU9oQmthWE53YjNOcGRHbHZia2tpQVk1cGJteHBibVU3SUdacGJHVnVZVzFsUFNKWGFXNWtaWFZ5YjNCbExWZHBibVF0Wlc1bGNtZDVMV2x1TFVWMWNtOXdaUzB5TURJeExYTjBZWFJwYzNScFkzTXVjR1JtSWpzZ1ptbHNaVzVoYldVcVBWVlVSaTA0SnlkWGFXNWtaWFZ5YjNCbExWZHBibVF0Wlc1bGNtZDVMV2x1TFVWMWNtOXdaUzB5TURJeExYTjBZWFJwYzNScFkzTXVjR1JtQmpzR1ZEb1JZMjl1ZEdWdWRGOTBlWEJsU1NJVVlYQndiR2xqWVhScGIyNHZjR1JtQmpzR1ZBPT0iLCJleHAiOiIyMDIyLTExLTAyVDE1OjU0OjAzLjEyNFoiLCJwdXIiOiJibG9iX2tleSJ9fQ==--c25280a7345257bd91bfaf6d64ddb75c55eef799/Windeurope-Wind-energy-in-Europe-2021-statistics.pdf?content_type=application%2Fpdf&disposition=inline%3B+filename%3D%22Windeurope-Wind-energy-in-Europe-2021-statistics.pdf%22%3B+filename%2A%3DUTF-8%27%27Windeurope-Wind-energy-in-Europe-2021-statistics.pdf
 timezone: Atlantic/Canary
 zone_name: Gran Canaria

--- a/config/zones/ES-CN-GC.yaml
+++ b/config/zones/ES-CN-GC.yaml
@@ -283,11 +283,15 @@ isLowCarbon:
       value: 1.0
     - datetime: '2021-01-01'
       value: 1.0
+    - datetime: '2022-01-01'
+      value: 1.0
 isRenewable:
   hydro discharge:
     - datetime: '2020-01-01'
       value: 1.0
     - datetime: '2021-01-01'
+      value: 1.0
+    - datetime: '2022-01-01'
       value: 1.0
 parsers:
   consumption: ES.fetch_consumption

--- a/config/zones/ES-CN-GC.yaml
+++ b/config/zones/ES-CN-GC.yaml
@@ -281,9 +281,13 @@ isLowCarbon:
   hydro discharge:
     - datetime: '2020-01-01'
       value: 1.0
+    - datetime: '2021-01-01'
+      value: 1.0
 isRenewable:
   hydro discharge:
     - datetime: '2020-01-01'
+      value: 1.0
+    - datetime: '2021-01-01'
       value: 1.0
 parsers:
   consumption: ES.fetch_consumption

--- a/config/zones/ES-CN-GC.yaml
+++ b/config/zones/ES-CN-GC.yaml
@@ -285,6 +285,12 @@ isLowCarbon:
       value: 1.0
     - datetime: '2022-01-01'
       value: 1.0
+    - datetime: '2023-01-01'
+      value: 1.0
+    - datetime: '2024-01-01'
+      value: 1.0
+    - datetime: '2025-01-01'
+      value: 1.0
 isRenewable:
   hydro discharge:
     - datetime: '2020-01-01'
@@ -292,6 +298,12 @@ isRenewable:
     - datetime: '2021-01-01'
       value: 1.0
     - datetime: '2022-01-01'
+      value: 1.0
+    - datetime: '2023-01-01'
+      value: 1.0
+    - datetime: '2024-01-01'
+      value: 1.0
+    - datetime: '2025-01-01'
       value: 1.0
 parsers:
   consumption: ES.fetch_consumption

--- a/config/zones/ES-CN-HI.yaml
+++ b/config/zones/ES-CN-HI.yaml
@@ -287,12 +287,16 @@ isLowCarbon:
       value: 1.0
     - datetime: '2021-01-01'
       value: 1.0
+    - datetime: '2022-01-01'
+      value: 0.7471
 isRenewable:
   hydro discharge:
     - datetime: '2020-01-01'
       value: 1.0
     - datetime: '2021-01-01'
       value: 1.0
+    - datetime: '2022-01-01'
+      value: 0.7471
 parsers:
   consumption: ES.fetch_consumption
   production: ES.fetch_production

--- a/config/zones/ES-CN-HI.yaml
+++ b/config/zones/ES-CN-HI.yaml
@@ -285,9 +285,13 @@ isLowCarbon:
   hydro discharge:
     - datetime: '2020-01-01'
       value: 1.0
+    - datetime: '2021-01-01'
+      value: 1.0
 isRenewable:
   hydro discharge:
     - datetime: '2020-01-01'
+      value: 1.0
+    - datetime: '2021-01-01'
       value: 1.0
 parsers:
   consumption: ES.fetch_consumption

--- a/config/zones/ES-CN-HI.yaml
+++ b/config/zones/ES-CN-HI.yaml
@@ -91,10 +91,12 @@ emissionFactors:
       value: 230.0
     coal:
       - datetime: '2021-01-01'
-        source: EU-ETS, ENTSO-E 2021; Oberschelp, Christopher, et al. "Global emission hotspots of coal power generation."
+        source: EU-ETS, ENTSO-E 2021; Oberschelp, Christopher, et al. "Global emission
+          hotspots of coal power generation."
         value: 1050.5643503
       - datetime: '2022-01-01'
-        source: EU-ETS, ENTSO-E 2022; Oberschelp, Christopher, et al. "Global emission hotspots of coal power generation."
+        source: EU-ETS, ENTSO-E 2022; Oberschelp, Christopher, et al. "Global emission
+          hotspots of coal power generation."
         value: 1235.586989
     gas:
       - datetime: '2021-01-01'
@@ -167,7 +169,8 @@ emissionFactors:
       value: 25.6
     wind:
       datetime: '2021-01-01'
-      source: UNECE 2022, WindEurope "Wind energy in Europe, 2021 Statistics and the outlook for 2022-2026" Wind Europe Proceedings (2021)
+      source: UNECE 2022, WindEurope "Wind energy in Europe, 2021 Statistics and the
+        outlook for 2022-2026" Wind Europe Proceedings (2021)
       value: 12.62
 fallbackZoneMixes:
   powerOriginRatios:
@@ -276,8 +279,16 @@ fallbackZoneMixes:
         solar: 0.0
         unknown: 0.0
         wind: 0.4601475232281346
-has_day_ahead_price_license: True
-hide_day_ahead_price: False
+has_day_ahead_price_license: true
+hide_day_ahead_price: false
+isLowCarbon:
+  hydro discharge:
+    - datetime: '2020-01-01'
+      value: 1.0
+isRenewable:
+  hydro discharge:
+    - datetime: '2020-01-01'
+      value: 1.0
 parsers:
   consumption: ES.fetch_consumption
   production: ES.fetch_production
@@ -295,7 +306,10 @@ sources:
     link: https://www.ipcc.ch/site/assets/uploads/2018/02/ipcc_wg3_ar5_annex-iii.pdf#page=7
   UNECE 2022:
     link: https://unece.org/sites/default/files/2022-04/LCA_3_FINAL%20March%202022.pdf
-  UNECE 2022, WindEurope "Wind energy in Europe, 2021 Statistics and the outlook for 2022-2026" Wind Europe Proceedings (2021):
-    link: https://unece.org/sites/default/files/2022-04/LCA_3_FINAL%20March%202022.pdf#page=37, https://proceedings.windeurope.org/biplatform/rails/active_storage/disk/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdDRG9JYTJWNVNTSWhORFJ0ZDJJMWVUbG9OMll6TVRaaGEza3lkamgxZG1aM056WnZZZ1k2QmtWVU9oQmthWE53YjNOcGRHbHZia2tpQVk1cGJteHBibVU3SUdacGJHVnVZVzFsUFNKWGFXNWtaWFZ5YjNCbExWZHBibVF0Wlc1bGNtZDVMV2x1TFVWMWNtOXdaUzB5TURJeExYTjBZWFJwYzNScFkzTXVjR1JtSWpzZ1ptbHNaVzVoYldVcVBWVlVSaTA0SnlkWGFXNWtaWFZ5YjNCbExWZHBibVF0Wlc1bGNtZDVMV2x1TFVWMWNtOXdaUzB5TURJeExYTjBZWFJwYzNScFkzTXVjR1JtQmpzR1ZEb1JZMjl1ZEdWdWRGOTBlWEJsU1NJVVlYQndiR2xqWVhScGIyNHZjR1JtQmpzR1ZBPT0iLCJleHAiOiIyMDIyLTExLTAyVDE1OjU0OjAzLjEyNFoiLCJwdXIiOiJibG9iX2tleSJ9fQ==--c25280a7345257bd91bfaf6d64ddb75c55eef799/Windeurope-Wind-energy-in-Europe-2021-statistics.pdf?content_type=application%2Fpdf&disposition=inline%3B+filename%3D%22Windeurope-Wind-energy-in-Europe-2021-statistics.pdf%22%3B+filename%2A%3DUTF-8%27%27Windeurope-Wind-energy-in-Europe-2021-statistics.pdf
+  ? UNECE 2022, WindEurope "Wind energy in Europe, 2021 Statistics and the outlook
+    for 2022-2026" Wind Europe Proceedings (2021)
+  : link:
+      https://unece.org/sites/default/files/2022-04/LCA_3_FINAL%20March%202022.pdf#page=37,
+      https://proceedings.windeurope.org/biplatform/rails/active_storage/disk/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdDRG9JYTJWNVNTSWhORFJ0ZDJJMWVUbG9OMll6TVRaaGEza3lkamgxZG1aM056WnZZZ1k2QmtWVU9oQmthWE53YjNOcGRHbHZia2tpQVk1cGJteHBibVU3SUdacGJHVnVZVzFsUFNKWGFXNWtaWFZ5YjNCbExWZHBibVF0Wlc1bGNtZDVMV2x1TFVWMWNtOXdaUzB5TURJeExYTjBZWFJwYzNScFkzTXVjR1JtSWpzZ1ptbHNaVzVoYldVcVBWVlVSaTA0SnlkWGFXNWtaWFZ5YjNCbExWZHBibVF0Wlc1bGNtZDVMV2x1TFVWMWNtOXdaUzB5TURJeExYTjBZWFJwYzNScFkzTXVjR1JtQmpzR1ZEb1JZMjl1ZEdWdWRGOTBlWEJsU1NJVVlYQndiR2xqWVhScGIyNHZjR1JtQmpzR1ZBPT0iLCJleHAiOiIyMDIyLTExLTAyVDE1OjU0OjAzLjEyNFoiLCJwdXIiOiJibG9iX2tleSJ9fQ==--c25280a7345257bd91bfaf6d64ddb75c55eef799/Windeurope-Wind-energy-in-Europe-2021-statistics.pdf?content_type=application%2Fpdf&disposition=inline%3B+filename%3D%22Windeurope-Wind-energy-in-Europe-2021-statistics.pdf%22%3B+filename%2A%3DUTF-8%27%27Windeurope-Wind-energy-in-Europe-2021-statistics.pdf
 timezone: Atlantic/Canary
 zone_name: El Hierro

--- a/config/zones/ES-CN-HI.yaml
+++ b/config/zones/ES-CN-HI.yaml
@@ -58,7 +58,7 @@ emissionFactors:
       - _comment: used storage values greater than zero.
         datetime: '2025-01-01'
         source: Electricity Maps, 2025 zone average
-        value: 211.13
+        value: 211.03
     oil:
       - datetime: '2017-01-01'
         source: EU-ETS, REE
@@ -133,7 +133,7 @@ emissionFactors:
       - _comment: used storage values greater than zero.
         datetime: '2025-01-01'
         source: Electricity Maps, 2025 zone average; UNECE 2022
-        value: 221.83
+        value: 221.73
     nuclear:
       datetime: '2020-01-01'
       source: UNECE 2022
@@ -294,7 +294,7 @@ isLowCarbon:
     - datetime: '2024-01-01'
       value: 0.7253
     - datetime: '2025-01-01'
-      value: 0.7034
+      value: 0.7035
 isRenewable:
   hydro discharge:
     - datetime: '2020-01-01'
@@ -308,7 +308,7 @@ isRenewable:
     - datetime: '2024-01-01'
       value: 0.7253
     - datetime: '2025-01-01'
-      value: 0.7034
+      value: 0.7035
 parsers:
   consumption: ES.fetch_consumption
   production: ES.fetch_production

--- a/config/zones/ES-CN-HI.yaml
+++ b/config/zones/ES-CN-HI.yaml
@@ -289,6 +289,12 @@ isLowCarbon:
       value: 1.0
     - datetime: '2022-01-01'
       value: 0.7471
+    - datetime: '2023-01-01'
+      value: 0.6575
+    - datetime: '2024-01-01'
+      value: 0.7253
+    - datetime: '2025-01-01'
+      value: 0.7034
 isRenewable:
   hydro discharge:
     - datetime: '2020-01-01'
@@ -297,6 +303,12 @@ isRenewable:
       value: 1.0
     - datetime: '2022-01-01'
       value: 0.7471
+    - datetime: '2023-01-01'
+      value: 0.6575
+    - datetime: '2024-01-01'
+      value: 0.7253
+    - datetime: '2025-01-01'
+      value: 0.7034
 parsers:
   consumption: ES.fetch_consumption
   production: ES.fetch_production

--- a/config/zones/ES-CN-IG.yaml
+++ b/config/zones/ES-CN-IG.yaml
@@ -89,10 +89,12 @@ emissionFactors:
       value: 230.0
     coal:
       - datetime: '2021-01-01'
-        source: EU-ETS, ENTSO-E 2021; Oberschelp, Christopher, et al. "Global emission hotspots of coal power generation."
+        source: EU-ETS, ENTSO-E 2021; Oberschelp, Christopher, et al. "Global emission
+          hotspots of coal power generation."
         value: 1050.5643503
       - datetime: '2022-01-01'
-        source: EU-ETS, ENTSO-E 2022; Oberschelp, Christopher, et al. "Global emission hotspots of coal power generation."
+        source: EU-ETS, ENTSO-E 2022; Oberschelp, Christopher, et al. "Global emission
+          hotspots of coal power generation."
         value: 1235.586989
     gas:
       - datetime: '2021-01-01'
@@ -165,7 +167,8 @@ emissionFactors:
       value: 25.6
     wind:
       datetime: '2021-01-01'
-      source: UNECE 2022, WindEurope "Wind energy in Europe, 2021 Statistics and the outlook for 2022-2026" Wind Europe Proceedings (2021)
+      source: UNECE 2022, WindEurope "Wind energy in Europe, 2021 Statistics and the
+        outlook for 2022-2026" Wind Europe Proceedings (2021)
       value: 12.62
 fallbackZoneMixes:
   powerOriginRatios:
@@ -274,8 +277,16 @@ fallbackZoneMixes:
         solar: 0.0
         unknown: 0.0
         wind: 0.10116250460286508
-has_day_ahead_price_license: True
-hide_day_ahead_price: False
+has_day_ahead_price_license: true
+hide_day_ahead_price: false
+isLowCarbon:
+  hydro discharge:
+    - datetime: '2020-01-01'
+      value: 1.0
+isRenewable:
+  hydro discharge:
+    - datetime: '2020-01-01'
+      value: 1.0
 parsers:
   consumption: ES.fetch_consumption
   production: ES.fetch_production
@@ -293,7 +304,10 @@ sources:
     link: https://www.ipcc.ch/site/assets/uploads/2018/02/ipcc_wg3_ar5_annex-iii.pdf#page=7
   UNECE 2022:
     link: https://unece.org/sites/default/files/2022-04/LCA_3_FINAL%20March%202022.pdf
-  UNECE 2022, WindEurope "Wind energy in Europe, 2021 Statistics and the outlook for 2022-2026" Wind Europe Proceedings (2021):
-    link: https://unece.org/sites/default/files/2022-04/LCA_3_FINAL%20March%202022.pdf#page=37, https://proceedings.windeurope.org/biplatform/rails/active_storage/disk/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdDRG9JYTJWNVNTSWhORFJ0ZDJJMWVUbG9OMll6TVRaaGEza3lkamgxZG1aM056WnZZZ1k2QmtWVU9oQmthWE53YjNOcGRHbHZia2tpQVk1cGJteHBibVU3SUdacGJHVnVZVzFsUFNKWGFXNWtaWFZ5YjNCbExWZHBibVF0Wlc1bGNtZDVMV2x1TFVWMWNtOXdaUzB5TURJeExYTjBZWFJwYzNScFkzTXVjR1JtSWpzZ1ptbHNaVzVoYldVcVBWVlVSaTA0SnlkWGFXNWtaWFZ5YjNCbExWZHBibVF0Wlc1bGNtZDVMV2x1TFVWMWNtOXdaUzB5TURJeExYTjBZWFJwYzNScFkzTXVjR1JtQmpzR1ZEb1JZMjl1ZEdWdWRGOTBlWEJsU1NJVVlYQndiR2xqWVhScGIyNHZjR1JtQmpzR1ZBPT0iLCJleHAiOiIyMDIyLTExLTAyVDE1OjU0OjAzLjEyNFoiLCJwdXIiOiJibG9iX2tleSJ9fQ==--c25280a7345257bd91bfaf6d64ddb75c55eef799/Windeurope-Wind-energy-in-Europe-2021-statistics.pdf?content_type=application%2Fpdf&disposition=inline%3B+filename%3D%22Windeurope-Wind-energy-in-Europe-2021-statistics.pdf%22%3B+filename%2A%3DUTF-8%27%27Windeurope-Wind-energy-in-Europe-2021-statistics.pdf
+  ? UNECE 2022, WindEurope "Wind energy in Europe, 2021 Statistics and the outlook
+    for 2022-2026" Wind Europe Proceedings (2021)
+  : link:
+      https://unece.org/sites/default/files/2022-04/LCA_3_FINAL%20March%202022.pdf#page=37,
+      https://proceedings.windeurope.org/biplatform/rails/active_storage/disk/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdDRG9JYTJWNVNTSWhORFJ0ZDJJMWVUbG9OMll6TVRaaGEza3lkamgxZG1aM056WnZZZ1k2QmtWVU9oQmthWE53YjNOcGRHbHZia2tpQVk1cGJteHBibVU3SUdacGJHVnVZVzFsUFNKWGFXNWtaWFZ5YjNCbExWZHBibVF0Wlc1bGNtZDVMV2x1TFVWMWNtOXdaUzB5TURJeExYTjBZWFJwYzNScFkzTXVjR1JtSWpzZ1ptbHNaVzVoYldVcVBWVlVSaTA0SnlkWGFXNWtaWFZ5YjNCbExWZHBibVF0Wlc1bGNtZDVMV2x1TFVWMWNtOXdaUzB5TURJeExYTjBZWFJwYzNScFkzTXVjR1JtQmpzR1ZEb1JZMjl1ZEdWdWRGOTBlWEJsU1NJVVlYQndiR2xqWVhScGIyNHZjR1JtQmpzR1ZBPT0iLCJleHAiOiIyMDIyLTExLTAyVDE1OjU0OjAzLjEyNFoiLCJwdXIiOiJibG9iX2tleSJ9fQ==--c25280a7345257bd91bfaf6d64ddb75c55eef799/Windeurope-Wind-energy-in-Europe-2021-statistics.pdf?content_type=application%2Fpdf&disposition=inline%3B+filename%3D%22Windeurope-Wind-energy-in-Europe-2021-statistics.pdf%22%3B+filename%2A%3DUTF-8%27%27Windeurope-Wind-energy-in-Europe-2021-statistics.pdf
 timezone: Atlantic/Canary
 zone_name: Isla de la Gomera

--- a/config/zones/ES-CN-IG.yaml
+++ b/config/zones/ES-CN-IG.yaml
@@ -285,11 +285,15 @@ isLowCarbon:
       value: 1.0
     - datetime: '2021-01-01'
       value: 1.0
+    - datetime: '2022-01-01'
+      value: 1.0
 isRenewable:
   hydro discharge:
     - datetime: '2020-01-01'
       value: 1.0
     - datetime: '2021-01-01'
+      value: 1.0
+    - datetime: '2022-01-01'
       value: 1.0
 parsers:
   consumption: ES.fetch_consumption

--- a/config/zones/ES-CN-IG.yaml
+++ b/config/zones/ES-CN-IG.yaml
@@ -287,6 +287,12 @@ isLowCarbon:
       value: 1.0
     - datetime: '2022-01-01'
       value: 1.0
+    - datetime: '2023-01-01'
+      value: 1.0
+    - datetime: '2024-01-01'
+      value: 1.0
+    - datetime: '2025-01-01'
+      value: 1.0
 isRenewable:
   hydro discharge:
     - datetime: '2020-01-01'
@@ -294,6 +300,12 @@ isRenewable:
     - datetime: '2021-01-01'
       value: 1.0
     - datetime: '2022-01-01'
+      value: 1.0
+    - datetime: '2023-01-01'
+      value: 1.0
+    - datetime: '2024-01-01'
+      value: 1.0
+    - datetime: '2025-01-01'
       value: 1.0
 parsers:
   consumption: ES.fetch_consumption

--- a/config/zones/ES-CN-IG.yaml
+++ b/config/zones/ES-CN-IG.yaml
@@ -283,9 +283,13 @@ isLowCarbon:
   hydro discharge:
     - datetime: '2020-01-01'
       value: 1.0
+    - datetime: '2021-01-01'
+      value: 1.0
 isRenewable:
   hydro discharge:
     - datetime: '2020-01-01'
+      value: 1.0
+    - datetime: '2021-01-01'
       value: 1.0
 parsers:
   consumption: ES.fetch_consumption

--- a/config/zones/ES-CN-LP.yaml
+++ b/config/zones/ES-CN-LP.yaml
@@ -283,11 +283,15 @@ isLowCarbon:
       value: 1.0
     - datetime: '2021-01-01'
       value: 1.0
+    - datetime: '2022-01-01'
+      value: 1.0
 isRenewable:
   hydro discharge:
     - datetime: '2020-01-01'
       value: 1.0
     - datetime: '2021-01-01'
+      value: 1.0
+    - datetime: '2022-01-01'
       value: 1.0
 parsers:
   consumption: ES.fetch_consumption

--- a/config/zones/ES-CN-LP.yaml
+++ b/config/zones/ES-CN-LP.yaml
@@ -87,10 +87,12 @@ emissionFactors:
       value: 230.0
     coal:
       - datetime: '2021-01-01'
-        source: EU-ETS, ENTSO-E 2021; Oberschelp, Christopher, et al. "Global emission hotspots of coal power generation."
+        source: EU-ETS, ENTSO-E 2021; Oberschelp, Christopher, et al. "Global emission
+          hotspots of coal power generation."
         value: 1050.5643503
       - datetime: '2022-01-01'
-        source: EU-ETS, ENTSO-E 2022; Oberschelp, Christopher, et al. "Global emission hotspots of coal power generation."
+        source: EU-ETS, ENTSO-E 2022; Oberschelp, Christopher, et al. "Global emission
+          hotspots of coal power generation."
         value: 1235.586989
     gas:
       - datetime: '2021-01-01'
@@ -163,7 +165,8 @@ emissionFactors:
       value: 25.6
     wind:
       datetime: '2021-01-01'
-      source: UNECE 2022, WindEurope "Wind energy in Europe, 2021 Statistics and the outlook for 2022-2026" Wind Europe Proceedings (2021)
+      source: UNECE 2022, WindEurope "Wind energy in Europe, 2021 Statistics and the
+        outlook for 2022-2026" Wind Europe Proceedings (2021)
       value: 12.62
 fallbackZoneMixes:
   powerOriginRatios:
@@ -272,8 +275,16 @@ fallbackZoneMixes:
         solar: 0.018142231715055784
         unknown: 0.0
         wind: 0.0686308771428057
-has_day_ahead_price_license: True
-hide_day_ahead_price: False
+has_day_ahead_price_license: true
+hide_day_ahead_price: false
+isLowCarbon:
+  hydro discharge:
+    - datetime: '2020-01-01'
+      value: 1.0
+isRenewable:
+  hydro discharge:
+    - datetime: '2020-01-01'
+      value: 1.0
 parsers:
   consumption: ES.fetch_consumption
   production: ES.fetch_production
@@ -291,7 +302,10 @@ sources:
     link: https://www.ipcc.ch/site/assets/uploads/2018/02/ipcc_wg3_ar5_annex-iii.pdf#page=7
   UNECE 2022:
     link: https://unece.org/sites/default/files/2022-04/LCA_3_FINAL%20March%202022.pdf
-  UNECE 2022, WindEurope "Wind energy in Europe, 2021 Statistics and the outlook for 2022-2026" Wind Europe Proceedings (2021):
-    link: https://unece.org/sites/default/files/2022-04/LCA_3_FINAL%20March%202022.pdf#page=37, https://proceedings.windeurope.org/biplatform/rails/active_storage/disk/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdDRG9JYTJWNVNTSWhORFJ0ZDJJMWVUbG9OMll6TVRaaGEza3lkamgxZG1aM056WnZZZ1k2QmtWVU9oQmthWE53YjNOcGRHbHZia2tpQVk1cGJteHBibVU3SUdacGJHVnVZVzFsUFNKWGFXNWtaWFZ5YjNCbExWZHBibVF0Wlc1bGNtZDVMV2x1TFVWMWNtOXdaUzB5TURJeExYTjBZWFJwYzNScFkzTXVjR1JtSWpzZ1ptbHNaVzVoYldVcVBWVlVSaTA0SnlkWGFXNWtaWFZ5YjNCbExWZHBibVF0Wlc1bGNtZDVMV2x1TFVWMWNtOXdaUzB5TURJeExYTjBZWFJwYzNScFkzTXVjR1JtQmpzR1ZEb1JZMjl1ZEdWdWRGOTBlWEJsU1NJVVlYQndiR2xqWVhScGIyNHZjR1JtQmpzR1ZBPT0iLCJleHAiOiIyMDIyLTExLTAyVDE1OjU0OjAzLjEyNFoiLCJwdXIiOiJibG9iX2tleSJ9fQ==--c25280a7345257bd91bfaf6d64ddb75c55eef799/Windeurope-Wind-energy-in-Europe-2021-statistics.pdf?content_type=application%2Fpdf&disposition=inline%3B+filename%3D%22Windeurope-Wind-energy-in-Europe-2021-statistics.pdf%22%3B+filename%2A%3DUTF-8%27%27Windeurope-Wind-energy-in-Europe-2021-statistics.pdf
+  ? UNECE 2022, WindEurope "Wind energy in Europe, 2021 Statistics and the outlook
+    for 2022-2026" Wind Europe Proceedings (2021)
+  : link:
+      https://unece.org/sites/default/files/2022-04/LCA_3_FINAL%20March%202022.pdf#page=37,
+      https://proceedings.windeurope.org/biplatform/rails/active_storage/disk/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdDRG9JYTJWNVNTSWhORFJ0ZDJJMWVUbG9OMll6TVRaaGEza3lkamgxZG1aM056WnZZZ1k2QmtWVU9oQmthWE53YjNOcGRHbHZia2tpQVk1cGJteHBibVU3SUdacGJHVnVZVzFsUFNKWGFXNWtaWFZ5YjNCbExWZHBibVF0Wlc1bGNtZDVMV2x1TFVWMWNtOXdaUzB5TURJeExYTjBZWFJwYzNScFkzTXVjR1JtSWpzZ1ptbHNaVzVoYldVcVBWVlVSaTA0SnlkWGFXNWtaWFZ5YjNCbExWZHBibVF0Wlc1bGNtZDVMV2x1TFVWMWNtOXdaUzB5TURJeExYTjBZWFJwYzNScFkzTXVjR1JtQmpzR1ZEb1JZMjl1ZEdWdWRGOTBlWEJsU1NJVVlYQndiR2xqWVhScGIyNHZjR1JtQmpzR1ZBPT0iLCJleHAiOiIyMDIyLTExLTAyVDE1OjU0OjAzLjEyNFoiLCJwdXIiOiJibG9iX2tleSJ9fQ==--c25280a7345257bd91bfaf6d64ddb75c55eef799/Windeurope-Wind-energy-in-Europe-2021-statistics.pdf?content_type=application%2Fpdf&disposition=inline%3B+filename%3D%22Windeurope-Wind-energy-in-Europe-2021-statistics.pdf%22%3B+filename%2A%3DUTF-8%27%27Windeurope-Wind-energy-in-Europe-2021-statistics.pdf
 timezone: Atlantic/Canary
 zone_name: La Palma

--- a/config/zones/ES-CN-LP.yaml
+++ b/config/zones/ES-CN-LP.yaml
@@ -281,9 +281,13 @@ isLowCarbon:
   hydro discharge:
     - datetime: '2020-01-01'
       value: 1.0
+    - datetime: '2021-01-01'
+      value: 1.0
 isRenewable:
   hydro discharge:
     - datetime: '2020-01-01'
+      value: 1.0
+    - datetime: '2021-01-01'
       value: 1.0
 parsers:
   consumption: ES.fetch_consumption

--- a/config/zones/ES-CN-LP.yaml
+++ b/config/zones/ES-CN-LP.yaml
@@ -285,6 +285,12 @@ isLowCarbon:
       value: 1.0
     - datetime: '2022-01-01'
       value: 1.0
+    - datetime: '2023-01-01'
+      value: 1.0
+    - datetime: '2024-01-01'
+      value: 1.0
+    - datetime: '2025-01-01'
+      value: 1.0
 isRenewable:
   hydro discharge:
     - datetime: '2020-01-01'
@@ -292,6 +298,12 @@ isRenewable:
     - datetime: '2021-01-01'
       value: 1.0
     - datetime: '2022-01-01'
+      value: 1.0
+    - datetime: '2023-01-01'
+      value: 1.0
+    - datetime: '2024-01-01'
+      value: 1.0
+    - datetime: '2025-01-01'
       value: 1.0
 parsers:
   consumption: ES.fetch_consumption

--- a/config/zones/ES-CN-LZ.yaml
+++ b/config/zones/ES-CN-LZ.yaml
@@ -178,11 +178,15 @@ isLowCarbon:
       value: 1.0
     - datetime: '2021-01-01'
       value: 1.0
+    - datetime: '2022-01-01'
+      value: 1.0
 isRenewable:
   hydro discharge:
     - datetime: '2020-01-01'
       value: 1.0
     - datetime: '2021-01-01'
+      value: 1.0
+    - datetime: '2022-01-01'
       value: 1.0
 parsers:
   consumption: ES.fetch_consumption

--- a/config/zones/ES-CN-LZ.yaml
+++ b/config/zones/ES-CN-LZ.yaml
@@ -176,9 +176,13 @@ isLowCarbon:
   hydro discharge:
     - datetime: '2020-01-01'
       value: 1.0
+    - datetime: '2021-01-01'
+      value: 1.0
 isRenewable:
   hydro discharge:
     - datetime: '2020-01-01'
+      value: 1.0
+    - datetime: '2021-01-01'
       value: 1.0
 parsers:
   consumption: ES.fetch_consumption

--- a/config/zones/ES-CN-LZ.yaml
+++ b/config/zones/ES-CN-LZ.yaml
@@ -89,10 +89,12 @@ emissionFactors:
       value: 230
     coal:
       - datetime: '2021-01-01'
-        source: EU-ETS, ENTSO-E 2021; Oberschelp, Christopher, et al. "Global emission hotspots of coal power generation."
+        source: EU-ETS, ENTSO-E 2021; Oberschelp, Christopher, et al. "Global emission
+          hotspots of coal power generation."
         value: 1050.5643503
       - datetime: '2022-01-01'
-        source: EU-ETS, ENTSO-E 2022; Oberschelp, Christopher, et al. "Global emission hotspots of coal power generation."
+        source: EU-ETS, ENTSO-E 2022; Oberschelp, Christopher, et al. "Global emission
+          hotspots of coal power generation."
         value: 1235.586989
     gas:
       - datetime: '2021-01-01'
@@ -165,10 +167,19 @@ emissionFactors:
       value: 25.6
     wind:
       datetime: '2021-01-01'
-      source: UNECE 2022, WindEurope "Wind energy in Europe, 2021 Statistics and the outlook for 2022-2026" Wind Europe Proceedings (2021)
+      source: UNECE 2022, WindEurope "Wind energy in Europe, 2021 Statistics and the
+        outlook for 2022-2026" Wind Europe Proceedings (2021)
       value: 12.62
-has_day_ahead_price_license: True
-hide_day_ahead_price: False
+has_day_ahead_price_license: true
+hide_day_ahead_price: false
+isLowCarbon:
+  hydro discharge:
+    - datetime: '2020-01-01'
+      value: 1.0
+isRenewable:
+  hydro discharge:
+    - datetime: '2020-01-01'
+      value: 1.0
 parsers:
   consumption: ES.fetch_consumption
   production: ES.fetch_production
@@ -186,7 +197,10 @@ sources:
     link: https://www.ipcc.ch/site/assets/uploads/2018/02/ipcc_wg3_ar5_annex-iii.pdf#page=7
   UNECE 2022:
     link: https://unece.org/sites/default/files/2022-04/LCA_3_FINAL%20March%202022.pdf
-  UNECE 2022, WindEurope "Wind energy in Europe, 2021 Statistics and the outlook for 2022-2026" Wind Europe Proceedings (2021):
-    link: https://unece.org/sites/default/files/2022-04/LCA_3_FINAL%20March%202022.pdf#page=37, https://proceedings.windeurope.org/biplatform/rails/active_storage/disk/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdDRG9JYTJWNVNTSWhORFJ0ZDJJMWVUbG9OMll6TVRaaGEza3lkamgxZG1aM056WnZZZ1k2QmtWVU9oQmthWE53YjNOcGRHbHZia2tpQVk1cGJteHBibVU3SUdacGJHVnVZVzFsUFNKWGFXNWtaWFZ5YjNCbExWZHBibVF0Wlc1bGNtZDVMV2x1TFVWMWNtOXdaUzB5TURJeExYTjBZWFJwYzNScFkzTXVjR1JtSWpzZ1ptbHNaVzVoYldVcVBWVlVSaTA0SnlkWGFXNWtaWFZ5YjNCbExWZHBibVF0Wlc1bGNtZDVMV2x1TFVWMWNtOXdaUzB5TURJeExYTjBZWFJwYzNScFkzTXVjR1JtQmpzR1ZEb1JZMjl1ZEdWdWRGOTBlWEJsU1NJVVlYQndiR2xqWVhScGIyNHZjR1JtQmpzR1ZBPT0iLCJleHAiOiIyMDIyLTExLTAyVDE1OjU0OjAzLjEyNFoiLCJwdXIiOiJibG9iX2tleSJ9fQ==--c25280a7345257bd91bfaf6d64ddb75c55eef799/Windeurope-Wind-energy-in-Europe-2021-statistics.pdf?content_type=application%2Fpdf&disposition=inline%3B+filename%3D%22Windeurope-Wind-energy-in-Europe-2021-statistics.pdf%22%3B+filename%2A%3DUTF-8%27%27Windeurope-Wind-energy-in-Europe-2021-statistics.pdf
+  ? UNECE 2022, WindEurope "Wind energy in Europe, 2021 Statistics and the outlook
+    for 2022-2026" Wind Europe Proceedings (2021)
+  : link:
+      https://unece.org/sites/default/files/2022-04/LCA_3_FINAL%20March%202022.pdf#page=37,
+      https://proceedings.windeurope.org/biplatform/rails/active_storage/disk/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdDRG9JYTJWNVNTSWhORFJ0ZDJJMWVUbG9OMll6TVRaaGEza3lkamgxZG1aM056WnZZZ1k2QmtWVU9oQmthWE53YjNOcGRHbHZia2tpQVk1cGJteHBibVU3SUdacGJHVnVZVzFsUFNKWGFXNWtaWFZ5YjNCbExWZHBibVF0Wlc1bGNtZDVMV2x1TFVWMWNtOXdaUzB5TURJeExYTjBZWFJwYzNScFkzTXVjR1JtSWpzZ1ptbHNaVzVoYldVcVBWVlVSaTA0SnlkWGFXNWtaWFZ5YjNCbExWZHBibVF0Wlc1bGNtZDVMV2x1TFVWMWNtOXdaUzB5TURJeExYTjBZWFJwYzNScFkzTXVjR1JtQmpzR1ZEb1JZMjl1ZEdWdWRGOTBlWEJsU1NJVVlYQndiR2xqWVhScGIyNHZjR1JtQmpzR1ZBPT0iLCJleHAiOiIyMDIyLTExLTAyVDE1OjU0OjAzLjEyNFoiLCJwdXIiOiJibG9iX2tleSJ9fQ==--c25280a7345257bd91bfaf6d64ddb75c55eef799/Windeurope-Wind-energy-in-Europe-2021-statistics.pdf?content_type=application%2Fpdf&disposition=inline%3B+filename%3D%22Windeurope-Wind-energy-in-Europe-2021-statistics.pdf%22%3B+filename%2A%3DUTF-8%27%27Windeurope-Wind-energy-in-Europe-2021-statistics.pdf
 timezone: Atlantic/Canary
 zone_name: Lanzarote

--- a/config/zones/ES-CN-LZ.yaml
+++ b/config/zones/ES-CN-LZ.yaml
@@ -180,6 +180,12 @@ isLowCarbon:
       value: 1.0
     - datetime: '2022-01-01'
       value: 1.0
+    - datetime: '2023-01-01'
+      value: 1.0
+    - datetime: '2024-01-01'
+      value: 1.0
+    - datetime: '2025-01-01'
+      value: 1.0
 isRenewable:
   hydro discharge:
     - datetime: '2020-01-01'
@@ -187,6 +193,12 @@ isRenewable:
     - datetime: '2021-01-01'
       value: 1.0
     - datetime: '2022-01-01'
+      value: 1.0
+    - datetime: '2023-01-01'
+      value: 1.0
+    - datetime: '2024-01-01'
+      value: 1.0
+    - datetime: '2025-01-01'
       value: 1.0
 parsers:
   consumption: ES.fetch_consumption

--- a/config/zones/ES-CN-TE.yaml
+++ b/config/zones/ES-CN-TE.yaml
@@ -283,11 +283,15 @@ isLowCarbon:
       value: 1.0
     - datetime: '2021-01-01'
       value: 1.0
+    - datetime: '2022-01-01'
+      value: 1.0
 isRenewable:
   hydro discharge:
     - datetime: '2020-01-01'
       value: 1.0
     - datetime: '2021-01-01'
+      value: 1.0
+    - datetime: '2022-01-01'
       value: 1.0
 parsers:
   consumption: ES.fetch_consumption

--- a/config/zones/ES-CN-TE.yaml
+++ b/config/zones/ES-CN-TE.yaml
@@ -281,9 +281,13 @@ isLowCarbon:
   hydro discharge:
     - datetime: '2020-01-01'
       value: 1.0
+    - datetime: '2021-01-01'
+      value: 1.0
 isRenewable:
   hydro discharge:
     - datetime: '2020-01-01'
+      value: 1.0
+    - datetime: '2021-01-01'
       value: 1.0
 parsers:
   consumption: ES.fetch_consumption

--- a/config/zones/ES-CN-TE.yaml
+++ b/config/zones/ES-CN-TE.yaml
@@ -87,10 +87,12 @@ emissionFactors:
       value: 230.0
     coal:
       - datetime: '2021-01-01'
-        source: EU-ETS, ENTSO-E 2021; Oberschelp, Christopher, et al. "Global emission hotspots of coal power generation."
+        source: EU-ETS, ENTSO-E 2021; Oberschelp, Christopher, et al. "Global emission
+          hotspots of coal power generation."
         value: 1050.5643503
       - datetime: '2022-01-01'
-        source: EU-ETS, ENTSO-E 2022; Oberschelp, Christopher, et al. "Global emission hotspots of coal power generation."
+        source: EU-ETS, ENTSO-E 2022; Oberschelp, Christopher, et al. "Global emission
+          hotspots of coal power generation."
         value: 1235.586989
     gas:
       - datetime: '2021-01-01'
@@ -163,7 +165,8 @@ emissionFactors:
       value: 25.6
     wind:
       datetime: '2021-01-01'
-      source: UNECE 2022, WindEurope "Wind energy in Europe, 2021 Statistics and the outlook for 2022-2026" Wind Europe Proceedings (2021)
+      source: UNECE 2022, WindEurope "Wind energy in Europe, 2021 Statistics and the
+        outlook for 2022-2026" Wind Europe Proceedings (2021)
       value: 12.62
 fallbackZoneMixes:
   powerOriginRatios:
@@ -272,8 +275,16 @@ fallbackZoneMixes:
         solar: 0.04704794606775687
         unknown: 0.0
         wind: 0.1431409807238982
-has_day_ahead_price_license: True
-hide_day_ahead_price: False
+has_day_ahead_price_license: true
+hide_day_ahead_price: false
+isLowCarbon:
+  hydro discharge:
+    - datetime: '2020-01-01'
+      value: 1.0
+isRenewable:
+  hydro discharge:
+    - datetime: '2020-01-01'
+      value: 1.0
 parsers:
   consumption: ES.fetch_consumption
   production: ES.fetch_production
@@ -291,7 +302,10 @@ sources:
     link: https://www.ipcc.ch/site/assets/uploads/2018/02/ipcc_wg3_ar5_annex-iii.pdf#page=7
   UNECE 2022:
     link: https://unece.org/sites/default/files/2022-04/LCA_3_FINAL%20March%202022.pdf
-  UNECE 2022, WindEurope "Wind energy in Europe, 2021 Statistics and the outlook for 2022-2026" Wind Europe Proceedings (2021):
-    link: https://unece.org/sites/default/files/2022-04/LCA_3_FINAL%20March%202022.pdf#page=37, https://proceedings.windeurope.org/biplatform/rails/active_storage/disk/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdDRG9JYTJWNVNTSWhORFJ0ZDJJMWVUbG9OMll6TVRaaGEza3lkamgxZG1aM056WnZZZ1k2QmtWVU9oQmthWE53YjNOcGRHbHZia2tpQVk1cGJteHBibVU3SUdacGJHVnVZVzFsUFNKWGFXNWtaWFZ5YjNCbExWZHBibVF0Wlc1bGNtZDVMV2x1TFVWMWNtOXdaUzB5TURJeExYTjBZWFJwYzNScFkzTXVjR1JtSWpzZ1ptbHNaVzVoYldVcVBWVlVSaTA0SnlkWGFXNWtaWFZ5YjNCbExWZHBibVF0Wlc1bGNtZDVMV2x1TFVWMWNtOXdaUzB5TURJeExYTjBZWFJwYzNScFkzTXVjR1JtQmpzR1ZEb1JZMjl1ZEdWdWRGOTBlWEJsU1NJVVlYQndiR2xqWVhScGIyNHZjR1JtQmpzR1ZBPT0iLCJleHAiOiIyMDIyLTExLTAyVDE1OjU0OjAzLjEyNFoiLCJwdXIiOiJibG9iX2tleSJ9fQ==--c25280a7345257bd91bfaf6d64ddb75c55eef799/Windeurope-Wind-energy-in-Europe-2021-statistics.pdf?content_type=application%2Fpdf&disposition=inline%3B+filename%3D%22Windeurope-Wind-energy-in-Europe-2021-statistics.pdf%22%3B+filename%2A%3DUTF-8%27%27Windeurope-Wind-energy-in-Europe-2021-statistics.pdf
+  ? UNECE 2022, WindEurope "Wind energy in Europe, 2021 Statistics and the outlook
+    for 2022-2026" Wind Europe Proceedings (2021)
+  : link:
+      https://unece.org/sites/default/files/2022-04/LCA_3_FINAL%20March%202022.pdf#page=37,
+      https://proceedings.windeurope.org/biplatform/rails/active_storage/disk/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdDRG9JYTJWNVNTSWhORFJ0ZDJJMWVUbG9OMll6TVRaaGEza3lkamgxZG1aM056WnZZZ1k2QmtWVU9oQmthWE53YjNOcGRHbHZia2tpQVk1cGJteHBibVU3SUdacGJHVnVZVzFsUFNKWGFXNWtaWFZ5YjNCbExWZHBibVF0Wlc1bGNtZDVMV2x1TFVWMWNtOXdaUzB5TURJeExYTjBZWFJwYzNScFkzTXVjR1JtSWpzZ1ptbHNaVzVoYldVcVBWVlVSaTA0SnlkWGFXNWtaWFZ5YjNCbExWZHBibVF0Wlc1bGNtZDVMV2x1TFVWMWNtOXdaUzB5TURJeExYTjBZWFJwYzNScFkzTXVjR1JtQmpzR1ZEb1JZMjl1ZEdWdWRGOTBlWEJsU1NJVVlYQndiR2xqWVhScGIyNHZjR1JtQmpzR1ZBPT0iLCJleHAiOiIyMDIyLTExLTAyVDE1OjU0OjAzLjEyNFoiLCJwdXIiOiJibG9iX2tleSJ9fQ==--c25280a7345257bd91bfaf6d64ddb75c55eef799/Windeurope-Wind-energy-in-Europe-2021-statistics.pdf?content_type=application%2Fpdf&disposition=inline%3B+filename%3D%22Windeurope-Wind-energy-in-Europe-2021-statistics.pdf%22%3B+filename%2A%3DUTF-8%27%27Windeurope-Wind-energy-in-Europe-2021-statistics.pdf
 timezone: Atlantic/Canary
 zone_name: Tenerife

--- a/config/zones/ES-CN-TE.yaml
+++ b/config/zones/ES-CN-TE.yaml
@@ -285,6 +285,12 @@ isLowCarbon:
       value: 1.0
     - datetime: '2022-01-01'
       value: 1.0
+    - datetime: '2023-01-01'
+      value: 1.0
+    - datetime: '2024-01-01'
+      value: 1.0
+    - datetime: '2025-01-01'
+      value: 1.0
 isRenewable:
   hydro discharge:
     - datetime: '2020-01-01'
@@ -292,6 +298,12 @@ isRenewable:
     - datetime: '2021-01-01'
       value: 1.0
     - datetime: '2022-01-01'
+      value: 1.0
+    - datetime: '2023-01-01'
+      value: 1.0
+    - datetime: '2024-01-01'
+      value: 1.0
+    - datetime: '2025-01-01'
       value: 1.0
 parsers:
   consumption: ES.fetch_consumption

--- a/config/zones/ES-IB-MA.yaml
+++ b/config/zones/ES-IB-MA.yaml
@@ -18,7 +18,7 @@ emissionFactors:
       - _comment: used non-null storage values
         datetime: '2022-01-01'
         source: Electricity Maps, 2022 zone average
-        value: 378.29
+        value: 378.09
     biomass:
       datetime: '2021-01-01'
       source: BEIS 2021
@@ -54,7 +54,7 @@ emissionFactors:
       - _comment: used non-null storage values
         datetime: '2022-01-01'
         source: Electricity Maps, 2022 zone average; National Laboratory of the Rockies
-        value: 411.29
+        value: 411.09
     biomass:
       datetime: '2014-01-01'
       source: BEIS 2021; IPCC 2014
@@ -231,14 +231,14 @@ hide_day_ahead_price: false
 isLowCarbon:
   battery discharge:
     - datetime: '2022-01-01'
-      value: 0.1189
+      value: 0.119
   hydro discharge:
     - datetime: '2022-01-01'
       value: 1.0
 isRenewable:
   battery discharge:
     - datetime: '2022-01-01'
-      value: 0.1026
+      value: 0.1027
   hydro discharge:
     - datetime: '2022-01-01'
       value: 1.0

--- a/config/zones/ES-IB-MA.yaml
+++ b/config/zones/ES-IB-MA.yaml
@@ -61,10 +61,12 @@ emissionFactors:
       value: 230.0
     coal:
       - datetime: '2021-01-01'
-        source: EU-ETS, ENTSO-E 2021; Oberschelp, Christopher, et al. "Global emission hotspots of coal power generation."
+        source: EU-ETS, ENTSO-E 2021; Oberschelp, Christopher, et al. "Global emission
+          hotspots of coal power generation."
         value: 1050.5643503
       - datetime: '2022-01-01'
-        source: EU-ETS, ENTSO-E 2022; Oberschelp, Christopher, et al. "Global emission hotspots of coal power generation."
+        source: EU-ETS, ENTSO-E 2022; Oberschelp, Christopher, et al. "Global emission
+          hotspots of coal power generation."
         value: 1235.586989
     gas:
       - datetime: '2021-01-01'
@@ -99,7 +101,8 @@ emissionFactors:
       value: 25.6
     wind:
       datetime: '2021-01-01'
-      source: UNECE 2022, WindEurope "Wind energy in Europe, 2021 Statistics and the outlook for 2022-2026" Wind Europe Proceedings (2021)
+      source: UNECE 2022, WindEurope "Wind energy in Europe, 2021 Statistics and the
+        outlook for 2022-2026" Wind Europe Proceedings (2021)
       value: 12.62
 fallbackZoneMixes:
   powerOriginRatios:
@@ -223,15 +226,27 @@ fallbackZoneMixes:
         solar: 0.1366875017345735
         unknown: 0.010697864190356308
         wind: 0.06758167342075513
-has_day_ahead_price_license: True
-hide_day_ahead_price: False
+has_day_ahead_price_license: true
+hide_day_ahead_price: false
+isLowCarbon:
+  battery discharge:
+    - datetime: '2022-01-01'
+      value: 0.1189
+  hydro discharge:
+    - datetime: '2022-01-01'
+      value: 1.0
+isRenewable:
+  battery discharge:
+    - datetime: '2022-01-01'
+      value: 0.1026
+  hydro discharge:
+    - datetime: '2022-01-01'
+      value: 1.0
 parsers:
   consumption: ES.fetch_consumption
   production: ES.fetch_production
 region: Europe
 sources:
-  National Laboratory of the Rockies:
-    link: https://docs.nrel.gov/docs/fy21osti/80580.pdf
   EU-ETS, ENTSO-E 2021:
     link: https://drive.google.com/file/d/15UeUHyhcjVw8fGLc0Zx_HELSx20cw_-e/view?usp=share_link
   EU-ETS, ENTSO-E 2022:
@@ -240,9 +255,14 @@ sources:
     link: https://docs.google.com/spreadsheets/d/1w5DJ7sPen6axIHU8TCVcuzNCjlct4I6JAbhUlw-ZXu8/edit?usp=sharing
   IPCC 2014:
     link: https://www.ipcc.ch/site/assets/uploads/2018/02/ipcc_wg3_ar5_annex-iii.pdf#page=7
+  National Laboratory of the Rockies:
+    link: https://docs.nrel.gov/docs/fy21osti/80580.pdf
   UNECE 2022:
     link: https://unece.org/sites/default/files/2022-04/LCA_3_FINAL%20March%202022.pdf
-  UNECE 2022, WindEurope "Wind energy in Europe, 2021 Statistics and the outlook for 2022-2026" Wind Europe Proceedings (2021):
-    link: https://unece.org/sites/default/files/2022-04/LCA_3_FINAL%20March%202022.pdf#page=37, https://proceedings.windeurope.org/biplatform/rails/active_storage/disk/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdDRG9JYTJWNVNTSWhORFJ0ZDJJMWVUbG9OMll6TVRaaGEza3lkamgxZG1aM056WnZZZ1k2QmtWVU9oQmthWE53YjNOcGRHbHZia2tpQVk1cGJteHBibVU3SUdacGJHVnVZVzFsUFNKWGFXNWtaWFZ5YjNCbExWZHBibVF0Wlc1bGNtZDVMV2x1TFVWMWNtOXdaUzB5TURJeExYTjBZWFJwYzNScFkzTXVjR1JtSWpzZ1ptbHNaVzVoYldVcVBWVlVSaTA0SnlkWGFXNWtaWFZ5YjNCbExWZHBibVF0Wlc1bGNtZDVMV2x1TFVWMWNtOXdaUzB5TURJeExYTjBZWFJwYzNScFkzTXVjR1JtQmpzR1ZEb1JZMjl1ZEdWdWRGOTBlWEJsU1NJVVlYQndiR2xqWVhScGIyNHZjR1JtQmpzR1ZBPT0iLCJleHAiOiIyMDIyLTExLTAyVDE1OjU0OjAzLjEyNFoiLCJwdXIiOiJibG9iX2tleSJ9fQ==--c25280a7345257bd91bfaf6d64ddb75c55eef799/Windeurope-Wind-energy-in-Europe-2021-statistics.pdf?content_type=application%2Fpdf&disposition=inline%3B+filename%3D%22Windeurope-Wind-energy-in-Europe-2021-statistics.pdf%22%3B+filename%2A%3DUTF-8%27%27Windeurope-Wind-energy-in-Europe-2021-statistics.pdf
+  ? UNECE 2022, WindEurope "Wind energy in Europe, 2021 Statistics and the outlook
+    for 2022-2026" Wind Europe Proceedings (2021)
+  : link:
+      https://unece.org/sites/default/files/2022-04/LCA_3_FINAL%20March%202022.pdf#page=37,
+      https://proceedings.windeurope.org/biplatform/rails/active_storage/disk/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdDRG9JYTJWNVNTSWhORFJ0ZDJJMWVUbG9OMll6TVRaaGEza3lkamgxZG1aM056WnZZZ1k2QmtWVU9oQmthWE53YjNOcGRHbHZia2tpQVk1cGJteHBibVU3SUdacGJHVnVZVzFsUFNKWGFXNWtaWFZ5YjNCbExWZHBibVF0Wlc1bGNtZDVMV2x1TFVWMWNtOXdaUzB5TURJeExYTjBZWFJwYzNScFkzTXVjR1JtSWpzZ1ptbHNaVzVoYldVcVBWVlVSaTA0SnlkWGFXNWtaWFZ5YjNCbExWZHBibVF0Wlc1bGNtZDVMV2x1TFVWMWNtOXdaUzB5TURJeExYTjBZWFJwYzNScFkzTXVjR1JtQmpzR1ZEb1JZMjl1ZEdWdWRGOTBlWEJsU1NJVVlYQndiR2xqWVhScGIyNHZjR1JtQmpzR1ZBPT0iLCJleHAiOiIyMDIyLTExLTAyVDE1OjU0OjAzLjEyNFoiLCJwdXIiOiJibG9iX2tleSJ9fQ==--c25280a7345257bd91bfaf6d64ddb75c55eef799/Windeurope-Wind-energy-in-Europe-2021-statistics.pdf?content_type=application%2Fpdf&disposition=inline%3B+filename%3D%22Windeurope-Wind-energy-in-Europe-2021-statistics.pdf%22%3B+filename%2A%3DUTF-8%27%27Windeurope-Wind-energy-in-Europe-2021-statistics.pdf
 timezone: Europe/Madrid
 zone_name: Mallorca

--- a/config/zones/ES-ML.yaml
+++ b/config/zones/ES-ML.yaml
@@ -137,12 +137,16 @@ isLowCarbon:
       value: 0.0747
     - datetime: '2021-01-01'
       value: 0.0602
+    - datetime: '2022-01-01'
+      value: 0.0759
 isRenewable:
   battery discharge:
     - datetime: '2020-01-01'
       value: 0.0747
     - datetime: '2021-01-01'
       value: 0.0602
+    - datetime: '2022-01-01'
+      value: 0.0759
 parsers:
   consumption: ES.fetch_consumption
   production: ES.fetch_production

--- a/config/zones/ES-ML.yaml
+++ b/config/zones/ES-ML.yaml
@@ -129,17 +129,25 @@ fallbackZoneMixes:
         solar: 0.0
         unknown: 0.0
         wind: 0.0
-has_day_ahead_price_license: True
-hide_day_ahead_price: False
+has_day_ahead_price_license: true
+hide_day_ahead_price: false
+isLowCarbon:
+  battery discharge:
+    - datetime: '2020-01-01'
+      value: 0.0747
+isRenewable:
+  battery discharge:
+    - datetime: '2020-01-01'
+      value: 0.0747
 parsers:
   consumption: ES.fetch_consumption
   production: ES.fetch_production
   productionCapacity: REE.fetch_production_capacity
 region: Europe
-timezone: Europe/Madrid
-zone_name: Melilla
 sources:
   IPCC 2014:
     link: https://www.ipcc.ch/site/assets/uploads/2018/02/ipcc_wg3_ar5_annex-iii.pdf#page=7
   National Laboratory of the Rockies:
     link: https://docs.nrel.gov/docs/fy21osti/80580.pdf
+timezone: Europe/Madrid
+zone_name: Melilla

--- a/config/zones/ES-ML.yaml
+++ b/config/zones/ES-ML.yaml
@@ -135,10 +135,14 @@ isLowCarbon:
   battery discharge:
     - datetime: '2020-01-01'
       value: 0.0747
+    - datetime: '2021-01-01'
+      value: 0.0602
 isRenewable:
   battery discharge:
     - datetime: '2020-01-01'
       value: 0.0747
+    - datetime: '2021-01-01'
+      value: 0.0602
 parsers:
   consumption: ES.fetch_consumption
   production: ES.fetch_production

--- a/config/zones/ES-ML.yaml
+++ b/config/zones/ES-ML.yaml
@@ -35,15 +35,15 @@ emissionFactors:
       - _comment: used non-null storage values
         datetime: '2020-01-01'
         source: Electricity Maps, 2020 zone average
-        value: 375.65
+        value: 375.83
       - _comment: used non-null storage values
         datetime: '2021-01-01'
         source: Electricity Maps, 2021 zone average
-        value: 372.63
+        value: 375.83
       - _comment: used non-null storage values
         datetime: '2022-01-01'
         source: Electricity Maps, 2022 zone average
-        value: 375.17
+        value: 375.01
       - _comment: used non-null storage values
         datetime: '2023-01-01'
         source: Electricity Maps, 2023 zone average
@@ -55,21 +55,21 @@ emissionFactors:
       - _comment: used non-null storage values
         datetime: '2025-01-01'
         source: Electricity Maps, 2025 zone average
-        value: 374.15
+        value: 374.12
   lifecycle:
     battery discharge:
       - _comment: used non-null storage values
         datetime: '2020-01-01'
         source: Electricity Maps, 2020 zone average; National Laboratory of the Rockies
-        value: 408.65
+        value: 408.83
       - _comment: used non-null storage values
         datetime: '2021-01-01'
         source: Electricity Maps, 2021 zone average; National Laboratory of the Rockies
-        value: 405.63
+        value: 408.83
       - _comment: used non-null storage values
         datetime: '2022-01-01'
         source: Electricity Maps, 2022 zone average; National Laboratory of the Rockies
-        value: 408.17
+        value: 408.01
       - _comment: used non-null storage values
         datetime: '2023-01-01'
         source: Electricity Maps, 2023 zone average; National Laboratory of the Rockies
@@ -81,7 +81,7 @@ emissionFactors:
       - _comment: used non-null storage values
         datetime: '2025-01-01'
         source: Electricity Maps, 2025 zone average; National Laboratory of the Rockies
-        value: 407.15
+        value: 407.12
 fallbackZoneMixes:
   powerOriginRatios:
     - _source: Electricity Maps, 2022 average
@@ -134,31 +134,31 @@ hide_day_ahead_price: false
 isLowCarbon:
   battery discharge:
     - datetime: '2020-01-01'
-      value: 0.0747
+      value: 0.0743
     - datetime: '2021-01-01'
-      value: 0.0602
+      value: 0.0743
     - datetime: '2022-01-01'
-      value: 0.0759
+      value: 0.0763
     - datetime: '2023-01-01'
       value: 0.0709
     - datetime: '2024-01-01'
       value: 0.0735
     - datetime: '2025-01-01'
-      value: 0.0784
+      value: 0.0785
 isRenewable:
   battery discharge:
     - datetime: '2020-01-01'
-      value: 0.0747
+      value: 0.0743
     - datetime: '2021-01-01'
-      value: 0.0602
+      value: 0.0743
     - datetime: '2022-01-01'
-      value: 0.0759
+      value: 0.0763
     - datetime: '2023-01-01'
       value: 0.0709
     - datetime: '2024-01-01'
       value: 0.0735
     - datetime: '2025-01-01'
-      value: 0.0784
+      value: 0.0785
 parsers:
   consumption: ES.fetch_consumption
   production: ES.fetch_production

--- a/config/zones/ES-ML.yaml
+++ b/config/zones/ES-ML.yaml
@@ -139,6 +139,12 @@ isLowCarbon:
       value: 0.0602
     - datetime: '2022-01-01'
       value: 0.0759
+    - datetime: '2023-01-01'
+      value: 0.0709
+    - datetime: '2024-01-01'
+      value: 0.0735
+    - datetime: '2025-01-01'
+      value: 0.0784
 isRenewable:
   battery discharge:
     - datetime: '2020-01-01'
@@ -147,6 +153,12 @@ isRenewable:
       value: 0.0602
     - datetime: '2022-01-01'
       value: 0.0759
+    - datetime: '2023-01-01'
+      value: 0.0709
+    - datetime: '2024-01-01'
+      value: 0.0735
+    - datetime: '2025-01-01'
+      value: 0.0784
 parsers:
   consumption: ES.fetch_consumption
   production: ES.fetch_production

--- a/config/zones/ES.yaml
+++ b/config/zones/ES.yaml
@@ -236,10 +236,10 @@ delays:
 emissionFactors:
   direct:
     battery discharge:
-      - _comment: used non-null storage values
+      - _comment: used storage values greater than zero.
         datetime: '2025-01-01'
         source: Electricity Maps, 2025 zone average
-        value: 104.29
+        value: 94.75
     biomass:
       datetime: '2021-01-01'
       source: BEIS 2021
@@ -274,15 +274,15 @@ emissionFactors:
       - _comment: used storage values greater than zero.
         datetime: '2020-01-01'
         source: Electricity Maps, 2020 zone average
-        value: 130.34
+        value: 127.8
       - _comment: used storage values greater than zero.
         datetime: '2021-01-01'
         source: Electricity Maps, 2021 zone average
-        value: 118.86
+        value: 114.03
       - _comment: used storage values greater than zero.
         datetime: '2022-01-01'
         source: Electricity Maps, 2022 zone average
-        value: 164.11
+        value: 161.38
       - _comment: used storage values greater than zero.
         datetime: '2023-01-01'
         source: Electricity Maps, 2023 zone average
@@ -294,7 +294,7 @@ emissionFactors:
       - _comment: used storage values greater than zero.
         datetime: '2025-01-01'
         source: Electricity Maps, 2025 zone average
-        value: 66.47
+        value: 66.6
     oil:
       - datetime: '2021-01-01'
         source: EU-ETS, ENTSO-E 2021
@@ -310,10 +310,10 @@ emissionFactors:
         value: 857.84
   lifecycle:
     battery discharge:
-      - _comment: used non-null storage values
+      - _comment: used storage values greater than zero.
         datetime: '2025-01-01'
         source: Electricity Maps, 2025 zone average; National Laboratory of the Rockies
-        value: 137.29
+        value: 127.75
     biomass:
       datetime: '2014-01-01'
       source: BEIS 2021; IPCC 2014
@@ -354,15 +354,15 @@ emissionFactors:
       - _comment: used storage values greater than zero.
         datetime: '2020-01-01'
         source: Electricity Maps, 2020 zone average; UNECE 2022
-        value: 141.04
+        value: 138.5
       - _comment: used storage values greater than zero.
         datetime: '2021-01-01'
         source: Electricity Maps, 2021 zone average; UNECE 2022
-        value: 129.56
+        value: 124.73
       - _comment: used storage values greater than zero.
         datetime: '2022-01-01'
         source: Electricity Maps, 2022 zone average; UNECE 2022
-        value: 174.81
+        value: 172.08
       - _comment: used storage values greater than zero.
         datetime: '2023-01-01'
         source: Electricity Maps, 2023 zone average; UNECE 2022
@@ -374,7 +374,7 @@ emissionFactors:
       - _comment: used storage values greater than zero.
         datetime: '2025-01-01'
         source: Electricity Maps, 2025 zone average; UNECE 2022
-        value: 77.17
+        value: 77.3
     nuclear:
       datetime: '2020-01-01'
       source: UNECE 2022
@@ -558,37 +558,37 @@ hide_day_ahead_price: false
 isLowCarbon:
   battery discharge:
     - datetime: '2025-01-01'
-      value: 0.7534
+      value: 0.7723
   hydro discharge:
     - datetime: '2020-01-01'
-      value: 0.7189
+      value: 0.7211
     - datetime: '2021-01-01'
-      value: 0.7475
+      value: 0.7519
     - datetime: '2022-01-01'
-      value: 0.6783
+      value: 0.6802
     - datetime: '2023-01-01'
       value: 0.8129
     - datetime: '2024-01-01'
       value: 0.8709
     - datetime: '2025-01-01'
-      value: 0.8536
+      value: 0.8533
 isRenewable:
   battery discharge:
     - datetime: '2025-01-01'
-      value: 0.5297
+      value: 0.5509
   hydro discharge:
     - datetime: '2020-01-01'
-      value: 0.4654
+      value: 0.4667
     - datetime: '2021-01-01'
-      value: 0.5063
+      value: 0.5088
     - datetime: '2022-01-01'
-      value: 0.4599
+      value: 0.461
     - datetime: '2023-01-01'
       value: 0.5891
     - datetime: '2024-01-01'
-      value: 0.6583
+      value: 0.6584
     - datetime: '2025-01-01'
-      value: 0.6597
+      value: 0.6595
 parsers:
   consumption: ENTSOE.fetch_consumption
   consumptionForecast: ENTSOE.fetch_consumption_forecast

--- a/config/zones/ES.yaml
+++ b/config/zones/ES.yaml
@@ -559,10 +559,14 @@ isLowCarbon:
   hydro discharge:
     - datetime: '2020-01-01'
       value: 0.7189
+    - datetime: '2021-01-01'
+      value: 0.7475
 isRenewable:
   hydro discharge:
     - datetime: '2020-01-01'
       value: 0.4654
+    - datetime: '2021-01-01'
+      value: 0.5063
 parsers:
   consumption: ENTSOE.fetch_consumption
   consumptionForecast: ENTSOE.fetch_consumption_forecast

--- a/config/zones/ES.yaml
+++ b/config/zones/ES.yaml
@@ -239,7 +239,7 @@ emissionFactors:
       - _comment: used non-null storage values
         datetime: '2025-01-01'
         source: Electricity Maps, 2025 zone average
-        value: 105.43
+        value: 104.29
     biomass:
       datetime: '2021-01-01'
       source: BEIS 2021
@@ -286,15 +286,15 @@ emissionFactors:
       - _comment: used storage values greater than zero.
         datetime: '2023-01-01'
         source: Electricity Maps, 2023 zone average
-        value: 88.93
+        value: 89.35
       - _comment: used storage values greater than zero.
         datetime: '2024-01-01'
         source: Electricity Maps, 2024 zone average
-        value: 65.94
+        value: 66.98
       - _comment: used storage values greater than zero.
         datetime: '2025-01-01'
         source: Electricity Maps, 2025 zone average
-        value: 66.56
+        value: 66.47
     oil:
       - datetime: '2021-01-01'
         source: EU-ETS, ENTSO-E 2021
@@ -313,7 +313,7 @@ emissionFactors:
       - _comment: used non-null storage values
         datetime: '2025-01-01'
         source: Electricity Maps, 2025 zone average; National Laboratory of the Rockies
-        value: 138.43
+        value: 137.29
     biomass:
       datetime: '2014-01-01'
       source: BEIS 2021; IPCC 2014
@@ -366,15 +366,15 @@ emissionFactors:
       - _comment: used storage values greater than zero.
         datetime: '2023-01-01'
         source: Electricity Maps, 2023 zone average; UNECE 2022
-        value: 99.63
+        value: 100.05
       - _comment: used storage values greater than zero.
         datetime: '2024-01-01'
         source: Electricity Maps, 2024 zone average; UNECE 2022
-        value: 76.64
+        value: 77.68
       - _comment: used storage values greater than zero.
         datetime: '2025-01-01'
         source: Electricity Maps, 2025 zone average; UNECE 2022
-        value: 77.26
+        value: 77.17
     nuclear:
       datetime: '2020-01-01'
       source: UNECE 2022
@@ -556,6 +556,9 @@ fallbackZoneMixes:
 has_day_ahead_price_license: true
 hide_day_ahead_price: false
 isLowCarbon:
+  battery discharge:
+    - datetime: '2025-01-01'
+      value: 0.7534
   hydro discharge:
     - datetime: '2020-01-01'
       value: 0.7189
@@ -563,7 +566,16 @@ isLowCarbon:
       value: 0.7475
     - datetime: '2022-01-01'
       value: 0.6783
+    - datetime: '2023-01-01'
+      value: 0.8129
+    - datetime: '2024-01-01'
+      value: 0.8709
+    - datetime: '2025-01-01'
+      value: 0.8536
 isRenewable:
+  battery discharge:
+    - datetime: '2025-01-01'
+      value: 0.5297
   hydro discharge:
     - datetime: '2020-01-01'
       value: 0.4654
@@ -571,6 +583,12 @@ isRenewable:
       value: 0.5063
     - datetime: '2022-01-01'
       value: 0.4599
+    - datetime: '2023-01-01'
+      value: 0.5891
+    - datetime: '2024-01-01'
+      value: 0.6583
+    - datetime: '2025-01-01'
+      value: 0.6597
 parsers:
   consumption: ENTSOE.fetch_consumption
   consumptionForecast: ENTSOE.fetch_consumption_forecast

--- a/config/zones/ES.yaml
+++ b/config/zones/ES.yaml
@@ -274,7 +274,7 @@ emissionFactors:
       - _comment: used storage values greater than zero.
         datetime: '2020-01-01'
         source: Electricity Maps, 2020 zone average
-        value: 130.36
+        value: 130.34
       - _comment: used storage values greater than zero.
         datetime: '2021-01-01'
         source: Electricity Maps, 2021 zone average
@@ -354,7 +354,7 @@ emissionFactors:
       - _comment: used storage values greater than zero.
         datetime: '2020-01-01'
         source: Electricity Maps, 2020 zone average; UNECE 2022
-        value: 141.06
+        value: 141.04
       - _comment: used storage values greater than zero.
         datetime: '2021-01-01'
         source: Electricity Maps, 2021 zone average; UNECE 2022
@@ -555,6 +555,14 @@ fallbackZoneMixes:
         wind: 0.231907080406899
 has_day_ahead_price_license: true
 hide_day_ahead_price: false
+isLowCarbon:
+  hydro discharge:
+    - datetime: '2020-01-01'
+      value: 0.7189
+isRenewable:
+  hydro discharge:
+    - datetime: '2020-01-01'
+      value: 0.4654
 parsers:
   consumption: ENTSOE.fetch_consumption
   consumptionForecast: ENTSOE.fetch_consumption_forecast
@@ -565,8 +573,6 @@ parsers:
   productionPerModeForecast: ENTSOE.fetch_wind_solar_forecasts
 region: Europe
 sources:
-  National Laboratory of the Rockies:
-    link: https://docs.nrel.gov/docs/fy21osti/80580.pdf
   EU-ETS, ENTSO-E 2021:
     link: https://drive.google.com/file/d/15UeUHyhcjVw8fGLc0Zx_HELSx20cw_-e/view?usp=share_link
   EU-ETS, ENTSO-E 2022:
@@ -579,6 +585,8 @@ sources:
     link: https://docs.google.com/spreadsheets/d/1w5DJ7sPen6axIHU8TCVcuzNCjlct4I6JAbhUlw-ZXu8/edit?usp=sharing
   IPCC 2014:
     link: https://www.ipcc.ch/site/assets/uploads/2018/02/ipcc_wg3_ar5_annex-iii.pdf#page=7
+  National Laboratory of the Rockies:
+    link: https://docs.nrel.gov/docs/fy21osti/80580.pdf
   UNECE 2022:
     link: https://unece.org/sites/default/files/2022-04/LCA_3_FINAL%20March%202022.pdf
   ? UNECE 2022, WindEurope "Wind energy in Europe, 2021 Statistics and the outlook

--- a/config/zones/ES.yaml
+++ b/config/zones/ES.yaml
@@ -561,12 +561,16 @@ isLowCarbon:
       value: 0.7189
     - datetime: '2021-01-01'
       value: 0.7475
+    - datetime: '2022-01-01'
+      value: 0.6783
 isRenewable:
   hydro discharge:
     - datetime: '2020-01-01'
       value: 0.4654
     - datetime: '2021-01-01'
       value: 0.5063
+    - datetime: '2022-01-01'
+      value: 0.4599
 parsers:
   consumption: ENTSOE.fetch_consumption
   consumptionForecast: ENTSOE.fetch_consumption_forecast

--- a/config/zones/FR-COR.yaml
+++ b/config/zones/FR-COR.yaml
@@ -25,15 +25,15 @@ emissionFactors:
       - _comment: used storage values greater than zero.
         datetime: '2023-01-01'
         source: Electricity Maps, 2023 zone average
-        value: 363.43
+        value: 363.08
       - _comment: used storage values greater than zero.
         datetime: '2024-01-01'
         source: Electricity Maps, 2024 zone average
-        value: 430.23
+        value: 440.34
       - _comment: used storage values greater than zero.
         datetime: '2025-01-01'
         source: Electricity Maps, 2025 zone average
-        value: 479.73
+        value: 483.7
     biomass:
       datetime: '2021-01-01'
       source: BEIS 2021
@@ -82,15 +82,15 @@ emissionFactors:
       - _comment: used storage values greater than zero.
         datetime: '2023-01-01'
         source: Electricity Maps, 2023 zone average; National Laboratory of the Rockies
-        value: 396.43
+        value: 396.08
       - _comment: used storage values greater than zero.
         datetime: '2024-01-01'
         source: Electricity Maps, 2024 zone average; National Laboratory of the Rockies
-        value: 463.23
+        value: 473.34
       - _comment: used storage values greater than zero.
         datetime: '2025-01-01'
         source: Electricity Maps, 2025 zone average; National Laboratory of the Rockies
-        value: 512.73
+        value: 516.7
     biomass:
       datetime: '2014-01-01'
       source: BEIS 2021; IPCC 2014
@@ -295,19 +295,19 @@ hide_day_ahead_price: false
 isLowCarbon:
   battery discharge:
     - datetime: '2023-01-01'
-      value: 0.4826
+      value: 0.4884
     - datetime: '2024-01-01'
-      value: 0.4229
+      value: 0.4103
     - datetime: '2025-01-01'
-      value: 0.3939
+      value: 0.3944
 isRenewable:
   battery discharge:
     - datetime: '2023-01-01'
-      value: 0.4744
+      value: 0.4803
     - datetime: '2024-01-01'
-      value: 0.4199
+      value: 0.4072
     - datetime: '2025-01-01'
-      value: 0.3937
+      value: 0.3942
 parsers:
   price: FR_O.fetch_price
   production: FR_O.fetch_production

--- a/config/zones/FR-COR.yaml
+++ b/config/zones/FR-COR.yaml
@@ -25,15 +25,15 @@ emissionFactors:
       - _comment: used storage values greater than zero.
         datetime: '2023-01-01'
         source: Electricity Maps, 2023 zone average
-        value: 323.13
+        value: 363.43
       - _comment: used storage values greater than zero.
         datetime: '2024-01-01'
         source: Electricity Maps, 2024 zone average
-        value: 447.32
+        value: 430.23
       - _comment: used storage values greater than zero.
         datetime: '2025-01-01'
         source: Electricity Maps, 2025 zone average
-        value: 498.49
+        value: 479.73
     biomass:
       datetime: '2021-01-01'
       source: BEIS 2021
@@ -82,15 +82,15 @@ emissionFactors:
       - _comment: used storage values greater than zero.
         datetime: '2023-01-01'
         source: Electricity Maps, 2023 zone average; National Laboratory of the Rockies
-        value: 356.13
+        value: 396.43
       - _comment: used storage values greater than zero.
         datetime: '2024-01-01'
         source: Electricity Maps, 2024 zone average; National Laboratory of the Rockies
-        value: 480.32
+        value: 463.23
       - _comment: used storage values greater than zero.
         datetime: '2025-01-01'
         source: Electricity Maps, 2025 zone average; National Laboratory of the Rockies
-        value: 531.49
+        value: 512.73
     biomass:
       datetime: '2014-01-01'
       source: BEIS 2021; IPCC 2014
@@ -292,13 +292,27 @@ fallbackZoneMixes:
         wind: 0.07513672956538177
 has_day_ahead_price_license: false
 hide_day_ahead_price: false
+isLowCarbon:
+  battery discharge:
+    - datetime: '2023-01-01'
+      value: 0.4826
+    - datetime: '2024-01-01'
+      value: 0.4229
+    - datetime: '2025-01-01'
+      value: 0.3939
+isRenewable:
+  battery discharge:
+    - datetime: '2023-01-01'
+      value: 0.4744
+    - datetime: '2024-01-01'
+      value: 0.4199
+    - datetime: '2025-01-01'
+      value: 0.3937
 parsers:
   price: FR_O.fetch_price
   production: FR_O.fetch_production
 region: Europe
 sources:
-  National Laboratory of the Rockies:
-    link: https://docs.nrel.gov/docs/fy21osti/80580.pdf
   EU-ETS, ENTSO-E 2021:
     link: https://drive.google.com/file/d/15UeUHyhcjVw8fGLc0Zx_HELSx20cw_-e/view?usp=share_link
   EU-ETS, ENTSO-E 2022:
@@ -311,6 +325,8 @@ sources:
     link: https://docs.google.com/spreadsheets/d/1w5DJ7sPen6axIHU8TCVcuzNCjlct4I6JAbhUlw-ZXu8/edit?usp=sharing
   IPCC 2014:
     link: https://www.ipcc.ch/site/assets/uploads/2018/02/ipcc_wg3_ar5_annex-iii.pdf#page=7
+  National Laboratory of the Rockies:
+    link: https://docs.nrel.gov/docs/fy21osti/80580.pdf
   UNECE 2022:
     link: https://unece.org/sites/default/files/2022-04/LCA_3_FINAL%20March%202022.pdf
   ? UNECE 2022, WindEurope "Wind energy in Europe, 2021 Statistics and the outlook

--- a/config/zones/FR.yaml
+++ b/config/zones/FR.yaml
@@ -281,15 +281,15 @@ emissionFactors:
       - _comment: used storage values greater than zero.
         datetime: '2023-01-01'
         source: Electricity Maps, 2023 zone average
-        value: 23.36
+        value: 20.44
       - _comment: used storage values greater than zero.
         datetime: '2024-01-01'
         source: Electricity Maps, 2024 zone average
-        value: 19.99
+        value: 17.88
       - _comment: used storage values greater than zero.
         datetime: '2025-01-01'
         source: Electricity Maps, 2025 zone average
-        value: 17.04
+        value: 15.2
     biomass:
       datetime: '2021-01-01'
       source: BEIS 2021
@@ -336,15 +336,15 @@ emissionFactors:
       - _comment: used storage values greater than zero.
         datetime: '2023-01-01'
         source: Electricity Maps, 2023 zone average
-        value: 27.73
+        value: 24.61
       - _comment: used storage values greater than zero.
         datetime: '2024-01-01'
         source: Electricity Maps, 2024 zone average
-        value: 14.02
+        value: 12.59
       - _comment: used storage values greater than zero.
         datetime: '2025-01-01'
         source: Electricity Maps, 2025 zone average
-        value: 11.6
+        value: 10.36
     oil:
       - datetime: '2021-01-01'
         source: EU-ETS, ENTSO-E 2021
@@ -363,15 +363,15 @@ emissionFactors:
       - _comment: used storage values greater than zero.
         datetime: '2023-01-01'
         source: Electricity Maps, 2023 zone average; National Laboratory of the Rockies
-        value: 56.36
+        value: 53.44
       - _comment: used storage values greater than zero.
         datetime: '2024-01-01'
         source: Electricity Maps, 2024 zone average; National Laboratory of the Rockies
-        value: 52.99
+        value: 50.88
       - _comment: used storage values greater than zero.
         datetime: '2025-01-01'
         source: Electricity Maps, 2025 zone average; National Laboratory of the Rockies
-        value: 50.04
+        value: 48.2
     biomass:
       datetime: '2014-01-01'
       source: BEIS 2021; IPCC 2014
@@ -424,15 +424,15 @@ emissionFactors:
       - _comment: used storage values greater than zero.
         datetime: '2023-01-01'
         source: Electricity Maps, 2023 zone average; UNECE 2022
-        value: 38.43
+        value: 35.31
       - _comment: used storage values greater than zero.
         datetime: '2024-01-01'
         source: Electricity Maps, 2024 zone average; UNECE 2022
-        value: 24.72
+        value: 23.29
       - _comment: used storage values greater than zero.
         datetime: '2025-01-01'
         source: Electricity Maps, 2025 zone average; UNECE 2022
-        value: 22.3
+        value: 21.06
     nuclear:
       datetime: '2020-01-01'
       source: UNECE 2022
@@ -614,6 +614,13 @@ fallbackZoneMixes:
 has_day_ahead_price_license: true
 hide_day_ahead_price: false
 isLowCarbon:
+  battery discharge:
+    - datetime: '2023-01-01'
+      value: 0.9444
+    - datetime: '2024-01-01'
+      value: 0.9567
+    - datetime: '2025-01-01'
+      value: 0.9625
   hydro discharge:
     - datetime: '2020-01-01'
       value: 0.9304
@@ -621,7 +628,20 @@ isLowCarbon:
       value: 0.9281
     - datetime: '2022-01-01'
       value: 0.8724
+    - datetime: '2023-01-01'
+      value: 0.9376
+    - datetime: '2024-01-01'
+      value: 0.9702
+    - datetime: '2025-01-01'
+      value: 0.9748
 isRenewable:
+  battery discharge:
+    - datetime: '2023-01-01'
+      value: 0.2717
+    - datetime: '2024-01-01'
+      value: 0.2734
+    - datetime: '2025-01-01'
+      value: 0.2665
   hydro discharge:
     - datetime: '2020-01-01'
       value: 0.2493
@@ -629,6 +649,12 @@ isRenewable:
       value: 0.23
     - datetime: '2022-01-01'
       value: 0.2592
+    - datetime: '2023-01-01'
+      value: 0.2894
+    - datetime: '2024-01-01'
+      value: 0.3014
+    - datetime: '2025-01-01'
+      value: 0.3025
 parsers:
   consumption: FR.fetch_consumption
   consumptionForecast: ENTSOE.fetch_consumption_forecast

--- a/config/zones/FR.yaml
+++ b/config/zones/FR.yaml
@@ -619,12 +619,16 @@ isLowCarbon:
       value: 0.9304
     - datetime: '2021-01-01'
       value: 0.9281
+    - datetime: '2022-01-01'
+      value: 0.8724
 isRenewable:
   hydro discharge:
     - datetime: '2020-01-01'
       value: 0.2493
     - datetime: '2021-01-01'
       value: 0.23
+    - datetime: '2022-01-01'
+      value: 0.2592
 parsers:
   consumption: FR.fetch_consumption
   consumptionForecast: ENTSOE.fetch_consumption_forecast

--- a/config/zones/FR.yaml
+++ b/config/zones/FR.yaml
@@ -613,6 +613,14 @@ fallbackZoneMixes:
         wind: 0.09075636778437683
 has_day_ahead_price_license: true
 hide_day_ahead_price: false
+isLowCarbon:
+  hydro discharge:
+    - datetime: '2020-01-01'
+      value: 0.9304
+isRenewable:
+  hydro discharge:
+    - datetime: '2020-01-01'
+      value: 0.2493
 parsers:
   consumption: FR.fetch_consumption
   consumptionForecast: ENTSOE.fetch_consumption_forecast
@@ -623,8 +631,6 @@ parsers:
   productionPerModeForecast: ENTSOE.fetch_wind_solar_forecasts
 region: Europe
 sources:
-  National Laboratory of the Rockies:
-    link: https://docs.nrel.gov/docs/fy21osti/80580.pdf
   EU-ETS, ENTSO-E 2021:
     link: https://drive.google.com/file/d/15UeUHyhcjVw8fGLc0Zx_HELSx20cw_-e/view?usp=share_link
   EU-ETS, ENTSO-E 2022:
@@ -637,6 +643,8 @@ sources:
     link: https://docs.google.com/spreadsheets/d/1w5DJ7sPen6axIHU8TCVcuzNCjlct4I6JAbhUlw-ZXu8/edit?usp=sharing
   IPCC 2014:
     link: https://www.ipcc.ch/site/assets/uploads/2018/02/ipcc_wg3_ar5_annex-iii.pdf#page=7
+  National Laboratory of the Rockies:
+    link: https://docs.nrel.gov/docs/fy21osti/80580.pdf
   UNECE 2022:
     link: https://unece.org/sites/default/files/2022-04/LCA_3_FINAL%20March%202022.pdf
   ? UNECE 2022, WindEurope "Wind energy in Europe, 2021 Statistics and the outlook

--- a/config/zones/FR.yaml
+++ b/config/zones/FR.yaml
@@ -281,7 +281,7 @@ emissionFactors:
       - _comment: used storage values greater than zero.
         datetime: '2023-01-01'
         source: Electricity Maps, 2023 zone average
-        value: 20.44
+        value: 20.35
       - _comment: used storage values greater than zero.
         datetime: '2024-01-01'
         source: Electricity Maps, 2024 zone average
@@ -289,7 +289,7 @@ emissionFactors:
       - _comment: used storage values greater than zero.
         datetime: '2025-01-01'
         source: Electricity Maps, 2025 zone average
-        value: 15.2
+        value: 15.13
     biomass:
       datetime: '2021-01-01'
       source: BEIS 2021
@@ -324,19 +324,19 @@ emissionFactors:
       - _comment: used storage values greater than zero.
         datetime: '2020-01-01'
         source: Electricity Maps, 2020 zone average
-        value: 28.88
+        value: 28.86
       - _comment: used storage values greater than zero.
         datetime: '2021-01-01'
         source: Electricity Maps, 2021 zone average
-        value: 32.61
+        value: 32.58
       - _comment: used storage values greater than zero.
         datetime: '2022-01-01'
         source: Electricity Maps, 2022 zone average
-        value: 56.72
+        value: 56.67
       - _comment: used storage values greater than zero.
         datetime: '2023-01-01'
         source: Electricity Maps, 2023 zone average
-        value: 24.61
+        value: 24.57
       - _comment: used storage values greater than zero.
         datetime: '2024-01-01'
         source: Electricity Maps, 2024 zone average
@@ -363,7 +363,7 @@ emissionFactors:
       - _comment: used storage values greater than zero.
         datetime: '2023-01-01'
         source: Electricity Maps, 2023 zone average; National Laboratory of the Rockies
-        value: 53.44
+        value: 53.35
       - _comment: used storage values greater than zero.
         datetime: '2024-01-01'
         source: Electricity Maps, 2024 zone average; National Laboratory of the Rockies
@@ -371,7 +371,7 @@ emissionFactors:
       - _comment: used storage values greater than zero.
         datetime: '2025-01-01'
         source: Electricity Maps, 2025 zone average; National Laboratory of the Rockies
-        value: 48.2
+        value: 48.13
     biomass:
       datetime: '2014-01-01'
       source: BEIS 2021; IPCC 2014
@@ -412,19 +412,19 @@ emissionFactors:
       - _comment: used storage values greater than zero.
         datetime: '2020-01-01'
         source: Electricity Maps, 2020 zone average; UNECE 2022
-        value: 39.58
+        value: 39.56
       - _comment: used storage values greater than zero.
         datetime: '2021-01-01'
         source: Electricity Maps, 2021 zone average; UNECE 2022
-        value: 43.31
+        value: 43.28
       - _comment: used storage values greater than zero.
         datetime: '2022-01-01'
         source: Electricity Maps, 2022 zone average; UNECE 2022
-        value: 67.42
+        value: 67.37
       - _comment: used storage values greater than zero.
         datetime: '2023-01-01'
         source: Electricity Maps, 2023 zone average; UNECE 2022
-        value: 35.31
+        value: 35.27
       - _comment: used storage values greater than zero.
         datetime: '2024-01-01'
         source: Electricity Maps, 2024 zone average; UNECE 2022
@@ -616,20 +616,20 @@ hide_day_ahead_price: false
 isLowCarbon:
   battery discharge:
     - datetime: '2023-01-01'
-      value: 0.9444
+      value: 0.9447
     - datetime: '2024-01-01'
       value: 0.9567
     - datetime: '2025-01-01'
-      value: 0.9625
+      value: 0.9626
   hydro discharge:
     - datetime: '2020-01-01'
       value: 0.9304
     - datetime: '2021-01-01'
       value: 0.9281
     - datetime: '2022-01-01'
-      value: 0.8724
+      value: 0.8723
     - datetime: '2023-01-01'
-      value: 0.9376
+      value: 0.9377
     - datetime: '2024-01-01'
       value: 0.9702
     - datetime: '2025-01-01'
@@ -637,18 +637,18 @@ isLowCarbon:
 isRenewable:
   battery discharge:
     - datetime: '2023-01-01'
-      value: 0.2717
+      value: 0.2726
     - datetime: '2024-01-01'
       value: 0.2734
     - datetime: '2025-01-01'
-      value: 0.2665
+      value: 0.2663
   hydro discharge:
     - datetime: '2020-01-01'
       value: 0.2493
     - datetime: '2021-01-01'
-      value: 0.23
+      value: 0.2301
     - datetime: '2022-01-01'
-      value: 0.2592
+      value: 0.2605
     - datetime: '2023-01-01'
       value: 0.2894
     - datetime: '2024-01-01'

--- a/config/zones/FR.yaml
+++ b/config/zones/FR.yaml
@@ -617,10 +617,14 @@ isLowCarbon:
   hydro discharge:
     - datetime: '2020-01-01'
       value: 0.9304
+    - datetime: '2021-01-01'
+      value: 0.9281
 isRenewable:
   hydro discharge:
     - datetime: '2020-01-01'
       value: 0.2493
+    - datetime: '2021-01-01'
+      value: 0.23
 parsers:
   consumption: FR.fetch_consumption
   consumptionForecast: ENTSOE.fetch_consumption_forecast

--- a/config/zones/GB.yaml
+++ b/config/zones/GB.yaml
@@ -421,10 +421,14 @@ isLowCarbon:
   hydro discharge:
     - datetime: '2020-01-01'
       value: 0.6139
+    - datetime: '2021-01-01'
+      value: 0.5777
 isRenewable:
   hydro discharge:
     - datetime: '2020-01-01'
       value: 0.4101
+    - datetime: '2021-01-01'
+      value: 0.3753
 parsers:
   consumption: ELEXON.fetch_consumption
   consumptionForecast: ENTSOE.fetch_consumption_forecast

--- a/config/zones/GB.yaml
+++ b/config/zones/GB.yaml
@@ -260,7 +260,8 @@ emissionFactors:
       value: 39.72
     wind:
       datetime: '2021-01-01'
-      source: UNECE 2022, WindEurope "Wind energy in Europe, 2021 Statistics and the outlook for 2022-2026" Wind Europe Proceedings (2021)
+      source: UNECE 2022, WindEurope "Wind energy in Europe, 2021 Statistics and the
+        outlook for 2022-2026" Wind Europe Proceedings (2021)
       value: 12.62
 fallbackZoneMixes:
   powerOriginRatios:
@@ -414,8 +415,16 @@ fallbackZoneMixes:
         solar: 0.10642708161006456
         unknown: 0.01229548242156918
         wind: 0.324336935214777
-has_day_ahead_price_license: True
-hide_day_ahead_price: False
+has_day_ahead_price_license: true
+hide_day_ahead_price: false
+isLowCarbon:
+  hydro discharge:
+    - datetime: '2020-01-01'
+      value: 0.6139
+isRenewable:
+  hydro discharge:
+    - datetime: '2020-01-01'
+      value: 0.4101
 parsers:
   consumption: ELEXON.fetch_consumption
   consumptionForecast: ENTSOE.fetch_consumption_forecast
@@ -430,7 +439,10 @@ sources:
     link: https://docs.google.com/spreadsheets/d/1w5DJ7sPen6axIHU8TCVcuzNCjlct4I6JAbhUlw-ZXu8/edit?usp=sharing
   UNECE 2022:
     link: https://unece.org/sites/default/files/2022-04/LCA_3_FINAL%20March%202022.pdf
-  UNECE 2022, WindEurope "Wind energy in Europe, 2021 Statistics and the outlook for 2022-2026" Wind Europe Proceedings (2021):
-    link: https://unece.org/sites/default/files/2022-04/LCA_3_FINAL%20March%202022.pdf#page=37, https://proceedings.windeurope.org/biplatform/rails/active_storage/disk/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdDRG9JYTJWNVNTSWhORFJ0ZDJJMWVUbG9OMll6TVRaaGEza3lkamgxZG1aM056WnZZZ1k2QmtWVU9oQmthWE53YjNOcGRHbHZia2tpQVk1cGJteHBibVU3SUdacGJHVnVZVzFsUFNKWGFXNWtaWFZ5YjNCbExWZHBibVF0Wlc1bGNtZDVMV2x1TFVWMWNtOXdaUzB5TURJeExYTjBZWFJwYzNScFkzTXVjR1JtSWpzZ1ptbHNaVzVoYldVcVBWVlVSaTA0SnlkWGFXNWtaWFZ5YjNCbExWZHBibVF0Wlc1bGNtZDVMV2x1TFVWMWNtOXdaUzB5TURJeExYTjBZWFJwYzNScFkzTXVjR1JtQmpzR1ZEb1JZMjl1ZEdWdWRGOTBlWEJsU1NJVVlYQndiR2xqWVhScGIyNHZjR1JtQmpzR1ZBPT0iLCJleHAiOiIyMDIyLTExLTAyVDE1OjU0OjAzLjEyNFoiLCJwdXIiOiJibG9iX2tleSJ9fQ==--c25280a7345257bd91bfaf6d64ddb75c55eef799/Windeurope-Wind-energy-in-Europe-2021-statistics.pdf?content_type=application%2Fpdf&disposition=inline%3B+filename%3D%22Windeurope-Wind-energy-in-Europe-2021-statistics.pdf%22%3B+filename%2A%3DUTF-8%27%27Windeurope-Wind-energy-in-Europe-2021-statistics.pdf
+  ? UNECE 2022, WindEurope "Wind energy in Europe, 2021 Statistics and the outlook
+    for 2022-2026" Wind Europe Proceedings (2021)
+  : link:
+      https://unece.org/sites/default/files/2022-04/LCA_3_FINAL%20March%202022.pdf#page=37,
+      https://proceedings.windeurope.org/biplatform/rails/active_storage/disk/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdDRG9JYTJWNVNTSWhORFJ0ZDJJMWVUbG9OMll6TVRaaGEza3lkamgxZG1aM056WnZZZ1k2QmtWVU9oQmthWE53YjNOcGRHbHZia2tpQVk1cGJteHBibVU3SUdacGJHVnVZVzFsUFNKWGFXNWtaWFZ5YjNCbExWZHBibVF0Wlc1bGNtZDVMV2x1TFVWMWNtOXdaUzB5TURJeExYTjBZWFJwYzNScFkzTXVjR1JtSWpzZ1ptbHNaVzVoYldVcVBWVlVSaTA0SnlkWGFXNWtaWFZ5YjNCbExWZHBibVF0Wlc1bGNtZDVMV2x1TFVWMWNtOXdaUzB5TURJeExYTjBZWFJwYzNScFkzTXVjR1JtQmpzR1ZEb1JZMjl1ZEdWdWRGOTBlWEJsU1NJVVlYQndiR2xqWVhScGIyNHZjR1JtQmpzR1ZBPT0iLCJleHAiOiIyMDIyLTExLTAyVDE1OjU0OjAzLjEyNFoiLCJwdXIiOiJibG9iX2tleSJ9fQ==--c25280a7345257bd91bfaf6d64ddb75c55eef799/Windeurope-Wind-energy-in-Europe-2021-statistics.pdf?content_type=application%2Fpdf&disposition=inline%3B+filename%3D%22Windeurope-Wind-energy-in-Europe-2021-statistics.pdf%22%3B+filename%2A%3DUTF-8%27%27Windeurope-Wind-energy-in-Europe-2021-statistics.pdf
 timezone: Europe/London
 zone_name: Great Britain

--- a/config/zones/GB.yaml
+++ b/config/zones/GB.yaml
@@ -203,23 +203,23 @@ emissionFactors:
       - _comment: used storage values greater than zero.
         datetime: '2021-01-01'
         source: Electricity Maps, 2021 zone average
-        value: 165.97
+        value: 166.04
       - _comment: used storage values greater than zero.
         datetime: '2022-01-01'
         source: Electricity Maps, 2022 zone average
-        value: 164.75
+        value: 164.77
       - _comment: used storage values greater than zero.
         datetime: '2023-01-01'
         source: Electricity Maps, 2023 zone average
-        value: 137.98
+        value: 138.01
       - _comment: used storage values greater than zero.
         datetime: '2024-01-01'
         source: Electricity Maps, 2024 zone average
-        value: 114.5
+        value: 114.57
       - _comment: used storage values greater than zero.
         datetime: '2025-01-01'
         source: Electricity Maps, 2025 zone average
-        value: 119.58
+        value: 119.61
   lifecycle:
     hydro:
       datetime: '2020-01-01'
@@ -233,23 +233,23 @@ emissionFactors:
       - _comment: used storage values greater than zero.
         datetime: '2021-01-01'
         source: Electricity Maps, 2021 zone average; UNECE 2022
-        value: 176.67
+        value: 176.74
       - _comment: used storage values greater than zero.
         datetime: '2022-01-01'
         source: Electricity Maps, 2022 zone average; UNECE 2022
-        value: 175.45
+        value: 175.47
       - _comment: used storage values greater than zero.
         datetime: '2023-01-01'
         source: Electricity Maps, 2023 zone average; UNECE 2022
-        value: 148.68
+        value: 148.71
       - _comment: used storage values greater than zero.
         datetime: '2024-01-01'
         source: Electricity Maps, 2024 zone average; UNECE 2022
-        value: 125.2
+        value: 125.27
       - _comment: used storage values greater than zero.
         datetime: '2025-01-01'
         source: Electricity Maps, 2025 zone average; UNECE 2022
-        value: 130.28
+        value: 130.31
     nuclear:
       datetime: '2020-01-01'
       source: UNECE 2022
@@ -422,29 +422,29 @@ isLowCarbon:
     - datetime: '2020-01-01'
       value: 0.6139
     - datetime: '2021-01-01'
-      value: 0.5777
+      value: 0.5776
     - datetime: '2022-01-01'
       value: 0.5787
     - datetime: '2023-01-01'
-      value: 0.6459
+      value: 0.6458
     - datetime: '2024-01-01'
-      value: 0.7064
+      value: 0.7062
     - datetime: '2025-01-01'
-      value: 0.6884
+      value: 0.6883
 isRenewable:
   hydro discharge:
     - datetime: '2020-01-01'
       value: 0.4101
     - datetime: '2021-01-01'
-      value: 0.3753
+      value: 0.3752
     - datetime: '2022-01-01'
       value: 0.4125
     - datetime: '2023-01-01'
-      value: 0.4636
+      value: 0.4635
     - datetime: '2024-01-01'
-      value: 0.512
+      value: 0.5119
     - datetime: '2025-01-01'
-      value: 0.5146
+      value: 0.5145
 parsers:
   consumption: ELEXON.fetch_consumption
   consumptionForecast: ENTSOE.fetch_consumption_forecast

--- a/config/zones/GB.yaml
+++ b/config/zones/GB.yaml
@@ -423,12 +423,16 @@ isLowCarbon:
       value: 0.6139
     - datetime: '2021-01-01'
       value: 0.5777
+    - datetime: '2022-01-01'
+      value: 0.5787
 isRenewable:
   hydro discharge:
     - datetime: '2020-01-01'
       value: 0.4101
     - datetime: '2021-01-01'
       value: 0.3753
+    - datetime: '2022-01-01'
+      value: 0.4125
 parsers:
   consumption: ELEXON.fetch_consumption
   consumptionForecast: ENTSOE.fetch_consumption_forecast

--- a/config/zones/GB.yaml
+++ b/config/zones/GB.yaml
@@ -215,7 +215,7 @@ emissionFactors:
       - _comment: used storage values greater than zero.
         datetime: '2024-01-01'
         source: Electricity Maps, 2024 zone average
-        value: 114.46
+        value: 114.5
       - _comment: used storage values greater than zero.
         datetime: '2025-01-01'
         source: Electricity Maps, 2025 zone average
@@ -245,7 +245,7 @@ emissionFactors:
       - _comment: used storage values greater than zero.
         datetime: '2024-01-01'
         source: Electricity Maps, 2024 zone average; UNECE 2022
-        value: 125.16
+        value: 125.2
       - _comment: used storage values greater than zero.
         datetime: '2025-01-01'
         source: Electricity Maps, 2025 zone average; UNECE 2022
@@ -425,6 +425,12 @@ isLowCarbon:
       value: 0.5777
     - datetime: '2022-01-01'
       value: 0.5787
+    - datetime: '2023-01-01'
+      value: 0.6459
+    - datetime: '2024-01-01'
+      value: 0.7064
+    - datetime: '2025-01-01'
+      value: 0.6884
 isRenewable:
   hydro discharge:
     - datetime: '2020-01-01'
@@ -433,6 +439,12 @@ isRenewable:
       value: 0.3753
     - datetime: '2022-01-01'
       value: 0.4125
+    - datetime: '2023-01-01'
+      value: 0.4636
+    - datetime: '2024-01-01'
+      value: 0.512
+    - datetime: '2025-01-01'
+      value: 0.5146
 parsers:
   consumption: ELEXON.fetch_consumption
   consumptionForecast: ENTSOE.fetch_consumption_forecast

--- a/config/zones/GP.yaml
+++ b/config/zones/GP.yaml
@@ -152,8 +152,16 @@ fallbackZoneMixes:
         solar: 0.06917119460371109
         unknown: 0.0
         wind: 0.04311598615929433
-has_day_ahead_price_license: False
-hide_day_ahead_price: False
+has_day_ahead_price_license: false
+hide_day_ahead_price: false
+isLowCarbon:
+  battery discharge:
+    - datetime: '2022-01-01'
+      value: 0.1722
+isRenewable:
+  battery discharge:
+    - datetime: '2022-01-01'
+      value: 0.1722
 parsers:
   price: FR_O.fetch_price
   production: FR_O.fetch_production

--- a/config/zones/GR.yaml
+++ b/config/zones/GR.yaml
@@ -474,11 +474,15 @@ isLowCarbon:
       value: 0.2412
     - datetime: '2021-01-01'
       value: 1.0
+    - datetime: '2022-01-01'
+      value: 1.0
 isRenewable:
   hydro discharge:
     - datetime: '2020-01-01'
       value: 0.2131
     - datetime: '2021-01-01'
+      value: 1.0
+    - datetime: '2022-01-01'
       value: 1.0
 parsers:
   consumption: ENTSOE.fetch_consumption

--- a/config/zones/GR.yaml
+++ b/config/zones/GR.yaml
@@ -472,10 +472,14 @@ isLowCarbon:
   hydro discharge:
     - datetime: '2020-01-01'
       value: 0.2412
+    - datetime: '2021-01-01'
+      value: 1.0
 isRenewable:
   hydro discharge:
     - datetime: '2020-01-01'
       value: 0.2131
+    - datetime: '2021-01-01'
+      value: 1.0
 parsers:
   consumption: ENTSOE.fetch_consumption
   consumptionForecast: ENTSOE.fetch_consumption_forecast

--- a/config/zones/GR.yaml
+++ b/config/zones/GR.yaml
@@ -476,6 +476,12 @@ isLowCarbon:
       value: 1.0
     - datetime: '2022-01-01'
       value: 1.0
+    - datetime: '2023-01-01'
+      value: 1.0
+    - datetime: '2024-01-01'
+      value: 1.0
+    - datetime: '2025-01-01'
+      value: 1.0
 isRenewable:
   hydro discharge:
     - datetime: '2020-01-01'
@@ -483,6 +489,12 @@ isRenewable:
     - datetime: '2021-01-01'
       value: 1.0
     - datetime: '2022-01-01'
+      value: 1.0
+    - datetime: '2023-01-01'
+      value: 1.0
+    - datetime: '2024-01-01'
+      value: 1.0
+    - datetime: '2025-01-01'
       value: 1.0
 parsers:
   consumption: ENTSOE.fetch_consumption

--- a/config/zones/GR.yaml
+++ b/config/zones/GR.yaml
@@ -468,6 +468,14 @@ fallbackZoneMixes:
         wind: 0.20026030888063462
 has_day_ahead_price_license: false
 hide_day_ahead_price: false
+isLowCarbon:
+  hydro discharge:
+    - datetime: '2020-01-01'
+      value: 0.2412
+isRenewable:
+  hydro discharge:
+    - datetime: '2020-01-01'
+      value: 0.2131
 parsers:
   consumption: ENTSOE.fetch_consumption
   consumptionForecast: ENTSOE.fetch_consumption_forecast

--- a/config/zones/GR.yaml
+++ b/config/zones/GR.yaml
@@ -209,22 +209,22 @@ emissionFactors:
         datetime: '2021-01-01'
         source: Electricity Maps, 2021 zone average
         value: 0.0
-      - _comment: used default IPCC 2014 value of 0.0
+      - _comment: used storage values greater than zero.
         datetime: '2022-01-01'
         source: Electricity Maps, 2022 zone average
-        value: 0.0
-      - _comment: used default IPCC 2014 value of 0.0
+        value: 617.15
+      - _comment: used storage values greater than zero.
         datetime: '2023-01-01'
         source: Electricity Maps, 2023 zone average
-        value: 0.0
-      - _comment: used default IPCC 2014 value of 0.0
+        value: 430.14
+      - _comment: used storage values greater than zero.
         datetime: '2024-01-01'
         source: Electricity Maps, 2024 zone average
-        value: 0.0
-      - _comment: used default IPCC 2014 value of 0.0
+        value: 348.65
+      - _comment: used storage values greater than zero.
         datetime: '2025-01-01'
         source: Electricity Maps, 2025 zone average
-        value: 0.0
+        value: 312.4
     oil:
       - datetime: '2021-01-01'
         source: EU-ETS, ENTSO-E 2021
@@ -278,22 +278,22 @@ emissionFactors:
         datetime: '2021-01-01'
         source: Electricity Maps, 2021 zone average; UNECE 2022
         value: 10.7
-      - _comment: used default IPCC 2014 value of 24.0
+      - _comment: used storage values greater than zero.
         datetime: '2022-01-01'
         source: Electricity Maps, 2022 zone average; UNECE 2022
-        value: 10.7
-      - _comment: used default IPCC 2014 value of 24.0
+        value: 627.85
+      - _comment: used storage values greater than zero.
         datetime: '2023-01-01'
         source: Electricity Maps, 2023 zone average; UNECE 2022
-        value: 10.7
-      - _comment: used default IPCC 2014 value of 24.0
+        value: 440.84
+      - _comment: used storage values greater than zero.
         datetime: '2024-01-01'
         source: Electricity Maps, 2024 zone average; UNECE 2022
-        value: 10.7
-      - _comment: used default IPCC 2014 value of 24.0
+        value: 359.35
+      - _comment: used storage values greater than zero.
         datetime: '2025-01-01'
         source: Electricity Maps, 2025 zone average; UNECE 2022
-        value: 10.7
+        value: 323.1
     nuclear:
       datetime: '2020-01-01'
       source: UNECE 2022
@@ -475,13 +475,13 @@ isLowCarbon:
     - datetime: '2021-01-01'
       value: 1.0
     - datetime: '2022-01-01'
-      value: 1.0
+      value: 0.2971
     - datetime: '2023-01-01'
-      value: 1.0
+      value: 0.3338
     - datetime: '2024-01-01'
-      value: 1.0
+      value: 0.4134
     - datetime: '2025-01-01'
-      value: 1.0
+      value: 0.3915
 isRenewable:
   hydro discharge:
     - datetime: '2020-01-01'
@@ -489,13 +489,13 @@ isRenewable:
     - datetime: '2021-01-01'
       value: 1.0
     - datetime: '2022-01-01'
-      value: 1.0
+      value: 0.2482
     - datetime: '2023-01-01'
-      value: 1.0
+      value: 0.2686
     - datetime: '2024-01-01'
-      value: 1.0
+      value: 0.3172
     - datetime: '2025-01-01'
-      value: 1.0
+      value: 0.2619
 parsers:
   consumption: ENTSOE.fetch_consumption
   consumptionForecast: ENTSOE.fetch_consumption_forecast

--- a/config/zones/HR.yaml
+++ b/config/zones/HR.yaml
@@ -192,6 +192,11 @@ delays:
   production: 6
 emissionFactors:
   direct:
+    battery discharge:
+      - _comment: used storage values greater than zero.
+        datetime: '2025-01-01'
+        source: Electricity Maps, 2025 zone average
+        value: 221.69
     biomass:
       datetime: '2021-01-01'
       source: BEIS 2021
@@ -238,15 +243,15 @@ emissionFactors:
       - _comment: used storage values greater than zero.
         datetime: '2023-01-01'
         source: Electricity Maps, 2023 zone average
-        value: 258.08
+        value: 254.93
       - _comment: used storage values greater than zero.
         datetime: '2024-01-01'
         source: Electricity Maps, 2024 zone average
-        value: 188.92
+        value: 181.11
       - _comment: used storage values greater than zero.
         datetime: '2025-01-01'
         source: Electricity Maps, 2025 zone average
-        value: 206.61
+        value: 198.15
     oil:
       - datetime: '2021-01-01'
         source: EU-ETS, ENTSO-E 2021
@@ -261,6 +266,11 @@ emissionFactors:
         source: EU-ETS, ENTSO-E 2024
         value: 857.84
   lifecycle:
+    battery discharge:
+      - _comment: used storage values greater than zero.
+        datetime: '2025-01-01'
+        source: Electricity Maps, 2025 zone average; National Laboratory of the Rockies
+        value: 254.69
     biomass:
       datetime: '2014-01-01'
       source: BEIS 2021; IPCC 2014
@@ -313,15 +323,15 @@ emissionFactors:
       - _comment: used storage values greater than zero.
         datetime: '2023-01-01'
         source: Electricity Maps, 2023 zone average; UNECE 2022
-        value: 268.78
+        value: 265.63
       - _comment: used storage values greater than zero.
         datetime: '2024-01-01'
         source: Electricity Maps, 2024 zone average; UNECE 2022
-        value: 199.62
+        value: 191.81
       - _comment: used storage values greater than zero.
         datetime: '2025-01-01'
         source: Electricity Maps, 2025 zone average; UNECE 2022
-        value: 217.31
+        value: 208.85
     nuclear:
       datetime: '2020-01-01'
       source: UNECE 2022
@@ -473,6 +483,9 @@ fallbackZoneMixes:
 has_day_ahead_price_license: false
 hide_day_ahead_price: false
 isLowCarbon:
+  battery discharge:
+    - datetime: '2025-01-01'
+      value: 0.6645
   hydro discharge:
     - datetime: '2020-01-01'
       value: 0.6153
@@ -480,7 +493,16 @@ isLowCarbon:
       value: 0.6112
     - datetime: '2022-01-01'
       value: 0.5606
+    - datetime: '2023-01-01'
+      value: 0.6318
+    - datetime: '2024-01-01'
+      value: 0.713
+    - datetime: '2025-01-01'
+      value: 0.6991
 isRenewable:
+  battery discharge:
+    - datetime: '2025-01-01'
+      value: 0.5304
   hydro discharge:
     - datetime: '2020-01-01'
       value: 0.4602
@@ -488,6 +510,12 @@ isRenewable:
       value: 0.4909
     - datetime: '2022-01-01'
       value: 0.4224
+    - datetime: '2023-01-01'
+      value: 0.5396
+    - datetime: '2024-01-01'
+      value: 0.5624
+    - datetime: '2025-01-01'
+      value: 0.5447
 parsers:
   consumption: ENTSOE.fetch_consumption
   consumptionForecast: ENTSOE.fetch_consumption_forecast

--- a/config/zones/HR.yaml
+++ b/config/zones/HR.yaml
@@ -226,7 +226,7 @@ emissionFactors:
       - _comment: used storage values greater than zero.
         datetime: '2020-01-01'
         source: Electricity Maps, 2020 zone average
-        value: 264.14
+        value: 264.15
       - _comment: used storage values greater than zero.
         datetime: '2021-01-01'
         source: Electricity Maps, 2021 zone average
@@ -301,7 +301,7 @@ emissionFactors:
       - _comment: used storage values greater than zero.
         datetime: '2020-01-01'
         source: Electricity Maps, 2020 zone average; UNECE 2022
-        value: 274.84
+        value: 274.85
       - _comment: used storage values greater than zero.
         datetime: '2021-01-01'
         source: Electricity Maps, 2021 zone average; UNECE 2022
@@ -472,6 +472,14 @@ fallbackZoneMixes:
         wind: 0.12557913883108035
 has_day_ahead_price_license: false
 hide_day_ahead_price: false
+isLowCarbon:
+  hydro discharge:
+    - datetime: '2020-01-01'
+      value: 0.6153
+isRenewable:
+  hydro discharge:
+    - datetime: '2020-01-01'
+      value: 0.4602
 parsers:
   consumption: ENTSOE.fetch_consumption
   consumptionForecast: ENTSOE.fetch_consumption_forecast

--- a/config/zones/HR.yaml
+++ b/config/zones/HR.yaml
@@ -478,12 +478,16 @@ isLowCarbon:
       value: 0.6153
     - datetime: '2021-01-01'
       value: 0.6112
+    - datetime: '2022-01-01'
+      value: 0.5606
 isRenewable:
   hydro discharge:
     - datetime: '2020-01-01'
       value: 0.4602
     - datetime: '2021-01-01'
       value: 0.4909
+    - datetime: '2022-01-01'
+      value: 0.4224
 parsers:
   consumption: ENTSOE.fetch_consumption
   consumptionForecast: ENTSOE.fetch_consumption_forecast

--- a/config/zones/HR.yaml
+++ b/config/zones/HR.yaml
@@ -476,10 +476,14 @@ isLowCarbon:
   hydro discharge:
     - datetime: '2020-01-01'
       value: 0.6153
+    - datetime: '2021-01-01'
+      value: 0.6112
 isRenewable:
   hydro discharge:
     - datetime: '2020-01-01'
       value: 0.4602
+    - datetime: '2021-01-01'
+      value: 0.4909
 parsers:
   consumption: ENTSOE.fetch_consumption
   consumptionForecast: ENTSOE.fetch_consumption_forecast

--- a/config/zones/HR.yaml
+++ b/config/zones/HR.yaml
@@ -193,10 +193,10 @@ delays:
 emissionFactors:
   direct:
     battery discharge:
-      - _comment: used storage values greater than zero.
+      - _comment: used non-null storage values
         datetime: '2025-01-01'
         source: Electricity Maps, 2025 zone average
-        value: 221.69
+        value: 236.88
     biomass:
       datetime: '2021-01-01'
       source: BEIS 2021
@@ -231,27 +231,27 @@ emissionFactors:
       - _comment: used storage values greater than zero.
         datetime: '2020-01-01'
         source: Electricity Maps, 2020 zone average
-        value: 264.15
+        value: 264.14
       - _comment: used storage values greater than zero.
         datetime: '2021-01-01'
         source: Electricity Maps, 2021 zone average
-        value: 294.01
+        value: 294.03
       - _comment: used storage values greater than zero.
         datetime: '2022-01-01'
         source: Electricity Maps, 2022 zone average
-        value: 327.35
+        value: 327.75
       - _comment: used storage values greater than zero.
         datetime: '2023-01-01'
         source: Electricity Maps, 2023 zone average
-        value: 254.93
+        value: 255.0
       - _comment: used storage values greater than zero.
         datetime: '2024-01-01'
         source: Electricity Maps, 2024 zone average
-        value: 181.11
+        value: 181.56
       - _comment: used storage values greater than zero.
         datetime: '2025-01-01'
         source: Electricity Maps, 2025 zone average
-        value: 198.15
+        value: 200.66
     oil:
       - datetime: '2021-01-01'
         source: EU-ETS, ENTSO-E 2021
@@ -267,10 +267,10 @@ emissionFactors:
         value: 857.84
   lifecycle:
     battery discharge:
-      - _comment: used storage values greater than zero.
+      - _comment: used non-null storage values
         datetime: '2025-01-01'
         source: Electricity Maps, 2025 zone average; National Laboratory of the Rockies
-        value: 254.69
+        value: 269.88
     biomass:
       datetime: '2014-01-01'
       source: BEIS 2021; IPCC 2014
@@ -311,27 +311,27 @@ emissionFactors:
       - _comment: used storage values greater than zero.
         datetime: '2020-01-01'
         source: Electricity Maps, 2020 zone average; UNECE 2022
-        value: 274.85
+        value: 274.84
       - _comment: used storage values greater than zero.
         datetime: '2021-01-01'
         source: Electricity Maps, 2021 zone average; UNECE 2022
-        value: 304.71
+        value: 304.73
       - _comment: used storage values greater than zero.
         datetime: '2022-01-01'
         source: Electricity Maps, 2022 zone average; UNECE 2022
-        value: 338.05
+        value: 338.45
       - _comment: used storage values greater than zero.
         datetime: '2023-01-01'
         source: Electricity Maps, 2023 zone average; UNECE 2022
-        value: 265.63
+        value: 265.7
       - _comment: used storage values greater than zero.
         datetime: '2024-01-01'
         source: Electricity Maps, 2024 zone average; UNECE 2022
-        value: 191.81
+        value: 192.26
       - _comment: used storage values greater than zero.
         datetime: '2025-01-01'
         source: Electricity Maps, 2025 zone average; UNECE 2022
-        value: 208.85
+        value: 211.36
     nuclear:
       datetime: '2020-01-01'
       source: UNECE 2022
@@ -485,37 +485,37 @@ hide_day_ahead_price: false
 isLowCarbon:
   battery discharge:
     - datetime: '2025-01-01'
-      value: 0.6645
+      value: 0.6141
   hydro discharge:
     - datetime: '2020-01-01'
-      value: 0.6153
+      value: 0.6154
     - datetime: '2021-01-01'
       value: 0.6112
     - datetime: '2022-01-01'
-      value: 0.5606
+      value: 0.5602
     - datetime: '2023-01-01'
       value: 0.6318
     - datetime: '2024-01-01'
-      value: 0.713
+      value: 0.7126
     - datetime: '2025-01-01'
-      value: 0.6991
+      value: 0.6966
 isRenewable:
   battery discharge:
     - datetime: '2025-01-01'
-      value: 0.5304
+      value: 0.38
   hydro discharge:
     - datetime: '2020-01-01'
       value: 0.4602
     - datetime: '2021-01-01'
-      value: 0.4909
+      value: 0.4912
     - datetime: '2022-01-01'
-      value: 0.4224
+      value: 0.4222
     - datetime: '2023-01-01'
-      value: 0.5396
+      value: 0.5398
     - datetime: '2024-01-01'
-      value: 0.5624
+      value: 0.5621
     - datetime: '2025-01-01'
-      value: 0.5447
+      value: 0.5445
 parsers:
   consumption: ENTSOE.fetch_consumption
   consumptionForecast: ENTSOE.fetch_consumption_forecast
@@ -538,6 +538,8 @@ sources:
     link: https://docs.google.com/spreadsheets/d/1w5DJ7sPen6axIHU8TCVcuzNCjlct4I6JAbhUlw-ZXu8/edit?usp=sharing
   IPCC 2014:
     link: https://www.ipcc.ch/site/assets/uploads/2018/02/ipcc_wg3_ar5_annex-iii.pdf#page=7
+  National Laboratory of the Rockies:
+    link: https://docs.nrel.gov/docs/fy21osti/80580.pdf
   UNECE 2022:
     link: https://unece.org/sites/default/files/2022-04/LCA_3_FINAL%20March%202022.pdf
   ? UNECE 2022, WindEurope "Wind energy in Europe, 2021 Statistics and the outlook
@@ -545,7 +547,5 @@ sources:
   : link:
       https://unece.org/sites/default/files/2022-04/LCA_3_FINAL%20March%202022.pdf#page=37,
       https://proceedings.windeurope.org/biplatform/rails/active_storage/disk/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdDRG9JYTJWNVNTSWhORFJ0ZDJJMWVUbG9OMll6TVRaaGEza3lkamgxZG1aM056WnZZZ1k2QmtWVU9oQmthWE53YjNOcGRHbHZia2tpQVk1cGJteHBibVU3SUdacGJHVnVZVzFsUFNKWGFXNWtaWFZ5YjNCbExWZHBibVF0Wlc1bGNtZDVMV2x1TFVWMWNtOXdaUzB5TURJeExYTjBZWFJwYzNScFkzTXVjR1JtSWpzZ1ptbHNaVzVoYldVcVBWVlVSaTA0SnlkWGFXNWtaWFZ5YjNCbExWZHBibVF0Wlc1bGNtZDVMV2x1TFVWMWNtOXdaUzB5TURJeExYTjBZWFJwYzNScFkzTXVjR1JtQmpzR1ZEb1JZMjl1ZEdWdWRGOTBlWEJsU1NJVVlYQndiR2xqWVhScGIyNHZjR1JtQmpzR1ZBPT0iLCJleHAiOiIyMDIyLTExLTAyVDE1OjU0OjAzLjEyNFoiLCJwdXIiOiJibG9iX2tleSJ9fQ==--c25280a7345257bd91bfaf6d64ddb75c55eef799/Windeurope-Wind-energy-in-Europe-2021-statistics.pdf?content_type=application%2Fpdf&disposition=inline%3B+filename%3D%22Windeurope-Wind-energy-in-Europe-2021-statistics.pdf%22%3B+filename%2A%3DUTF-8%27%27Windeurope-Wind-energy-in-Europe-2021-statistics.pdf
-  National Laboratory of the Rockies:
-    link: https://docs.nrel.gov/docs/fy21osti/80580.pdf
 timezone: Europe/Belgrade
 zone_name: Croatia

--- a/config/zones/HR.yaml
+++ b/config/zones/HR.yaml
@@ -545,5 +545,7 @@ sources:
   : link:
       https://unece.org/sites/default/files/2022-04/LCA_3_FINAL%20March%202022.pdf#page=37,
       https://proceedings.windeurope.org/biplatform/rails/active_storage/disk/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdDRG9JYTJWNVNTSWhORFJ0ZDJJMWVUbG9OMll6TVRaaGEza3lkamgxZG1aM056WnZZZ1k2QmtWVU9oQmthWE53YjNOcGRHbHZia2tpQVk1cGJteHBibVU3SUdacGJHVnVZVzFsUFNKWGFXNWtaWFZ5YjNCbExWZHBibVF0Wlc1bGNtZDVMV2x1TFVWMWNtOXdaUzB5TURJeExYTjBZWFJwYzNScFkzTXVjR1JtSWpzZ1ptbHNaVzVoYldVcVBWVlVSaTA0SnlkWGFXNWtaWFZ5YjNCbExWZHBibVF0Wlc1bGNtZDVMV2x1TFVWMWNtOXdaUzB5TURJeExYTjBZWFJwYzNScFkzTXVjR1JtQmpzR1ZEb1JZMjl1ZEdWdWRGOTBlWEJsU1NJVVlYQndiR2xqWVhScGIyNHZjR1JtQmpzR1ZBPT0iLCJleHAiOiIyMDIyLTExLTAyVDE1OjU0OjAzLjEyNFoiLCJwdXIiOiJibG9iX2tleSJ9fQ==--c25280a7345257bd91bfaf6d64ddb75c55eef799/Windeurope-Wind-energy-in-Europe-2021-statistics.pdf?content_type=application%2Fpdf&disposition=inline%3B+filename%3D%22Windeurope-Wind-energy-in-Europe-2021-statistics.pdf%22%3B+filename%2A%3DUTF-8%27%27Windeurope-Wind-energy-in-Europe-2021-statistics.pdf
+  National Laboratory of the Rockies:
+    link: https://docs.nrel.gov/docs/fy21osti/80580.pdf
 timezone: Europe/Belgrade
 zone_name: Croatia

--- a/config/zones/IT-CNO.yaml
+++ b/config/zones/IT-CNO.yaml
@@ -73,11 +73,11 @@ emissionFactors:
       - _comment: used storage values greater than zero.
         datetime: '2024-01-01'
         source: Electricity Maps, 2024 zone average
-        value: 274.34
+        value: 256.99
       - _comment: used storage values greater than zero.
         datetime: '2025-01-01'
         source: Electricity Maps, 2025 zone average
-        value: 176.32
+        value: 165.08
     biomass:
       datetime: '2021-01-01'
       source: BEIS 2021
@@ -112,7 +112,7 @@ emissionFactors:
       - _comment: used storage values greater than zero.
         datetime: '2024-01-01'
         source: Electricity Maps, 2024 zone average
-        value: 275.15
+        value: 257.85
     oil:
       - datetime: '2021-01-01'
         source: EU-ETS, ENTSO-E 2021
@@ -131,11 +131,11 @@ emissionFactors:
       - _comment: used storage values greater than zero.
         datetime: '2024-01-01'
         source: Electricity Maps, 2024 zone average; National Laboratory of the Rockies
-        value: 307.34
+        value: 289.99
       - _comment: used storage values greater than zero.
         datetime: '2025-01-01'
         source: Electricity Maps, 2025 zone average; National Laboratory of the Rockies
-        value: 209.32
+        value: 198.08
     biomass:
       datetime: '2014-01-01'
       source: BEIS 2021; IPCC 2014
@@ -176,7 +176,7 @@ emissionFactors:
       - _comment: used storage values greater than zero.
         datetime: '2024-01-01'
         source: Electricity Maps, 2024 zone average; UNECE 2022
-        value: 285.85
+        value: 268.55
     nuclear:
       datetime: '2020-01-01'
       source: UNECE 2022
@@ -357,6 +357,24 @@ fallbackZoneMixes:
         wind: 0.053137961493694416
 has_day_ahead_price_license: false
 hide_day_ahead_price: false
+isLowCarbon:
+  battery discharge:
+    - datetime: '2024-01-01'
+      value: 0.4281
+    - datetime: '2025-01-01'
+      value: 0.6289
+  hydro discharge:
+    - datetime: '2024-01-01'
+      value: 0.4275
+isRenewable:
+  battery discharge:
+    - datetime: '2024-01-01'
+      value: 0.3653
+    - datetime: '2025-01-01'
+      value: 0.584
+  hydro discharge:
+    - datetime: '2024-01-01'
+      value: 0.3613
 parsers:
   consumption: ENTSOE.fetch_consumption
   consumptionForecast: ENTSOE.fetch_consumption_forecast
@@ -366,8 +384,6 @@ parsers:
   productionPerModeForecast: ENTSOE.fetch_wind_solar_forecasts
 region: Europe
 sources:
-  National Laboratory of the Rockies:
-    link: https://docs.nrel.gov/docs/fy21osti/80580.pdf
   EU-ETS, ENTSO-E 2021:
     link: https://drive.google.com/file/d/15UeUHyhcjVw8fGLc0Zx_HELSx20cw_-e/view?usp=share_link
   EU-ETS, ENTSO-E 2022:
@@ -380,6 +396,8 @@ sources:
     link: https://docs.google.com/spreadsheets/d/1w5DJ7sPen6axIHU8TCVcuzNCjlct4I6JAbhUlw-ZXu8/edit?usp=sharing
   IPCC 2014:
     link: https://www.ipcc.ch/site/assets/uploads/2018/02/ipcc_wg3_ar5_annex-iii.pdf#page=7
+  National Laboratory of the Rockies:
+    link: https://docs.nrel.gov/docs/fy21osti/80580.pdf
   UNECE 2022:
     link: https://unece.org/sites/default/files/2022-04/LCA_3_FINAL%20March%202022.pdf
   ? UNECE 2022, WindEurope "Wind energy in Europe, 2021 Statistics and the outlook

--- a/config/zones/IT-CNO.yaml
+++ b/config/zones/IT-CNO.yaml
@@ -70,14 +70,14 @@ delays:
 emissionFactors:
   direct:
     battery discharge:
-      - _comment: used storage values greater than zero.
+      - _comment: used non-null storage values
         datetime: '2024-01-01'
         source: Electricity Maps, 2024 zone average
-        value: 256.99
+        value: 351.1
       - _comment: used storage values greater than zero.
         datetime: '2025-01-01'
         source: Electricity Maps, 2025 zone average
-        value: 165.08
+        value: 153.09
     biomass:
       datetime: '2021-01-01'
       source: BEIS 2021
@@ -128,14 +128,14 @@ emissionFactors:
         value: 905.42
   lifecycle:
     battery discharge:
-      - _comment: used storage values greater than zero.
+      - _comment: used non-null storage values
         datetime: '2024-01-01'
         source: Electricity Maps, 2024 zone average; National Laboratory of the Rockies
-        value: 289.99
+        value: 384.1
       - _comment: used storage values greater than zero.
         datetime: '2025-01-01'
         source: Electricity Maps, 2025 zone average; National Laboratory of the Rockies
-        value: 198.08
+        value: 186.09
     biomass:
       datetime: '2014-01-01'
       source: BEIS 2021; IPCC 2014
@@ -360,18 +360,18 @@ hide_day_ahead_price: false
 isLowCarbon:
   battery discharge:
     - datetime: '2024-01-01'
-      value: 0.4281
+      value: 0.3357
     - datetime: '2025-01-01'
-      value: 0.6289
+      value: 0.6563
   hydro discharge:
     - datetime: '2024-01-01'
       value: 0.4275
 isRenewable:
   battery discharge:
     - datetime: '2024-01-01'
-      value: 0.3653
+      value: 0.3124
     - datetime: '2025-01-01'
-      value: 0.584
+      value: 0.6168
   hydro discharge:
     - datetime: '2024-01-01'
       value: 0.3613

--- a/config/zones/IT-CSO.yaml
+++ b/config/zones/IT-CSO.yaml
@@ -442,10 +442,14 @@ isLowCarbon:
   hydro discharge:
     - datetime: '2020-01-01'
       value: 0.4396
+    - datetime: '2021-01-01'
+      value: 0.4281
 isRenewable:
   hydro discharge:
     - datetime: '2020-01-01'
       value: 0.4367
+    - datetime: '2021-01-01'
+      value: 0.4223
 parsers:
   consumption: ENTSOE.fetch_consumption
   consumptionForecast: ENTSOE.fetch_consumption_forecast

--- a/config/zones/IT-CSO.yaml
+++ b/config/zones/IT-CSO.yaml
@@ -114,11 +114,11 @@ emissionFactors:
       - _comment: used non-null storage values
         datetime: '2024-01-01'
         source: Electricity Maps, 2024 zone average
-        value: 364.12
+        value: 344.1
       - _comment: used storage values greater than zero.
         datetime: '2025-01-01'
         source: Electricity Maps, 2025 zone average
-        value: 215.52
+        value: 201.83
     biomass:
       datetime: '2021-01-01'
       source: BEIS 2021
@@ -165,15 +165,15 @@ emissionFactors:
       - _comment: used storage values greater than zero.
         datetime: '2023-01-01'
         source: Electricity Maps, 2023 zone average
-        value: 280.76
+        value: 277.14
       - _comment: used storage values greater than zero.
         datetime: '2024-01-01'
         source: Electricity Maps, 2024 zone average
-        value: 231.45
+        value: 210.94
       - _comment: used storage values greater than zero.
         datetime: '2025-01-01'
         source: Electricity Maps, 2025 zone average
-        value: 204.77
+        value: 192.53
     oil:
       - datetime: '2021-01-01'
         source: EU-ETS, ENTSO-E 2021
@@ -192,11 +192,11 @@ emissionFactors:
       - _comment: used non-null storage values
         datetime: '2024-01-01'
         source: Electricity Maps, 2024 zone average; National Laboratory of the Rockies
-        value: 397.12
+        value: 377.1
       - _comment: used storage values greater than zero.
         datetime: '2025-01-01'
         source: Electricity Maps, 2025 zone average; National Laboratory of the Rockies
-        value: 248.52
+        value: 234.83
     biomass:
       datetime: '2014-01-01'
       source: BEIS 2021; IPCC 2014
@@ -249,15 +249,15 @@ emissionFactors:
       - _comment: used storage values greater than zero.
         datetime: '2023-01-01'
         source: Electricity Maps, 2023 zone average; UNECE 2022
-        value: 291.46
+        value: 287.84
       - _comment: used storage values greater than zero.
         datetime: '2024-01-01'
         source: Electricity Maps, 2024 zone average; UNECE 2022
-        value: 242.15
+        value: 221.64
       - _comment: used storage values greater than zero.
         datetime: '2025-01-01'
         source: Electricity Maps, 2025 zone average; UNECE 2022
-        value: 215.47
+        value: 203.23
     nuclear:
       datetime: '2020-01-01'
       source: UNECE 2022
@@ -439,6 +439,11 @@ fallbackZoneMixes:
 has_day_ahead_price_license: false
 hide_day_ahead_price: false
 isLowCarbon:
+  battery discharge:
+    - datetime: '2024-01-01'
+      value: 0.2608
+    - datetime: '2025-01-01'
+      value: 0.5539
   hydro discharge:
     - datetime: '2020-01-01'
       value: 0.4396
@@ -446,7 +451,18 @@ isLowCarbon:
       value: 0.4281
     - datetime: '2022-01-01'
       value: 0.4299
+    - datetime: '2023-01-01'
+      value: 0.5528
+    - datetime: '2024-01-01'
+      value: 0.5645
+    - datetime: '2025-01-01'
+      value: 0.5761
 isRenewable:
+  battery discharge:
+    - datetime: '2024-01-01'
+      value: 0.2515
+    - datetime: '2025-01-01'
+      value: 0.5426
   hydro discharge:
     - datetime: '2020-01-01'
       value: 0.4367
@@ -454,6 +470,12 @@ isRenewable:
       value: 0.4223
     - datetime: '2022-01-01'
       value: 0.4272
+    - datetime: '2023-01-01'
+      value: 0.5448
+    - datetime: '2024-01-01'
+      value: 0.5492
+    - datetime: '2025-01-01'
+      value: 0.5661
 parsers:
   consumption: ENTSOE.fetch_consumption
   consumptionForecast: ENTSOE.fetch_consumption_forecast

--- a/config/zones/IT-CSO.yaml
+++ b/config/zones/IT-CSO.yaml
@@ -114,11 +114,11 @@ emissionFactors:
       - _comment: used non-null storage values
         datetime: '2024-01-01'
         source: Electricity Maps, 2024 zone average
-        value: 344.1
+        value: 343.72
       - _comment: used storage values greater than zero.
         datetime: '2025-01-01'
         source: Electricity Maps, 2025 zone average
-        value: 201.83
+        value: 198.93
     biomass:
       datetime: '2021-01-01'
       source: BEIS 2021
@@ -157,23 +157,23 @@ emissionFactors:
       - _comment: used storage values greater than zero.
         datetime: '2021-01-01'
         source: Electricity Maps, 2021 zone average
-        value: 340.85
+        value: 327.84
       - _comment: used storage values greater than zero.
         datetime: '2022-01-01'
         source: Electricity Maps, 2022 zone average
-        value: 366.48
+        value: 367.56
       - _comment: used storage values greater than zero.
         datetime: '2023-01-01'
         source: Electricity Maps, 2023 zone average
-        value: 277.14
+        value: 268.72
       - _comment: used storage values greater than zero.
         datetime: '2024-01-01'
         source: Electricity Maps, 2024 zone average
-        value: 210.94
+        value: 211.51
       - _comment: used storage values greater than zero.
         datetime: '2025-01-01'
         source: Electricity Maps, 2025 zone average
-        value: 192.53
+        value: 197.55
     oil:
       - datetime: '2021-01-01'
         source: EU-ETS, ENTSO-E 2021
@@ -192,11 +192,11 @@ emissionFactors:
       - _comment: used non-null storage values
         datetime: '2024-01-01'
         source: Electricity Maps, 2024 zone average; National Laboratory of the Rockies
-        value: 377.1
+        value: 376.72
       - _comment: used storage values greater than zero.
         datetime: '2025-01-01'
         source: Electricity Maps, 2025 zone average; National Laboratory of the Rockies
-        value: 234.83
+        value: 231.93
     biomass:
       datetime: '2014-01-01'
       source: BEIS 2021; IPCC 2014
@@ -241,23 +241,23 @@ emissionFactors:
       - _comment: used storage values greater than zero.
         datetime: '2021-01-01'
         source: Electricity Maps, 2021 zone average; UNECE 2022
-        value: 351.55
+        value: 338.54
       - _comment: used storage values greater than zero.
         datetime: '2022-01-01'
         source: Electricity Maps, 2022 zone average; UNECE 2022
-        value: 377.18
+        value: 378.26
       - _comment: used storage values greater than zero.
         datetime: '2023-01-01'
         source: Electricity Maps, 2023 zone average; UNECE 2022
-        value: 287.84
+        value: 279.42
       - _comment: used storage values greater than zero.
         datetime: '2024-01-01'
         source: Electricity Maps, 2024 zone average; UNECE 2022
-        value: 221.64
+        value: 222.21
       - _comment: used storage values greater than zero.
         datetime: '2025-01-01'
         source: Electricity Maps, 2025 zone average; UNECE 2022
-        value: 203.23
+        value: 208.25
     nuclear:
       datetime: '2020-01-01'
       source: UNECE 2022
@@ -441,41 +441,41 @@ hide_day_ahead_price: false
 isLowCarbon:
   battery discharge:
     - datetime: '2024-01-01'
-      value: 0.2608
+      value: 0.2611
     - datetime: '2025-01-01'
-      value: 0.5539
+      value: 0.561
   hydro discharge:
     - datetime: '2020-01-01'
       value: 0.4396
     - datetime: '2021-01-01'
-      value: 0.4281
+      value: 0.441
     - datetime: '2022-01-01'
-      value: 0.4299
+      value: 0.4288
     - datetime: '2023-01-01'
-      value: 0.5528
+      value: 0.5506
     - datetime: '2024-01-01'
-      value: 0.5645
+      value: 0.5641
     - datetime: '2025-01-01'
-      value: 0.5761
+      value: 0.5641
 isRenewable:
   battery discharge:
     - datetime: '2024-01-01'
-      value: 0.2515
+      value: 0.2519
     - datetime: '2025-01-01'
-      value: 0.5426
+      value: 0.5506
   hydro discharge:
     - datetime: '2020-01-01'
       value: 0.4367
     - datetime: '2021-01-01'
-      value: 0.4223
+      value: 0.4363
     - datetime: '2022-01-01'
-      value: 0.4272
+      value: 0.4256
     - datetime: '2023-01-01'
-      value: 0.5448
+      value: 0.5426
     - datetime: '2024-01-01'
-      value: 0.5492
+      value: 0.5489
     - datetime: '2025-01-01'
-      value: 0.5661
+      value: 0.5532
 parsers:
   consumption: ENTSOE.fetch_consumption
   consumptionForecast: ENTSOE.fetch_consumption_forecast

--- a/config/zones/IT-CSO.yaml
+++ b/config/zones/IT-CSO.yaml
@@ -444,12 +444,16 @@ isLowCarbon:
       value: 0.4396
     - datetime: '2021-01-01'
       value: 0.4281
+    - datetime: '2022-01-01'
+      value: 0.4299
 isRenewable:
   hydro discharge:
     - datetime: '2020-01-01'
       value: 0.4367
     - datetime: '2021-01-01'
       value: 0.4223
+    - datetime: '2022-01-01'
+      value: 0.4272
 parsers:
   consumption: ENTSOE.fetch_consumption
   consumptionForecast: ENTSOE.fetch_consumption_forecast

--- a/config/zones/IT-CSO.yaml
+++ b/config/zones/IT-CSO.yaml
@@ -438,6 +438,14 @@ fallbackZoneMixes:
         wind: 0.16321543097369423
 has_day_ahead_price_license: false
 hide_day_ahead_price: false
+isLowCarbon:
+  hydro discharge:
+    - datetime: '2020-01-01'
+      value: 0.4396
+isRenewable:
+  hydro discharge:
+    - datetime: '2020-01-01'
+      value: 0.4367
 parsers:
   consumption: ENTSOE.fetch_consumption
   consumptionForecast: ENTSOE.fetch_consumption_forecast
@@ -447,8 +455,6 @@ parsers:
   productionPerModeForecast: ENTSOE.fetch_wind_solar_forecasts
 region: Europe
 sources:
-  National Laboratory of the Rockies:
-    link: https://docs.nrel.gov/docs/fy21osti/80580.pdf
   EU-ETS, ENTSO-E 2021:
     link: https://drive.google.com/file/d/15UeUHyhcjVw8fGLc0Zx_HELSx20cw_-e/view?usp=share_link
   EU-ETS, ENTSO-E 2022:
@@ -461,6 +467,8 @@ sources:
     link: https://docs.google.com/spreadsheets/d/1w5DJ7sPen6axIHU8TCVcuzNCjlct4I6JAbhUlw-ZXu8/edit?usp=sharing
   IPCC 2014:
     link: https://www.ipcc.ch/site/assets/uploads/2018/02/ipcc_wg3_ar5_annex-iii.pdf#page=7
+  National Laboratory of the Rockies:
+    link: https://docs.nrel.gov/docs/fy21osti/80580.pdf
   UNECE 2022:
     link: https://unece.org/sites/default/files/2022-04/LCA_3_FINAL%20March%202022.pdf
   ? UNECE 2022, WindEurope "Wind energy in Europe, 2021 Statistics and the outlook

--- a/config/zones/IT-NO.yaml
+++ b/config/zones/IT-NO.yaml
@@ -427,6 +427,14 @@ fallbackZoneMixes:
         wind: 0.02421630791921114
 has_day_ahead_price_license: false
 hide_day_ahead_price: false
+isLowCarbon:
+  hydro discharge:
+    - datetime: '2020-01-01'
+      value: 0.5047
+isRenewable:
+  hydro discharge:
+    - datetime: '2020-01-01'
+      value: 0.3907
 parsers:
   consumption: ENTSOE.fetch_consumption
   consumptionForecast: ENTSOE.fetch_consumption_forecast
@@ -436,8 +444,6 @@ parsers:
   productionPerModeForecast: ENTSOE.fetch_wind_solar_forecasts
 region: Europe
 sources:
-  National Laboratory of the Rockies:
-    link: https://docs.nrel.gov/docs/fy21osti/80580.pdf
   EU-ETS, ENTSO-E 2021:
     link: https://drive.google.com/file/d/15UeUHyhcjVw8fGLc0Zx_HELSx20cw_-e/view?usp=share_link
   EU-ETS, ENTSO-E 2022:
@@ -450,6 +456,8 @@ sources:
     link: https://docs.google.com/spreadsheets/d/1w5DJ7sPen6axIHU8TCVcuzNCjlct4I6JAbhUlw-ZXu8/edit?usp=sharing
   IPCC 2014:
     link: https://www.ipcc.ch/site/assets/uploads/2018/02/ipcc_wg3_ar5_annex-iii.pdf#page=7
+  National Laboratory of the Rockies:
+    link: https://docs.nrel.gov/docs/fy21osti/80580.pdf
   UNECE 2022:
     link: https://unece.org/sites/default/files/2022-04/LCA_3_FINAL%20March%202022.pdf
   ? UNECE 2022, WindEurope "Wind energy in Europe, 2021 Statistics and the outlook

--- a/config/zones/IT-NO.yaml
+++ b/config/zones/IT-NO.yaml
@@ -107,7 +107,7 @@ emissionFactors:
       - _comment: used storage values greater than zero.
         datetime: '2025-01-01'
         source: Electricity Maps, 2025 zone average
-        value: 199.5
+        value: 198.6
     biomass:
       datetime: '2021-01-01'
       source: BEIS 2021
@@ -146,23 +146,23 @@ emissionFactors:
       - _comment: used storage values greater than zero.
         datetime: '2021-01-01'
         source: Electricity Maps, 2021 zone average
-        value: 258.09
+        value: 263.95
       - _comment: used storage values greater than zero.
         datetime: '2022-01-01'
         source: Electricity Maps, 2022 zone average
-        value: 287.0
+        value: 293.03
       - _comment: used storage values greater than zero.
         datetime: '2023-01-01'
         source: Electricity Maps, 2023 zone average
-        value: 228.55
+        value: 223.05
       - _comment: used storage values greater than zero.
         datetime: '2024-01-01'
         source: Electricity Maps, 2024 zone average
-        value: 179.41
+        value: 179.42
       - _comment: used storage values greater than zero.
         datetime: '2025-01-01'
         source: Electricity Maps, 2025 zone average
-        value: 196.42
+        value: 191.91
     oil:
       - datetime: '2021-01-01'
         source: EU-ETS, ENTSO-E 2021
@@ -185,7 +185,7 @@ emissionFactors:
       - _comment: used storage values greater than zero.
         datetime: '2025-01-01'
         source: Electricity Maps, 2025 zone average; National Laboratory of the Rockies
-        value: 232.5
+        value: 231.6
     biomass:
       datetime: '2014-01-01'
       source: BEIS 2021; IPCC 2014
@@ -230,23 +230,23 @@ emissionFactors:
       - _comment: used storage values greater than zero.
         datetime: '2021-01-01'
         source: Electricity Maps, 2021 zone average; UNECE 2022
-        value: 268.79
+        value: 274.65
       - _comment: used storage values greater than zero.
         datetime: '2022-01-01'
         source: Electricity Maps, 2022 zone average; UNECE 2022
-        value: 297.7
+        value: 303.73
       - _comment: used storage values greater than zero.
         datetime: '2023-01-01'
         source: Electricity Maps, 2023 zone average; UNECE 2022
-        value: 239.25
+        value: 233.75
       - _comment: used storage values greater than zero.
         datetime: '2024-01-01'
         source: Electricity Maps, 2024 zone average; UNECE 2022
-        value: 190.11
+        value: 190.12
       - _comment: used storage values greater than zero.
         datetime: '2025-01-01'
         source: Electricity Maps, 2025 zone average; UNECE 2022
-        value: 207.12
+        value: 202.61
     nuclear:
       datetime: '2020-01-01'
       source: UNECE 2022
@@ -432,39 +432,39 @@ isLowCarbon:
     - datetime: '2024-01-01'
       value: 0.3193
     - datetime: '2025-01-01'
-      value: 0.5473
+      value: 0.5497
   hydro discharge:
     - datetime: '2020-01-01'
       value: 0.5047
     - datetime: '2021-01-01'
-      value: 0.4674
+      value: 0.4508
     - datetime: '2022-01-01'
-      value: 0.4349
+      value: 0.4123
     - datetime: '2023-01-01'
-      value: 0.5334
+      value: 0.5325
     - datetime: '2024-01-01'
       value: 0.6014
     - datetime: '2025-01-01'
-      value: 0.5558
+      value: 0.5665
 isRenewable:
   battery discharge:
     - datetime: '2024-01-01'
       value: 0.2248
     - datetime: '2025-01-01'
-      value: 0.3978
+      value: 0.4013
   hydro discharge:
     - datetime: '2020-01-01'
       value: 0.3907
     - datetime: '2021-01-01'
-      value: 0.3438
+      value: 0.3393
     - datetime: '2022-01-01'
-      value: 0.3133
+      value: 0.3024
     - datetime: '2023-01-01'
-      value: 0.3895
+      value: 0.3949
     - datetime: '2024-01-01'
       value: 0.4555
     - datetime: '2025-01-01'
-      value: 0.4099
+      value: 0.4216
 parsers:
   consumption: ENTSOE.fetch_consumption
   consumptionForecast: ENTSOE.fetch_consumption_forecast

--- a/config/zones/IT-NO.yaml
+++ b/config/zones/IT-NO.yaml
@@ -431,10 +431,14 @@ isLowCarbon:
   hydro discharge:
     - datetime: '2020-01-01'
       value: 0.5047
+    - datetime: '2021-01-01'
+      value: 0.4674
 isRenewable:
   hydro discharge:
     - datetime: '2020-01-01'
       value: 0.3907
+    - datetime: '2021-01-01'
+      value: 0.3438
 parsers:
   consumption: ENTSOE.fetch_consumption
   consumptionForecast: ENTSOE.fetch_consumption_forecast

--- a/config/zones/IT-NO.yaml
+++ b/config/zones/IT-NO.yaml
@@ -103,11 +103,11 @@ emissionFactors:
       - _comment: used non-null storage values
         datetime: '2024-01-01'
         source: Electricity Maps, 2024 zone average
-        value: 320.6
+        value: 301.11
       - _comment: used storage values greater than zero.
         datetime: '2025-01-01'
         source: Electricity Maps, 2025 zone average
-        value: 212.66
+        value: 199.5
     biomass:
       datetime: '2021-01-01'
       source: BEIS 2021
@@ -154,15 +154,15 @@ emissionFactors:
       - _comment: used storage values greater than zero.
         datetime: '2023-01-01'
         source: Electricity Maps, 2023 zone average
-        value: 232.81
+        value: 228.55
       - _comment: used storage values greater than zero.
         datetime: '2024-01-01'
         source: Electricity Maps, 2024 zone average
-        value: 186.05
+        value: 179.41
       - _comment: used storage values greater than zero.
         datetime: '2025-01-01'
         source: Electricity Maps, 2025 zone average
-        value: 209.14
+        value: 196.42
     oil:
       - datetime: '2021-01-01'
         source: EU-ETS, ENTSO-E 2021
@@ -181,11 +181,11 @@ emissionFactors:
       - _comment: used non-null storage values
         datetime: '2024-01-01'
         source: Electricity Maps, 2024 zone average; National Laboratory of the Rockies
-        value: 353.6
+        value: 334.11
       - _comment: used storage values greater than zero.
         datetime: '2025-01-01'
         source: Electricity Maps, 2025 zone average; National Laboratory of the Rockies
-        value: 245.66
+        value: 232.5
     biomass:
       datetime: '2014-01-01'
       source: BEIS 2021; IPCC 2014
@@ -238,15 +238,15 @@ emissionFactors:
       - _comment: used storage values greater than zero.
         datetime: '2023-01-01'
         source: Electricity Maps, 2023 zone average; UNECE 2022
-        value: 243.51
+        value: 239.25
       - _comment: used storage values greater than zero.
         datetime: '2024-01-01'
         source: Electricity Maps, 2024 zone average; UNECE 2022
-        value: 196.75
+        value: 190.11
       - _comment: used storage values greater than zero.
         datetime: '2025-01-01'
         source: Electricity Maps, 2025 zone average; UNECE 2022
-        value: 219.84
+        value: 207.12
     nuclear:
       datetime: '2020-01-01'
       source: UNECE 2022
@@ -428,6 +428,11 @@ fallbackZoneMixes:
 has_day_ahead_price_license: false
 hide_day_ahead_price: false
 isLowCarbon:
+  battery discharge:
+    - datetime: '2024-01-01'
+      value: 0.3193
+    - datetime: '2025-01-01'
+      value: 0.5473
   hydro discharge:
     - datetime: '2020-01-01'
       value: 0.5047
@@ -435,7 +440,18 @@ isLowCarbon:
       value: 0.4674
     - datetime: '2022-01-01'
       value: 0.4349
+    - datetime: '2023-01-01'
+      value: 0.5334
+    - datetime: '2024-01-01'
+      value: 0.6014
+    - datetime: '2025-01-01'
+      value: 0.5558
 isRenewable:
+  battery discharge:
+    - datetime: '2024-01-01'
+      value: 0.2248
+    - datetime: '2025-01-01'
+      value: 0.3978
   hydro discharge:
     - datetime: '2020-01-01'
       value: 0.3907
@@ -443,6 +459,12 @@ isRenewable:
       value: 0.3438
     - datetime: '2022-01-01'
       value: 0.3133
+    - datetime: '2023-01-01'
+      value: 0.3895
+    - datetime: '2024-01-01'
+      value: 0.4555
+    - datetime: '2025-01-01'
+      value: 0.4099
 parsers:
   consumption: ENTSOE.fetch_consumption
   consumptionForecast: ENTSOE.fetch_consumption_forecast

--- a/config/zones/IT-NO.yaml
+++ b/config/zones/IT-NO.yaml
@@ -433,12 +433,16 @@ isLowCarbon:
       value: 0.5047
     - datetime: '2021-01-01'
       value: 0.4674
+    - datetime: '2022-01-01'
+      value: 0.4349
 isRenewable:
   hydro discharge:
     - datetime: '2020-01-01'
       value: 0.3907
     - datetime: '2021-01-01'
       value: 0.3438
+    - datetime: '2022-01-01'
+      value: 0.3133
 parsers:
   consumption: ENTSOE.fetch_consumption
   consumptionForecast: ENTSOE.fetch_consumption_forecast

--- a/config/zones/IT-SAR.yaml
+++ b/config/zones/IT-SAR.yaml
@@ -406,10 +406,14 @@ isLowCarbon:
   hydro discharge:
     - datetime: '2020-01-01'
       value: 0.262
+    - datetime: '2021-01-01'
+      value: 0.3002
 isRenewable:
   hydro discharge:
     - datetime: '2020-01-01'
       value: 0.2619
+    - datetime: '2021-01-01'
+      value: 0.2995
 parsers:
   consumption: ENTSOE.fetch_consumption
   consumptionForecast: ENTSOE.fetch_consumption_forecast

--- a/config/zones/IT-SAR.yaml
+++ b/config/zones/IT-SAR.yaml
@@ -408,12 +408,16 @@ isLowCarbon:
       value: 0.262
     - datetime: '2021-01-01'
       value: 0.3002
+    - datetime: '2022-01-01'
+      value: 0.3068
 isRenewable:
   hydro discharge:
     - datetime: '2020-01-01'
       value: 0.2619
     - datetime: '2021-01-01'
       value: 0.2995
+    - datetime: '2022-01-01'
+      value: 0.3065
 parsers:
   consumption: ENTSOE.fetch_consumption
   consumptionForecast: ENTSOE.fetch_consumption_forecast

--- a/config/zones/IT-SAR.yaml
+++ b/config/zones/IT-SAR.yaml
@@ -78,11 +78,11 @@ emissionFactors:
       - _comment: used non-null storage values
         datetime: '2024-01-01'
         source: Electricity Maps, 2024 zone average
-        value: 426.4
+        value: 408.3
       - _comment: used storage values greater than zero.
         datetime: '2025-01-01'
         source: Electricity Maps, 2025 zone average
-        value: 394.58
+        value: 390.35
     biomass:
       datetime: '2021-01-01'
       source: BEIS 2021
@@ -129,15 +129,15 @@ emissionFactors:
       - _comment: used storage values greater than zero.
         datetime: '2023-01-01'
         source: Electricity Maps, 2023 zone average
-        value: 438.32
+        value: 433.78
       - _comment: used storage values greater than zero.
         datetime: '2024-01-01'
         source: Electricity Maps, 2024 zone average
-        value: 428.79
+        value: 431.57
       - _comment: used storage values greater than zero.
         datetime: '2025-01-01'
         source: Electricity Maps, 2025 zone average
-        value: 393.88
+        value: 388.4
     oil:
       - datetime: '2021-01-01'
         source: EU-ETS, ENTSO-E 2021
@@ -156,11 +156,11 @@ emissionFactors:
       - _comment: used non-null storage values
         datetime: '2024-01-01'
         source: Electricity Maps, 2024 zone average; National Laboratory of the Rockies
-        value: 459.4
+        value: 441.3
       - _comment: used storage values greater than zero.
         datetime: '2025-01-01'
         source: Electricity Maps, 2025 zone average; National Laboratory of the Rockies
-        value: 427.58
+        value: 423.35
     biomass:
       datetime: '2014-01-01'
       source: BEIS 2021; IPCC 2014
@@ -213,15 +213,15 @@ emissionFactors:
       - _comment: used storage values greater than zero.
         datetime: '2023-01-01'
         source: Electricity Maps, 2023 zone average; UNECE 2022
-        value: 449.02
+        value: 444.48
       - _comment: used storage values greater than zero.
         datetime: '2024-01-01'
         source: Electricity Maps, 2024 zone average; UNECE 2022
-        value: 439.49
+        value: 442.27
       - _comment: used storage values greater than zero.
         datetime: '2025-01-01'
         source: Electricity Maps, 2025 zone average; UNECE 2022
-        value: 404.58
+        value: 399.1
     nuclear:
       datetime: '2020-01-01'
       source: UNECE 2022
@@ -403,6 +403,11 @@ fallbackZoneMixes:
 has_day_ahead_price_license: false
 hide_day_ahead_price: false
 isLowCarbon:
+  battery discharge:
+    - datetime: '2024-01-01'
+      value: 0.1984
+    - datetime: '2025-01-01'
+      value: 0.3846
   hydro discharge:
     - datetime: '2020-01-01'
       value: 0.262
@@ -410,7 +415,18 @@ isLowCarbon:
       value: 0.3002
     - datetime: '2022-01-01'
       value: 0.3068
+    - datetime: '2023-01-01'
+      value: 0.3636
+    - datetime: '2024-01-01'
+      value: 0.3411
+    - datetime: '2025-01-01'
+      value: 0.3733
 isRenewable:
+  battery discharge:
+    - datetime: '2024-01-01'
+      value: 0.1983
+    - datetime: '2025-01-01'
+      value: 0.3838
   hydro discharge:
     - datetime: '2020-01-01'
       value: 0.2619
@@ -418,6 +434,12 @@ isRenewable:
       value: 0.2995
     - datetime: '2022-01-01'
       value: 0.3065
+    - datetime: '2023-01-01'
+      value: 0.3626
+    - datetime: '2024-01-01'
+      value: 0.3397
+    - datetime: '2025-01-01'
+      value: 0.3727
 parsers:
   consumption: ENTSOE.fetch_consumption
   consumptionForecast: ENTSOE.fetch_consumption_forecast

--- a/config/zones/IT-SAR.yaml
+++ b/config/zones/IT-SAR.yaml
@@ -82,7 +82,7 @@ emissionFactors:
       - _comment: used storage values greater than zero.
         datetime: '2025-01-01'
         source: Electricity Maps, 2025 zone average
-        value: 390.35
+        value: 379.86
     biomass:
       datetime: '2021-01-01'
       source: BEIS 2021
@@ -121,23 +121,23 @@ emissionFactors:
       - _comment: used storage values greater than zero.
         datetime: '2021-01-01'
         source: Electricity Maps, 2021 zone average
-        value: 480.15
+        value: 495.51
       - _comment: used storage values greater than zero.
         datetime: '2022-01-01'
         source: Electricity Maps, 2022 zone average
-        value: 486.68
+        value: 507.95
       - _comment: used storage values greater than zero.
         datetime: '2023-01-01'
         source: Electricity Maps, 2023 zone average
-        value: 433.78
+        value: 450.79
       - _comment: used storage values greater than zero.
         datetime: '2024-01-01'
         source: Electricity Maps, 2024 zone average
-        value: 431.57
+        value: 431.66
       - _comment: used storage values greater than zero.
         datetime: '2025-01-01'
         source: Electricity Maps, 2025 zone average
-        value: 388.4
+        value: 388.93
     oil:
       - datetime: '2021-01-01'
         source: EU-ETS, ENTSO-E 2021
@@ -160,7 +160,7 @@ emissionFactors:
       - _comment: used storage values greater than zero.
         datetime: '2025-01-01'
         source: Electricity Maps, 2025 zone average; National Laboratory of the Rockies
-        value: 423.35
+        value: 412.86
     biomass:
       datetime: '2014-01-01'
       source: BEIS 2021; IPCC 2014
@@ -205,23 +205,23 @@ emissionFactors:
       - _comment: used storage values greater than zero.
         datetime: '2021-01-01'
         source: Electricity Maps, 2021 zone average; UNECE 2022
-        value: 490.85
+        value: 506.21
       - _comment: used storage values greater than zero.
         datetime: '2022-01-01'
         source: Electricity Maps, 2022 zone average; UNECE 2022
-        value: 497.38
+        value: 518.65
       - _comment: used storage values greater than zero.
         datetime: '2023-01-01'
         source: Electricity Maps, 2023 zone average; UNECE 2022
-        value: 444.48
+        value: 461.49
       - _comment: used storage values greater than zero.
         datetime: '2024-01-01'
         source: Electricity Maps, 2024 zone average; UNECE 2022
-        value: 442.27
+        value: 442.36
       - _comment: used storage values greater than zero.
         datetime: '2025-01-01'
         source: Electricity Maps, 2025 zone average; UNECE 2022
-        value: 399.1
+        value: 399.63
     nuclear:
       datetime: '2020-01-01'
       source: UNECE 2022
@@ -407,39 +407,39 @@ isLowCarbon:
     - datetime: '2024-01-01'
       value: 0.1984
     - datetime: '2025-01-01'
-      value: 0.3846
+      value: 0.4069
   hydro discharge:
     - datetime: '2020-01-01'
       value: 0.262
     - datetime: '2021-01-01'
-      value: 0.3002
+      value: 0.2958
     - datetime: '2022-01-01'
-      value: 0.3068
+      value: 0.284
     - datetime: '2023-01-01'
-      value: 0.3636
+      value: 0.3468
     - datetime: '2024-01-01'
-      value: 0.3411
+      value: 0.3413
     - datetime: '2025-01-01'
-      value: 0.3733
+      value: 0.3988
 isRenewable:
   battery discharge:
     - datetime: '2024-01-01'
       value: 0.1983
     - datetime: '2025-01-01'
-      value: 0.3838
+      value: 0.406
   hydro discharge:
     - datetime: '2020-01-01'
       value: 0.2619
     - datetime: '2021-01-01'
-      value: 0.2995
+      value: 0.2951
     - datetime: '2022-01-01'
-      value: 0.3065
+      value: 0.2838
     - datetime: '2023-01-01'
-      value: 0.3626
+      value: 0.346
     - datetime: '2024-01-01'
-      value: 0.3397
+      value: 0.3399
     - datetime: '2025-01-01'
-      value: 0.3727
+      value: 0.3982
 parsers:
   consumption: ENTSOE.fetch_consumption
   consumptionForecast: ENTSOE.fetch_consumption_forecast

--- a/config/zones/IT-SAR.yaml
+++ b/config/zones/IT-SAR.yaml
@@ -402,6 +402,14 @@ fallbackZoneMixes:
         wind: 0.13867825558188832
 has_day_ahead_price_license: false
 hide_day_ahead_price: false
+isLowCarbon:
+  hydro discharge:
+    - datetime: '2020-01-01'
+      value: 0.262
+isRenewable:
+  hydro discharge:
+    - datetime: '2020-01-01'
+      value: 0.2619
 parsers:
   consumption: ENTSOE.fetch_consumption
   consumptionForecast: ENTSOE.fetch_consumption_forecast
@@ -411,8 +419,6 @@ parsers:
   productionPerModeForecast: ENTSOE.fetch_wind_solar_forecasts
 region: Europe
 sources:
-  National Laboratory of the Rockies:
-    link: https://docs.nrel.gov/docs/fy21osti/80580.pdf
   EU-ETS, ENTSO-E 2021:
     link: https://drive.google.com/file/d/15UeUHyhcjVw8fGLc0Zx_HELSx20cw_-e/view?usp=share_link
   EU-ETS, ENTSO-E 2022:
@@ -425,6 +431,8 @@ sources:
     link: https://docs.google.com/spreadsheets/d/1w5DJ7sPen6axIHU8TCVcuzNCjlct4I6JAbhUlw-ZXu8/edit?usp=sharing
   IPCC 2014:
     link: https://www.ipcc.ch/site/assets/uploads/2018/02/ipcc_wg3_ar5_annex-iii.pdf#page=7
+  National Laboratory of the Rockies:
+    link: https://docs.nrel.gov/docs/fy21osti/80580.pdf
   UNECE 2022:
     link: https://unece.org/sites/default/files/2022-04/LCA_3_FINAL%20March%202022.pdf
   ? UNECE 2022, WindEurope "Wind energy in Europe, 2021 Statistics and the outlook

--- a/config/zones/IT-SIC.yaml
+++ b/config/zones/IT-SIC.yaml
@@ -83,11 +83,11 @@ emissionFactors:
       - _comment: used non-null storage values
         datetime: '2024-01-01'
         source: Electricity Maps, 2024 zone average
-        value: 287.88
+        value: 263.77
       - _comment: used storage values greater than zero.
         datetime: '2025-01-01'
         source: Electricity Maps, 2025 zone average
-        value: 213.59
+        value: 198.8
     biomass:
       datetime: '2021-01-01'
       source: BEIS 2021
@@ -134,15 +134,15 @@ emissionFactors:
       - _comment: used storage values greater than zero.
         datetime: '2023-01-01'
         source: Electricity Maps, 2023 zone average
-        value: 244.26
+        value: 238.86
       - _comment: used storage values greater than zero.
         datetime: '2024-01-01'
         source: Electricity Maps, 2024 zone average
-        value: 186.76
+        value: 216.08
       - _comment: used storage values greater than zero.
         datetime: '2025-01-01'
         source: Electricity Maps, 2025 zone average
-        value: 203.26
+        value: 189.33
     oil:
       - datetime: '2021-01-01'
         source: EU-ETS, ENTSO-E 2021
@@ -161,11 +161,11 @@ emissionFactors:
       - _comment: used non-null storage values
         datetime: '2024-01-01'
         source: Electricity Maps, 2024 zone average; National Laboratory of the Rockies
-        value: 320.88
+        value: 296.77
       - _comment: used storage values greater than zero.
         datetime: '2025-01-01'
         source: Electricity Maps, 2025 zone average; National Laboratory of the Rockies
-        value: 246.59
+        value: 231.8
     biomass:
       datetime: '2014-01-01'
       source: BEIS 2021; IPCC 2014
@@ -218,15 +218,15 @@ emissionFactors:
       - _comment: used storage values greater than zero.
         datetime: '2023-01-01'
         source: Electricity Maps, 2023 zone average; UNECE 2022
-        value: 254.96
+        value: 249.56
       - _comment: used storage values greater than zero.
         datetime: '2024-01-01'
         source: Electricity Maps, 2024 zone average; UNECE 2022
-        value: 197.46
+        value: 226.78
       - _comment: used storage values greater than zero.
         datetime: '2025-01-01'
         source: Electricity Maps, 2025 zone average; UNECE 2022
-        value: 213.96
+        value: 200.03
     nuclear:
       datetime: '2020-01-01'
       source: UNECE 2022
@@ -408,6 +408,11 @@ fallbackZoneMixes:
 has_day_ahead_price_license: false
 hide_day_ahead_price: false
 isLowCarbon:
+  battery discharge:
+    - datetime: '2024-01-01'
+      value: 0.34
+    - datetime: '2025-01-01'
+      value: 0.5548
   hydro discharge:
     - datetime: '2020-01-01'
       value: 0.3866
@@ -415,7 +420,18 @@ isLowCarbon:
       value: 0.4399
     - datetime: '2022-01-01'
       value: 0.3699
+    - datetime: '2023-01-01'
+      value: 0.4857
+    - datetime: '2024-01-01'
+      value: 0.5041
+    - datetime: '2025-01-01'
+      value: 0.5801
 isRenewable:
+  battery discharge:
+    - datetime: '2024-01-01'
+      value: 0.3399
+    - datetime: '2025-01-01'
+      value: 0.5545
   hydro discharge:
     - datetime: '2020-01-01'
       value: 0.3866
@@ -423,6 +439,12 @@ isRenewable:
       value: 0.4398
     - datetime: '2022-01-01'
       value: 0.3698
+    - datetime: '2023-01-01'
+      value: 0.4854
+    - datetime: '2024-01-01'
+      value: 0.5034
+    - datetime: '2025-01-01'
+      value: 0.5798
 parsers:
   consumptionForecast: ENTSOE.fetch_consumption_forecast
   generationForecast: ENTSOE.fetch_generation_forecast

--- a/config/zones/IT-SIC.yaml
+++ b/config/zones/IT-SIC.yaml
@@ -411,10 +411,14 @@ isLowCarbon:
   hydro discharge:
     - datetime: '2020-01-01'
       value: 0.3866
+    - datetime: '2021-01-01'
+      value: 0.4399
 isRenewable:
   hydro discharge:
     - datetime: '2020-01-01'
       value: 0.3866
+    - datetime: '2021-01-01'
+      value: 0.4398
 parsers:
   consumptionForecast: ENTSOE.fetch_consumption_forecast
   generationForecast: ENTSOE.fetch_generation_forecast

--- a/config/zones/IT-SIC.yaml
+++ b/config/zones/IT-SIC.yaml
@@ -413,12 +413,16 @@ isLowCarbon:
       value: 0.3866
     - datetime: '2021-01-01'
       value: 0.4399
+    - datetime: '2022-01-01'
+      value: 0.3699
 isRenewable:
   hydro discharge:
     - datetime: '2020-01-01'
       value: 0.3866
     - datetime: '2021-01-01'
       value: 0.4398
+    - datetime: '2022-01-01'
+      value: 0.3698
 parsers:
   consumptionForecast: ENTSOE.fetch_consumption_forecast
   generationForecast: ENTSOE.fetch_generation_forecast

--- a/config/zones/IT-SIC.yaml
+++ b/config/zones/IT-SIC.yaml
@@ -87,7 +87,7 @@ emissionFactors:
       - _comment: used storage values greater than zero.
         datetime: '2025-01-01'
         source: Electricity Maps, 2025 zone average
-        value: 198.8
+        value: 186.61
     biomass:
       datetime: '2021-01-01'
       source: BEIS 2021
@@ -126,23 +126,23 @@ emissionFactors:
       - _comment: used storage values greater than zero.
         datetime: '2021-01-01'
         source: Electricity Maps, 2021 zone average
-        value: 288.12
+        value: 313.08
       - _comment: used storage values greater than zero.
         datetime: '2022-01-01'
         source: Electricity Maps, 2022 zone average
-        value: 325.82
+        value: 349.78
       - _comment: used storage values greater than zero.
         datetime: '2023-01-01'
         source: Electricity Maps, 2023 zone average
-        value: 238.86
+        value: 269.88
       - _comment: used storage values greater than zero.
         datetime: '2024-01-01'
         source: Electricity Maps, 2024 zone average
-        value: 216.08
+        value: 215.88
       - _comment: used storage values greater than zero.
         datetime: '2025-01-01'
         source: Electricity Maps, 2025 zone average
-        value: 189.33
+        value: 160.4
     oil:
       - datetime: '2021-01-01'
         source: EU-ETS, ENTSO-E 2021
@@ -165,7 +165,7 @@ emissionFactors:
       - _comment: used storage values greater than zero.
         datetime: '2025-01-01'
         source: Electricity Maps, 2025 zone average; National Laboratory of the Rockies
-        value: 231.8
+        value: 219.61
     biomass:
       datetime: '2014-01-01'
       source: BEIS 2021; IPCC 2014
@@ -210,23 +210,23 @@ emissionFactors:
       - _comment: used storage values greater than zero.
         datetime: '2021-01-01'
         source: Electricity Maps, 2021 zone average; UNECE 2022
-        value: 298.82
+        value: 323.78
       - _comment: used storage values greater than zero.
         datetime: '2022-01-01'
         source: Electricity Maps, 2022 zone average; UNECE 2022
-        value: 336.52
+        value: 360.48
       - _comment: used storage values greater than zero.
         datetime: '2023-01-01'
         source: Electricity Maps, 2023 zone average; UNECE 2022
-        value: 249.56
+        value: 280.58
       - _comment: used storage values greater than zero.
         datetime: '2024-01-01'
         source: Electricity Maps, 2024 zone average; UNECE 2022
-        value: 226.78
+        value: 226.58
       - _comment: used storage values greater than zero.
         datetime: '2025-01-01'
         source: Electricity Maps, 2025 zone average; UNECE 2022
-        value: 200.03
+        value: 171.1
     nuclear:
       datetime: '2020-01-01'
       source: UNECE 2022
@@ -412,39 +412,39 @@ isLowCarbon:
     - datetime: '2024-01-01'
       value: 0.34
     - datetime: '2025-01-01'
-      value: 0.5548
+      value: 0.5794
   hydro discharge:
     - datetime: '2020-01-01'
       value: 0.3866
     - datetime: '2021-01-01'
-      value: 0.4399
+      value: 0.3913
     - datetime: '2022-01-01'
-      value: 0.3699
+      value: 0.3201
     - datetime: '2023-01-01'
-      value: 0.4857
+      value: 0.4114
     - datetime: '2024-01-01'
-      value: 0.5041
+      value: 0.5046
     - datetime: '2025-01-01'
-      value: 0.5801
+      value: 0.642
 isRenewable:
   battery discharge:
     - datetime: '2024-01-01'
       value: 0.3399
     - datetime: '2025-01-01'
-      value: 0.5545
+      value: 0.5792
   hydro discharge:
     - datetime: '2020-01-01'
       value: 0.3866
     - datetime: '2021-01-01'
-      value: 0.4398
+      value: 0.3912
     - datetime: '2022-01-01'
-      value: 0.3698
+      value: 0.32
     - datetime: '2023-01-01'
-      value: 0.4854
+      value: 0.4112
     - datetime: '2024-01-01'
-      value: 0.5034
+      value: 0.5038
     - datetime: '2025-01-01'
-      value: 0.5798
+      value: 0.6419
 parsers:
   consumptionForecast: ENTSOE.fetch_consumption_forecast
   generationForecast: ENTSOE.fetch_generation_forecast

--- a/config/zones/IT-SIC.yaml
+++ b/config/zones/IT-SIC.yaml
@@ -407,6 +407,14 @@ fallbackZoneMixes:
         wind: 0.25378750961633484
 has_day_ahead_price_license: false
 hide_day_ahead_price: false
+isLowCarbon:
+  hydro discharge:
+    - datetime: '2020-01-01'
+      value: 0.3866
+isRenewable:
+  hydro discharge:
+    - datetime: '2020-01-01'
+      value: 0.3866
 parsers:
   consumptionForecast: ENTSOE.fetch_consumption_forecast
   generationForecast: ENTSOE.fetch_generation_forecast
@@ -415,8 +423,6 @@ parsers:
   productionPerModeForecast: ENTSOE.fetch_wind_solar_forecasts
 region: Europe
 sources:
-  National Laboratory of the Rockies:
-    link: https://docs.nrel.gov/docs/fy21osti/80580.pdf
   EU-ETS, ENTSO-E 2021:
     link: https://drive.google.com/file/d/15UeUHyhcjVw8fGLc0Zx_HELSx20cw_-e/view?usp=share_link
   EU-ETS, ENTSO-E 2022:
@@ -429,6 +435,8 @@ sources:
     link: https://docs.google.com/spreadsheets/d/1w5DJ7sPen6axIHU8TCVcuzNCjlct4I6JAbhUlw-ZXu8/edit?usp=sharing
   IPCC 2014:
     link: https://www.ipcc.ch/site/assets/uploads/2018/02/ipcc_wg3_ar5_annex-iii.pdf#page=7
+  National Laboratory of the Rockies:
+    link: https://docs.nrel.gov/docs/fy21osti/80580.pdf
   UNECE 2022:
     link: https://unece.org/sites/default/files/2022-04/LCA_3_FINAL%20March%202022.pdf
   ? UNECE 2022, WindEurope "Wind energy in Europe, 2021 Statistics and the outlook

--- a/config/zones/IT.yaml
+++ b/config/zones/IT.yaml
@@ -353,10 +353,14 @@ isLowCarbon:
   hydro discharge:
     - datetime: '2020-01-01'
       value: 0.4883
+    - datetime: '2021-01-01'
+      value: 0.4654
 isRenewable:
   hydro discharge:
     - datetime: '2020-01-01'
       value: 0.4217
+    - datetime: '2021-01-01'
+      value: 0.3944
 region: Europe
 sources:
   EU-ETS, ENTSO-E 2021:

--- a/config/zones/IT.yaml
+++ b/config/zones/IT.yaml
@@ -22,14 +22,14 @@ currency: EUR
 emissionFactors:
   direct:
     battery discharge:
-      - _comment: used storage values greater than zero.
+      - _comment: used non-null storage values
         datetime: '2024-01-01'
         source: Electricity Maps, 2024 zone average
-        value: 269.65
+        value: 324.62
       - _comment: used storage values greater than zero.
         datetime: '2025-01-01'
         source: Electricity Maps, 2025 zone average
-        value: 199.17
+        value: 199.31
     biomass:
       datetime: '2021-01-01'
       source: BEIS 2021
@@ -64,27 +64,27 @@ emissionFactors:
       - _comment: used storage values greater than zero.
         datetime: '2020-01-01'
         source: Electricity Maps, 2020 zone average
-        value: 264.72
+        value: 264.71
       - _comment: used storage values greater than zero.
         datetime: '2021-01-01'
         source: Electricity Maps, 2021 zone average
-        value: 279.69
+        value: 280.66
       - _comment: used storage values greater than zero.
         datetime: '2022-01-01'
         source: Electricity Maps, 2022 zone average
-        value: 317.15
+        value: 318.78
       - _comment: used storage values greater than zero.
         datetime: '2023-01-01'
         source: Electricity Maps, 2023 zone average
-        value: 238.35
+        value: 238.0
       - _comment: used storage values greater than zero.
         datetime: '2024-01-01'
         source: Electricity Maps, 2024 zone average
-        value: 190.17
+        value: 190.11
       - _comment: used storage values greater than zero.
         datetime: '2025-01-01'
         source: Electricity Maps, 2025 zone average
-        value: 193.79
+        value: 188.4
     oil:
       - datetime: '2021-01-01'
         source: EU-ETS, ENTSO-E 2021
@@ -100,14 +100,14 @@ emissionFactors:
         value: 905.42
   lifecycle:
     battery discharge:
-      - _comment: used storage values greater than zero.
+      - _comment: used non-null storage values
         datetime: '2024-01-01'
         source: Electricity Maps, 2024 zone average; National Laboratory of the Rockies
-        value: 302.65
+        value: 357.62
       - _comment: used storage values greater than zero.
         datetime: '2025-01-01'
         source: Electricity Maps, 2025 zone average; National Laboratory of the Rockies
-        value: 232.17
+        value: 232.31
     biomass:
       datetime: '2014-01-01'
       source: BEIS 2021; IPCC 2014
@@ -148,27 +148,27 @@ emissionFactors:
       - _comment: used storage values greater than zero.
         datetime: '2020-01-01'
         source: Electricity Maps, 2020 zone average; UNECE 2022
-        value: 275.42
+        value: 275.41
       - _comment: used storage values greater than zero.
         datetime: '2021-01-01'
         source: Electricity Maps, 2021 zone average; UNECE 2022
-        value: 290.39
+        value: 291.36
       - _comment: used storage values greater than zero.
         datetime: '2022-01-01'
         source: Electricity Maps, 2022 zone average; UNECE 2022
-        value: 327.85
+        value: 329.48
       - _comment: used storage values greater than zero.
         datetime: '2023-01-01'
         source: Electricity Maps, 2023 zone average; UNECE 2022
-        value: 249.05
+        value: 248.7
       - _comment: used storage values greater than zero.
         datetime: '2024-01-01'
         source: Electricity Maps, 2024 zone average; UNECE 2022
-        value: 200.87
+        value: 200.81
       - _comment: used storage values greater than zero.
         datetime: '2025-01-01'
         source: Electricity Maps, 2025 zone average; UNECE 2022
-        value: 204.49
+        value: 199.1
     nuclear:
       datetime: '2020-01-01'
       source: UNECE 2022
@@ -352,41 +352,41 @@ hide_day_ahead_price: false
 isLowCarbon:
   battery discharge:
     - datetime: '2024-01-01'
-      value: 0.3975
+      value: 0.2935
     - datetime: '2025-01-01'
-      value: 0.5568
+      value: 0.5567
   hydro discharge:
     - datetime: '2020-01-01'
       value: 0.4883
     - datetime: '2021-01-01'
-      value: 0.4654
+      value: 0.4571
     - datetime: '2022-01-01'
-      value: 0.4289
+      value: 0.4167
     - datetime: '2023-01-01'
-      value: 0.5436
+      value: 0.5318
     - datetime: '2024-01-01'
-      value: 0.5931
+      value: 0.5933
     - datetime: '2025-01-01'
-      value: 0.5703
+      value: 0.5825
 isRenewable:
   battery discharge:
     - datetime: '2024-01-01'
-      value: 0.3282
+      value: 0.2383
     - datetime: '2025-01-01'
-      value: 0.4689
+      value: 0.4691
   hydro discharge:
     - datetime: '2020-01-01'
       value: 0.4217
     - datetime: '2021-01-01'
-      value: 0.3944
+      value: 0.3924
     - datetime: '2022-01-01'
-      value: 0.3625
+      value: 0.3547
     - datetime: '2023-01-01'
-      value: 0.4639
+      value: 0.4547
     - datetime: '2024-01-01'
-      value: 0.5105
+      value: 0.5108
     - datetime: '2025-01-01'
-      value: 0.4853
+      value: 0.4996
 region: Europe
 sources:
   EU-ETS, ENTSO-E 2021:

--- a/config/zones/IT.yaml
+++ b/config/zones/IT.yaml
@@ -25,11 +25,11 @@ emissionFactors:
       - _comment: used storage values greater than zero.
         datetime: '2024-01-01'
         source: Electricity Maps, 2024 zone average
-        value: 288.15
+        value: 269.65
       - _comment: used storage values greater than zero.
         datetime: '2025-01-01'
         source: Electricity Maps, 2025 zone average
-        value: 212.11
+        value: 199.17
     biomass:
       datetime: '2021-01-01'
       source: BEIS 2021
@@ -76,15 +76,15 @@ emissionFactors:
       - _comment: used storage values greater than zero.
         datetime: '2023-01-01'
         source: Electricity Maps, 2023 zone average
-        value: 242.48
+        value: 238.35
       - _comment: used storage values greater than zero.
         datetime: '2024-01-01'
         source: Electricity Maps, 2024 zone average
-        value: 193.69
+        value: 190.17
       - _comment: used storage values greater than zero.
         datetime: '2025-01-01'
         source: Electricity Maps, 2025 zone average
-        value: 206.41
+        value: 193.79
     oil:
       - datetime: '2021-01-01'
         source: EU-ETS, ENTSO-E 2021
@@ -103,11 +103,11 @@ emissionFactors:
       - _comment: used storage values greater than zero.
         datetime: '2024-01-01'
         source: Electricity Maps, 2024 zone average; National Laboratory of the Rockies
-        value: 321.15
+        value: 302.65
       - _comment: used storage values greater than zero.
         datetime: '2025-01-01'
         source: Electricity Maps, 2025 zone average; National Laboratory of the Rockies
-        value: 245.11
+        value: 232.17
     biomass:
       datetime: '2014-01-01'
       source: BEIS 2021; IPCC 2014
@@ -160,15 +160,15 @@ emissionFactors:
       - _comment: used storage values greater than zero.
         datetime: '2023-01-01'
         source: Electricity Maps, 2023 zone average; UNECE 2022
-        value: 253.18
+        value: 249.05
       - _comment: used storage values greater than zero.
         datetime: '2024-01-01'
         source: Electricity Maps, 2024 zone average; UNECE 2022
-        value: 204.39
+        value: 200.87
       - _comment: used storage values greater than zero.
         datetime: '2025-01-01'
         source: Electricity Maps, 2025 zone average; UNECE 2022
-        value: 217.11
+        value: 204.49
     nuclear:
       datetime: '2020-01-01'
       source: UNECE 2022
@@ -350,6 +350,11 @@ fallbackZoneMixes:
 has_day_ahead_price_license: false
 hide_day_ahead_price: false
 isLowCarbon:
+  battery discharge:
+    - datetime: '2024-01-01'
+      value: 0.3975
+    - datetime: '2025-01-01'
+      value: 0.5568
   hydro discharge:
     - datetime: '2020-01-01'
       value: 0.4883
@@ -357,7 +362,18 @@ isLowCarbon:
       value: 0.4654
     - datetime: '2022-01-01'
       value: 0.4289
+    - datetime: '2023-01-01'
+      value: 0.5436
+    - datetime: '2024-01-01'
+      value: 0.5931
+    - datetime: '2025-01-01'
+      value: 0.5703
 isRenewable:
+  battery discharge:
+    - datetime: '2024-01-01'
+      value: 0.3282
+    - datetime: '2025-01-01'
+      value: 0.4689
   hydro discharge:
     - datetime: '2020-01-01'
       value: 0.4217
@@ -365,6 +381,12 @@ isRenewable:
       value: 0.3944
     - datetime: '2022-01-01'
       value: 0.3625
+    - datetime: '2023-01-01'
+      value: 0.4639
+    - datetime: '2024-01-01'
+      value: 0.5105
+    - datetime: '2025-01-01'
+      value: 0.4853
 region: Europe
 sources:
   EU-ETS, ENTSO-E 2021:

--- a/config/zones/IT.yaml
+++ b/config/zones/IT.yaml
@@ -355,12 +355,16 @@ isLowCarbon:
       value: 0.4883
     - datetime: '2021-01-01'
       value: 0.4654
+    - datetime: '2022-01-01'
+      value: 0.4289
 isRenewable:
   hydro discharge:
     - datetime: '2020-01-01'
       value: 0.4217
     - datetime: '2021-01-01'
       value: 0.3944
+    - datetime: '2022-01-01'
+      value: 0.3625
 region: Europe
 sources:
   EU-ETS, ENTSO-E 2021:

--- a/config/zones/IT.yaml
+++ b/config/zones/IT.yaml
@@ -64,7 +64,7 @@ emissionFactors:
       - _comment: used storage values greater than zero.
         datetime: '2020-01-01'
         source: Electricity Maps, 2020 zone average
-        value: 264.71
+        value: 264.72
       - _comment: used storage values greater than zero.
         datetime: '2021-01-01'
         source: Electricity Maps, 2021 zone average
@@ -148,7 +148,7 @@ emissionFactors:
       - _comment: used storage values greater than zero.
         datetime: '2020-01-01'
         source: Electricity Maps, 2020 zone average; UNECE 2022
-        value: 275.41
+        value: 275.42
       - _comment: used storage values greater than zero.
         datetime: '2021-01-01'
         source: Electricity Maps, 2021 zone average; UNECE 2022
@@ -349,10 +349,16 @@ fallbackZoneMixes:
         wind: 0.09017689210992368
 has_day_ahead_price_license: false
 hide_day_ahead_price: false
+isLowCarbon:
+  hydro discharge:
+    - datetime: '2020-01-01'
+      value: 0.4883
+isRenewable:
+  hydro discharge:
+    - datetime: '2020-01-01'
+      value: 0.4217
 region: Europe
 sources:
-  National Laboratory of the Rockies:
-    link: https://docs.nrel.gov/docs/fy21osti/80580.pdf
   EU-ETS, ENTSO-E 2021:
     link: https://drive.google.com/file/d/15UeUHyhcjVw8fGLc0Zx_HELSx20cw_-e/view?usp=share_link
   EU-ETS, ENTSO-E 2022:
@@ -365,6 +371,8 @@ sources:
     link: https://docs.google.com/spreadsheets/d/1w5DJ7sPen6axIHU8TCVcuzNCjlct4I6JAbhUlw-ZXu8/edit?usp=sharing
   IPCC 2014:
     link: https://www.ipcc.ch/site/assets/uploads/2018/02/ipcc_wg3_ar5_annex-iii.pdf#page=7
+  National Laboratory of the Rockies:
+    link: https://docs.nrel.gov/docs/fy21osti/80580.pdf
   UNECE 2022:
     link: https://unece.org/sites/default/files/2022-04/LCA_3_FINAL%20March%202022.pdf
   ? UNECE 2022, WindEurope "Wind energy in Europe, 2021 Statistics and the outlook

--- a/config/zones/JP-CB.yaml
+++ b/config/zones/JP-CB.yaml
@@ -25,7 +25,8 @@ country_name: Japan
 currency: JPY
 delays:
   production: 5
-disclaimer: The data provided for solar power production is suspected to be too high (source; Chubu Electric Power Co.,Inc.).
+disclaimer: The data provided for solar power production is suspected to be too high
+  (source; Chubu Electric Power Co.,Inc.).
 emissionFactors:
   direct:
     hydro discharge:
@@ -34,11 +35,13 @@ emissionFactors:
         source: Electricity Maps, 2025 zone average
         value: 0.0
     unknown:
-      _comment: 'Source: Derived from 2016-2019 Chubu area supply statistics and 2017-2018 Chubu Electric report'
+      _comment: 'Source: Derived from 2016-2019 Chubu area supply statistics and 2017-2018
+        Chubu Electric report'
       _url:
         - https://www.chuden.co.jp/corporate/publicity/datalist/juyo/dat_kousei/index.html
         - http://denki-yoho.chuden.jp/denki_yoho_content_data/areabalance_current_term.csv
-      source: Chubu Electric Power 2022; assumes 26.3% coal, 2.2% oil, 62.5% gas, 9% hydro and wind
+      source: Chubu Electric Power 2022; assumes 26.3% coal, 2.2% oil, 62.5% gas,
+        9% hydro and wind
       value: 440.062
   lifecycle:
     hydro discharge:
@@ -168,8 +171,16 @@ fallbackZoneMixes:
         solar: 0.12244614660850632
         unknown: 0.003769750267899515
         wind: 0.004048155359128435
-has_day_ahead_price_license: False
-hide_day_ahead_price: False
+has_day_ahead_price_license: false
+hide_day_ahead_price: false
+isLowCarbon:
+  hydro discharge:
+    - datetime: '2025-01-01'
+      value: 1.0
+isRenewable:
+  hydro discharge:
+    - datetime: '2025-01-01'
+      value: 1.0
 parsers:
   consumptionForecast: JP.fetch_consumption_forecast
   generationForecast: JP.fetch_generation_forecast
@@ -177,11 +188,11 @@ parsers:
   production: JP.fetch_production
 region: Asia
 sources:
+  Chubu Electric Power 2022:
+    link: https://www.chuden.co.jp/corporate/publicity/datalist/juyo/dat_kousei/index.html
   IPCC 2014:
     link: https://www.ipcc.ch/site/assets/uploads/2018/02/ipcc_wg3_ar5_annex-iii.pdf#page=7
   National Laboratory of the Rockies:
     link: https://docs.nrel.gov/docs/fy21osti/80580.pdf
-  Chubu Electric Power 2022:
-    link: https://www.chuden.co.jp/corporate/publicity/datalist/juyo/dat_kousei/index.html
 timezone: Asia/Tokyo
-zone_name: 'Chūbu'
+zone_name: "Ch\u016Bbu"

--- a/config/zones/JP-CG.yaml
+++ b/config/zones/JP-CG.yaml
@@ -159,8 +159,16 @@ fallbackZoneMixes:
         solar: 0.12844791109956524
         unknown: 0.0022459561300016023
         wind: 0.00644645444675968
-has_day_ahead_price_license: False
-hide_day_ahead_price: False
+has_day_ahead_price_license: false
+hide_day_ahead_price: false
+isLowCarbon:
+  hydro discharge:
+    - datetime: '2020-01-01'
+      value: 1.0
+isRenewable:
+  hydro discharge:
+    - datetime: '2020-01-01'
+      value: 1.0
 parsers:
   consumptionForecast: JP.fetch_consumption_forecast
   generationForecast: JP.fetch_generation_forecast
@@ -173,4 +181,4 @@ sources:
   National Laboratory of the Rockies:
     link: https://docs.nrel.gov/docs/fy21osti/80580.pdf
 timezone: Asia/Tokyo
-zone_name: 'Chūgoku'
+zone_name: "Ch\u016Bgoku"

--- a/config/zones/JP-CG.yaml
+++ b/config/zones/JP-CG.yaml
@@ -31,11 +31,19 @@ emissionFactors:
         datetime: '2020-01-01'
         source: Electricity Maps, 2020 zone average
         value: 0.0
+      - _comment: used default IPCC 2014 value of 0.0
+        datetime: '2021-01-01'
+        source: Electricity Maps, 2021 zone average
+        value: 0.0
   lifecycle:
     hydro discharge:
       - _comment: used default IPCC 2014 value of 24.0
         datetime: '2020-01-01'
         source: Electricity Maps, 2020 zone average; IPCC 2014
+        value: 24.0
+      - _comment: used default IPCC 2014 value of 24.0
+        datetime: '2021-01-01'
+        source: Electricity Maps, 2021 zone average; IPCC 2014
         value: 24.0
 fallbackZoneMixes:
   powerOriginRatios:
@@ -165,9 +173,13 @@ isLowCarbon:
   hydro discharge:
     - datetime: '2020-01-01'
       value: 1.0
+    - datetime: '2021-01-01'
+      value: 1.0
 isRenewable:
   hydro discharge:
     - datetime: '2020-01-01'
+      value: 1.0
+    - datetime: '2021-01-01'
       value: 1.0
 parsers:
   consumptionForecast: JP.fetch_consumption_forecast

--- a/config/zones/JP-HKD.yaml
+++ b/config/zones/JP-HKD.yaml
@@ -34,11 +34,19 @@ emissionFactors:
         datetime: '2020-01-01'
         source: Electricity Maps, 2020 zone average
         value: 0.0
+      - _comment: used default IPCC 2014 value of 0.0
+        datetime: '2021-01-01'
+        source: Electricity Maps, 2021 zone average
+        value: 0.0
   lifecycle:
     hydro discharge:
       - _comment: used default IPCC 2014 value of 24.0
         datetime: '2020-01-01'
         source: Electricity Maps, 2020 zone average; IPCC 2014
+        value: 24.0
+      - _comment: used default IPCC 2014 value of 24.0
+        datetime: '2021-01-01'
+        source: Electricity Maps, 2021 zone average; IPCC 2014
         value: 24.0
 fallbackZoneMixes:
   powerOriginRatios:
@@ -168,9 +176,13 @@ isLowCarbon:
   hydro discharge:
     - datetime: '2020-01-01'
       value: 1.0
+    - datetime: '2021-01-01'
+      value: 1.0
 isRenewable:
   hydro discharge:
     - datetime: '2020-01-01'
+      value: 1.0
+    - datetime: '2021-01-01'
       value: 1.0
 parsers:
   consumptionForecast: JP.fetch_consumption_forecast

--- a/config/zones/JP-HKD.yaml
+++ b/config/zones/JP-HKD.yaml
@@ -162,8 +162,16 @@ fallbackZoneMixes:
         solar: 0.10087912421308973
         unknown: 0.000405576948770854
         wind: 0.03530341402815505
-has_day_ahead_price_license: False
-hide_day_ahead_price: False
+has_day_ahead_price_license: false
+hide_day_ahead_price: false
+isLowCarbon:
+  hydro discharge:
+    - datetime: '2020-01-01'
+      value: 1.0
+isRenewable:
+  hydro discharge:
+    - datetime: '2020-01-01'
+      value: 1.0
 parsers:
   consumptionForecast: JP.fetch_consumption_forecast
   generationForecast: JP.fetch_generation_forecast
@@ -176,4 +184,4 @@ sources:
   National Laboratory of the Rockies:
     link: https://docs.nrel.gov/docs/fy21osti/80580.pdf
 timezone: Asia/Tokyo
-zone_name: 'Hokkaidō'
+zone_name: "Hokkaid\u014D"

--- a/config/zones/JP-HR.yaml
+++ b/config/zones/JP-HR.yaml
@@ -161,9 +161,13 @@ isLowCarbon:
   hydro discharge:
     - datetime: '2020-01-01'
       value: 1.0
+    - datetime: '2025-01-01'
+      value: 1.0
 isRenewable:
   hydro discharge:
     - datetime: '2020-01-01'
+      value: 1.0
+    - datetime: '2025-01-01'
       value: 1.0
 parsers:
   consumptionForecast: JP.fetch_consumption_forecast

--- a/config/zones/JP-HR.yaml
+++ b/config/zones/JP-HR.yaml
@@ -24,7 +24,9 @@ country_name: Japan
 currency: JPY
 delays:
   production: 5
-disclaimer: The data provider (Hokuriku Electric Power Co.,Inc.) provides live data only for solar and unknown. We are working on improving the data quality for this zone.
+disclaimer: The data provider (Hokuriku Electric Power Co.,Inc.) provides live data
+  only for solar and unknown. We are working on improving the data quality for this
+  zone.
 emissionFactors:
   direct:
     hydro discharge:
@@ -153,8 +155,16 @@ fallbackZoneMixes:
         solar: 0.05969048291522835
         unknown: 0.02047979428559259
         wind: 0.005666854920707754
-has_day_ahead_price_license: False
-hide_day_ahead_price: False
+has_day_ahead_price_license: false
+hide_day_ahead_price: false
+isLowCarbon:
+  hydro discharge:
+    - datetime: '2020-01-01'
+      value: 1.0
+isRenewable:
+  hydro discharge:
+    - datetime: '2020-01-01'
+      value: 1.0
 parsers:
   consumptionForecast: JP.fetch_consumption_forecast
   generationForecast: JP.fetch_generation_forecast

--- a/config/zones/JP-HR.yaml
+++ b/config/zones/JP-HR.yaml
@@ -35,6 +35,10 @@ emissionFactors:
         source: Electricity Maps, 2020 zone average
         value: 0.0
       - _comment: used default IPCC 2014 value of 0.0
+        datetime: '2021-01-01'
+        source: Electricity Maps, 2021 zone average
+        value: 0.0
+      - _comment: used default IPCC 2014 value of 0.0
         datetime: '2025-01-01'
         source: Electricity Maps, 2025 zone average
         value: 0.0
@@ -43,6 +47,10 @@ emissionFactors:
       - _comment: used default IPCC 2014 value of 24.0
         datetime: '2020-01-01'
         source: Electricity Maps, 2020 zone average; IPCC 2014
+        value: 24.0
+      - _comment: used default IPCC 2014 value of 24.0
+        datetime: '2021-01-01'
+        source: Electricity Maps, 2021 zone average; IPCC 2014
         value: 24.0
       - _comment: used default IPCC 2014 value of 24.0
         datetime: '2025-01-01'
@@ -161,11 +169,15 @@ isLowCarbon:
   hydro discharge:
     - datetime: '2020-01-01'
       value: 1.0
+    - datetime: '2021-01-01'
+      value: 1.0
     - datetime: '2025-01-01'
       value: 1.0
 isRenewable:
   hydro discharge:
     - datetime: '2020-01-01'
+      value: 1.0
+    - datetime: '2021-01-01'
       value: 1.0
     - datetime: '2025-01-01'
       value: 1.0

--- a/config/zones/JP-KN.yaml
+++ b/config/zones/JP-KN.yaml
@@ -197,11 +197,15 @@ isLowCarbon:
       value: 1.0
     - datetime: '2021-01-01'
       value: 1.0
+    - datetime: '2023-01-01'
+      value: 1.0
 isRenewable:
   hydro discharge:
     - datetime: '2020-01-01'
       value: 1.0
     - datetime: '2021-01-01'
+      value: 1.0
+    - datetime: '2023-01-01'
       value: 1.0
 parsers:
   consumptionForecast: JP.fetch_consumption_forecast

--- a/config/zones/JP-KN.yaml
+++ b/config/zones/JP-KN.yaml
@@ -189,18 +189,26 @@ fallbackZoneMixes:
         solar: 0.07460594186010626
         unknown: 0.030073678811974553
         wind: 0.002427072768801394
-has_day_ahead_price_license: False
-hide_day_ahead_price: False
+has_day_ahead_price_license: false
+hide_day_ahead_price: false
+isLowCarbon:
+  hydro discharge:
+    - datetime: '2020-01-01'
+      value: 1.0
+isRenewable:
+  hydro discharge:
+    - datetime: '2020-01-01'
+      value: 1.0
 parsers:
   consumptionForecast: JP.fetch_consumption_forecast
   generationForecast: JP.fetch_generation_forecast
   price: JP.fetch_price
   production: JP_KN.fetch_production
 region: Asia
-timezone: Asia/Tokyo
-zone_name: Kansai
 sources:
   IPCC 2014:
     link: https://www.ipcc.ch/site/assets/uploads/2018/02/ipcc_wg3_ar5_annex-iii.pdf#page=7
   National Laboratory of the Rockies:
     link: https://docs.nrel.gov/docs/fy21osti/80580.pdf
+timezone: Asia/Tokyo
+zone_name: Kansai

--- a/config/zones/JP-KN.yaml
+++ b/config/zones/JP-KN.yaml
@@ -195,9 +195,13 @@ isLowCarbon:
   hydro discharge:
     - datetime: '2020-01-01'
       value: 1.0
+    - datetime: '2021-01-01'
+      value: 1.0
 isRenewable:
   hydro discharge:
     - datetime: '2020-01-01'
+      value: 1.0
+    - datetime: '2021-01-01'
       value: 1.0
 parsers:
   consumptionForecast: JP.fetch_consumption_forecast

--- a/config/zones/JP-KN.yaml
+++ b/config/zones/JP-KN.yaml
@@ -26,10 +26,10 @@ delays:
 emissionFactors:
   direct:
     hydro discharge:
-      - _comment: used default IPCC 2014 value of 0.0
+      - _comment: used storage values greater than zero.
         datetime: '2020-01-01'
         source: Electricity Maps, 2020 zone average
-        value: 0.0
+        value: 373.6
       - _comment: used default IPCC 2014 value of 0.0
         datetime: '2021-01-01'
         source: Electricity Maps, 2021 zone average
@@ -40,10 +40,10 @@ emissionFactors:
         value: 0.0
   lifecycle:
     hydro discharge:
-      - _comment: used default IPCC 2014 value of 24.0
+      - _comment: used storage values greater than zero.
         datetime: '2020-01-01'
         source: Electricity Maps, 2020 zone average; IPCC 2014
-        value: 24.0
+        value: 397.6
       - _comment: used default IPCC 2014 value of 24.0
         datetime: '2021-01-01'
         source: Electricity Maps, 2021 zone average; IPCC 2014
@@ -194,7 +194,7 @@ hide_day_ahead_price: false
 isLowCarbon:
   hydro discharge:
     - datetime: '2020-01-01'
-      value: 1.0
+      value: 0.3069
     - datetime: '2021-01-01'
       value: 1.0
     - datetime: '2023-01-01'
@@ -202,7 +202,7 @@ isLowCarbon:
 isRenewable:
   hydro discharge:
     - datetime: '2020-01-01'
-      value: 1.0
+      value: 0.2433
     - datetime: '2021-01-01'
       value: 1.0
     - datetime: '2023-01-01'

--- a/config/zones/JP-KY.yaml
+++ b/config/zones/JP-KY.yaml
@@ -163,8 +163,20 @@ fallbackZoneMixes:
         solar: 0.1382906879744919
         unknown: 1.0724997702627927e-06
         wind: 0.006801352931139955
-has_day_ahead_price_license: False
-hide_day_ahead_price: False
+has_day_ahead_price_license: false
+hide_day_ahead_price: false
+isLowCarbon:
+  hydro discharge:
+    - datetime: '2023-01-01'
+      value: 1.0
+    - datetime: '2025-01-01'
+      value: 1.0
+isRenewable:
+  hydro discharge:
+    - datetime: '2023-01-01'
+      value: 1.0
+    - datetime: '2025-01-01'
+      value: 1.0
 parsers:
   consumptionForecast: JP.fetch_consumption_forecast
   generationForecast: JP.fetch_generation_forecast
@@ -177,4 +189,4 @@ sources:
   National Laboratory of the Rockies:
     link: https://docs.nrel.gov/docs/fy21osti/80580.pdf
 timezone: Asia/Tokyo
-zone_name: 'Kyūshū'
+zone_name: "Ky\u016Bsh\u016B"

--- a/config/zones/JP-ON.yaml
+++ b/config/zones/JP-ON.yaml
@@ -165,8 +165,16 @@ fallbackZoneMixes:
         solar: 0.054360569237001784
         unknown: 0.0
         wind: 0.002148162038523783
-has_day_ahead_price_license: False
-hide_day_ahead_price: False
+has_day_ahead_price_license: false
+hide_day_ahead_price: false
+isLowCarbon:
+  hydro discharge:
+    - datetime: '2020-01-01'
+      value: 1.0
+isRenewable:
+  hydro discharge:
+    - datetime: '2020-01-01'
+      value: 1.0
 parsers:
   consumptionForecast: JP.fetch_consumption_forecast
   generationForecast: JP.fetch_generation_forecast

--- a/config/zones/JP-ON.yaml
+++ b/config/zones/JP-ON.yaml
@@ -171,9 +171,13 @@ isLowCarbon:
   hydro discharge:
     - datetime: '2020-01-01'
       value: 1.0
+    - datetime: '2021-01-01'
+      value: 1.0
 isRenewable:
   hydro discharge:
     - datetime: '2020-01-01'
+      value: 1.0
+    - datetime: '2021-01-01'
       value: 1.0
 parsers:
   consumptionForecast: JP.fetch_consumption_forecast

--- a/config/zones/JP-SK.yaml
+++ b/config/zones/JP-SK.yaml
@@ -31,12 +31,20 @@ disclaimer: The data provider (Yonden Shikoku Electric Power Co.,Inc.) provides 
 emissionFactors:
   direct:
     hydro discharge:
+      - _comment: used storage values greater than zero.
+        datetime: '2020-01-01'
+        source: Electricity Maps, 2020 zone average
+        value: 380.86
       - _comment: used default IPCC 2014 value of 0.0
         datetime: '2025-01-01'
         source: Electricity Maps, 2025 zone average
         value: 0.0
   lifecycle:
     hydro discharge:
+      - _comment: used storage values greater than zero.
+        datetime: '2020-01-01'
+        source: Electricity Maps, 2020 zone average; IPCC 2014
+        value: 404.86
       - _comment: used default IPCC 2014 value of 24.0
         datetime: '2025-01-01'
         source: Electricity Maps, 2025 zone average; IPCC 2014
@@ -182,10 +190,14 @@ has_day_ahead_price_license: false
 hide_day_ahead_price: false
 isLowCarbon:
   hydro discharge:
+    - datetime: '2020-01-01'
+      value: 0.3375
     - datetime: '2025-01-01'
       value: 1.0
 isRenewable:
   hydro discharge:
+    - datetime: '2020-01-01'
+      value: 0.2581
     - datetime: '2025-01-01'
       value: 1.0
 parsers:

--- a/config/zones/JP-SK.yaml
+++ b/config/zones/JP-SK.yaml
@@ -25,7 +25,9 @@ country_name: Japan
 currency: JPY
 delays:
   production: 5
-disclaimer: The data provider (Yonden Shikoku Electric Power Co.,Inc.) provides live data only for solar and unknown. We are working on improving the data quality for this zone.
+disclaimer: The data provider (Yonden Shikoku Electric Power Co.,Inc.) provides live
+  data only for solar and unknown. We are working on improving the data quality for
+  this zone.
 emissionFactors:
   direct:
     hydro discharge:
@@ -176,8 +178,16 @@ fallbackZoneMixes:
         solar: 0.15121531986285167
         unknown: 0.6105501241479387
         wind: 0.0012775695365145267
-has_day_ahead_price_license: False
-hide_day_ahead_price: False
+has_day_ahead_price_license: false
+hide_day_ahead_price: false
+isLowCarbon:
+  hydro discharge:
+    - datetime: '2025-01-01'
+      value: 1.0
+isRenewable:
+  hydro discharge:
+    - datetime: '2025-01-01'
+      value: 1.0
 parsers:
   consumptionForecast: JP.fetch_consumption_forecast
   generationForecast: JP.fetch_generation_forecast

--- a/config/zones/JP-TK.yaml
+++ b/config/zones/JP-TK.yaml
@@ -172,8 +172,16 @@ fallbackZoneMixes:
         solar: 0.09707166612504159
         unknown: 0.0026074670238986205
         wind: 0.005644454624628442
-has_day_ahead_price_license: False
-hide_day_ahead_price: False
+has_day_ahead_price_license: false
+hide_day_ahead_price: false
+isLowCarbon:
+  hydro discharge:
+    - datetime: '2025-01-01'
+      value: 1.0
+isRenewable:
+  hydro discharge:
+    - datetime: '2025-01-01'
+      value: 1.0
 parsers:
   consumptionForecast: JP.fetch_consumption_forecast
   generationForecast: JP.fetch_generation_forecast
@@ -184,4 +192,4 @@ sources:
   IPCC 2014:
     link: https://www.ipcc.ch/site/assets/uploads/2018/02/ipcc_wg3_ar5_annex-iii.pdf#page=7
 timezone: Asia/Tokyo
-zone_name: 'Tōkyō'
+zone_name: "T\u014Dky\u014D"

--- a/config/zones/JP.yaml
+++ b/config/zones/JP.yaml
@@ -192,9 +192,13 @@ isLowCarbon:
   hydro discharge:
     - datetime: '2020-01-01'
       value: 1.0
+    - datetime: '2021-01-01'
+      value: 1.0
 isRenewable:
   hydro discharge:
     - datetime: '2020-01-01'
+      value: 1.0
+    - datetime: '2021-01-01'
       value: 1.0
 region: Asia
 sources:

--- a/config/zones/JP.yaml
+++ b/config/zones/JP.yaml
@@ -30,10 +30,10 @@ currency: JPY
 emissionFactors:
   direct:
     hydro discharge:
-      - _comment: used default IPCC 2014 value of 0.0
+      - _comment: used storage values greater than zero.
         datetime: '2020-01-01'
         source: Electricity Maps, 2020 zone average
-        value: 0.0
+        value: 354.18
       - _comment: used default IPCC 2014 value of 0.0
         datetime: '2021-01-01'
         source: Electricity Maps, 2021 zone average
@@ -48,10 +48,10 @@ emissionFactors:
         value: 0.0
   lifecycle:
     hydro discharge:
-      - _comment: used default IPCC 2014 value of 24.0
+      - _comment: used storage values greater than zero.
         datetime: '2020-01-01'
         source: Electricity Maps, 2020 zone average; IPCC 2014
-        value: 24.0
+        value: 378.18
       - _comment: used default IPCC 2014 value of 24.0
         datetime: '2021-01-01'
         source: Electricity Maps, 2021 zone average; IPCC 2014
@@ -191,7 +191,7 @@ hide_day_ahead_price: false
 isLowCarbon:
   hydro discharge:
     - datetime: '2020-01-01'
-      value: 1.0
+      value: 0.3458
     - datetime: '2021-01-01'
       value: 1.0
     - datetime: '2023-01-01'
@@ -201,7 +201,7 @@ isLowCarbon:
 isRenewable:
   hydro discharge:
     - datetime: '2020-01-01'
-      value: 1.0
+      value: 0.2874
     - datetime: '2021-01-01'
       value: 1.0
     - datetime: '2023-01-01'

--- a/config/zones/JP.yaml
+++ b/config/zones/JP.yaml
@@ -186,9 +186,22 @@ fallbackZoneMixes:
         solar: 0.10342626615078988
         unknown: 0.029215896952754124
         wind: 0.008046150827843417
-has_day_ahead_price_license: False
-hide_day_ahead_price: False
+has_day_ahead_price_license: false
+hide_day_ahead_price: false
+isLowCarbon:
+  hydro discharge:
+    - datetime: '2020-01-01'
+      value: 1.0
+isRenewable:
+  hydro discharge:
+    - datetime: '2020-01-01'
+      value: 1.0
 region: Asia
+sources:
+  IPCC 2014:
+    link: https://www.ipcc.ch/site/assets/uploads/2018/02/ipcc_wg3_ar5_annex-iii.pdf#page=7
+  National Laboratory of the Rockies:
+    link: https://docs.nrel.gov/docs/fy21osti/80580.pdf
 subZoneNames:
   - JP-CB
   - JP-CG
@@ -202,8 +215,3 @@ subZoneNames:
   - JP-TK
 timezone: Asia/Tokyo
 zone_name: Japan
-sources:
-  IPCC 2014:
-    link: https://www.ipcc.ch/site/assets/uploads/2018/02/ipcc_wg3_ar5_annex-iii.pdf#page=7
-  National Laboratory of the Rockies:
-    link: https://docs.nrel.gov/docs/fy21osti/80580.pdf

--- a/config/zones/JP.yaml
+++ b/config/zones/JP.yaml
@@ -194,11 +194,19 @@ isLowCarbon:
       value: 1.0
     - datetime: '2021-01-01'
       value: 1.0
+    - datetime: '2023-01-01'
+      value: 1.0
+    - datetime: '2025-01-01'
+      value: 1.0
 isRenewable:
   hydro discharge:
     - datetime: '2020-01-01'
       value: 1.0
     - datetime: '2021-01-01'
+      value: 1.0
+    - datetime: '2023-01-01'
+      value: 1.0
+    - datetime: '2025-01-01'
       value: 1.0
 region: Asia
 sources:

--- a/config/zones/KR.yaml
+++ b/config/zones/KR.yaml
@@ -213,7 +213,7 @@ emissionFactors:
       - _comment: used storage values greater than zero.
         datetime: '2025-01-01'
         source: Electricity Maps, 2025 zone average
-        value: 353.41
+        value: 353.42
   lifecycle:
     hydro discharge:
       - _comment: used storage values greater than zero.
@@ -235,7 +235,7 @@ emissionFactors:
       - _comment: used storage values greater than zero.
         datetime: '2025-01-01'
         source: Electricity Maps, 2025 zone average; IPCC 2014
-        value: 377.41
+        value: 377.42
     unknown:
       _comment: 'Source: 2020 annual electricity production by IEA'
       _url: https://www.iea.org/fuels-and-technologies/electricity
@@ -402,6 +402,12 @@ isLowCarbon:
       value: 0.3322
     - datetime: '2022-01-01'
       value: 0.338
+    - datetime: '2023-01-01'
+      value: 0.36
+    - datetime: '2024-01-01'
+      value: 0.3815
+    - datetime: '2025-01-01'
+      value: 0.3839
   unknown:
     _comment: 'Source: 2020 annual electricity production by IEA'
     _url: https://www.iea.org/fuels-and-technologies/electricity
@@ -414,6 +420,12 @@ isRenewable:
       value: 0.0015
     - datetime: '2022-01-01'
       value: 0.0143
+    - datetime: '2023-01-01'
+      value: 0.0306
+    - datetime: '2024-01-01'
+      value: 0.0389
+    - datetime: '2025-01-01'
+      value: 0.0501
   unknown:
     _comment: 'Source: 2020 annual electricity production by IEA'
     _url: https://www.iea.org/fuels-and-technologies/electricity

--- a/config/zones/KR.yaml
+++ b/config/zones/KR.yaml
@@ -239,7 +239,8 @@ emissionFactors:
     unknown:
       _comment: 'Source: 2020 annual electricity production by IEA'
       _url: https://www.iea.org/fuels-and-technologies/electricity
-      source: IEA 2020; assumes 54.1% coal, 36.1% gas, 1.5% oil, 4.4% solar, 0.8% wind, 2.2% biofuels, 1.0% other
+      source: IEA 2020; assumes 54.1% coal, 36.1% gas, 1.5% oil, 4.4% solar, 0.8%
+        wind, 2.2% biofuels, 1.0% other
       value: 644
 fallbackZoneMixes:
   powerOriginRatios:
@@ -393,8 +394,28 @@ fallbackZoneMixes:
         solar: 0.019400257201052595
         unknown: 0.055175449564712
         wind: 0.0
-has_day_ahead_price_license: False
-hide_day_ahead_price: False
+has_day_ahead_price_license: false
+hide_day_ahead_price: false
+isLowCarbon:
+  hydro discharge:
+    - datetime: '2021-01-01'
+      value: 0.3322
+  unknown:
+    _comment: 'Source: 2020 annual electricity production by IEA'
+    _url: https://www.iea.org/fuels-and-technologies/electricity
+    source: IEA 2020; assumes 54.1% coal, 36.1% gas, 1.5% oil, 4.4% solar, 0.8% wind,
+      2.2% biofuels, 1.0% other
+    value: 0.084
+isRenewable:
+  hydro discharge:
+    - datetime: '2021-01-01'
+      value: 0.0015
+  unknown:
+    _comment: 'Source: 2020 annual electricity production by IEA'
+    _url: https://www.iea.org/fuels-and-technologies/electricity
+    source: IEA 2020; assumes 54.1% coal, 36.1% gas, 1.5% oil, 4.4% solar, 0.8% wind,
+      2.2% biofuels, 1.0% other
+    value: 0.084
 parsers:
   consumption: KPX.fetch_consumption
   price: KPX.fetch_price
@@ -406,15 +427,3 @@ sources:
     link: https://www.ipcc.ch/site/assets/uploads/2018/02/ipcc_wg3_ar5_annex-iii.pdf#page=7
 timezone: Asia/Seoul
 zone_name: South Korea
-isRenewable:
-  unknown:
-    _comment: 'Source: 2020 annual electricity production by IEA'
-    _url: https://www.iea.org/fuels-and-technologies/electricity
-    source: IEA 2020; assumes 54.1% coal, 36.1% gas, 1.5% oil, 4.4% solar, 0.8% wind, 2.2% biofuels, 1.0% other
-    value: 0.084
-isLowCarbon:
-  unknown:
-    _comment: 'Source: 2020 annual electricity production by IEA'
-    _url: https://www.iea.org/fuels-and-technologies/electricity
-    source: IEA 2020; assumes 54.1% coal, 36.1% gas, 1.5% oil, 4.4% solar, 0.8% wind, 2.2% biofuels, 1.0% other
-    value: 0.084

--- a/config/zones/KR.yaml
+++ b/config/zones/KR.yaml
@@ -205,15 +205,15 @@ emissionFactors:
       - _comment: used storage values greater than zero.
         datetime: '2023-01-01'
         source: Electricity Maps, 2023 zone average
-        value: 373.62
+        value: 373.65
       - _comment: used storage values greater than zero.
         datetime: '2024-01-01'
         source: Electricity Maps, 2024 zone average
-        value: 351.52
+        value: 351.53
       - _comment: used storage values greater than zero.
         datetime: '2025-01-01'
         source: Electricity Maps, 2025 zone average
-        value: 353.42
+        value: 353.43
   lifecycle:
     hydro discharge:
       - _comment: used storage values greater than zero.
@@ -227,15 +227,15 @@ emissionFactors:
       - _comment: used storage values greater than zero.
         datetime: '2023-01-01'
         source: Electricity Maps, 2023 zone average; IPCC 2014
-        value: 397.62
+        value: 397.65
       - _comment: used storage values greater than zero.
         datetime: '2024-01-01'
         source: Electricity Maps, 2024 zone average; IPCC 2014
-        value: 375.52
+        value: 375.53
       - _comment: used storage values greater than zero.
         datetime: '2025-01-01'
         source: Electricity Maps, 2025 zone average; IPCC 2014
-        value: 377.42
+        value: 377.43
     unknown:
       _comment: 'Source: 2020 annual electricity production by IEA'
       _url: https://www.iea.org/fuels-and-technologies/electricity

--- a/config/zones/KR.yaml
+++ b/config/zones/KR.yaml
@@ -400,6 +400,8 @@ isLowCarbon:
   hydro discharge:
     - datetime: '2021-01-01'
       value: 0.3322
+    - datetime: '2022-01-01'
+      value: 0.338
   unknown:
     _comment: 'Source: 2020 annual electricity production by IEA'
     _url: https://www.iea.org/fuels-and-technologies/electricity
@@ -410,6 +412,8 @@ isRenewable:
   hydro discharge:
     - datetime: '2021-01-01'
       value: 0.0015
+    - datetime: '2022-01-01'
+      value: 0.0143
   unknown:
     _comment: 'Source: 2020 annual electricity production by IEA'
     _url: https://www.iea.org/fuels-and-technologies/electricity

--- a/config/zones/LT.yaml
+++ b/config/zones/LT.yaml
@@ -482,6 +482,14 @@ fallbackZoneMixes:
         wind: 0.32657023348461944
 has_day_ahead_price_license: true
 hide_day_ahead_price: false
+isLowCarbon:
+  hydro discharge:
+    - datetime: '2020-01-01'
+      value: 1.0
+isRenewable:
+  hydro discharge:
+    - datetime: '2020-01-01'
+      value: 1.0
 parsers:
   consumption: ENTSOE.fetch_consumption
   consumptionForecast: ENTSOE.fetch_consumption_forecast
@@ -492,8 +500,6 @@ parsers:
   productionPerModeForecast: ENTSOE.fetch_wind_solar_forecasts
 region: Europe
 sources:
-  National Laboratory of the Rockies:
-    link: https://docs.nrel.gov/docs/fy21osti/80580.pdf
   EU-ETS, ENTSO-E 2021:
     link: https://drive.google.com/file/d/15UeUHyhcjVw8fGLc0Zx_HELSx20cw_-e/view?usp=share_link
   EU-ETS, ENTSO-E 2022:
@@ -506,6 +512,8 @@ sources:
     link: https://docs.google.com/spreadsheets/d/1w5DJ7sPen6axIHU8TCVcuzNCjlct4I6JAbhUlw-ZXu8/edit?usp=sharing
   IPCC 2014:
     link: https://www.ipcc.ch/site/assets/uploads/2018/02/ipcc_wg3_ar5_annex-iii.pdf#page=7
+  National Laboratory of the Rockies:
+    link: https://docs.nrel.gov/docs/fy21osti/80580.pdf
   UNECE 2022:
     link: https://unece.org/sites/default/files/2022-04/LCA_3_FINAL%20March%202022.pdf
   ? UNECE 2022, WindEurope "Wind energy in Europe, 2021 Statistics and the outlook

--- a/config/zones/LT.yaml
+++ b/config/zones/LT.yaml
@@ -180,7 +180,7 @@ emissionFactors:
       - _comment: used storage values greater than zero.
         datetime: '2025-01-01'
         source: Electricity Maps, 2025 zone average
-        value: 104.2
+        value: 92.47
     biomass:
       datetime: '2021-01-01'
       source: BEIS 2021
@@ -219,23 +219,23 @@ emissionFactors:
       - _comment: used storage values greater than zero.
         datetime: '2021-01-01'
         source: Electricity Maps, 2021 zone average
-        value: 186.95
+        value: 186.79
       - _comment: used storage values greater than zero.
         datetime: '2022-01-01'
         source: Electricity Maps, 2022 zone average
-        value: 185.15
+        value: 185.05
       - _comment: used storage values greater than zero.
         datetime: '2023-01-01'
         source: Electricity Maps, 2023 zone average
-        value: 133.37
+        value: 133.35
       - _comment: used storage values greater than zero.
         datetime: '2024-01-01'
         source: Electricity Maps, 2024 zone average
-        value: 110.73
+        value: 109.9
       - _comment: used storage values greater than zero.
         datetime: '2025-01-01'
         source: Electricity Maps, 2025 zone average
-        value: 85.44
+        value: 84.94
     oil:
       - datetime: '2021-01-01'
         source: EU-ETS, ENTSO-E 2021
@@ -248,7 +248,7 @@ emissionFactors:
       - _comment: used storage values greater than zero.
         datetime: '2025-01-01'
         source: Electricity Maps, 2025 zone average; National Laboratory of the Rockies
-        value: 137.2
+        value: 125.47
     biomass:
       datetime: '2014-01-01'
       source: BEIS 2021; IPCC 2014
@@ -291,23 +291,23 @@ emissionFactors:
       - _comment: used storage values greater than zero.
         datetime: '2021-01-01'
         source: Electricity Maps, 2021 zone average; UNECE 2022
-        value: 197.65
+        value: 197.49
       - _comment: used storage values greater than zero.
         datetime: '2022-01-01'
         source: Electricity Maps, 2022 zone average; UNECE 2022
-        value: 195.85
+        value: 195.75
       - _comment: used storage values greater than zero.
         datetime: '2023-01-01'
         source: Electricity Maps, 2023 zone average; UNECE 2022
-        value: 144.07
+        value: 144.05
       - _comment: used storage values greater than zero.
         datetime: '2024-01-01'
         source: Electricity Maps, 2024 zone average; UNECE 2022
-        value: 121.43
+        value: 120.6
       - _comment: used storage values greater than zero.
         datetime: '2025-01-01'
         source: Electricity Maps, 2025 zone average; UNECE 2022
-        value: 96.14
+        value: 95.64
     nuclear:
       datetime: '2020-01-01'
       source: UNECE 2022
@@ -485,37 +485,37 @@ hide_day_ahead_price: false
 isLowCarbon:
   battery discharge:
     - datetime: '2025-01-01'
-      value: 0.7713
+      value: 0.8031
   hydro discharge:
     - datetime: '2020-01-01'
       value: 1.0
     - datetime: '2021-01-01'
-      value: 0.566
+      value: 0.5664
     - datetime: '2022-01-01'
-      value: 0.6857
+      value: 0.6858
     - datetime: '2023-01-01'
       value: 0.7743
     - datetime: '2024-01-01'
-      value: 0.8255
+      value: 0.8268
     - datetime: '2025-01-01'
-      value: 0.8253
+      value: 0.8259
 isRenewable:
   battery discharge:
     - datetime: '2025-01-01'
-      value: 0.6569
+      value: 0.6911
   hydro discharge:
     - datetime: '2020-01-01'
       value: 1.0
     - datetime: '2021-01-01'
-      value: 0.4169
+      value: 0.4172
     - datetime: '2022-01-01'
-      value: 0.5275
+      value: 0.5276
     - datetime: '2023-01-01'
       value: 0.6457
     - datetime: '2024-01-01'
-      value: 0.7176
+      value: 0.7216
     - datetime: '2025-01-01'
-      value: 0.757
+      value: 0.7566
 parsers:
   consumption: ENTSOE.fetch_consumption
   consumptionForecast: ENTSOE.fetch_consumption_forecast

--- a/config/zones/LT.yaml
+++ b/config/zones/LT.yaml
@@ -486,10 +486,14 @@ isLowCarbon:
   hydro discharge:
     - datetime: '2020-01-01'
       value: 1.0
+    - datetime: '2021-01-01'
+      value: 0.566
 isRenewable:
   hydro discharge:
     - datetime: '2020-01-01'
       value: 1.0
+    - datetime: '2021-01-01'
+      value: 0.4169
 parsers:
   consumption: ENTSOE.fetch_consumption
   consumptionForecast: ENTSOE.fetch_consumption_forecast

--- a/config/zones/LT.yaml
+++ b/config/zones/LT.yaml
@@ -488,12 +488,16 @@ isLowCarbon:
       value: 1.0
     - datetime: '2021-01-01'
       value: 0.566
+    - datetime: '2022-01-01'
+      value: 0.6857
 isRenewable:
   hydro discharge:
     - datetime: '2020-01-01'
       value: 1.0
     - datetime: '2021-01-01'
       value: 0.4169
+    - datetime: '2022-01-01'
+      value: 0.5275
 parsers:
   consumption: ENTSOE.fetch_consumption
   consumptionForecast: ENTSOE.fetch_consumption_forecast

--- a/config/zones/LT.yaml
+++ b/config/zones/LT.yaml
@@ -180,7 +180,7 @@ emissionFactors:
       - _comment: used storage values greater than zero.
         datetime: '2025-01-01'
         source: Electricity Maps, 2025 zone average
-        value: 116.19
+        value: 104.2
     biomass:
       datetime: '2021-01-01'
       source: BEIS 2021
@@ -227,15 +227,15 @@ emissionFactors:
       - _comment: used storage values greater than zero.
         datetime: '2023-01-01'
         source: Electricity Maps, 2023 zone average
-        value: 133.56
+        value: 133.37
       - _comment: used storage values greater than zero.
         datetime: '2024-01-01'
         source: Electricity Maps, 2024 zone average
-        value: 112.85
+        value: 110.73
       - _comment: used storage values greater than zero.
         datetime: '2025-01-01'
         source: Electricity Maps, 2025 zone average
-        value: 86.07
+        value: 85.44
     oil:
       - datetime: '2021-01-01'
         source: EU-ETS, ENTSO-E 2021
@@ -248,7 +248,7 @@ emissionFactors:
       - _comment: used storage values greater than zero.
         datetime: '2025-01-01'
         source: Electricity Maps, 2025 zone average; National Laboratory of the Rockies
-        value: 149.19
+        value: 137.2
     biomass:
       datetime: '2014-01-01'
       source: BEIS 2021; IPCC 2014
@@ -299,15 +299,15 @@ emissionFactors:
       - _comment: used storage values greater than zero.
         datetime: '2023-01-01'
         source: Electricity Maps, 2023 zone average; UNECE 2022
-        value: 144.26
+        value: 144.07
       - _comment: used storage values greater than zero.
         datetime: '2024-01-01'
         source: Electricity Maps, 2024 zone average; UNECE 2022
-        value: 123.55
+        value: 121.43
       - _comment: used storage values greater than zero.
         datetime: '2025-01-01'
         source: Electricity Maps, 2025 zone average; UNECE 2022
-        value: 96.77
+        value: 96.14
     nuclear:
       datetime: '2020-01-01'
       source: UNECE 2022
@@ -483,6 +483,9 @@ fallbackZoneMixes:
 has_day_ahead_price_license: true
 hide_day_ahead_price: false
 isLowCarbon:
+  battery discharge:
+    - datetime: '2025-01-01'
+      value: 0.7713
   hydro discharge:
     - datetime: '2020-01-01'
       value: 1.0
@@ -490,7 +493,16 @@ isLowCarbon:
       value: 0.566
     - datetime: '2022-01-01'
       value: 0.6857
+    - datetime: '2023-01-01'
+      value: 0.7743
+    - datetime: '2024-01-01'
+      value: 0.8255
+    - datetime: '2025-01-01'
+      value: 0.8253
 isRenewable:
+  battery discharge:
+    - datetime: '2025-01-01'
+      value: 0.6569
   hydro discharge:
     - datetime: '2020-01-01'
       value: 1.0
@@ -498,6 +510,12 @@ isRenewable:
       value: 0.4169
     - datetime: '2022-01-01'
       value: 0.5275
+    - datetime: '2023-01-01'
+      value: 0.6457
+    - datetime: '2024-01-01'
+      value: 0.7176
+    - datetime: '2025-01-01'
+      value: 0.757
 parsers:
   consumption: ENTSOE.fetch_consumption
   consumptionForecast: ENTSOE.fetch_consumption_forecast

--- a/config/zones/LV.yaml
+++ b/config/zones/LV.yaml
@@ -133,7 +133,7 @@ emissionFactors:
       - _comment: used non-null storage values
         datetime: '2025-01-01'
         source: Electricity Maps, 2025 zone average
-        value: 90.36
+        value: 107.46
     biomass:
       datetime: '2021-01-01'
       source: BEIS 2021
@@ -182,7 +182,7 @@ emissionFactors:
       - _comment: used non-null storage values
         datetime: '2025-01-01'
         source: Electricity Maps, 2025 zone average; National Laboratory of the Rockies
-        value: 123.36
+        value: 140.46
     biomass:
       datetime: '2014-01-01'
       source: BEIS 2021; IPCC 2014
@@ -400,11 +400,11 @@ hide_day_ahead_price: false
 isLowCarbon:
   battery discharge:
     - datetime: '2025-01-01'
-      value: 0.7949
+      value: 0.7664
 isRenewable:
   battery discharge:
     - datetime: '2025-01-01'
-      value: 0.7019
+      value: 0.6684
 parsers:
   consumption: ENTSOE.fetch_consumption
   consumptionForecast: ENTSOE.fetch_consumption_forecast

--- a/config/zones/LV.yaml
+++ b/config/zones/LV.yaml
@@ -133,7 +133,7 @@ emissionFactors:
       - _comment: used non-null storage values
         datetime: '2025-01-01'
         source: Electricity Maps, 2025 zone average
-        value: 87.74
+        value: 90.36
     biomass:
       datetime: '2021-01-01'
       source: BEIS 2021
@@ -182,7 +182,7 @@ emissionFactors:
       - _comment: used non-null storage values
         datetime: '2025-01-01'
         source: Electricity Maps, 2025 zone average; National Laboratory of the Rockies
-        value: 120.74
+        value: 123.36
     biomass:
       datetime: '2014-01-01'
       source: BEIS 2021; IPCC 2014
@@ -397,6 +397,14 @@ fallbackZoneMixes:
         wind: 0.14035237273662302
 has_day_ahead_price_license: true
 hide_day_ahead_price: false
+isLowCarbon:
+  battery discharge:
+    - datetime: '2025-01-01'
+      value: 0.7949
+isRenewable:
+  battery discharge:
+    - datetime: '2025-01-01'
+      value: 0.7019
 parsers:
   consumption: ENTSOE.fetch_consumption
   consumptionForecast: ENTSOE.fetch_consumption_forecast
@@ -407,8 +415,6 @@ parsers:
   productionPerModeForecast: ENTSOE.fetch_wind_solar_forecasts
 region: Europe
 sources:
-  National Laboratory of the Rockies:
-    link: https://docs.nrel.gov/docs/fy21osti/80580.pdf
   EU-ETS, ENTSO-E 2021:
     link: https://drive.google.com/file/d/15UeUHyhcjVw8fGLc0Zx_HELSx20cw_-e/view?usp=share_link
   EU-ETS, ENTSO-E 2022:
@@ -421,6 +427,8 @@ sources:
     link: https://docs.google.com/spreadsheets/d/1w5DJ7sPen6axIHU8TCVcuzNCjlct4I6JAbhUlw-ZXu8/edit?usp=sharing
   IPCC 2014:
     link: https://www.ipcc.ch/site/assets/uploads/2018/02/ipcc_wg3_ar5_annex-iii.pdf#page=7
+  National Laboratory of the Rockies:
+    link: https://docs.nrel.gov/docs/fy21osti/80580.pdf
   UNECE 2022:
     link: https://unece.org/sites/default/files/2022-04/LCA_3_FINAL%20March%202022.pdf
   ? UNECE 2022, WindEurope "Wind energy in Europe, 2021 Statistics and the outlook

--- a/config/zones/NO-NO2.yaml
+++ b/config/zones/NO-NO2.yaml
@@ -308,8 +308,16 @@ fallbackZoneMixes:
         solar: 0.014173657554839382
         unknown: 0.0009148912252796965
         wind: 0.11531147882892007
-has_day_ahead_price_license: True
-hide_day_ahead_price: False
+has_day_ahead_price_license: true
+hide_day_ahead_price: false
+isLowCarbon:
+  hydro discharge:
+    - datetime: '2020-01-01'
+      value: 1.0
+isRenewable:
+  hydro discharge:
+    - datetime: '2020-01-01'
+      value: 1.0
 parsers:
   consumption: ENTSOE.fetch_consumption
   consumptionForecast: ENTSOE.fetch_consumption_forecast

--- a/config/zones/NO-NO2.yaml
+++ b/config/zones/NO-NO2.yaml
@@ -117,7 +117,7 @@ emissionFactors:
       - _comment: used storage values greater than zero.
         datetime: '2025-01-01'
         source: Electricity Maps, 2025 zone average
-        value: 5.58
+        value: 5.61
   lifecycle:
     biomass:
       datetime: '2014-01-01'
@@ -151,7 +151,7 @@ emissionFactors:
       - _comment: used storage values greater than zero.
         datetime: '2025-01-01'
         source: Electricity Maps, 2025 zone average; IPCC 2014
-        value: 29.58
+        value: 29.61
     oil:
       datetime: '2014-01-01'
       source: EIA 2020/BEIS 2021; IPCC 2014
@@ -318,6 +318,12 @@ isLowCarbon:
       value: 1.0
     - datetime: '2022-01-01'
       value: 1.0
+    - datetime: '2023-01-01'
+      value: 0.9011
+    - datetime: '2024-01-01'
+      value: 1.0
+    - datetime: '2025-01-01'
+      value: 0.9889
 isRenewable:
   hydro discharge:
     - datetime: '2020-01-01'
@@ -326,6 +332,12 @@ isRenewable:
       value: 1.0
     - datetime: '2022-01-01'
       value: 1.0
+    - datetime: '2023-01-01'
+      value: 0.8655
+    - datetime: '2024-01-01'
+      value: 1.0
+    - datetime: '2025-01-01'
+      value: 0.9729
 parsers:
   consumption: ENTSOE.fetch_consumption
   consumptionForecast: ENTSOE.fetch_consumption_forecast

--- a/config/zones/NO-NO2.yaml
+++ b/config/zones/NO-NO2.yaml
@@ -316,11 +316,15 @@ isLowCarbon:
       value: 1.0
     - datetime: '2021-01-01'
       value: 1.0
+    - datetime: '2022-01-01'
+      value: 1.0
 isRenewable:
   hydro discharge:
     - datetime: '2020-01-01'
       value: 1.0
     - datetime: '2021-01-01'
+      value: 1.0
+    - datetime: '2022-01-01'
       value: 1.0
 parsers:
   consumption: ENTSOE.fetch_consumption

--- a/config/zones/NO-NO2.yaml
+++ b/config/zones/NO-NO2.yaml
@@ -109,7 +109,7 @@ emissionFactors:
       - _comment: used storage values greater than zero.
         datetime: '2023-01-01'
         source: Electricity Maps, 2023 zone average
-        value: 51.77
+        value: 48.32
       - _comment: used default IPCC 2014 value of 0.0
         datetime: '2024-01-01'
         source: Electricity Maps, 2024 zone average
@@ -117,7 +117,7 @@ emissionFactors:
       - _comment: used storage values greater than zero.
         datetime: '2025-01-01'
         source: Electricity Maps, 2025 zone average
-        value: 5.61
+        value: 5.75
   lifecycle:
     biomass:
       datetime: '2014-01-01'
@@ -143,7 +143,7 @@ emissionFactors:
       - _comment: used storage values greater than zero.
         datetime: '2023-01-01'
         source: Electricity Maps, 2023 zone average; IPCC 2014
-        value: 75.77
+        value: 72.32
       - _comment: used default IPCC 2014 value of 24.0
         datetime: '2024-01-01'
         source: Electricity Maps, 2024 zone average; IPCC 2014
@@ -151,7 +151,7 @@ emissionFactors:
       - _comment: used storage values greater than zero.
         datetime: '2025-01-01'
         source: Electricity Maps, 2025 zone average; IPCC 2014
-        value: 29.61
+        value: 29.75
     oil:
       datetime: '2014-01-01'
       source: EIA 2020/BEIS 2021; IPCC 2014
@@ -319,11 +319,11 @@ isLowCarbon:
     - datetime: '2022-01-01'
       value: 1.0
     - datetime: '2023-01-01'
-      value: 0.9011
+      value: 0.9094
     - datetime: '2024-01-01'
       value: 1.0
     - datetime: '2025-01-01'
-      value: 0.9889
+      value: 0.9887
 isRenewable:
   hydro discharge:
     - datetime: '2020-01-01'
@@ -333,11 +333,11 @@ isRenewable:
     - datetime: '2022-01-01'
       value: 1.0
     - datetime: '2023-01-01'
-      value: 0.8655
+      value: 0.8814
     - datetime: '2024-01-01'
       value: 1.0
     - datetime: '2025-01-01'
-      value: 0.9729
+      value: 0.9726
 parsers:
   consumption: ENTSOE.fetch_consumption
   consumptionForecast: ENTSOE.fetch_consumption_forecast

--- a/config/zones/NO-NO2.yaml
+++ b/config/zones/NO-NO2.yaml
@@ -314,9 +314,13 @@ isLowCarbon:
   hydro discharge:
     - datetime: '2020-01-01'
       value: 1.0
+    - datetime: '2021-01-01'
+      value: 1.0
 isRenewable:
   hydro discharge:
     - datetime: '2020-01-01'
+      value: 1.0
+    - datetime: '2021-01-01'
       value: 1.0
 parsers:
   consumption: ENTSOE.fetch_consumption

--- a/config/zones/NO-NO3.yaml
+++ b/config/zones/NO-NO3.yaml
@@ -320,9 +320,13 @@ isLowCarbon:
   hydro discharge:
     - datetime: '2020-01-01'
       value: 1.0
+    - datetime: '2021-01-01'
+      value: 1.0
 isRenewable:
   hydro discharge:
     - datetime: '2020-01-01'
+      value: 1.0
+    - datetime: '2021-01-01'
       value: 1.0
 parsers:
   consumption: ENTSOE.fetch_consumption

--- a/config/zones/NO-NO3.yaml
+++ b/config/zones/NO-NO3.yaml
@@ -322,11 +322,15 @@ isLowCarbon:
       value: 1.0
     - datetime: '2021-01-01'
       value: 1.0
+    - datetime: '2022-01-01'
+      value: 1.0
 isRenewable:
   hydro discharge:
     - datetime: '2020-01-01'
       value: 1.0
     - datetime: '2021-01-01'
+      value: 1.0
+    - datetime: '2022-01-01'
       value: 1.0
 parsers:
   consumption: ENTSOE.fetch_consumption

--- a/config/zones/NO-NO3.yaml
+++ b/config/zones/NO-NO3.yaml
@@ -123,7 +123,7 @@ emissionFactors:
       - _comment: used storage values greater than zero.
         datetime: '2025-01-01'
         source: Electricity Maps, 2025 zone average
-        value: 7.54
+        value: 7.68
   lifecycle:
     biomass:
       datetime: '2014-01-01'
@@ -157,7 +157,7 @@ emissionFactors:
       - _comment: used storage values greater than zero.
         datetime: '2025-01-01'
         source: Electricity Maps, 2025 zone average; IPCC 2014
-        value: 31.54
+        value: 31.68
     oil:
       datetime: '2014-01-01'
       source: EIA 2020/BEIS 2021; IPCC 2014
@@ -329,7 +329,7 @@ isLowCarbon:
     - datetime: '2024-01-01'
       value: 1.0
     - datetime: '2025-01-01'
-      value: 0.9845
+      value: 0.9841
 isRenewable:
   hydro discharge:
     - datetime: '2020-01-01'
@@ -343,7 +343,7 @@ isRenewable:
     - datetime: '2024-01-01'
       value: 1.0
     - datetime: '2025-01-01'
-      value: 0.9838
+      value: 0.9834
 parsers:
   consumption: ENTSOE.fetch_consumption
   consumptionForecast: ENTSOE.fetch_consumption_forecast

--- a/config/zones/NO-NO3.yaml
+++ b/config/zones/NO-NO3.yaml
@@ -314,8 +314,16 @@ fallbackZoneMixes:
         solar: 0.0003611325736471347
         unknown: 0.00822168167101805
         wind: 0.23964172535285017
-has_day_ahead_price_license: True
-hide_day_ahead_price: False
+has_day_ahead_price_license: true
+hide_day_ahead_price: false
+isLowCarbon:
+  hydro discharge:
+    - datetime: '2020-01-01'
+      value: 1.0
+isRenewable:
+  hydro discharge:
+    - datetime: '2020-01-01'
+      value: 1.0
 parsers:
   consumption: ENTSOE.fetch_consumption
   consumptionForecast: ENTSOE.fetch_consumption_forecast

--- a/config/zones/NO-NO3.yaml
+++ b/config/zones/NO-NO3.yaml
@@ -324,6 +324,12 @@ isLowCarbon:
       value: 1.0
     - datetime: '2022-01-01'
       value: 1.0
+    - datetime: '2023-01-01'
+      value: 1.0
+    - datetime: '2024-01-01'
+      value: 1.0
+    - datetime: '2025-01-01'
+      value: 0.9845
 isRenewable:
   hydro discharge:
     - datetime: '2020-01-01'
@@ -332,6 +338,12 @@ isRenewable:
       value: 1.0
     - datetime: '2022-01-01'
       value: 1.0
+    - datetime: '2023-01-01'
+      value: 1.0
+    - datetime: '2024-01-01'
+      value: 1.0
+    - datetime: '2025-01-01'
+      value: 0.9838
 parsers:
   consumption: ENTSOE.fetch_consumption
   consumptionForecast: ENTSOE.fetch_consumption_forecast

--- a/config/zones/NO-NO5.yaml
+++ b/config/zones/NO-NO5.yaml
@@ -293,8 +293,16 @@ fallbackZoneMixes:
         solar: 0.0007275091951828923
         unknown: 0.00041495388875751785
         wind: 0.014746060245185884
-has_day_ahead_price_license: True
-hide_day_ahead_price: False
+has_day_ahead_price_license: true
+hide_day_ahead_price: false
+isLowCarbon:
+  hydro discharge:
+    - datetime: '2020-01-01'
+      value: 1.0
+isRenewable:
+  hydro discharge:
+    - datetime: '2020-01-01'
+      value: 1.0
 parsers:
   consumption: ENTSOE.fetch_consumption
   consumptionForecast: ENTSOE.fetch_consumption_forecast

--- a/config/zones/NO-NO5.yaml
+++ b/config/zones/NO-NO5.yaml
@@ -299,9 +299,13 @@ isLowCarbon:
   hydro discharge:
     - datetime: '2020-01-01'
       value: 1.0
+    - datetime: '2021-01-01'
+      value: 1.0
 isRenewable:
   hydro discharge:
     - datetime: '2020-01-01'
+      value: 1.0
+    - datetime: '2021-01-01'
       value: 1.0
 parsers:
   consumption: ENTSOE.fetch_consumption

--- a/config/zones/NO-NO5.yaml
+++ b/config/zones/NO-NO5.yaml
@@ -303,6 +303,12 @@ isLowCarbon:
       value: 1.0
     - datetime: '2022-01-01'
       value: 1.0
+    - datetime: '2023-01-01'
+      value: 1.0
+    - datetime: '2024-01-01'
+      value: 1.0
+    - datetime: '2025-01-01'
+      value: 0.9975
 isRenewable:
   hydro discharge:
     - datetime: '2020-01-01'
@@ -311,6 +317,12 @@ isRenewable:
       value: 1.0
     - datetime: '2022-01-01'
       value: 1.0
+    - datetime: '2023-01-01'
+      value: 1.0
+    - datetime: '2024-01-01'
+      value: 1.0
+    - datetime: '2025-01-01'
+      value: 0.9951
 parsers:
   consumption: ENTSOE.fetch_consumption
   consumptionForecast: ENTSOE.fetch_consumption_forecast

--- a/config/zones/NO-NO5.yaml
+++ b/config/zones/NO-NO5.yaml
@@ -301,11 +301,15 @@ isLowCarbon:
       value: 1.0
     - datetime: '2021-01-01'
       value: 1.0
+    - datetime: '2022-01-01'
+      value: 1.0
 isRenewable:
   hydro discharge:
     - datetime: '2020-01-01'
       value: 1.0
     - datetime: '2021-01-01'
+      value: 1.0
+    - datetime: '2022-01-01'
       value: 1.0
 parsers:
   consumption: ENTSOE.fetch_consumption

--- a/config/zones/NO-NO5.yaml
+++ b/config/zones/NO-NO5.yaml
@@ -322,7 +322,7 @@ isRenewable:
     - datetime: '2024-01-01'
       value: 1.0
     - datetime: '2025-01-01'
-      value: 0.9951
+      value: 0.995
 parsers:
   consumption: ENTSOE.fetch_consumption
   consumptionForecast: ENTSOE.fetch_consumption_forecast

--- a/config/zones/NO.yaml
+++ b/config/zones/NO.yaml
@@ -249,11 +249,15 @@ isLowCarbon:
       value: 1.0
     - datetime: '2021-01-01'
       value: 1.0
+    - datetime: '2022-01-01'
+      value: 1.0
 isRenewable:
   hydro discharge:
     - datetime: '2020-01-01'
       value: 1.0
     - datetime: '2021-01-01'
+      value: 1.0
+    - datetime: '2022-01-01'
       value: 1.0
 parsers:
   consumption: ENTSOE.fetch_consumption

--- a/config/zones/NO.yaml
+++ b/config/zones/NO.yaml
@@ -247,9 +247,13 @@ isLowCarbon:
   hydro discharge:
     - datetime: '2020-01-01'
       value: 1.0
+    - datetime: '2021-01-01'
+      value: 1.0
 isRenewable:
   hydro discharge:
     - datetime: '2020-01-01'
+      value: 1.0
+    - datetime: '2021-01-01'
       value: 1.0
 parsers:
   consumption: ENTSOE.fetch_consumption

--- a/config/zones/NO.yaml
+++ b/config/zones/NO.yaml
@@ -19,7 +19,6 @@ contributors:
   - corradio
 country: 'NO'
 country_name: Norway
-# Electricity is traded in EUR
 currency: EUR
 emissionFactors:
   direct:
@@ -242,8 +241,16 @@ fallbackZoneMixes:
         solar: 0.005032172878244702
         unknown: 0.004538204352072401
         wind: 0.12701186508811527
-has_day_ahead_price_license: True
-hide_day_ahead_price: False
+has_day_ahead_price_license: true
+hide_day_ahead_price: false
+isLowCarbon:
+  hydro discharge:
+    - datetime: '2020-01-01'
+      value: 1.0
+isRenewable:
+  hydro discharge:
+    - datetime: '2020-01-01'
+      value: 1.0
 parsers:
   consumption: ENTSOE.fetch_consumption
   consumptionForecast: ENTSOE.fetch_consumption_forecast

--- a/config/zones/NO.yaml
+++ b/config/zones/NO.yaml
@@ -50,7 +50,7 @@ emissionFactors:
       - _comment: used storage values greater than zero.
         datetime: '2025-01-01'
         source: Electricity Maps, 2025 zone average
-        value: 9.43
+        value: 9.44
   lifecycle:
     biomass:
       datetime: '2014-01-01'
@@ -84,7 +84,7 @@ emissionFactors:
       - _comment: used storage values greater than zero.
         datetime: '2025-01-01'
         source: Electricity Maps, 2025 zone average; IPCC 2014
-        value: 33.43
+        value: 33.44
     oil:
       datetime: '2014-01-01'
       source: EIA 2020/BEIS 2021; IPCC 2014
@@ -251,6 +251,12 @@ isLowCarbon:
       value: 1.0
     - datetime: '2022-01-01'
       value: 1.0
+    - datetime: '2023-01-01'
+      value: 1.0
+    - datetime: '2024-01-01'
+      value: 1.0
+    - datetime: '2025-01-01'
+      value: 0.9795
 isRenewable:
   hydro discharge:
     - datetime: '2020-01-01'
@@ -259,6 +265,12 @@ isRenewable:
       value: 1.0
     - datetime: '2022-01-01'
       value: 1.0
+    - datetime: '2023-01-01'
+      value: 1.0
+    - datetime: '2024-01-01'
+      value: 1.0
+    - datetime: '2025-01-01'
+      value: 0.9503
 parsers:
   consumption: ENTSOE.fetch_consumption
   consumptionForecast: ENTSOE.fetch_consumption_forecast

--- a/config/zones/NO.yaml
+++ b/config/zones/NO.yaml
@@ -270,7 +270,7 @@ isRenewable:
     - datetime: '2024-01-01'
       value: 1.0
     - datetime: '2025-01-01'
-      value: 0.9503
+      value: 0.9498
 parsers:
   consumption: ENTSOE.fetch_consumption
   consumptionForecast: ENTSOE.fetch_consumption_forecast

--- a/config/zones/NZ.yaml
+++ b/config/zones/NZ.yaml
@@ -310,10 +310,14 @@ isLowCarbon:
   battery discharge:
     - datetime: '2020-01-01'
       value: 0.7847
+    - datetime: '2021-01-01'
+      value: 0.842
 isRenewable:
   battery discharge:
     - datetime: '2020-01-01'
       value: 0.7847
+    - datetime: '2021-01-01'
+      value: 0.842
 parsers:
   price: NZ.fetch_price
   production: NZ.fetch_production

--- a/config/zones/NZ.yaml
+++ b/config/zones/NZ.yaml
@@ -312,12 +312,16 @@ isLowCarbon:
       value: 0.7847
     - datetime: '2021-01-01'
       value: 0.842
+    - datetime: '2022-01-01'
+      value: 0.8265
 isRenewable:
   battery discharge:
     - datetime: '2020-01-01'
       value: 0.7847
     - datetime: '2021-01-01'
       value: 0.842
+    - datetime: '2022-01-01'
+      value: 0.8265
 parsers:
   price: NZ.fetch_price
   production: NZ.fetch_production

--- a/config/zones/NZ.yaml
+++ b/config/zones/NZ.yaml
@@ -304,17 +304,25 @@ fallbackZoneMixes:
         solar: 0.0022427556771429237
         unknown: 0.020886705386506124
         wind: 0.09329579500153248
-has_day_ahead_price_license: False
-hide_day_ahead_price: False
+has_day_ahead_price_license: false
+hide_day_ahead_price: false
+isLowCarbon:
+  battery discharge:
+    - datetime: '2020-01-01'
+      value: 0.7847
+isRenewable:
+  battery discharge:
+    - datetime: '2020-01-01'
+      value: 0.7847
 parsers:
   price: NZ.fetch_price
   production: NZ.fetch_production
   productionCapacity: EMBER.fetch_production_capacity
 region: Oceania
-timezone: Pacific/Auckland
-zone_name: New Zealand
 sources:
   IPCC 2014:
     link: https://www.ipcc.ch/site/assets/uploads/2018/02/ipcc_wg3_ar5_annex-iii.pdf#page=7
   National Laboratory of the Rockies:
     link: https://docs.nrel.gov/docs/fy21osti/80580.pdf
+timezone: Pacific/Auckland
+zone_name: New Zealand

--- a/config/zones/NZ.yaml
+++ b/config/zones/NZ.yaml
@@ -105,23 +105,23 @@ emissionFactors:
       - _comment: used storage values greater than zero.
         datetime: '2020-01-01'
         source: Electricity Maps, 2020 zone average
-        value: 113.84
+        value: 113.81
       - _comment: used storage values greater than zero.
         datetime: '2021-01-01'
         source: Electricity Maps, 2021 zone average
-        value: 81.61
+        value: 81.06
       - _comment: used storage values greater than zero.
         datetime: '2022-01-01'
         source: Electricity Maps, 2022 zone average
-        value: 85.21
+        value: 84.45
       - _comment: used storage values greater than zero.
         datetime: '2023-01-01'
         source: Electricity Maps, 2023 zone average
-        value: 83.63
+        value: 65.2
       - _comment: used storage values greater than zero.
         datetime: '2024-01-01'
         source: Electricity Maps, 2024 zone average
-        value: 82.49
+        value: 80.38
       - _comment: used storage values greater than zero.
         datetime: '2025-01-01'
         source: Electricity Maps, 2025 zone average
@@ -131,23 +131,23 @@ emissionFactors:
       - _comment: used storage values greater than zero.
         datetime: '2020-01-01'
         source: Electricity Maps, 2020 zone average; National Laboratory of the Rockies
-        value: 146.84
+        value: 146.81
       - _comment: used storage values greater than zero.
         datetime: '2021-01-01'
         source: Electricity Maps, 2021 zone average; National Laboratory of the Rockies
-        value: 114.61
+        value: 114.06
       - _comment: used storage values greater than zero.
         datetime: '2022-01-01'
         source: Electricity Maps, 2022 zone average; National Laboratory of the Rockies
-        value: 118.21
+        value: 117.45
       - _comment: used storage values greater than zero.
         datetime: '2023-01-01'
         source: Electricity Maps, 2023 zone average; National Laboratory of the Rockies
-        value: 116.63
+        value: 98.2
       - _comment: used storage values greater than zero.
         datetime: '2024-01-01'
         source: Electricity Maps, 2024 zone average; National Laboratory of the Rockies
-        value: 115.49
+        value: 113.38
       - _comment: used storage values greater than zero.
         datetime: '2025-01-01'
         source: Electricity Maps, 2025 zone average; National Laboratory of the Rockies
@@ -311,13 +311,13 @@ isLowCarbon:
     - datetime: '2020-01-01'
       value: 0.7847
     - datetime: '2021-01-01'
-      value: 0.842
+      value: 0.843
     - datetime: '2022-01-01'
-      value: 0.8265
+      value: 0.8267
     - datetime: '2023-01-01'
-      value: 0.863
+      value: 0.8958
     - datetime: '2024-01-01'
-      value: 0.8383
+      value: 0.8422
     - datetime: '2025-01-01'
       value: 0.8901
 isRenewable:
@@ -325,13 +325,13 @@ isRenewable:
     - datetime: '2020-01-01'
       value: 0.7847
     - datetime: '2021-01-01'
-      value: 0.842
+      value: 0.843
     - datetime: '2022-01-01'
-      value: 0.8265
+      value: 0.8267
     - datetime: '2023-01-01'
-      value: 0.863
+      value: 0.8958
     - datetime: '2024-01-01'
-      value: 0.8383
+      value: 0.8422
     - datetime: '2025-01-01'
       value: 0.8901
 parsers:

--- a/config/zones/NZ.yaml
+++ b/config/zones/NZ.yaml
@@ -314,6 +314,12 @@ isLowCarbon:
       value: 0.842
     - datetime: '2022-01-01'
       value: 0.8265
+    - datetime: '2023-01-01'
+      value: 0.863
+    - datetime: '2024-01-01'
+      value: 0.8383
+    - datetime: '2025-01-01'
+      value: 0.8901
 isRenewable:
   battery discharge:
     - datetime: '2020-01-01'
@@ -322,6 +328,12 @@ isRenewable:
       value: 0.842
     - datetime: '2022-01-01'
       value: 0.8265
+    - datetime: '2023-01-01'
+      value: 0.863
+    - datetime: '2024-01-01'
+      value: 0.8383
+    - datetime: '2025-01-01'
+      value: 0.8901
 parsers:
   price: NZ.fetch_price
   production: NZ.fetch_production

--- a/config/zones/PH-LU.yaml
+++ b/config/zones/PH-LU.yaml
@@ -259,10 +259,14 @@ isLowCarbon:
       value: 0.1354
     - datetime: '2021-01-01'
       value: 0.1302
+    - datetime: '2022-01-01'
+      value: 0.1302
   hydro discharge:
     - datetime: '2020-01-01'
       value: 0.1124
     - datetime: '2021-01-01'
+      value: 0.1069
+    - datetime: '2022-01-01'
       value: 0.1069
 isRenewable:
   battery discharge:
@@ -270,10 +274,14 @@ isRenewable:
       value: 0.1354
     - datetime: '2021-01-01'
       value: 0.1302
+    - datetime: '2022-01-01'
+      value: 0.1302
   hydro discharge:
     - datetime: '2020-01-01'
       value: 0.1124
     - datetime: '2021-01-01'
+      value: 0.1069
+    - datetime: '2022-01-01'
       value: 0.1069
 parsers:
   production: IEMOP.fetch_production

--- a/config/zones/PH-LU.yaml
+++ b/config/zones/PH-LU.yaml
@@ -261,6 +261,12 @@ isLowCarbon:
       value: 0.1302
     - datetime: '2022-01-01'
       value: 0.1302
+    - datetime: '2023-01-01'
+      value: 0.1322
+    - datetime: '2024-01-01'
+      value: 0.146
+    - datetime: '2025-01-01'
+      value: 0.148
   hydro discharge:
     - datetime: '2020-01-01'
       value: 0.1124
@@ -268,6 +274,12 @@ isLowCarbon:
       value: 0.1069
     - datetime: '2022-01-01'
       value: 0.1069
+    - datetime: '2023-01-01'
+      value: 0.1211
+    - datetime: '2024-01-01'
+      value: 0.118
+    - datetime: '2025-01-01'
+      value: 0.1273
 isRenewable:
   battery discharge:
     - datetime: '2020-01-01'
@@ -276,6 +288,12 @@ isRenewable:
       value: 0.1302
     - datetime: '2022-01-01'
       value: 0.1302
+    - datetime: '2023-01-01'
+      value: 0.1322
+    - datetime: '2024-01-01'
+      value: 0.146
+    - datetime: '2025-01-01'
+      value: 0.148
   hydro discharge:
     - datetime: '2020-01-01'
       value: 0.1124
@@ -283,6 +301,12 @@ isRenewable:
       value: 0.1069
     - datetime: '2022-01-01'
       value: 0.1069
+    - datetime: '2023-01-01'
+      value: 0.1211
+    - datetime: '2024-01-01'
+      value: 0.118
+    - datetime: '2025-01-01'
+      value: 0.1273
 parsers:
   production: IEMOP.fetch_production
 region: Asia

--- a/config/zones/PH-LU.yaml
+++ b/config/zones/PH-LU.yaml
@@ -257,16 +257,24 @@ isLowCarbon:
   battery discharge:
     - datetime: '2020-01-01'
       value: 0.1354
+    - datetime: '2021-01-01'
+      value: 0.1302
   hydro discharge:
     - datetime: '2020-01-01'
       value: 0.1124
+    - datetime: '2021-01-01'
+      value: 0.1069
 isRenewable:
   battery discharge:
     - datetime: '2020-01-01'
       value: 0.1354
+    - datetime: '2021-01-01'
+      value: 0.1302
   hydro discharge:
     - datetime: '2020-01-01'
       value: 0.1124
+    - datetime: '2021-01-01'
+      value: 0.1069
 parsers:
   production: IEMOP.fetch_production
 region: Asia

--- a/config/zones/PH-LU.yaml
+++ b/config/zones/PH-LU.yaml
@@ -251,15 +251,29 @@ fallbackZoneMixes:
         solar: 0.020418652513402993
         unknown: 0.054426137887670575
         wind: 0.01113649280728119
-has_day_ahead_price_license: False
-hide_day_ahead_price: False
+has_day_ahead_price_license: false
+hide_day_ahead_price: false
+isLowCarbon:
+  battery discharge:
+    - datetime: '2020-01-01'
+      value: 0.1354
+  hydro discharge:
+    - datetime: '2020-01-01'
+      value: 0.1124
+isRenewable:
+  battery discharge:
+    - datetime: '2020-01-01'
+      value: 0.1354
+  hydro discharge:
+    - datetime: '2020-01-01'
+      value: 0.1124
 parsers:
   production: IEMOP.fetch_production
 region: Asia
 sources:
-  National Laboratory of the Rockies:
-    link: https://docs.nrel.gov/docs/fy21osti/80580.pdf
   IPCC 2014:
     link: https://www.ipcc.ch/site/assets/uploads/2018/02/ipcc_wg3_ar5_annex-iii.pdf#page=7
+  National Laboratory of the Rockies:
+    link: https://docs.nrel.gov/docs/fy21osti/80580.pdf
 timezone: Asia/Manila
 zone_name: Luzon

--- a/config/zones/PH-LU.yaml
+++ b/config/zones/PH-LU.yaml
@@ -32,15 +32,15 @@ emissionFactors:
       - _comment: used storage values greater than zero.
         datetime: '2020-01-01'
         source: Electricity Maps, 2020 zone average
-        value: 562.65
+        value: 562.52
       - _comment: used storage values greater than zero.
         datetime: '2021-01-01'
         source: Electricity Maps, 2021 zone average
-        value: 567.84
+        value: 562.53
       - _comment: used storage values greater than zero.
         datetime: '2022-01-01'
         source: Electricity Maps, 2022 zone average
-        value: 567.84
+        value: 562.52
       - _comment: used storage values greater than zero.
         datetime: '2023-01-01'
         source: Electricity Maps, 2023 zone average
@@ -57,15 +57,15 @@ emissionFactors:
       - _comment: used storage values greater than zero.
         datetime: '2020-01-01'
         source: Electricity Maps, 2020 zone average
-        value: 578.8
+        value: 578.71
       - _comment: used storage values greater than zero.
         datetime: '2021-01-01'
         source: Electricity Maps, 2021 zone average
-        value: 583.75
+        value: 578.7
       - _comment: used storage values greater than zero.
         datetime: '2022-01-01'
         source: Electricity Maps, 2022 zone average
-        value: 583.76
+        value: 578.71
       - _comment: used storage values greater than zero.
         datetime: '2023-01-01'
         source: Electricity Maps, 2023 zone average
@@ -83,15 +83,15 @@ emissionFactors:
       - _comment: used storage values greater than zero.
         datetime: '2020-01-01'
         source: Electricity Maps, 2020 zone average; National Laboratory of the Rockies
-        value: 595.65
+        value: 595.52
       - _comment: used storage values greater than zero.
         datetime: '2021-01-01'
         source: Electricity Maps, 2021 zone average; National Laboratory of the Rockies
-        value: 600.84
+        value: 595.53
       - _comment: used storage values greater than zero.
         datetime: '2022-01-01'
         source: Electricity Maps, 2022 zone average; National Laboratory of the Rockies
-        value: 600.84
+        value: 595.52
       - _comment: used storage values greater than zero.
         datetime: '2023-01-01'
         source: Electricity Maps, 2023 zone average; National Laboratory of the Rockies
@@ -108,15 +108,15 @@ emissionFactors:
       - _comment: used storage values greater than zero.
         datetime: '2020-01-01'
         source: Electricity Maps, 2020 zone average; IPCC 2014
-        value: 602.8
+        value: 602.71
       - _comment: used storage values greater than zero.
         datetime: '2021-01-01'
         source: Electricity Maps, 2021 zone average; IPCC 2014
-        value: 607.75
+        value: 602.7
       - _comment: used storage values greater than zero.
         datetime: '2022-01-01'
         source: Electricity Maps, 2022 zone average; IPCC 2014
-        value: 607.76
+        value: 602.71
       - _comment: used storage values greater than zero.
         datetime: '2023-01-01'
         source: Electricity Maps, 2023 zone average; IPCC 2014
@@ -256,11 +256,11 @@ hide_day_ahead_price: false
 isLowCarbon:
   battery discharge:
     - datetime: '2020-01-01'
-      value: 0.1354
+      value: 0.1358
     - datetime: '2021-01-01'
-      value: 0.1302
+      value: 0.1358
     - datetime: '2022-01-01'
-      value: 0.1302
+      value: 0.1358
     - datetime: '2023-01-01'
       value: 0.1322
     - datetime: '2024-01-01'
@@ -269,11 +269,11 @@ isLowCarbon:
       value: 0.148
   hydro discharge:
     - datetime: '2020-01-01'
-      value: 0.1124
+      value: 0.1129
     - datetime: '2021-01-01'
-      value: 0.1069
+      value: 0.1129
     - datetime: '2022-01-01'
-      value: 0.1069
+      value: 0.1129
     - datetime: '2023-01-01'
       value: 0.1211
     - datetime: '2024-01-01'
@@ -283,11 +283,11 @@ isLowCarbon:
 isRenewable:
   battery discharge:
     - datetime: '2020-01-01'
-      value: 0.1354
+      value: 0.1358
     - datetime: '2021-01-01'
-      value: 0.1302
+      value: 0.1358
     - datetime: '2022-01-01'
-      value: 0.1302
+      value: 0.1358
     - datetime: '2023-01-01'
       value: 0.1322
     - datetime: '2024-01-01'
@@ -296,11 +296,11 @@ isRenewable:
       value: 0.148
   hydro discharge:
     - datetime: '2020-01-01'
-      value: 0.1124
+      value: 0.1129
     - datetime: '2021-01-01'
-      value: 0.1069
+      value: 0.1129
     - datetime: '2022-01-01'
-      value: 0.1069
+      value: 0.1129
     - datetime: '2023-01-01'
       value: 0.1211
     - datetime: '2024-01-01'

--- a/config/zones/PH-MI.yaml
+++ b/config/zones/PH-MI.yaml
@@ -205,10 +205,14 @@ isLowCarbon:
   battery discharge:
     - datetime: '2020-01-01'
       value: 0.3512
+    - datetime: '2021-01-01'
+      value: 0.3392
 isRenewable:
   battery discharge:
     - datetime: '2020-01-01'
       value: 0.3512
+    - datetime: '2021-01-01'
+      value: 0.3392
 parsers:
   production: IEMOP.fetch_production
 region: Asia

--- a/config/zones/PH-MI.yaml
+++ b/config/zones/PH-MI.yaml
@@ -30,7 +30,7 @@ emissionFactors:
       - _comment: used storage values greater than zero.
         datetime: '2020-01-01'
         source: Electricity Maps, 2020 zone average
-        value: 475.45
+        value: 475.44
       - _comment: used storage values greater than zero.
         datetime: '2021-01-01'
         source: Electricity Maps, 2021 zone average
@@ -56,7 +56,7 @@ emissionFactors:
       - _comment: used storage values greater than zero.
         datetime: '2020-01-01'
         source: Electricity Maps, 2020 zone average; National Laboratory of the Rockies
-        value: 508.45
+        value: 508.44
       - _comment: used storage values greater than zero.
         datetime: '2021-01-01'
         source: Electricity Maps, 2021 zone average; National Laboratory of the Rockies
@@ -199,15 +199,23 @@ fallbackZoneMixes:
         solar: 0.006548497102706934
         unknown: 0.007487106321175432
         wind: 9.209647219998301e-06
-has_day_ahead_price_license: False
-hide_day_ahead_price: False
+has_day_ahead_price_license: false
+hide_day_ahead_price: false
+isLowCarbon:
+  battery discharge:
+    - datetime: '2020-01-01'
+      value: 0.3512
+isRenewable:
+  battery discharge:
+    - datetime: '2020-01-01'
+      value: 0.3512
 parsers:
   production: IEMOP.fetch_production
 region: Asia
 sources:
-  National Laboratory of the Rockies:
-    link: https://docs.nrel.gov/docs/fy21osti/80580.pdf
   IPCC 2014:
     link: https://www.ipcc.ch/site/assets/uploads/2018/02/ipcc_wg3_ar5_annex-iii.pdf#page=7
+  National Laboratory of the Rockies:
+    link: https://docs.nrel.gov/docs/fy21osti/80580.pdf
 timezone: Asia/Manila
 zone_name: Mindanao

--- a/config/zones/PH-MI.yaml
+++ b/config/zones/PH-MI.yaml
@@ -209,6 +209,12 @@ isLowCarbon:
       value: 0.3392
     - datetime: '2022-01-01'
       value: 0.3392
+    - datetime: '2023-01-01'
+      value: 0.3713
+    - datetime: '2024-01-01'
+      value: 0.3317
+    - datetime: '2025-01-01'
+      value: 0.367
 isRenewable:
   battery discharge:
     - datetime: '2020-01-01'
@@ -217,6 +223,12 @@ isRenewable:
       value: 0.3392
     - datetime: '2022-01-01'
       value: 0.3392
+    - datetime: '2023-01-01'
+      value: 0.3713
+    - datetime: '2024-01-01'
+      value: 0.3317
+    - datetime: '2025-01-01'
+      value: 0.367
 parsers:
   production: IEMOP.fetch_production
 region: Asia

--- a/config/zones/PH-MI.yaml
+++ b/config/zones/PH-MI.yaml
@@ -207,11 +207,15 @@ isLowCarbon:
       value: 0.3512
     - datetime: '2021-01-01'
       value: 0.3392
+    - datetime: '2022-01-01'
+      value: 0.3392
 isRenewable:
   battery discharge:
     - datetime: '2020-01-01'
       value: 0.3512
     - datetime: '2021-01-01'
+      value: 0.3392
+    - datetime: '2022-01-01'
       value: 0.3392
 parsers:
   production: IEMOP.fetch_production

--- a/config/zones/PH-MI.yaml
+++ b/config/zones/PH-MI.yaml
@@ -30,15 +30,15 @@ emissionFactors:
       - _comment: used storage values greater than zero.
         datetime: '2020-01-01'
         source: Electricity Maps, 2020 zone average
-        value: 475.44
+        value: 475.14
       - _comment: used storage values greater than zero.
         datetime: '2021-01-01'
         source: Electricity Maps, 2021 zone average
-        value: 483.32
+        value: 475.13
       - _comment: used storage values greater than zero.
         datetime: '2022-01-01'
         source: Electricity Maps, 2022 zone average
-        value: 483.32
+        value: 475.14
       - _comment: used storage values greater than zero.
         datetime: '2023-01-01'
         source: Electricity Maps, 2023 zone average
@@ -50,21 +50,21 @@ emissionFactors:
       - _comment: used storage values greater than zero.
         datetime: '2025-01-01'
         source: Electricity Maps, 2025 zone average
-        value: 463.63
+        value: 463.64
   lifecycle:
     battery discharge:
       - _comment: used storage values greater than zero.
         datetime: '2020-01-01'
         source: Electricity Maps, 2020 zone average; National Laboratory of the Rockies
-        value: 508.44
+        value: 508.14
       - _comment: used storage values greater than zero.
         datetime: '2021-01-01'
         source: Electricity Maps, 2021 zone average; National Laboratory of the Rockies
-        value: 516.32
+        value: 508.13
       - _comment: used storage values greater than zero.
         datetime: '2022-01-01'
         source: Electricity Maps, 2022 zone average; National Laboratory of the Rockies
-        value: 516.32
+        value: 508.14
       - _comment: used storage values greater than zero.
         datetime: '2023-01-01'
         source: Electricity Maps, 2023 zone average; National Laboratory of the Rockies
@@ -76,7 +76,7 @@ emissionFactors:
       - _comment: used storage values greater than zero.
         datetime: '2025-01-01'
         source: Electricity Maps, 2025 zone average; National Laboratory of the Rockies
-        value: 496.63
+        value: 496.64
 fallbackZoneMixes:
   powerOriginRatios:
     - _source: Electricity Maps, 2017 average
@@ -204,11 +204,11 @@ hide_day_ahead_price: false
 isLowCarbon:
   battery discharge:
     - datetime: '2020-01-01'
-      value: 0.3512
+      value: 0.3516
     - datetime: '2021-01-01'
-      value: 0.3392
+      value: 0.3516
     - datetime: '2022-01-01'
-      value: 0.3392
+      value: 0.3516
     - datetime: '2023-01-01'
       value: 0.3713
     - datetime: '2024-01-01'
@@ -218,11 +218,11 @@ isLowCarbon:
 isRenewable:
   battery discharge:
     - datetime: '2020-01-01'
-      value: 0.3512
+      value: 0.3516
     - datetime: '2021-01-01'
-      value: 0.3392
+      value: 0.3516
     - datetime: '2022-01-01'
-      value: 0.3392
+      value: 0.3516
     - datetime: '2023-01-01'
       value: 0.3713
     - datetime: '2024-01-01'

--- a/config/zones/PH-VI.yaml
+++ b/config/zones/PH-VI.yaml
@@ -208,12 +208,16 @@ isLowCarbon:
       value: 0.2874
     - datetime: '2021-01-01'
       value: 0.298
+    - datetime: '2022-01-01'
+      value: 0.2981
 isRenewable:
   battery discharge:
     - datetime: '2020-01-01'
       value: 0.2874
     - datetime: '2021-01-01'
       value: 0.298
+    - datetime: '2022-01-01'
+      value: 0.2981
 parsers:
   production: IEMOP.fetch_production
 region: Asia

--- a/config/zones/PH-VI.yaml
+++ b/config/zones/PH-VI.yaml
@@ -206,10 +206,14 @@ isLowCarbon:
   battery discharge:
     - datetime: '2020-01-01'
       value: 0.2874
+    - datetime: '2021-01-01'
+      value: 0.298
 isRenewable:
   battery discharge:
     - datetime: '2020-01-01'
       value: 0.2874
+    - datetime: '2021-01-01'
+      value: 0.298
 parsers:
   production: IEMOP.fetch_production
 region: Asia

--- a/config/zones/PH-VI.yaml
+++ b/config/zones/PH-VI.yaml
@@ -210,6 +210,12 @@ isLowCarbon:
       value: 0.298
     - datetime: '2022-01-01'
       value: 0.2981
+    - datetime: '2023-01-01'
+      value: 0.2533
+    - datetime: '2024-01-01'
+      value: 0.2606
+    - datetime: '2025-01-01'
+      value: 0.2763
 isRenewable:
   battery discharge:
     - datetime: '2020-01-01'
@@ -218,6 +224,12 @@ isRenewable:
       value: 0.298
     - datetime: '2022-01-01'
       value: 0.2981
+    - datetime: '2023-01-01'
+      value: 0.2533
+    - datetime: '2024-01-01'
+      value: 0.2606
+    - datetime: '2025-01-01'
+      value: 0.2763
 parsers:
   production: IEMOP.fetch_production
 region: Asia

--- a/config/zones/PH-VI.yaml
+++ b/config/zones/PH-VI.yaml
@@ -31,7 +31,7 @@ emissionFactors:
       - _comment: used storage values greater than zero.
         datetime: '2020-01-01'
         source: Electricity Maps, 2020 zone average
-        value: 505.25
+        value: 505.23
       - _comment: used storage values greater than zero.
         datetime: '2021-01-01'
         source: Electricity Maps, 2021 zone average
@@ -57,7 +57,7 @@ emissionFactors:
       - _comment: used storage values greater than zero.
         datetime: '2020-01-01'
         source: Electricity Maps, 2020 zone average; National Laboratory of the Rockies
-        value: 538.25
+        value: 538.23
       - _comment: used storage values greater than zero.
         datetime: '2021-01-01'
         source: Electricity Maps, 2021 zone average; National Laboratory of the Rockies
@@ -200,15 +200,23 @@ fallbackZoneMixes:
         solar: 0.04010653633275602
         unknown: 0.1408642231758758
         wind: 0.010172876605430417
-has_day_ahead_price_license: False
-hide_day_ahead_price: False
+has_day_ahead_price_license: false
+hide_day_ahead_price: false
+isLowCarbon:
+  battery discharge:
+    - datetime: '2020-01-01'
+      value: 0.2874
+isRenewable:
+  battery discharge:
+    - datetime: '2020-01-01'
+      value: 0.2874
 parsers:
   production: IEMOP.fetch_production
 region: Asia
 sources:
-  National Laboratory of the Rockies:
-    link: https://docs.nrel.gov/docs/fy21osti/80580.pdf
   IPCC 2014:
     link: https://www.ipcc.ch/site/assets/uploads/2018/02/ipcc_wg3_ar5_annex-iii.pdf#page=7
+  National Laboratory of the Rockies:
+    link: https://docs.nrel.gov/docs/fy21osti/80580.pdf
 timezone: Asia/Manila
 zone_name: Visayas

--- a/config/zones/PH-VI.yaml
+++ b/config/zones/PH-VI.yaml
@@ -31,15 +31,15 @@ emissionFactors:
       - _comment: used storage values greater than zero.
         datetime: '2020-01-01'
         source: Electricity Maps, 2020 zone average
-        value: 505.23
+        value: 505.67
       - _comment: used storage values greater than zero.
         datetime: '2021-01-01'
         source: Electricity Maps, 2021 zone average
-        value: 498.23
+        value: 505.67
       - _comment: used storage values greater than zero.
         datetime: '2022-01-01'
         source: Electricity Maps, 2022 zone average
-        value: 498.23
+        value: 505.67
       - _comment: used storage values greater than zero.
         datetime: '2023-01-01'
         source: Electricity Maps, 2023 zone average
@@ -57,15 +57,15 @@ emissionFactors:
       - _comment: used storage values greater than zero.
         datetime: '2020-01-01'
         source: Electricity Maps, 2020 zone average; National Laboratory of the Rockies
-        value: 538.23
+        value: 538.67
       - _comment: used storage values greater than zero.
         datetime: '2021-01-01'
         source: Electricity Maps, 2021 zone average; National Laboratory of the Rockies
-        value: 531.23
+        value: 538.67
       - _comment: used storage values greater than zero.
         datetime: '2022-01-01'
         source: Electricity Maps, 2022 zone average; National Laboratory of the Rockies
-        value: 531.23
+        value: 538.67
       - _comment: used storage values greater than zero.
         datetime: '2023-01-01'
         source: Electricity Maps, 2023 zone average; National Laboratory of the Rockies
@@ -205,11 +205,11 @@ hide_day_ahead_price: false
 isLowCarbon:
   battery discharge:
     - datetime: '2020-01-01'
-      value: 0.2874
+      value: 0.2859
     - datetime: '2021-01-01'
-      value: 0.298
+      value: 0.2859
     - datetime: '2022-01-01'
-      value: 0.2981
+      value: 0.2859
     - datetime: '2023-01-01'
       value: 0.2533
     - datetime: '2024-01-01'
@@ -219,11 +219,11 @@ isLowCarbon:
 isRenewable:
   battery discharge:
     - datetime: '2020-01-01'
-      value: 0.2874
+      value: 0.2859
     - datetime: '2021-01-01'
-      value: 0.298
+      value: 0.2859
     - datetime: '2022-01-01'
-      value: 0.2981
+      value: 0.2859
     - datetime: '2023-01-01'
       value: 0.2533
     - datetime: '2024-01-01'

--- a/config/zones/PH.yaml
+++ b/config/zones/PH.yaml
@@ -245,14 +245,28 @@ fallbackZoneMixes:
         solar: 0.021186116587224194
         unknown: 0.05981327473921477
         wind: 0.009391697715065647
-has_day_ahead_price_license: False
-hide_day_ahead_price: False
+has_day_ahead_price_license: false
+hide_day_ahead_price: false
+isLowCarbon:
+  battery discharge:
+    - datetime: '2020-01-01'
+      value: 0.1854
+  hydro discharge:
+    - datetime: '2020-01-01'
+      value: 0.1695
+isRenewable:
+  battery discharge:
+    - datetime: '2020-01-01'
+      value: 0.1854
+  hydro discharge:
+    - datetime: '2020-01-01'
+      value: 0.1695
 region: Asia
 sources:
-  National Laboratory of the Rockies:
-    link: https://docs.nrel.gov/docs/fy21osti/80580.pdf
   IPCC 2014:
     link: https://www.ipcc.ch/site/assets/uploads/2018/02/ipcc_wg3_ar5_annex-iii.pdf#page=7
+  National Laboratory of the Rockies:
+    link: https://docs.nrel.gov/docs/fy21osti/80580.pdf
 subZoneNames:
   - PH-LU
   - PH-MI

--- a/config/zones/PH.yaml
+++ b/config/zones/PH.yaml
@@ -26,15 +26,15 @@ emissionFactors:
       - _comment: used storage values greater than zero.
         datetime: '2020-01-01'
         source: Electricity Maps, 2020 zone average
-        value: 544.55
+        value: 544.52
       - _comment: used storage values greater than zero.
         datetime: '2021-01-01'
         source: Electricity Maps, 2021 zone average
-        value: 548.21
+        value: 544.52
       - _comment: used storage values greater than zero.
         datetime: '2022-01-01'
         source: Electricity Maps, 2022 zone average
-        value: 548.21
+        value: 544.52
       - _comment: used storage values greater than zero.
         datetime: '2023-01-01'
         source: Electricity Maps, 2023 zone average
@@ -42,7 +42,7 @@ emissionFactors:
       - _comment: used storage values greater than zero.
         datetime: '2024-01-01'
         source: Electricity Maps, 2024 zone average
-        value: 542.93
+        value: 542.94
       - _comment: used storage values greater than zero.
         datetime: '2025-01-01'
         source: Electricity Maps, 2025 zone average
@@ -51,15 +51,15 @@ emissionFactors:
       - _comment: used storage values greater than zero.
         datetime: '2020-01-01'
         source: Electricity Maps, 2020 zone average
-        value: 556.07
+        value: 556.06
       - _comment: used storage values greater than zero.
         datetime: '2021-01-01'
         source: Electricity Maps, 2021 zone average
-        value: 559.72
+        value: 556.05
       - _comment: used storage values greater than zero.
         datetime: '2022-01-01'
         source: Electricity Maps, 2022 zone average
-        value: 559.72
+        value: 556.06
       - _comment: used storage values greater than zero.
         datetime: '2023-01-01'
         source: Electricity Maps, 2023 zone average
@@ -77,15 +77,15 @@ emissionFactors:
       - _comment: used storage values greater than zero.
         datetime: '2020-01-01'
         source: Electricity Maps, 2020 zone average; National Laboratory of the Rockies
-        value: 577.55
+        value: 577.52
       - _comment: used storage values greater than zero.
         datetime: '2021-01-01'
         source: Electricity Maps, 2021 zone average; National Laboratory of the Rockies
-        value: 581.21
+        value: 577.52
       - _comment: used storage values greater than zero.
         datetime: '2022-01-01'
         source: Electricity Maps, 2022 zone average; National Laboratory of the Rockies
-        value: 581.21
+        value: 577.52
       - _comment: used storage values greater than zero.
         datetime: '2023-01-01'
         source: Electricity Maps, 2023 zone average; National Laboratory of the Rockies
@@ -93,7 +93,7 @@ emissionFactors:
       - _comment: used storage values greater than zero.
         datetime: '2024-01-01'
         source: Electricity Maps, 2024 zone average; National Laboratory of the Rockies
-        value: 575.93
+        value: 575.94
       - _comment: used storage values greater than zero.
         datetime: '2025-01-01'
         source: Electricity Maps, 2025 zone average; National Laboratory of the Rockies
@@ -102,15 +102,15 @@ emissionFactors:
       - _comment: used storage values greater than zero.
         datetime: '2020-01-01'
         source: Electricity Maps, 2020 zone average; IPCC 2014
-        value: 580.07
+        value: 580.06
       - _comment: used storage values greater than zero.
         datetime: '2021-01-01'
         source: Electricity Maps, 2021 zone average; IPCC 2014
-        value: 583.72
+        value: 580.05
       - _comment: used storage values greater than zero.
         datetime: '2022-01-01'
         source: Electricity Maps, 2022 zone average; IPCC 2014
-        value: 583.72
+        value: 580.06
       - _comment: used storage values greater than zero.
         datetime: '2023-01-01'
         source: Electricity Maps, 2023 zone average; IPCC 2014
@@ -250,11 +250,11 @@ hide_day_ahead_price: false
 isLowCarbon:
   battery discharge:
     - datetime: '2020-01-01'
-      value: 0.1854
+      value: 0.1856
     - datetime: '2021-01-01'
-      value: 0.1818
+      value: 0.1856
     - datetime: '2022-01-01'
-      value: 0.1818
+      value: 0.1856
     - datetime: '2023-01-01'
       value: 0.1825
     - datetime: '2024-01-01'
@@ -263,11 +263,11 @@ isLowCarbon:
       value: 0.1965
   hydro discharge:
     - datetime: '2020-01-01'
-      value: 0.1695
+      value: 0.1697
     - datetime: '2021-01-01'
-      value: 0.1654
+      value: 0.1697
     - datetime: '2022-01-01'
-      value: 0.1654
+      value: 0.1697
     - datetime: '2023-01-01'
       value: 0.1765
     - datetime: '2024-01-01'
@@ -277,11 +277,11 @@ isLowCarbon:
 isRenewable:
   battery discharge:
     - datetime: '2020-01-01'
-      value: 0.1854
+      value: 0.1856
     - datetime: '2021-01-01'
-      value: 0.1818
+      value: 0.1856
     - datetime: '2022-01-01'
-      value: 0.1818
+      value: 0.1856
     - datetime: '2023-01-01'
       value: 0.1825
     - datetime: '2024-01-01'
@@ -290,11 +290,11 @@ isRenewable:
       value: 0.1965
   hydro discharge:
     - datetime: '2020-01-01'
-      value: 0.1695
+      value: 0.1697
     - datetime: '2021-01-01'
-      value: 0.1654
+      value: 0.1697
     - datetime: '2022-01-01'
-      value: 0.1654
+      value: 0.1697
     - datetime: '2023-01-01'
       value: 0.1765
     - datetime: '2024-01-01'

--- a/config/zones/PH.yaml
+++ b/config/zones/PH.yaml
@@ -255,6 +255,12 @@ isLowCarbon:
       value: 0.1818
     - datetime: '2022-01-01'
       value: 0.1818
+    - datetime: '2023-01-01'
+      value: 0.1825
+    - datetime: '2024-01-01'
+      value: 0.1896
+    - datetime: '2025-01-01'
+      value: 0.1965
   hydro discharge:
     - datetime: '2020-01-01'
       value: 0.1695
@@ -262,6 +268,12 @@ isLowCarbon:
       value: 0.1654
     - datetime: '2022-01-01'
       value: 0.1654
+    - datetime: '2023-01-01'
+      value: 0.1765
+    - datetime: '2024-01-01'
+      value: 0.1686
+    - datetime: '2025-01-01'
+      value: 0.1827
 isRenewable:
   battery discharge:
     - datetime: '2020-01-01'
@@ -270,6 +282,12 @@ isRenewable:
       value: 0.1818
     - datetime: '2022-01-01'
       value: 0.1818
+    - datetime: '2023-01-01'
+      value: 0.1825
+    - datetime: '2024-01-01'
+      value: 0.1896
+    - datetime: '2025-01-01'
+      value: 0.1965
   hydro discharge:
     - datetime: '2020-01-01'
       value: 0.1695
@@ -277,6 +295,12 @@ isRenewable:
       value: 0.1654
     - datetime: '2022-01-01'
       value: 0.1654
+    - datetime: '2023-01-01'
+      value: 0.1765
+    - datetime: '2024-01-01'
+      value: 0.1686
+    - datetime: '2025-01-01'
+      value: 0.1827
 region: Asia
 sources:
   IPCC 2014:

--- a/config/zones/PH.yaml
+++ b/config/zones/PH.yaml
@@ -253,10 +253,14 @@ isLowCarbon:
       value: 0.1854
     - datetime: '2021-01-01'
       value: 0.1818
+    - datetime: '2022-01-01'
+      value: 0.1818
   hydro discharge:
     - datetime: '2020-01-01'
       value: 0.1695
     - datetime: '2021-01-01'
+      value: 0.1654
+    - datetime: '2022-01-01'
       value: 0.1654
 isRenewable:
   battery discharge:
@@ -264,10 +268,14 @@ isRenewable:
       value: 0.1854
     - datetime: '2021-01-01'
       value: 0.1818
+    - datetime: '2022-01-01'
+      value: 0.1818
   hydro discharge:
     - datetime: '2020-01-01'
       value: 0.1695
     - datetime: '2021-01-01'
+      value: 0.1654
+    - datetime: '2022-01-01'
       value: 0.1654
 region: Asia
 sources:

--- a/config/zones/PH.yaml
+++ b/config/zones/PH.yaml
@@ -251,16 +251,24 @@ isLowCarbon:
   battery discharge:
     - datetime: '2020-01-01'
       value: 0.1854
+    - datetime: '2021-01-01'
+      value: 0.1818
   hydro discharge:
     - datetime: '2020-01-01'
       value: 0.1695
+    - datetime: '2021-01-01'
+      value: 0.1654
 isRenewable:
   battery discharge:
     - datetime: '2020-01-01'
       value: 0.1854
+    - datetime: '2021-01-01'
+      value: 0.1818
   hydro discharge:
     - datetime: '2020-01-01'
       value: 0.1695
+    - datetime: '2021-01-01'
+      value: 0.1654
 region: Asia
 sources:
   IPCC 2014:

--- a/config/zones/PL.yaml
+++ b/config/zones/PL.yaml
@@ -284,7 +284,7 @@ emissionFactors:
       - _comment: used storage values greater than zero.
         datetime: '2025-01-01'
         source: Electricity Maps, 2025 zone average
-        value: 468.79
+        value: 470.25
     oil:
       - datetime: '2021-01-01'
         source: EU-ETS, ENTSO-E 2021
@@ -359,7 +359,7 @@ emissionFactors:
       - _comment: used storage values greater than zero.
         datetime: '2025-01-01'
         source: Electricity Maps, 2025 zone average; UNECE 2022
-        value: 479.49
+        value: 480.95
     nuclear:
       datetime: '2020-01-01'
       source: UNECE 2022
@@ -553,7 +553,7 @@ isLowCarbon:
     - datetime: '2024-01-01'
       value: 0.4494
     - datetime: '2025-01-01'
-      value: 0.3653
+      value: 0.3634
 isRenewable:
   hydro discharge:
     - datetime: '2020-01-01'
@@ -567,7 +567,7 @@ isRenewable:
     - datetime: '2024-01-01'
       value: 0.448
     - datetime: '2025-01-01'
-      value: 0.3553
+      value: 0.3533
 parsers:
   consumption: ENTSOE.fetch_consumption
   consumptionForecast: ENTSOE.fetch_consumption_forecast

--- a/config/zones/PL.yaml
+++ b/config/zones/PL.yaml
@@ -546,11 +546,15 @@ isLowCarbon:
       value: 1.0
     - datetime: '2021-01-01'
       value: 1.0
+    - datetime: '2022-01-01'
+      value: 1.0
 isRenewable:
   hydro discharge:
     - datetime: '2020-01-01'
       value: 1.0
     - datetime: '2021-01-01'
+      value: 1.0
+    - datetime: '2022-01-01'
       value: 1.0
 parsers:
   consumption: ENTSOE.fetch_consumption

--- a/config/zones/PL.yaml
+++ b/config/zones/PL.yaml
@@ -544,9 +544,13 @@ isLowCarbon:
   hydro discharge:
     - datetime: '2020-01-01'
       value: 1.0
+    - datetime: '2021-01-01'
+      value: 1.0
 isRenewable:
   hydro discharge:
     - datetime: '2020-01-01'
+      value: 1.0
+    - datetime: '2021-01-01'
       value: 1.0
 parsers:
   consumption: ENTSOE.fetch_consumption

--- a/config/zones/PL.yaml
+++ b/config/zones/PL.yaml
@@ -540,6 +540,14 @@ fallbackZoneMixes:
         wind: 0.15788617303391778
 has_day_ahead_price_license: true
 hide_day_ahead_price: false
+isLowCarbon:
+  hydro discharge:
+    - datetime: '2020-01-01'
+      value: 1.0
+isRenewable:
+  hydro discharge:
+    - datetime: '2020-01-01'
+      value: 1.0
 parsers:
   consumption: ENTSOE.fetch_consumption
   consumptionForecast: ENTSOE.fetch_consumption_forecast

--- a/config/zones/PL.yaml
+++ b/config/zones/PL.yaml
@@ -280,11 +280,11 @@ emissionFactors:
       - _comment: used storage values greater than zero.
         datetime: '2024-01-01'
         source: Electricity Maps, 2024 zone average
-        value: 476.34
+        value: 400.7
       - _comment: used storage values greater than zero.
         datetime: '2025-01-01'
         source: Electricity Maps, 2025 zone average
-        value: 559.85
+        value: 468.79
     oil:
       - datetime: '2021-01-01'
         source: EU-ETS, ENTSO-E 2021
@@ -355,11 +355,11 @@ emissionFactors:
       - _comment: used storage values greater than zero.
         datetime: '2024-01-01'
         source: Electricity Maps, 2024 zone average; UNECE 2022
-        value: 487.04
+        value: 411.4
       - _comment: used storage values greater than zero.
         datetime: '2025-01-01'
         source: Electricity Maps, 2025 zone average; UNECE 2022
-        value: 570.55
+        value: 479.49
     nuclear:
       datetime: '2020-01-01'
       source: UNECE 2022
@@ -548,6 +548,12 @@ isLowCarbon:
       value: 1.0
     - datetime: '2022-01-01'
       value: 1.0
+    - datetime: '2023-01-01'
+      value: 1.0
+    - datetime: '2024-01-01'
+      value: 0.4494
+    - datetime: '2025-01-01'
+      value: 0.3653
 isRenewable:
   hydro discharge:
     - datetime: '2020-01-01'
@@ -556,6 +562,12 @@ isRenewable:
       value: 1.0
     - datetime: '2022-01-01'
       value: 1.0
+    - datetime: '2023-01-01'
+      value: 1.0
+    - datetime: '2024-01-01'
+      value: 0.448
+    - datetime: '2025-01-01'
+      value: 0.3553
 parsers:
   consumption: ENTSOE.fetch_consumption
   consumptionForecast: ENTSOE.fetch_consumption_forecast

--- a/config/zones/PT.yaml
+++ b/config/zones/PT.yaml
@@ -250,27 +250,27 @@ emissionFactors:
       - _comment: used storage values greater than zero.
         datetime: '2020-01-01'
         source: Electricity Maps, 2020 zone average
-        value: 166.7
+        value: 165.98
       - _comment: used storage values greater than zero.
         datetime: '2021-01-01'
         source: Electricity Maps, 2021 zone average
-        value: 127.8
+        value: 126.06
       - _comment: used storage values greater than zero.
         datetime: '2022-01-01'
         source: Electricity Maps, 2022 zone average
-        value: 149.33
+        value: 148.57
       - _comment: used storage values greater than zero.
         datetime: '2023-01-01'
         source: Electricity Maps, 2023 zone average
-        value: 90.71
+        value: 90.72
       - _comment: used storage values greater than zero.
         datetime: '2024-01-01'
         source: Electricity Maps, 2024 zone average
-        value: 52.14
+        value: 52.26
       - _comment: used storage values greater than zero.
         datetime: '2025-01-01'
         source: Electricity Maps, 2025 zone average
-        value: 66.1
+        value: 66.05
     oil:
       - datetime: '2021-01-01'
         source: EU-ETS, ENTSO-E 2021
@@ -313,27 +313,27 @@ emissionFactors:
       - _comment: used storage values greater than zero.
         datetime: '2020-01-01'
         source: Electricity Maps, 2020 zone average; UNECE 2022
-        value: 177.4
+        value: 176.68
       - _comment: used storage values greater than zero.
         datetime: '2021-01-01'
         source: Electricity Maps, 2021 zone average; UNECE 2022
-        value: 138.5
+        value: 136.76
       - _comment: used storage values greater than zero.
         datetime: '2022-01-01'
         source: Electricity Maps, 2022 zone average; UNECE 2022
-        value: 160.03
+        value: 159.27
       - _comment: used storage values greater than zero.
         datetime: '2023-01-01'
         source: Electricity Maps, 2023 zone average; UNECE 2022
-        value: 101.41
+        value: 101.42
       - _comment: used storage values greater than zero.
         datetime: '2024-01-01'
         source: Electricity Maps, 2024 zone average; UNECE 2022
-        value: 62.84
+        value: 62.96
       - _comment: used storage values greater than zero.
         datetime: '2025-01-01'
         source: Electricity Maps, 2025 zone average; UNECE 2022
-        value: 76.8
+        value: 76.75
     nuclear:
       datetime: '2020-01-01'
       source: UNECE 2022
@@ -511,31 +511,31 @@ hide_day_ahead_price: false
 isLowCarbon:
   hydro discharge:
     - datetime: '2020-01-01'
-      value: 0.6331
+      value: 0.6337
     - datetime: '2021-01-01'
-      value: 0.6908
+      value: 0.6927
     - datetime: '2022-01-01'
-      value: 0.6202
+      value: 0.6207
     - datetime: '2023-01-01'
       value: 0.7675
     - datetime: '2024-01-01'
-      value: 0.8741
+      value: 0.8738
     - datetime: '2025-01-01'
-      value: 0.8318
+      value: 0.832
 isRenewable:
   hydro discharge:
     - datetime: '2020-01-01'
-      value: 0.576
+      value: 0.5762
     - datetime: '2021-01-01'
-      value: 0.626
+      value: 0.6272
     - datetime: '2022-01-01'
-      value: 0.5577
+      value: 0.5579
     - datetime: '2023-01-01'
-      value: 0.693
+      value: 0.6929
     - datetime: '2024-01-01'
-      value: 0.8005
+      value: 0.8002
     - datetime: '2025-01-01'
-      value: 0.776
+      value: 0.7763
 parsers:
   consumption: ENTSOE.fetch_consumption
   consumptionForecast: ENTSOE.fetch_consumption_forecast

--- a/config/zones/PT.yaml
+++ b/config/zones/PT.yaml
@@ -262,15 +262,15 @@ emissionFactors:
       - _comment: used storage values greater than zero.
         datetime: '2023-01-01'
         source: Electricity Maps, 2023 zone average
-        value: 92.36
+        value: 90.71
       - _comment: used storage values greater than zero.
         datetime: '2024-01-01'
         source: Electricity Maps, 2024 zone average
-        value: 52.74
+        value: 52.14
       - _comment: used storage values greater than zero.
         datetime: '2025-01-01'
         source: Electricity Maps, 2025 zone average
-        value: 66.92
+        value: 66.1
     oil:
       - datetime: '2021-01-01'
         source: EU-ETS, ENTSO-E 2021
@@ -325,15 +325,15 @@ emissionFactors:
       - _comment: used storage values greater than zero.
         datetime: '2023-01-01'
         source: Electricity Maps, 2023 zone average; UNECE 2022
-        value: 103.06
+        value: 101.41
       - _comment: used storage values greater than zero.
         datetime: '2024-01-01'
         source: Electricity Maps, 2024 zone average; UNECE 2022
-        value: 63.44
+        value: 62.84
       - _comment: used storage values greater than zero.
         datetime: '2025-01-01'
         source: Electricity Maps, 2025 zone average; UNECE 2022
-        value: 77.62
+        value: 76.8
     nuclear:
       datetime: '2020-01-01'
       source: UNECE 2022
@@ -516,6 +516,12 @@ isLowCarbon:
       value: 0.6908
     - datetime: '2022-01-01'
       value: 0.6202
+    - datetime: '2023-01-01'
+      value: 0.7675
+    - datetime: '2024-01-01'
+      value: 0.8741
+    - datetime: '2025-01-01'
+      value: 0.8318
 isRenewable:
   hydro discharge:
     - datetime: '2020-01-01'
@@ -524,6 +530,12 @@ isRenewable:
       value: 0.626
     - datetime: '2022-01-01'
       value: 0.5577
+    - datetime: '2023-01-01'
+      value: 0.693
+    - datetime: '2024-01-01'
+      value: 0.8005
+    - datetime: '2025-01-01'
+      value: 0.776
 parsers:
   consumption: ENTSOE.fetch_consumption
   consumptionForecast: ENTSOE.fetch_consumption_forecast

--- a/config/zones/PT.yaml
+++ b/config/zones/PT.yaml
@@ -514,12 +514,16 @@ isLowCarbon:
       value: 0.6331
     - datetime: '2021-01-01'
       value: 0.6908
+    - datetime: '2022-01-01'
+      value: 0.6202
 isRenewable:
   hydro discharge:
     - datetime: '2020-01-01'
       value: 0.576
     - datetime: '2021-01-01'
       value: 0.626
+    - datetime: '2022-01-01'
+      value: 0.5577
 parsers:
   consumption: ENTSOE.fetch_consumption
   consumptionForecast: ENTSOE.fetch_consumption_forecast

--- a/config/zones/PT.yaml
+++ b/config/zones/PT.yaml
@@ -512,10 +512,14 @@ isLowCarbon:
   hydro discharge:
     - datetime: '2020-01-01'
       value: 0.6331
+    - datetime: '2021-01-01'
+      value: 0.6908
 isRenewable:
   hydro discharge:
     - datetime: '2020-01-01'
       value: 0.576
+    - datetime: '2021-01-01'
+      value: 0.626
 parsers:
   consumption: ENTSOE.fetch_consumption
   consumptionForecast: ENTSOE.fetch_consumption_forecast

--- a/config/zones/PT.yaml
+++ b/config/zones/PT.yaml
@@ -508,6 +508,14 @@ fallbackZoneMixes:
         wind: 0.28972267240405203
 has_day_ahead_price_license: true
 hide_day_ahead_price: false
+isLowCarbon:
+  hydro discharge:
+    - datetime: '2020-01-01'
+      value: 0.6331
+isRenewable:
+  hydro discharge:
+    - datetime: '2020-01-01'
+      value: 0.576
 parsers:
   consumption: ENTSOE.fetch_consumption
   consumptionForecast: ENTSOE.fetch_consumption_forecast

--- a/config/zones/RE.yaml
+++ b/config/zones/RE.yaml
@@ -255,10 +255,14 @@ isLowCarbon:
   battery discharge:
     - datetime: '2020-01-01'
       value: 0.1048
+    - datetime: '2022-01-01'
+      value: 0.157
 isRenewable:
   battery discharge:
     - datetime: '2020-01-01'
       value: 0.1048
+    - datetime: '2022-01-01'
+      value: 0.157
 parsers:
   price: FR_O.fetch_price
   production: FR_O.fetch_production

--- a/config/zones/RE.yaml
+++ b/config/zones/RE.yaml
@@ -257,12 +257,30 @@ isLowCarbon:
       value: 0.1048
     - datetime: '2022-01-01'
       value: 0.157
+    - datetime: '2023-01-01'
+      value: 0.3501
+    - datetime: '2024-01-01'
+      value: 0.4024
+    - datetime: '2025-01-01'
+      value: 0.8668
+  hydro discharge:
+    - datetime: '2025-01-01'
+      value: 1.0
 isRenewable:
   battery discharge:
     - datetime: '2020-01-01'
       value: 0.1048
     - datetime: '2022-01-01'
       value: 0.157
+    - datetime: '2023-01-01'
+      value: 0.3501
+    - datetime: '2024-01-01'
+      value: 0.4024
+    - datetime: '2025-01-01'
+      value: 0.8668
+  hydro discharge:
+    - datetime: '2025-01-01'
+      value: 1.0
 parsers:
   price: FR_O.fetch_price
   production: FR_O.fetch_production

--- a/config/zones/RE.yaml
+++ b/config/zones/RE.yaml
@@ -65,9 +65,13 @@ emissionFactors:
         source: Electricity Maps, 2020 zone average
         value: 424.87
       - _comment: used storage values greater than zero.
+        datetime: '2021-01-01'
+        source: Electricity Maps, 2021 zone average
+        value: 385.68
+      - _comment: used storage values greater than zero.
         datetime: '2022-01-01'
         source: Electricity Maps, 2022 zone average
-        value: 410.42
+        value: 418.01
       - _comment: used storage values greater than zero.
         datetime: '2023-01-01'
         source: Electricity Maps, 2023 zone average
@@ -75,11 +79,11 @@ emissionFactors:
       - _comment: used storage values greater than zero.
         datetime: '2024-01-01'
         source: Electricity Maps, 2024 zone average
-        value: 316.62
+        value: 316.59
       - _comment: used storage values greater than zero.
         datetime: '2025-01-01'
         source: Electricity Maps, 2025 zone average
-        value: 70.32
+        value: 11.86
     hydro discharge:
       - _comment: used default IPCC 2014 value of 0.0
         datetime: '2025-01-01'
@@ -92,9 +96,13 @@ emissionFactors:
         source: Electricity Maps, 2020 zone average; National Laboratory of the Rockies
         value: 457.87
       - _comment: used storage values greater than zero.
+        datetime: '2021-01-01'
+        source: Electricity Maps, 2021 zone average; National Laboratory of the Rockies
+        value: 418.68
+      - _comment: used storage values greater than zero.
         datetime: '2022-01-01'
         source: Electricity Maps, 2022 zone average; National Laboratory of the Rockies
-        value: 443.42
+        value: 451.01
       - _comment: used storage values greater than zero.
         datetime: '2023-01-01'
         source: Electricity Maps, 2023 zone average; National Laboratory of the Rockies
@@ -102,11 +110,11 @@ emissionFactors:
       - _comment: used storage values greater than zero.
         datetime: '2024-01-01'
         source: Electricity Maps, 2024 zone average; National Laboratory of the Rockies
-        value: 349.62
+        value: 349.59
       - _comment: used storage values greater than zero.
         datetime: '2025-01-01'
         source: Electricity Maps, 2025 zone average; National Laboratory of the Rockies
-        value: 103.32
+        value: 44.86
     hydro discharge:
       - _comment: used default IPCC 2014 value of 24.0
         datetime: '2025-01-01'
@@ -255,14 +263,16 @@ isLowCarbon:
   battery discharge:
     - datetime: '2020-01-01'
       value: 0.1048
+    - datetime: '2021-01-01'
+      value: 0.1605
     - datetime: '2022-01-01'
-      value: 0.157
+      value: 0.1354
     - datetime: '2023-01-01'
       value: 0.3501
     - datetime: '2024-01-01'
       value: 0.4024
     - datetime: '2025-01-01'
-      value: 0.8668
+      value: 0.9679
   hydro discharge:
     - datetime: '2025-01-01'
       value: 1.0
@@ -270,14 +280,16 @@ isRenewable:
   battery discharge:
     - datetime: '2020-01-01'
       value: 0.1048
+    - datetime: '2021-01-01'
+      value: 0.1605
     - datetime: '2022-01-01'
-      value: 0.157
+      value: 0.1354
     - datetime: '2023-01-01'
       value: 0.3501
     - datetime: '2024-01-01'
       value: 0.4024
     - datetime: '2025-01-01'
-      value: 0.8668
+      value: 0.9679
   hydro discharge:
     - datetime: '2025-01-01'
       value: 1.0

--- a/config/zones/RE.yaml
+++ b/config/zones/RE.yaml
@@ -55,7 +55,7 @@ contributors:
   - VIKTORVAV99
   - PaulRoms
 country: RE
-country_name: 'Réunion'
+country_name: "R\xE9union"
 currency: EUR
 emissionFactors:
   direct:
@@ -249,16 +249,24 @@ fallbackZoneMixes:
         solar: 0.0663331354651612
         unknown: 0.0
         wind: 0.010511245973335337
-has_day_ahead_price_license: False
-hide_day_ahead_price: False
+has_day_ahead_price_license: false
+hide_day_ahead_price: false
+isLowCarbon:
+  battery discharge:
+    - datetime: '2020-01-01'
+      value: 0.1048
+isRenewable:
+  battery discharge:
+    - datetime: '2020-01-01'
+      value: 0.1048
 parsers:
   price: FR_O.fetch_price
   production: FR_O.fetch_production
 region: Africa
-timezone: Indian/Reunion
-zone_name: 'Réunion'
 sources:
   IPCC 2014:
     link: https://www.ipcc.ch/site/assets/uploads/2018/02/ipcc_wg3_ar5_annex-iii.pdf#page=7
   National Laboratory of the Rockies:
     link: https://docs.nrel.gov/docs/fy21osti/80580.pdf
+timezone: Indian/Reunion
+zone_name: "R\xE9union"

--- a/config/zones/RO.yaml
+++ b/config/zones/RO.yaml
@@ -180,7 +180,7 @@ emissionFactors:
       - _comment: used storage values greater than zero.
         datetime: '2025-01-01'
         source: Electricity Maps, 2025 zone average
-        value: 276.54
+        value: 253.92
     biomass:
       datetime: '2021-01-01'
       source: BEIS 2021
@@ -229,7 +229,7 @@ emissionFactors:
       - _comment: used storage values greater than zero.
         datetime: '2025-01-01'
         source: Electricity Maps, 2025 zone average; National Laboratory of the Rockies
-        value: 309.54
+        value: 286.92
     biomass:
       datetime: '2014-01-01'
       source: BEIS 2021; IPCC 2014
@@ -446,6 +446,14 @@ fallbackZoneMixes:
         wind: 0.10556203829169036
 has_day_ahead_price_license: false
 hide_day_ahead_price: false
+isLowCarbon:
+  battery discharge:
+    - datetime: '2025-01-01'
+      value: 0.6622
+isRenewable:
+  battery discharge:
+    - datetime: '2025-01-01'
+      value: 0.3978
 parsers:
   consumption: ENTSOE.fetch_consumption
   consumptionForecast: ENTSOE.fetch_consumption_forecast
@@ -456,8 +464,6 @@ parsers:
   productionPerModeForecast: ENTSOE.fetch_wind_solar_forecasts
 region: Europe
 sources:
-  National Laboratory of the Rockies:
-    link: https://docs.nrel.gov/docs/fy21osti/80580.pdf
   EU-ETS, ENTSO-E 2021:
     link: https://drive.google.com/file/d/15UeUHyhcjVw8fGLc0Zx_HELSx20cw_-e/view?usp=share_link
   EU-ETS, ENTSO-E 2022:
@@ -470,6 +476,8 @@ sources:
     link: https://docs.google.com/spreadsheets/d/1w5DJ7sPen6axIHU8TCVcuzNCjlct4I6JAbhUlw-ZXu8/edit?usp=sharing
   IPCC 2014:
     link: https://www.ipcc.ch/site/assets/uploads/2018/02/ipcc_wg3_ar5_annex-iii.pdf#page=7
+  National Laboratory of the Rockies:
+    link: https://docs.nrel.gov/docs/fy21osti/80580.pdf
   UNECE 2022:
     link: https://unece.org/sites/default/files/2022-04/LCA_3_FINAL%20March%202022.pdf
   ? UNECE 2022, WindEurope "Wind energy in Europe, 2021 Statistics and the outlook

--- a/config/zones/RO.yaml
+++ b/config/zones/RO.yaml
@@ -177,10 +177,10 @@ delays:
 emissionFactors:
   direct:
     battery discharge:
-      - _comment: used storage values greater than zero.
+      - _comment: used non-null storage values
         datetime: '2025-01-01'
         source: Electricity Maps, 2025 zone average
-        value: 253.92
+        value: 262.12
     biomass:
       datetime: '2021-01-01'
       source: BEIS 2021
@@ -226,10 +226,10 @@ emissionFactors:
         value: 857.84
   lifecycle:
     battery discharge:
-      - _comment: used storage values greater than zero.
+      - _comment: used non-null storage values
         datetime: '2025-01-01'
         source: Electricity Maps, 2025 zone average; National Laboratory of the Rockies
-        value: 286.92
+        value: 295.12
     biomass:
       datetime: '2014-01-01'
       source: BEIS 2021; IPCC 2014
@@ -449,11 +449,11 @@ hide_day_ahead_price: false
 isLowCarbon:
   battery discharge:
     - datetime: '2025-01-01'
-      value: 0.6622
+      value: 0.6649
 isRenewable:
   battery discharge:
     - datetime: '2025-01-01'
-      value: 0.3978
+      value: 0.4207
 parsers:
   consumption: ENTSOE.fetch_consumption
   consumptionForecast: ENTSOE.fetch_consumption_forecast

--- a/config/zones/RS.yaml
+++ b/config/zones/RS.yaml
@@ -177,11 +177,11 @@ emissionFactors:
       - _comment: used storage values greater than zero.
         datetime: '2024-01-01'
         source: Electricity Maps, 2024 zone average
-        value: 453.97
+        value: 453.96
       - _comment: used storage values greater than zero.
         datetime: '2025-01-01'
         source: Electricity Maps, 2025 zone average
-        value: 483.26
+        value: 474.61
   lifecycle:
     hydro:
       datetime: '2020-01-01'
@@ -207,11 +207,11 @@ emissionFactors:
       - _comment: used storage values greater than zero.
         datetime: '2024-01-01'
         source: Electricity Maps, 2024 zone average; UNECE 2022
-        value: 464.67
+        value: 464.66
       - _comment: used storage values greater than zero.
         datetime: '2025-01-01'
         source: Electricity Maps, 2025 zone average; UNECE 2022
-        value: 493.96
+        value: 485.31
     nuclear:
       datetime: '2020-01-01'
       source: UNECE 2022
@@ -352,6 +352,12 @@ isLowCarbon:
       value: 1.0
     - datetime: '2022-01-01'
       value: 0.2838
+    - datetime: '2023-01-01'
+      value: 0.3901
+    - datetime: '2024-01-01'
+      value: 0.369
+    - datetime: '2025-01-01'
+      value: 0.3413
 isRenewable:
   hydro discharge:
     - datetime: '2020-01-01'
@@ -360,6 +366,12 @@ isRenewable:
       value: 1.0
     - datetime: '2022-01-01'
       value: 0.2144
+    - datetime: '2023-01-01'
+      value: 0.3771
+    - datetime: '2024-01-01'
+      value: 0.3456
+    - datetime: '2025-01-01'
+      value: 0.2789
 parsers:
   consumption: ENTSOE.fetch_consumption
   consumptionForecast: ENTSOE.fetch_consumption_forecast

--- a/config/zones/RS.yaml
+++ b/config/zones/RS.yaml
@@ -342,8 +342,16 @@ fallbackZoneMixes:
         solar: 0.01441557250678779
         unknown: 0.006567137148345253
         wind: 0.03546266393241745
-has_day_ahead_price_license: False
-hide_day_ahead_price: False
+has_day_ahead_price_license: false
+hide_day_ahead_price: false
+isLowCarbon:
+  hydro discharge:
+    - datetime: '2020-01-01'
+      value: 1.0
+isRenewable:
+  hydro discharge:
+    - datetime: '2020-01-01'
+      value: 1.0
 parsers:
   consumption: ENTSOE.fetch_consumption
   consumptionForecast: ENTSOE.fetch_consumption_forecast

--- a/config/zones/RS.yaml
+++ b/config/zones/RS.yaml
@@ -348,9 +348,13 @@ isLowCarbon:
   hydro discharge:
     - datetime: '2020-01-01'
       value: 1.0
+    - datetime: '2021-01-01'
+      value: 1.0
 isRenewable:
   hydro discharge:
     - datetime: '2020-01-01'
+      value: 1.0
+    - datetime: '2021-01-01'
       value: 1.0
 parsers:
   consumption: ENTSOE.fetch_consumption

--- a/config/zones/RS.yaml
+++ b/config/zones/RS.yaml
@@ -169,19 +169,19 @@ emissionFactors:
       - _comment: used storage values greater than zero.
         datetime: '2022-01-01'
         source: Electricity Maps, 2022 zone average
-        value: 529.5
+        value: 539.32
       - _comment: used storage values greater than zero.
         datetime: '2023-01-01'
         source: Electricity Maps, 2023 zone average
         value: 442.29
-      - _comment: used storage values greater than zero.
+      - _comment: used default IPCC 2014 value of 0.0
         datetime: '2024-01-01'
         source: Electricity Maps, 2024 zone average
-        value: 453.96
+        value: 0.0
       - _comment: used storage values greater than zero.
         datetime: '2025-01-01'
         source: Electricity Maps, 2025 zone average
-        value: 474.61
+        value: 553.89
   lifecycle:
     hydro:
       datetime: '2020-01-01'
@@ -199,19 +199,19 @@ emissionFactors:
       - _comment: used storage values greater than zero.
         datetime: '2022-01-01'
         source: Electricity Maps, 2022 zone average; UNECE 2022
-        value: 540.2
+        value: 550.02
       - _comment: used storage values greater than zero.
         datetime: '2023-01-01'
         source: Electricity Maps, 2023 zone average; UNECE 2022
         value: 452.99
-      - _comment: used storage values greater than zero.
+      - _comment: used default IPCC 2014 value of 24.0
         datetime: '2024-01-01'
         source: Electricity Maps, 2024 zone average; UNECE 2022
-        value: 464.66
+        value: 10.7
       - _comment: used storage values greater than zero.
         datetime: '2025-01-01'
         source: Electricity Maps, 2025 zone average; UNECE 2022
-        value: 485.31
+        value: 564.59
     nuclear:
       datetime: '2020-01-01'
       source: UNECE 2022
@@ -351,13 +351,13 @@ isLowCarbon:
     - datetime: '2021-01-01'
       value: 1.0
     - datetime: '2022-01-01'
-      value: 0.2838
+      value: 0.2672
     - datetime: '2023-01-01'
       value: 0.3901
     - datetime: '2024-01-01'
-      value: 0.369
+      value: 1.0
     - datetime: '2025-01-01'
-      value: 0.3413
+      value: 0.2583
 isRenewable:
   hydro discharge:
     - datetime: '2020-01-01'
@@ -365,13 +365,13 @@ isRenewable:
     - datetime: '2021-01-01'
       value: 1.0
     - datetime: '2022-01-01'
-      value: 0.2144
+      value: 0.2049
     - datetime: '2023-01-01'
       value: 0.3771
     - datetime: '2024-01-01'
-      value: 0.3456
+      value: 1.0
     - datetime: '2025-01-01'
-      value: 0.2789
+      value: 0.2188
 parsers:
   consumption: ENTSOE.fetch_consumption
   consumptionForecast: ENTSOE.fetch_consumption_forecast

--- a/config/zones/RS.yaml
+++ b/config/zones/RS.yaml
@@ -350,12 +350,16 @@ isLowCarbon:
       value: 1.0
     - datetime: '2021-01-01'
       value: 1.0
+    - datetime: '2022-01-01'
+      value: 0.2838
 isRenewable:
   hydro discharge:
     - datetime: '2020-01-01'
       value: 1.0
     - datetime: '2021-01-01'
       value: 1.0
+    - datetime: '2022-01-01'
+      value: 0.2144
 parsers:
   consumption: ENTSOE.fetch_consumption
   consumptionForecast: ENTSOE.fetch_consumption_forecast

--- a/config/zones/SI.yaml
+++ b/config/zones/SI.yaml
@@ -479,11 +479,15 @@ isLowCarbon:
       value: 1.0
     - datetime: '2021-01-01'
       value: 1.0
+    - datetime: '2022-01-01'
+      value: 1.0
 isRenewable:
   hydro discharge:
     - datetime: '2020-01-01'
       value: 1.0
     - datetime: '2021-01-01'
+      value: 1.0
+    - datetime: '2022-01-01'
       value: 1.0
 parsers:
   consumption: ENTSOE.fetch_consumption

--- a/config/zones/SI.yaml
+++ b/config/zones/SI.yaml
@@ -473,6 +473,14 @@ fallbackZoneMixes:
         wind: 0.04625761651149296
 has_day_ahead_price_license: false
 hide_day_ahead_price: false
+isLowCarbon:
+  hydro discharge:
+    - datetime: '2020-01-01'
+      value: 1.0
+isRenewable:
+  hydro discharge:
+    - datetime: '2020-01-01'
+      value: 1.0
 parsers:
   consumption: ENTSOE.fetch_consumption
   consumptionForecast: ENTSOE.fetch_consumption_forecast

--- a/config/zones/SI.yaml
+++ b/config/zones/SI.yaml
@@ -209,7 +209,7 @@ emissionFactors:
       - _comment: used storage values greater than zero.
         datetime: '2023-01-01'
         source: Electricity Maps, 2023 zone average
-        value: 281.03
+        value: 278.23
       - _comment: used default IPCC 2014 value of 0.0
         datetime: '2024-01-01'
         source: Electricity Maps, 2024 zone average
@@ -284,7 +284,7 @@ emissionFactors:
       - _comment: used storage values greater than zero.
         datetime: '2023-01-01'
         source: Electricity Maps, 2023 zone average; UNECE 2022
-        value: 291.73
+        value: 288.93
       - _comment: used default IPCC 2014 value of 24.0
         datetime: '2024-01-01'
         source: Electricity Maps, 2024 zone average; UNECE 2022
@@ -481,6 +481,12 @@ isLowCarbon:
       value: 1.0
     - datetime: '2022-01-01'
       value: 1.0
+    - datetime: '2023-01-01'
+      value: 0.653
+    - datetime: '2024-01-01'
+      value: 1.0
+    - datetime: '2025-01-01'
+      value: 1.0
 isRenewable:
   hydro discharge:
     - datetime: '2020-01-01'
@@ -488,6 +494,12 @@ isRenewable:
     - datetime: '2021-01-01'
       value: 1.0
     - datetime: '2022-01-01'
+      value: 1.0
+    - datetime: '2023-01-01'
+      value: 0.2829
+    - datetime: '2024-01-01'
+      value: 1.0
+    - datetime: '2025-01-01'
       value: 1.0
 parsers:
   consumption: ENTSOE.fetch_consumption

--- a/config/zones/SI.yaml
+++ b/config/zones/SI.yaml
@@ -477,9 +477,13 @@ isLowCarbon:
   hydro discharge:
     - datetime: '2020-01-01'
       value: 1.0
+    - datetime: '2021-01-01'
+      value: 1.0
 isRenewable:
   hydro discharge:
     - datetime: '2020-01-01'
+      value: 1.0
+    - datetime: '2021-01-01'
       value: 1.0
 parsers:
   consumption: ENTSOE.fetch_consumption

--- a/config/zones/SI.yaml
+++ b/config/zones/SI.yaml
@@ -209,7 +209,7 @@ emissionFactors:
       - _comment: used storage values greater than zero.
         datetime: '2023-01-01'
         source: Electricity Maps, 2023 zone average
-        value: 278.23
+        value: 278.19
       - _comment: used default IPCC 2014 value of 0.0
         datetime: '2024-01-01'
         source: Electricity Maps, 2024 zone average
@@ -284,7 +284,7 @@ emissionFactors:
       - _comment: used storage values greater than zero.
         datetime: '2023-01-01'
         source: Electricity Maps, 2023 zone average; UNECE 2022
-        value: 288.93
+        value: 288.89
       - _comment: used default IPCC 2014 value of 24.0
         datetime: '2024-01-01'
         source: Electricity Maps, 2024 zone average; UNECE 2022
@@ -496,7 +496,7 @@ isRenewable:
     - datetime: '2022-01-01'
       value: 1.0
     - datetime: '2023-01-01'
-      value: 0.2829
+      value: 0.2828
     - datetime: '2024-01-01'
       value: 1.0
     - datetime: '2025-01-01'

--- a/config/zones/SK.yaml
+++ b/config/zones/SK.yaml
@@ -440,10 +440,14 @@ isLowCarbon:
   hydro discharge:
     - datetime: '2020-01-01'
       value: 0.6602
+    - datetime: '2021-01-01'
+      value: 0.6272
 isRenewable:
   hydro discharge:
     - datetime: '2020-01-01'
       value: 0.1875
+    - datetime: '2021-01-01'
+      value: 0.168
 parsers:
   consumption: ENTSOE.fetch_consumption
   consumptionForecast: ENTSOE.fetch_consumption_forecast

--- a/config/zones/SK.yaml
+++ b/config/zones/SK.yaml
@@ -442,12 +442,16 @@ isLowCarbon:
       value: 0.6602
     - datetime: '2021-01-01'
       value: 0.6272
+    - datetime: '2022-01-01'
+      value: 0.6498
 isRenewable:
   hydro discharge:
     - datetime: '2020-01-01'
       value: 0.1875
     - datetime: '2021-01-01'
       value: 0.168
+    - datetime: '2022-01-01'
+      value: 0.1736
 parsers:
   consumption: ENTSOE.fetch_consumption
   consumptionForecast: ENTSOE.fetch_consumption_forecast

--- a/config/zones/SK.yaml
+++ b/config/zones/SK.yaml
@@ -160,19 +160,19 @@ emissionFactors:
       - _comment: used storage values greater than zero.
         datetime: '2020-01-01'
         source: Electricity Maps, 2020 zone average
-        value: 280.97
+        value: 280.95
       - _comment: used storage values greater than zero.
         datetime: '2021-01-01'
         source: Electricity Maps, 2021 zone average
-        value: 309.49
+        value: 304.93
       - _comment: used storage values greater than zero.
         datetime: '2022-01-01'
         source: Electricity Maps, 2022 zone average
-        value: 368.11
+        value: 370.76
       - _comment: used storage values greater than zero.
         datetime: '2023-01-01'
         source: Electricity Maps, 2023 zone average
-        value: 222.91
+        value: 233.95
       - _comment: used storage values greater than zero.
         datetime: '2024-01-01'
         source: Electricity Maps, 2024 zone average
@@ -180,7 +180,7 @@ emissionFactors:
       - _comment: used storage values greater than zero.
         datetime: '2025-01-01'
         source: Electricity Maps, 2025 zone average
-        value: 165.69
+        value: 156.6
     oil:
       - datetime: '2021-01-01'
         source: EU-ETS, ENTSO-E 2021
@@ -235,19 +235,19 @@ emissionFactors:
       - _comment: used storage values greater than zero.
         datetime: '2020-01-01'
         source: Electricity Maps, 2020 zone average; UNECE 2022
-        value: 291.67
+        value: 291.65
       - _comment: used storage values greater than zero.
         datetime: '2021-01-01'
         source: Electricity Maps, 2021 zone average; UNECE 2022
-        value: 320.19
+        value: 315.63
       - _comment: used storage values greater than zero.
         datetime: '2022-01-01'
         source: Electricity Maps, 2022 zone average; UNECE 2022
-        value: 378.81
+        value: 381.46
       - _comment: used storage values greater than zero.
         datetime: '2023-01-01'
         source: Electricity Maps, 2023 zone average; UNECE 2022
-        value: 233.61
+        value: 244.65
       - _comment: used storage values greater than zero.
         datetime: '2024-01-01'
         source: Electricity Maps, 2024 zone average; UNECE 2022
@@ -255,7 +255,7 @@ emissionFactors:
       - _comment: used storage values greater than zero.
         datetime: '2025-01-01'
         source: Electricity Maps, 2025 zone average; UNECE 2022
-        value: 176.39
+        value: 167.3
     nuclear:
       datetime: '2020-01-01'
       source: UNECE 2022
@@ -441,29 +441,29 @@ isLowCarbon:
     - datetime: '2020-01-01'
       value: 0.6602
     - datetime: '2021-01-01'
-      value: 0.6272
+      value: 0.6294
     - datetime: '2022-01-01'
-      value: 0.6498
+      value: 0.6463
     - datetime: '2023-01-01'
-      value: 0.7594
+      value: 0.7469
     - datetime: '2024-01-01'
       value: 0.7519
     - datetime: '2025-01-01'
-      value: 0.7336
+      value: 0.7484
 isRenewable:
   hydro discharge:
     - datetime: '2020-01-01'
-      value: 0.1875
+      value: 0.1876
     - datetime: '2021-01-01'
-      value: 0.168
+      value: 0.1782
     - datetime: '2022-01-01'
-      value: 0.1736
+      value: 0.1788
     - datetime: '2023-01-01'
-      value: 0.2056
+      value: 0.204
     - datetime: '2024-01-01'
-      value: 0.2267
+      value: 0.2268
     - datetime: '2025-01-01'
-      value: 0.1906
+      value: 0.2022
 parsers:
   consumption: ENTSOE.fetch_consumption
   consumptionForecast: ENTSOE.fetch_consumption_forecast

--- a/config/zones/SK.yaml
+++ b/config/zones/SK.yaml
@@ -172,15 +172,15 @@ emissionFactors:
       - _comment: used storage values greater than zero.
         datetime: '2023-01-01'
         source: Electricity Maps, 2023 zone average
-        value: 193.78
+        value: 222.91
       - _comment: used storage values greater than zero.
         datetime: '2024-01-01'
         source: Electricity Maps, 2024 zone average
-        value: 147.17
+        value: 156.29
       - _comment: used storage values greater than zero.
         datetime: '2025-01-01'
         source: Electricity Maps, 2025 zone average
-        value: 165.93
+        value: 165.69
     oil:
       - datetime: '2021-01-01'
         source: EU-ETS, ENTSO-E 2021
@@ -247,15 +247,15 @@ emissionFactors:
       - _comment: used storage values greater than zero.
         datetime: '2023-01-01'
         source: Electricity Maps, 2023 zone average; UNECE 2022
-        value: 204.48
+        value: 233.61
       - _comment: used storage values greater than zero.
         datetime: '2024-01-01'
         source: Electricity Maps, 2024 zone average; UNECE 2022
-        value: 157.87
+        value: 166.99
       - _comment: used storage values greater than zero.
         datetime: '2025-01-01'
         source: Electricity Maps, 2025 zone average; UNECE 2022
-        value: 176.63
+        value: 176.39
     nuclear:
       datetime: '2020-01-01'
       source: UNECE 2022
@@ -444,6 +444,12 @@ isLowCarbon:
       value: 0.6272
     - datetime: '2022-01-01'
       value: 0.6498
+    - datetime: '2023-01-01'
+      value: 0.7594
+    - datetime: '2024-01-01'
+      value: 0.7519
+    - datetime: '2025-01-01'
+      value: 0.7336
 isRenewable:
   hydro discharge:
     - datetime: '2020-01-01'
@@ -452,6 +458,12 @@ isRenewable:
       value: 0.168
     - datetime: '2022-01-01'
       value: 0.1736
+    - datetime: '2023-01-01'
+      value: 0.2056
+    - datetime: '2024-01-01'
+      value: 0.2267
+    - datetime: '2025-01-01'
+      value: 0.1906
 parsers:
   consumption: ENTSOE.fetch_consumption
   consumptionForecast: ENTSOE.fetch_consumption_forecast

--- a/config/zones/SK.yaml
+++ b/config/zones/SK.yaml
@@ -160,7 +160,7 @@ emissionFactors:
       - _comment: used storage values greater than zero.
         datetime: '2020-01-01'
         source: Electricity Maps, 2020 zone average
-        value: 280.95
+        value: 280.97
       - _comment: used storage values greater than zero.
         datetime: '2021-01-01'
         source: Electricity Maps, 2021 zone average
@@ -235,7 +235,7 @@ emissionFactors:
       - _comment: used storage values greater than zero.
         datetime: '2020-01-01'
         source: Electricity Maps, 2020 zone average; UNECE 2022
-        value: 291.65
+        value: 291.67
       - _comment: used storage values greater than zero.
         datetime: '2021-01-01'
         source: Electricity Maps, 2021 zone average; UNECE 2022
@@ -436,6 +436,14 @@ fallbackZoneMixes:
         wind: 0.027443728652431654
 has_day_ahead_price_license: false
 hide_day_ahead_price: false
+isLowCarbon:
+  hydro discharge:
+    - datetime: '2020-01-01'
+      value: 0.6602
+isRenewable:
+  hydro discharge:
+    - datetime: '2020-01-01'
+      value: 0.1875
 parsers:
   consumption: ENTSOE.fetch_consumption
   consumptionForecast: ENTSOE.fetch_consumption_forecast

--- a/config/zones/TW.yaml
+++ b/config/zones/TW.yaml
@@ -198,7 +198,7 @@ emissionFactors:
       - _comment: used storage values greater than zero.
         datetime: '2020-01-01'
         source: Electricity Maps, 2020 zone average
-        value: 465.73
+        value: 465.71
       - _comment: used storage values greater than zero.
         datetime: '2021-01-01'
         source: Electricity Maps, 2021 zone average
@@ -249,7 +249,7 @@ emissionFactors:
       - _comment: used storage values greater than zero.
         datetime: '2020-01-01'
         source: Electricity Maps, 2020 zone average; IPCC 2014
-        value: 489.73
+        value: 489.71
       - _comment: used storage values greater than zero.
         datetime: '2021-01-01'
         source: Electricity Maps, 2021 zone average; IPCC 2014
@@ -422,16 +422,30 @@ fallbackZoneMixes:
         solar: 0.06550111905166345
         unknown: 0.03142705539402686
         wind: 0.037479238587619625
-has_day_ahead_price_license: False
-hide_day_ahead_price: False
+has_day_ahead_price_license: false
+hide_day_ahead_price: false
+isLowCarbon:
+  battery discharge:
+    - datetime: '2020-01-01'
+      value: 0.2042
+  hydro discharge:
+    - datetime: '2020-01-01'
+      value: 0.1756
+isRenewable:
+  battery discharge:
+    - datetime: '2020-01-01'
+      value: 0.0776
+  hydro discharge:
+    - datetime: '2020-01-01'
+      value: 0.0352
 parsers:
   production: TAIPOWER.fetch_production
   productionCapacity: EMBER.fetch_production_capacity
 region: Asia
-timezone: Asia/Taipei
-zone_name: Taiwan
 sources:
   IPCC 2014:
     link: https://www.ipcc.ch/site/assets/uploads/2018/02/ipcc_wg3_ar5_annex-iii.pdf#page=7
   National Laboratory of the Rockies:
     link: https://docs.nrel.gov/docs/fy21osti/80580.pdf
+timezone: Asia/Taipei
+zone_name: Taiwan

--- a/config/zones/TW.yaml
+++ b/config/zones/TW.yaml
@@ -432,6 +432,12 @@ isLowCarbon:
       value: 0.1911
     - datetime: '2022-01-01'
       value: 0.191
+    - datetime: '2023-01-01'
+      value: 0.2081
+    - datetime: '2024-01-01'
+      value: 0.2154
+    - datetime: '2025-01-01'
+      value: 0.1437
   hydro discharge:
     - datetime: '2020-01-01'
       value: 0.1756
@@ -439,6 +445,12 @@ isLowCarbon:
       value: 0.1689
     - datetime: '2022-01-01'
       value: 0.1737
+    - datetime: '2023-01-01'
+      value: 0.1772
+    - datetime: '2024-01-01'
+      value: 0.2283
+    - datetime: '2025-01-01'
+      value: 0.1457
 isRenewable:
   battery discharge:
     - datetime: '2020-01-01'
@@ -447,6 +459,12 @@ isRenewable:
       value: 0.0996
     - datetime: '2022-01-01'
       value: 0.1131
+    - datetime: '2023-01-01'
+      value: 0.127
+    - datetime: '2024-01-01'
+      value: 0.1423
+    - datetime: '2025-01-01'
+      value: 0.1437
   hydro discharge:
     - datetime: '2020-01-01'
       value: 0.0352
@@ -454,6 +472,12 @@ isRenewable:
       value: 0.0518
     - datetime: '2022-01-01'
       value: 0.0751
+    - datetime: '2023-01-01'
+      value: 0.1084
+    - datetime: '2024-01-01'
+      value: 0.1523
+    - datetime: '2025-01-01'
+      value: 0.1457
 parsers:
   production: TAIPOWER.fetch_production
   productionCapacity: EMBER.fetch_production_capacity

--- a/config/zones/TW.yaml
+++ b/config/zones/TW.yaml
@@ -428,16 +428,24 @@ isLowCarbon:
   battery discharge:
     - datetime: '2020-01-01'
       value: 0.2042
+    - datetime: '2021-01-01'
+      value: 0.1911
   hydro discharge:
     - datetime: '2020-01-01'
       value: 0.1756
+    - datetime: '2021-01-01'
+      value: 0.1689
 isRenewable:
   battery discharge:
     - datetime: '2020-01-01'
       value: 0.0776
+    - datetime: '2021-01-01'
+      value: 0.0996
   hydro discharge:
     - datetime: '2020-01-01'
       value: 0.0352
+    - datetime: '2021-01-01'
+      value: 0.0518
 parsers:
   production: TAIPOWER.fetch_production
   productionCapacity: EMBER.fetch_production_capacity

--- a/config/zones/TW.yaml
+++ b/config/zones/TW.yaml
@@ -177,19 +177,19 @@ emissionFactors:
       - _comment: used storage values greater than zero.
         datetime: '2021-01-01'
         source: Electricity Maps, 2021 zone average
-        value: 430.5
+        value: 434.48
       - _comment: used storage values greater than zero.
         datetime: '2022-01-01'
         source: Electricity Maps, 2022 zone average
-        value: 425.23
+        value: 428.64
       - _comment: used storage values greater than zero.
         datetime: '2023-01-01'
         source: Electricity Maps, 2023 zone average
-        value: 416.16
+        value: 407.82
       - _comment: used storage values greater than zero.
         datetime: '2024-01-01'
         source: Electricity Maps, 2024 zone average
-        value: 389.0
+        value: 394.58
       - _comment: used storage values greater than zero.
         datetime: '2025-01-01'
         source: Electricity Maps, 2025 zone average
@@ -198,7 +198,7 @@ emissionFactors:
       - _comment: used storage values greater than zero.
         datetime: '2020-01-01'
         source: Electricity Maps, 2020 zone average
-        value: 465.71
+        value: 465.73
       - _comment: used storage values greater than zero.
         datetime: '2021-01-01'
         source: Electricity Maps, 2021 zone average
@@ -210,11 +210,11 @@ emissionFactors:
       - _comment: used storage values greater than zero.
         datetime: '2023-01-01'
         source: Electricity Maps, 2023 zone average
-        value: 446.47
+        value: 442.33
       - _comment: used storage values greater than zero.
         datetime: '2024-01-01'
         source: Electricity Maps, 2024 zone average
-        value: 401.03
+        value: 400.71
       - _comment: used storage values greater than zero.
         datetime: '2025-01-01'
         source: Electricity Maps, 2025 zone average
@@ -228,19 +228,19 @@ emissionFactors:
       - _comment: used storage values greater than zero.
         datetime: '2021-01-01'
         source: Electricity Maps, 2021 zone average; National Laboratory of the Rockies
-        value: 463.5
+        value: 467.48
       - _comment: used storage values greater than zero.
         datetime: '2022-01-01'
         source: Electricity Maps, 2022 zone average; National Laboratory of the Rockies
-        value: 458.23
+        value: 461.64
       - _comment: used storage values greater than zero.
         datetime: '2023-01-01'
         source: Electricity Maps, 2023 zone average; National Laboratory of the Rockies
-        value: 449.16
+        value: 440.82
       - _comment: used storage values greater than zero.
         datetime: '2024-01-01'
         source: Electricity Maps, 2024 zone average; National Laboratory of the Rockies
-        value: 422.0
+        value: 427.58
       - _comment: used storage values greater than zero.
         datetime: '2025-01-01'
         source: Electricity Maps, 2025 zone average; National Laboratory of the Rockies
@@ -249,7 +249,7 @@ emissionFactors:
       - _comment: used storage values greater than zero.
         datetime: '2020-01-01'
         source: Electricity Maps, 2020 zone average; IPCC 2014
-        value: 489.71
+        value: 489.73
       - _comment: used storage values greater than zero.
         datetime: '2021-01-01'
         source: Electricity Maps, 2021 zone average; IPCC 2014
@@ -261,11 +261,11 @@ emissionFactors:
       - _comment: used storage values greater than zero.
         datetime: '2023-01-01'
         source: Electricity Maps, 2023 zone average; IPCC 2014
-        value: 470.47
+        value: 466.33
       - _comment: used storage values greater than zero.
         datetime: '2024-01-01'
         source: Electricity Maps, 2024 zone average; IPCC 2014
-        value: 425.03
+        value: 424.71
       - _comment: used storage values greater than zero.
         datetime: '2025-01-01'
         source: Electricity Maps, 2025 zone average; IPCC 2014
@@ -429,13 +429,13 @@ isLowCarbon:
     - datetime: '2020-01-01'
       value: 0.2042
     - datetime: '2021-01-01'
-      value: 0.1911
+      value: 0.1856
     - datetime: '2022-01-01'
-      value: 0.191
+      value: 0.1873
     - datetime: '2023-01-01'
-      value: 0.2081
+      value: 0.2296
     - datetime: '2024-01-01'
-      value: 0.2154
+      value: 0.2046
     - datetime: '2025-01-01'
       value: 0.1437
   hydro discharge:
@@ -446,9 +446,9 @@ isLowCarbon:
     - datetime: '2022-01-01'
       value: 0.1737
     - datetime: '2023-01-01'
-      value: 0.1772
+      value: 0.1834
     - datetime: '2024-01-01'
-      value: 0.2283
+      value: 0.2292
     - datetime: '2025-01-01'
       value: 0.1457
 isRenewable:
@@ -456,26 +456,26 @@ isRenewable:
     - datetime: '2020-01-01'
       value: 0.0776
     - datetime: '2021-01-01'
-      value: 0.0996
+      value: 0.0922
     - datetime: '2022-01-01'
-      value: 0.1131
+      value: 0.1078
     - datetime: '2023-01-01'
-      value: 0.127
+      value: 0.1217
     - datetime: '2024-01-01'
-      value: 0.1423
+      value: 0.1307
     - datetime: '2025-01-01'
       value: 0.1437
   hydro discharge:
     - datetime: '2020-01-01'
-      value: 0.0352
+      value: 0.0351
     - datetime: '2021-01-01'
       value: 0.0518
     - datetime: '2022-01-01'
       value: 0.0751
     - datetime: '2023-01-01'
-      value: 0.1084
+      value: 0.1073
     - datetime: '2024-01-01'
-      value: 0.1523
+      value: 0.1531
     - datetime: '2025-01-01'
       value: 0.1457
 parsers:

--- a/config/zones/TW.yaml
+++ b/config/zones/TW.yaml
@@ -430,22 +430,30 @@ isLowCarbon:
       value: 0.2042
     - datetime: '2021-01-01'
       value: 0.1911
+    - datetime: '2022-01-01'
+      value: 0.191
   hydro discharge:
     - datetime: '2020-01-01'
       value: 0.1756
     - datetime: '2021-01-01'
       value: 0.1689
+    - datetime: '2022-01-01'
+      value: 0.1737
 isRenewable:
   battery discharge:
     - datetime: '2020-01-01'
       value: 0.0776
     - datetime: '2021-01-01'
       value: 0.0996
+    - datetime: '2022-01-01'
+      value: 0.1131
   hydro discharge:
     - datetime: '2020-01-01'
       value: 0.0352
     - datetime: '2021-01-01'
       value: 0.0518
+    - datetime: '2022-01-01'
+      value: 0.0751
 parsers:
   production: TAIPOWER.fetch_production
   productionCapacity: EMBER.fetch_production_capacity

--- a/config/zones/UA.yaml
+++ b/config/zones/UA.yaml
@@ -28,15 +28,15 @@ emissionFactors:
       - _comment: used storage values greater than zero.
         datetime: '2020-01-01'
         source: Electricity Maps, 2020 zone average
-        value: 231.07
+        value: 231.08
       - _comment: used storage values greater than zero.
         datetime: '2021-01-01'
         source: Electricity Maps, 2021 zone average
-        value: 197.61
+        value: 197.62
       - _comment: used storage values greater than zero.
         datetime: '2022-01-01'
         source: Electricity Maps, 2022 zone average
-        value: 188.55
+        value: 188.58
     unknown:
       _comment: estimated yearly share of solar & wind in this mixed renewable category
         based on installed capacity in Y2018; assumes 50% solar, 50% wind renewable
@@ -49,15 +49,15 @@ emissionFactors:
       - _comment: used storage values greater than zero.
         datetime: '2020-01-01'
         source: Electricity Maps, 2020 zone average; IPCC 2014
-        value: 255.07
+        value: 255.08
       - _comment: used storage values greater than zero.
         datetime: '2021-01-01'
         source: Electricity Maps, 2021 zone average; IPCC 2014
-        value: 221.61
+        value: 221.62
       - _comment: used storage values greater than zero.
         datetime: '2022-01-01'
         source: Electricity Maps, 2022 zone average; IPCC 2014
-        value: 212.55
+        value: 212.58
     unknown:
       _comment: estimated yearly share of solar & wind in this mixed renewable category
         based on installed capacity in Y2018; assumes 50% solar, 50% wind renewable
@@ -166,7 +166,7 @@ isLowCarbon:
     - datetime: '2021-01-01'
       value: 0.7077
     - datetime: '2022-01-01'
-      value: 0.7126
+      value: 0.7125
   unknown:
     value: 1
 isRenewable:
@@ -176,7 +176,7 @@ isRenewable:
     - datetime: '2021-01-01'
       value: 0.1171
     - datetime: '2022-01-01'
-      value: 0.1191
+      value: 0.119
   unknown:
     value: 1
 parsers:

--- a/config/zones/UA.yaml
+++ b/config/zones/UA.yaml
@@ -28,7 +28,7 @@ emissionFactors:
       - _comment: used storage values greater than zero.
         datetime: '2020-01-01'
         source: Electricity Maps, 2020 zone average
-        value: 231.08
+        value: 231.07
       - _comment: used storage values greater than zero.
         datetime: '2021-01-01'
         source: Electricity Maps, 2021 zone average
@@ -38,15 +38,18 @@ emissionFactors:
         source: Electricity Maps, 2022 zone average
         value: 188.55
     unknown:
-      _comment: estimated yearly share of solar & wind in this mixed renewable category based on installed capacity in Y2018; assumes 50% solar, 50% wind renewable mix
-      source: Wikipedia page for Renewable energy in Ukraine; Electricity Maps contrib issue number 1809
+      _comment: estimated yearly share of solar & wind in this mixed renewable category
+        based on installed capacity in Y2018; assumes 50% solar, 50% wind renewable
+        mix
+      source: Wikipedia page for Renewable energy in Ukraine; Electricity Maps contrib
+        issue number 1809
       value: 0.0
   lifecycle:
     hydro discharge:
       - _comment: used storage values greater than zero.
         datetime: '2020-01-01'
         source: Electricity Maps, 2020 zone average; IPCC 2014
-        value: 255.08
+        value: 255.07
       - _comment: used storage values greater than zero.
         datetime: '2021-01-01'
         source: Electricity Maps, 2021 zone average; IPCC 2014
@@ -56,8 +59,11 @@ emissionFactors:
         source: Electricity Maps, 2022 zone average; IPCC 2014
         value: 212.55
     unknown:
-      _comment: estimated yearly share of solar & wind in this mixed renewable category based on installed capacity in Y2018; assumes 50% solar, 50% wind renewable mix
-      source: Wikipedia page for Renewable energy in Ukraine; Electricity Maps contrib issue number 1809
+      _comment: estimated yearly share of solar & wind in this mixed renewable category
+        based on installed capacity in Y2018; assumes 50% solar, 50% wind renewable
+        mix
+      source: Wikipedia page for Renewable energy in Ukraine; Electricity Maps contrib
+        issue number 1809
       value: 28.0
 fallbackZoneMixes:
   powerOriginRatios:
@@ -151,12 +157,18 @@ fallbackZoneMixes:
         solar: 0.0003683239452081555
         unknown: 0.06410479689732768
         wind: 0.001572880539009946
-has_day_ahead_price_license: False
-hide_day_ahead_price: False
+has_day_ahead_price_license: false
+hide_day_ahead_price: false
 isLowCarbon:
+  hydro discharge:
+    - datetime: '2020-01-01'
+      value: 0.6475
   unknown:
     value: 1
 isRenewable:
+  hydro discharge:
+    - datetime: '2020-01-01'
+      value: 0.0958
   unknown:
     value: 1
 parsers:
@@ -171,9 +183,9 @@ region: Europe
 sources:
   Electricity Maps contrib issue number 1809:
     link: https://github.com/electricitymaps/electricitymaps-contrib/issues/1809
-  Wikipedia page for Renewable energy in Ukraine:
-    link: https://en.wikipedia.org/wiki/Renewable_energy_in_Ukraine
   IPCC 2014:
     link: https://www.ipcc.ch/site/assets/uploads/2018/02/ipcc_wg3_ar5_annex-iii.pdf#page=7
+  Wikipedia page for Renewable energy in Ukraine:
+    link: https://en.wikipedia.org/wiki/Renewable_energy_in_Ukraine
 timezone: Europe/Kiev
 zone_name: Ukraine

--- a/config/zones/UA.yaml
+++ b/config/zones/UA.yaml
@@ -163,12 +163,16 @@ isLowCarbon:
   hydro discharge:
     - datetime: '2020-01-01'
       value: 0.6475
+    - datetime: '2021-01-01'
+      value: 0.7077
   unknown:
     value: 1
 isRenewable:
   hydro discharge:
     - datetime: '2020-01-01'
       value: 0.0958
+    - datetime: '2021-01-01'
+      value: 0.1171
   unknown:
     value: 1
 parsers:

--- a/config/zones/UA.yaml
+++ b/config/zones/UA.yaml
@@ -165,6 +165,8 @@ isLowCarbon:
       value: 0.6475
     - datetime: '2021-01-01'
       value: 0.7077
+    - datetime: '2022-01-01'
+      value: 0.7126
   unknown:
     value: 1
 isRenewable:
@@ -173,6 +175,8 @@ isRenewable:
       value: 0.0958
     - datetime: '2021-01-01'
       value: 0.1171
+    - datetime: '2022-01-01'
+      value: 0.1191
   unknown:
     value: 1
 parsers:

--- a/config/zones/US-CAL-CISO.yaml
+++ b/config/zones/US-CAL-CISO.yaml
@@ -1018,7 +1018,7 @@ emissionFactors:
       - _comment: used storage values greater than zero.
         datetime: '2021-01-01'
         source: Electricity Maps, 2021 zone average
-        value: 179.31
+        value: 179.7
       - _comment: used storage values greater than zero.
         datetime: '2022-01-01'
         source: Electricity Maps, 2022 zone average
@@ -1095,7 +1095,7 @@ emissionFactors:
       - _comment: used storage values greater than zero.
         datetime: '2021-01-01'
         source: Electricity Maps, 2021 zone average
-        value: 133.14
+        value: 133.42
       - _comment: used storage values greater than zero.
         datetime: '2022-01-01'
         source: Electricity Maps, 2022 zone average
@@ -1134,7 +1134,7 @@ emissionFactors:
       - _comment: used storage values greater than zero.
         datetime: '2021-01-01'
         source: Electricity Maps, 2021 zone average; National Laboratory of the Rockies
-        value: 212.31
+        value: 212.7
       - _comment: used storage values greater than zero.
         datetime: '2022-01-01'
         source: Electricity Maps, 2022 zone average; National Laboratory of the Rockies
@@ -1215,7 +1215,7 @@ emissionFactors:
       - _comment: used storage values greater than zero.
         datetime: '2021-01-01'
         source: Electricity Maps, 2021 zone average; IPCC 2014
-        value: 157.14
+        value: 157.42
       - _comment: used storage values greater than zero.
         datetime: '2022-01-01'
         source: Electricity Maps, 2022 zone average; IPCC 2014
@@ -1407,16 +1407,24 @@ isLowCarbon:
   battery discharge:
     - datetime: '2020-01-01'
       value: 0.5582
+    - datetime: '2021-01-01'
+      value: 0.5664
   hydro discharge:
     - datetime: '2020-01-01'
       value: 0.605
+    - datetime: '2021-01-01'
+      value: 0.6811
 isRenewable:
   battery discharge:
     - datetime: '2020-01-01'
       value: 0.4489
+    - datetime: '2021-01-01'
+      value: 0.4561
   hydro discharge:
     - datetime: '2020-01-01'
       value: 0.4731
+    - datetime: '2021-01-01'
+      value: 0.584
 parsers:
   consumption: US_CA.fetch_consumption
   consumptionForecast: US_CA.fetch_consumption_forecast

--- a/config/zones/US-CAL-CISO.yaml
+++ b/config/zones/US-CAL-CISO.yaml
@@ -1018,23 +1018,23 @@ emissionFactors:
       - _comment: used storage values greater than zero.
         datetime: '2021-01-01'
         source: Electricity Maps, 2021 zone average
-        value: 179.7
+        value: 178.09
       - _comment: used storage values greater than zero.
         datetime: '2022-01-01'
         source: Electricity Maps, 2022 zone average
-        value: 163.29
+        value: 163.12
       - _comment: used storage values greater than zero.
         datetime: '2023-01-01'
         source: Electricity Maps, 2023 zone average
-        value: 164.97
+        value: 164.49
       - _comment: used storage values greater than zero.
         datetime: '2024-01-01'
         source: Electricity Maps, 2024 zone average
-        value: 129.51
+        value: 127.78
       - _comment: used storage values greater than zero.
         datetime: '2025-01-01'
         source: Electricity Maps, 2025 zone average
-        value: 105.32
+        value: 105.29
     biomass:
       - datetime: '2020-01-01'
         source: BEIS 2021
@@ -1095,15 +1095,15 @@ emissionFactors:
       - _comment: used storage values greater than zero.
         datetime: '2021-01-01'
         source: Electricity Maps, 2021 zone average
-        value: 133.42
+        value: 131.67
       - _comment: used storage values greater than zero.
         datetime: '2022-01-01'
         source: Electricity Maps, 2022 zone average
-        value: 166.06
+        value: 166.22
       - _comment: used storage values greater than zero.
         datetime: '2023-01-01'
         source: Electricity Maps, 2023 zone average
-        value: 156.65
+        value: 156.71
       - _comment: used storage values greater than zero.
         datetime: '2024-01-01'
         source: Electricity Maps, 2024 zone average
@@ -1134,23 +1134,23 @@ emissionFactors:
       - _comment: used storage values greater than zero.
         datetime: '2021-01-01'
         source: Electricity Maps, 2021 zone average; National Laboratory of the Rockies
-        value: 212.7
+        value: 211.09
       - _comment: used storage values greater than zero.
         datetime: '2022-01-01'
         source: Electricity Maps, 2022 zone average; National Laboratory of the Rockies
-        value: 196.29
+        value: 196.12
       - _comment: used storage values greater than zero.
         datetime: '2023-01-01'
         source: Electricity Maps, 2023 zone average; National Laboratory of the Rockies
-        value: 197.97
+        value: 197.49
       - _comment: used storage values greater than zero.
         datetime: '2024-01-01'
         source: Electricity Maps, 2024 zone average; National Laboratory of the Rockies
-        value: 162.51
+        value: 160.78
       - _comment: used storage values greater than zero.
         datetime: '2025-01-01'
         source: Electricity Maps, 2025 zone average; National Laboratory of the Rockies
-        value: 138.32
+        value: 138.29
     biomass:
       - _comment: Mean of all US zones
         datetime: '2020-01-01'
@@ -1215,15 +1215,15 @@ emissionFactors:
       - _comment: used storage values greater than zero.
         datetime: '2021-01-01'
         source: Electricity Maps, 2021 zone average; IPCC 2014
-        value: 157.42
+        value: 155.67
       - _comment: used storage values greater than zero.
         datetime: '2022-01-01'
         source: Electricity Maps, 2022 zone average; IPCC 2014
-        value: 190.06
+        value: 190.22
       - _comment: used storage values greater than zero.
         datetime: '2023-01-01'
         source: Electricity Maps, 2023 zone average; IPCC 2014
-        value: 180.65
+        value: 180.71
       - _comment: used storage values greater than zero.
         datetime: '2024-01-01'
         source: Electricity Maps, 2024 zone average; IPCC 2014
@@ -1408,24 +1408,24 @@ isLowCarbon:
     - datetime: '2020-01-01'
       value: 0.5582
     - datetime: '2021-01-01'
-      value: 0.5664
+      value: 0.5701
     - datetime: '2022-01-01'
-      value: 0.5964
-    - datetime: '2023-01-01'
       value: 0.5967
+    - datetime: '2023-01-01'
+      value: 0.5977
     - datetime: '2024-01-01'
-      value: 0.6857
+      value: 0.6896
     - datetime: '2025-01-01'
-      value: 0.7437
+      value: 0.7438
   hydro discharge:
     - datetime: '2020-01-01'
       value: 0.605
     - datetime: '2021-01-01'
-      value: 0.6811
+      value: 0.6853
     - datetime: '2022-01-01'
-      value: 0.5875
+      value: 0.5872
     - datetime: '2023-01-01'
-      value: 0.6185
+      value: 0.6183
     - datetime: '2024-01-01'
       value: 0.825
     - datetime: '2025-01-01'
@@ -1435,28 +1435,28 @@ isRenewable:
     - datetime: '2020-01-01'
       value: 0.4489
     - datetime: '2021-01-01'
-      value: 0.4561
+      value: 0.4551
     - datetime: '2022-01-01'
-      value: 0.482
+      value: 0.4818
     - datetime: '2023-01-01'
-      value: 0.4939
+      value: 0.494
     - datetime: '2024-01-01'
-      value: 0.5832
+      value: 0.5824
     - datetime: '2025-01-01'
       value: 0.6461
   hydro discharge:
     - datetime: '2020-01-01'
       value: 0.4731
     - datetime: '2021-01-01'
-      value: 0.584
+      value: 0.5826
     - datetime: '2022-01-01'
       value: 0.4891
     - datetime: '2023-01-01'
-      value: 0.4885
+      value: 0.4907
     - datetime: '2024-01-01'
-      value: 0.6995
+      value: 0.6999
     - datetime: '2025-01-01'
-      value: 0.7631
+      value: 0.7632
 parsers:
   consumption: US_CA.fetch_consumption
   consumptionForecast: US_CA.fetch_consumption_forecast

--- a/config/zones/US-CAL-CISO.yaml
+++ b/config/zones/US-CAL-CISO.yaml
@@ -1034,7 +1034,7 @@ emissionFactors:
       - _comment: used storage values greater than zero.
         datetime: '2025-01-01'
         source: Electricity Maps, 2025 zone average
-        value: 105.31
+        value: 105.32
     biomass:
       - datetime: '2020-01-01'
         source: BEIS 2021
@@ -1150,7 +1150,7 @@ emissionFactors:
       - _comment: used storage values greater than zero.
         datetime: '2025-01-01'
         source: Electricity Maps, 2025 zone average; National Laboratory of the Rockies
-        value: 138.31
+        value: 138.32
     biomass:
       - _comment: Mean of all US zones
         datetime: '2020-01-01'
@@ -1411,6 +1411,12 @@ isLowCarbon:
       value: 0.5664
     - datetime: '2022-01-01'
       value: 0.5964
+    - datetime: '2023-01-01'
+      value: 0.5967
+    - datetime: '2024-01-01'
+      value: 0.6857
+    - datetime: '2025-01-01'
+      value: 0.7437
   hydro discharge:
     - datetime: '2020-01-01'
       value: 0.605
@@ -1418,6 +1424,12 @@ isLowCarbon:
       value: 0.6811
     - datetime: '2022-01-01'
       value: 0.5875
+    - datetime: '2023-01-01'
+      value: 0.6185
+    - datetime: '2024-01-01'
+      value: 0.825
+    - datetime: '2025-01-01'
+      value: 0.8306
 isRenewable:
   battery discharge:
     - datetime: '2020-01-01'
@@ -1426,6 +1438,12 @@ isRenewable:
       value: 0.4561
     - datetime: '2022-01-01'
       value: 0.482
+    - datetime: '2023-01-01'
+      value: 0.4939
+    - datetime: '2024-01-01'
+      value: 0.5832
+    - datetime: '2025-01-01'
+      value: 0.6461
   hydro discharge:
     - datetime: '2020-01-01'
       value: 0.4731
@@ -1433,6 +1451,12 @@ isRenewable:
       value: 0.584
     - datetime: '2022-01-01'
       value: 0.4891
+    - datetime: '2023-01-01'
+      value: 0.4885
+    - datetime: '2024-01-01'
+      value: 0.6995
+    - datetime: '2025-01-01'
+      value: 0.7631
 parsers:
   consumption: US_CA.fetch_consumption
   consumptionForecast: US_CA.fetch_consumption_forecast

--- a/config/zones/US-CAL-CISO.yaml
+++ b/config/zones/US-CAL-CISO.yaml
@@ -1014,7 +1014,7 @@ emissionFactors:
       - _comment: used storage values greater than zero.
         datetime: '2020-01-01'
         source: Electricity Maps, 2020 zone average
-        value: 187.55
+        value: 187.8
       - _comment: used storage values greater than zero.
         datetime: '2021-01-01'
         source: Electricity Maps, 2021 zone average
@@ -1091,7 +1091,7 @@ emissionFactors:
       - _comment: used storage values greater than zero.
         datetime: '2020-01-01'
         source: Electricity Maps, 2020 zone average
-        value: 168.68
+        value: 168.9
       - _comment: used storage values greater than zero.
         datetime: '2021-01-01'
         source: Electricity Maps, 2021 zone average
@@ -1130,7 +1130,7 @@ emissionFactors:
       - _comment: used storage values greater than zero.
         datetime: '2020-01-01'
         source: Electricity Maps, 2020 zone average; National Laboratory of the Rockies
-        value: 220.55
+        value: 220.8
       - _comment: used storage values greater than zero.
         datetime: '2021-01-01'
         source: Electricity Maps, 2021 zone average; National Laboratory of the Rockies
@@ -1211,7 +1211,7 @@ emissionFactors:
       - _comment: used storage values greater than zero.
         datetime: '2020-01-01'
         source: Electricity Maps, 2020 zone average; IPCC 2014
-        value: 192.68
+        value: 192.9
       - _comment: used storage values greater than zero.
         datetime: '2021-01-01'
         source: Electricity Maps, 2021 zone average; IPCC 2014
@@ -1403,6 +1403,20 @@ fallbackZoneMixes:
         wind: 0.10376508129748757
 has_day_ahead_price_license: false
 hide_day_ahead_price: false
+isLowCarbon:
+  battery discharge:
+    - datetime: '2020-01-01'
+      value: 0.5582
+  hydro discharge:
+    - datetime: '2020-01-01'
+      value: 0.605
+isRenewable:
+  battery discharge:
+    - datetime: '2020-01-01'
+      value: 0.4489
+  hydro discharge:
+    - datetime: '2020-01-01'
+      value: 0.4731
 parsers:
   consumption: US_CA.fetch_consumption
   consumptionForecast: US_CA.fetch_consumption_forecast
@@ -1412,12 +1426,12 @@ parsers:
   productionPerModeForecast: US_CA.fetch_wind_solar_forecasts
 region: Americas
 sources:
-  National Laboratory of the Rockies:
-    link: https://docs.nrel.gov/docs/fy21osti/80580.pdf
   INCER ACV:
     link: https://docs.google.com/spreadsheets/d/1w5DJ7sPen6axIHU8TCVcuzNCjlct4I6JAbhUlw-ZXu8/edit?usp=sharing
   IPCC 2014:
     link: https://www.ipcc.ch/site/assets/uploads/2018/02/ipcc_wg3_ar5_annex-iii.pdf#page=7
+  National Laboratory of the Rockies:
+    link: https://docs.nrel.gov/docs/fy21osti/80580.pdf
   eGrid 2020:
     link: https://drive.google.com/file/d/1_FAAuTtIdMuORZKsqHnd9vMNHlQgYarh/view?usp=sharing
   eGrid 2021:

--- a/config/zones/US-CAL-CISO.yaml
+++ b/config/zones/US-CAL-CISO.yaml
@@ -1022,7 +1022,7 @@ emissionFactors:
       - _comment: used storage values greater than zero.
         datetime: '2022-01-01'
         source: Electricity Maps, 2022 zone average
-        value: 163.06
+        value: 163.29
       - _comment: used storage values greater than zero.
         datetime: '2023-01-01'
         source: Electricity Maps, 2023 zone average
@@ -1099,7 +1099,7 @@ emissionFactors:
       - _comment: used storage values greater than zero.
         datetime: '2022-01-01'
         source: Electricity Maps, 2022 zone average
-        value: 165.82
+        value: 166.06
       - _comment: used storage values greater than zero.
         datetime: '2023-01-01'
         source: Electricity Maps, 2023 zone average
@@ -1138,7 +1138,7 @@ emissionFactors:
       - _comment: used storage values greater than zero.
         datetime: '2022-01-01'
         source: Electricity Maps, 2022 zone average; National Laboratory of the Rockies
-        value: 196.06
+        value: 196.29
       - _comment: used storage values greater than zero.
         datetime: '2023-01-01'
         source: Electricity Maps, 2023 zone average; National Laboratory of the Rockies
@@ -1219,7 +1219,7 @@ emissionFactors:
       - _comment: used storage values greater than zero.
         datetime: '2022-01-01'
         source: Electricity Maps, 2022 zone average; IPCC 2014
-        value: 189.82
+        value: 190.06
       - _comment: used storage values greater than zero.
         datetime: '2023-01-01'
         source: Electricity Maps, 2023 zone average; IPCC 2014
@@ -1409,22 +1409,30 @@ isLowCarbon:
       value: 0.5582
     - datetime: '2021-01-01'
       value: 0.5664
+    - datetime: '2022-01-01'
+      value: 0.5964
   hydro discharge:
     - datetime: '2020-01-01'
       value: 0.605
     - datetime: '2021-01-01'
       value: 0.6811
+    - datetime: '2022-01-01'
+      value: 0.5875
 isRenewable:
   battery discharge:
     - datetime: '2020-01-01'
       value: 0.4489
     - datetime: '2021-01-01'
       value: 0.4561
+    - datetime: '2022-01-01'
+      value: 0.482
   hydro discharge:
     - datetime: '2020-01-01'
       value: 0.4731
     - datetime: '2021-01-01'
       value: 0.584
+    - datetime: '2022-01-01'
+      value: 0.4891
 parsers:
   consumption: US_CA.fetch_consumption
   consumptionForecast: US_CA.fetch_consumption_forecast

--- a/config/zones/US-CAL-IID.yaml
+++ b/config/zones/US-CAL-IID.yaml
@@ -145,9 +145,13 @@ emissionFactors:
   direct:
     battery discharge:
       - _comment: used storage values greater than zero.
+        datetime: '2022-01-01'
+        source: Electricity Maps, 2022 zone average
+        value: 206.01
+      - _comment: used storage values greater than zero.
         datetime: '2025-01-01'
         source: Electricity Maps, 2025 zone average
-        value: 99.06
+        value: 98.96
     biomass:
       - datetime: '2020-01-01'
         source: BEIS 2021
@@ -212,7 +216,7 @@ emissionFactors:
       - _comment: used storage values greater than zero.
         datetime: '2025-01-01'
         source: Electricity Maps, 2025 zone average
-        value: 86.59
+        value: 62.51
     oil:
       - _comment: Mean of all US zones
         datetime: '2020-01-01'
@@ -233,9 +237,13 @@ emissionFactors:
   lifecycle:
     battery discharge:
       - _comment: used storage values greater than zero.
+        datetime: '2022-01-01'
+        source: Electricity Maps, 2022 zone average; National Laboratory of the Rockies
+        value: 239.01
+      - _comment: used storage values greater than zero.
         datetime: '2025-01-01'
         source: Electricity Maps, 2025 zone average; National Laboratory of the Rockies
-        value: 132.06
+        value: 131.96
     biomass:
       - _comment: Mean of all US zones
         datetime: '2020-01-01'
@@ -304,7 +312,7 @@ emissionFactors:
       - _comment: used storage values greater than zero.
         datetime: '2025-01-01'
         source: Electricity Maps, 2025 zone average; IPCC 2014
-        value: 110.59
+        value: 86.51
     oil:
       - _comment: Mean of all US zones
         datetime: '2020-01-01'
@@ -482,22 +490,26 @@ has_day_ahead_price_license: false
 hide_day_ahead_price: false
 isLowCarbon:
   battery discharge:
+    - datetime: '2022-01-01'
+      value: 0.6587
     - datetime: '2025-01-01'
-      value: 0.8279
+      value: 0.8282
   hydro discharge:
     - datetime: '2024-01-01'
       value: 0.486
     - datetime: '2025-01-01'
-      value: 0.9414
+      value: 0.9568
 isRenewable:
   battery discharge:
+    - datetime: '2022-01-01'
+      value: 0.6587
     - datetime: '2025-01-01'
-      value: 0.8252
+      value: 0.8255
   hydro discharge:
     - datetime: '2024-01-01'
       value: 0.486
     - datetime: '2025-01-01'
-      value: 0.9378
+      value: 0.9452
 parsers:
   consumption: EIA.fetch_consumption
   consumptionForecast: EIA.fetch_consumption_forecast

--- a/config/zones/US-CAL-IID.yaml
+++ b/config/zones/US-CAL-IID.yaml
@@ -147,7 +147,7 @@ emissionFactors:
       - _comment: used storage values greater than zero.
         datetime: '2025-01-01'
         source: Electricity Maps, 2025 zone average
-        value: 99.04
+        value: 99.06
     biomass:
       - datetime: '2020-01-01'
         source: BEIS 2021
@@ -212,7 +212,7 @@ emissionFactors:
       - _comment: used storage values greater than zero.
         datetime: '2025-01-01'
         source: Electricity Maps, 2025 zone average
-        value: 86.52
+        value: 86.59
     oil:
       - _comment: Mean of all US zones
         datetime: '2020-01-01'
@@ -235,7 +235,7 @@ emissionFactors:
       - _comment: used storage values greater than zero.
         datetime: '2025-01-01'
         source: Electricity Maps, 2025 zone average; National Laboratory of the Rockies
-        value: 132.04
+        value: 132.06
     biomass:
       - _comment: Mean of all US zones
         datetime: '2020-01-01'
@@ -304,7 +304,7 @@ emissionFactors:
       - _comment: used storage values greater than zero.
         datetime: '2025-01-01'
         source: Electricity Maps, 2025 zone average; IPCC 2014
-        value: 110.52
+        value: 110.59
     oil:
       - _comment: Mean of all US zones
         datetime: '2020-01-01'
@@ -480,6 +480,24 @@ fallbackZoneMixes:
         wind: 0.0053857770760136646
 has_day_ahead_price_license: false
 hide_day_ahead_price: false
+isLowCarbon:
+  battery discharge:
+    - datetime: '2025-01-01'
+      value: 0.8279
+  hydro discharge:
+    - datetime: '2024-01-01'
+      value: 0.486
+    - datetime: '2025-01-01'
+      value: 0.9414
+isRenewable:
+  battery discharge:
+    - datetime: '2025-01-01'
+      value: 0.8252
+  hydro discharge:
+    - datetime: '2024-01-01'
+      value: 0.486
+    - datetime: '2025-01-01'
+      value: 0.9378
 parsers:
   consumption: EIA.fetch_consumption
   consumptionForecast: EIA.fetch_consumption_forecast
@@ -487,12 +505,12 @@ parsers:
   productionCapacity: EIA.fetch_production_capacity
 region: Americas
 sources:
-  National Laboratory of the Rockies:
-    link: https://docs.nrel.gov/docs/fy21osti/80580.pdf
   INCER ACV:
     link: https://docs.google.com/spreadsheets/d/1w5DJ7sPen6axIHU8TCVcuzNCjlct4I6JAbhUlw-ZXu8/edit?usp=sharing
   IPCC 2014:
     link: https://www.ipcc.ch/site/assets/uploads/2018/02/ipcc_wg3_ar5_annex-iii.pdf#page=7
+  National Laboratory of the Rockies:
+    link: https://docs.nrel.gov/docs/fy21osti/80580.pdf
   eGrid 2020:
     link: https://drive.google.com/file/d/1_FAAuTtIdMuORZKsqHnd9vMNHlQgYarh/view?usp=sharing
   eGrid 2021:

--- a/config/zones/US-CAL-LDWP.yaml
+++ b/config/zones/US-CAL-LDWP.yaml
@@ -231,11 +231,11 @@ emissionFactors:
       - _comment: used non-null storage values
         datetime: '2022-01-01'
         source: Electricity Maps, 2022 zone average
-        value: 428.13
+        value: 461.83
       - _comment: used non-null storage values
         datetime: '2025-01-01'
         source: Electricity Maps, 2025 zone average
-        value: 288.81
+        value: 288.59
     biomass:
       - datetime: '2020-01-01'
         source: BEIS 2021
@@ -300,7 +300,7 @@ emissionFactors:
       - _comment: used storage values greater than zero.
         datetime: '2021-01-01'
         source: Electricity Maps, 2021 zone average
-        value: 343.42
+        value: 340.31
       - _comment: used default IPCC 2014 value of 0.0
         datetime: '2022-01-01'
         source: Electricity Maps, 2022 zone average
@@ -331,11 +331,11 @@ emissionFactors:
       - _comment: used non-null storage values
         datetime: '2022-01-01'
         source: Electricity Maps, 2022 zone average; National Laboratory of the Rockies
-        value: 461.13
+        value: 494.83
       - _comment: used non-null storage values
         datetime: '2025-01-01'
         source: Electricity Maps, 2025 zone average; National Laboratory of the Rockies
-        value: 321.81
+        value: 321.59
     biomass:
       - _comment: Mean of all US zones
         datetime: '2020-01-01'
@@ -404,7 +404,7 @@ emissionFactors:
       - _comment: used storage values greater than zero.
         datetime: '2021-01-01'
         source: Electricity Maps, 2021 zone average; IPCC 2014
-        value: 367.42
+        value: 364.31
       - _comment: used default IPCC 2014 value of 24.0
         datetime: '2022-01-01'
         source: Electricity Maps, 2022 zone average; IPCC 2014
@@ -591,14 +591,14 @@ hide_day_ahead_price: false
 isLowCarbon:
   battery discharge:
     - datetime: '2022-01-01'
-      value: 0.2687
+      value: 0.2326
     - datetime: '2025-01-01'
-      value: 0.4999
+      value: 0.5013
   hydro discharge:
     - datetime: '2020-01-01'
       value: 0.3464
     - datetime: '2021-01-01'
-      value: 0.4423
+      value: 0.4489
     - datetime: '2022-01-01'
       value: 1.0
     - datetime: '2025-01-01'
@@ -606,14 +606,14 @@ isLowCarbon:
 isRenewable:
   battery discharge:
     - datetime: '2022-01-01'
-      value: 0.1886
+      value: 0.1878
     - datetime: '2025-01-01'
-      value: 0.4503
+      value: 0.4516
   hydro discharge:
     - datetime: '2020-01-01'
       value: 0.325
     - datetime: '2021-01-01'
-      value: 0.3961
+      value: 0.3958
     - datetime: '2022-01-01'
       value: 1.0
     - datetime: '2025-01-01'

--- a/config/zones/US-CAL-LDWP.yaml
+++ b/config/zones/US-CAL-LDWP.yaml
@@ -592,10 +592,14 @@ isLowCarbon:
   hydro discharge:
     - datetime: '2020-01-01'
       value: 0.3464
+    - datetime: '2021-01-01'
+      value: 0.4423
 isRenewable:
   hydro discharge:
     - datetime: '2020-01-01'
       value: 0.325
+    - datetime: '2021-01-01'
+      value: 0.3961
 parsers:
   consumption: EIA.fetch_consumption
   consumptionForecast: EIA.fetch_consumption_forecast

--- a/config/zones/US-CAL-LDWP.yaml
+++ b/config/zones/US-CAL-LDWP.yaml
@@ -588,6 +588,14 @@ fallbackZoneMixes:
         wind: 0.07888732648126635
 has_day_ahead_price_license: false
 hide_day_ahead_price: false
+isLowCarbon:
+  hydro discharge:
+    - datetime: '2020-01-01'
+      value: 0.3464
+isRenewable:
+  hydro discharge:
+    - datetime: '2020-01-01'
+      value: 0.325
 parsers:
   consumption: EIA.fetch_consumption
   consumptionForecast: EIA.fetch_consumption_forecast
@@ -595,12 +603,12 @@ parsers:
   productionCapacity: EIA.fetch_production_capacity
 region: Americas
 sources:
-  National Laboratory of the Rockies:
-    link: https://docs.nrel.gov/docs/fy21osti/80580.pdf
   INCER ACV:
     link: https://docs.google.com/spreadsheets/d/1w5DJ7sPen6axIHU8TCVcuzNCjlct4I6JAbhUlw-ZXu8/edit?usp=sharing
   IPCC 2014:
     link: https://www.ipcc.ch/site/assets/uploads/2018/02/ipcc_wg3_ar5_annex-iii.pdf#page=7
+  National Laboratory of the Rockies:
+    link: https://docs.nrel.gov/docs/fy21osti/80580.pdf
   eGrid 2020:
     link: https://drive.google.com/file/d/1_FAAuTtIdMuORZKsqHnd9vMNHlQgYarh/view?usp=sharing
   eGrid 2021:

--- a/config/zones/US-CAL-LDWP.yaml
+++ b/config/zones/US-CAL-LDWP.yaml
@@ -235,7 +235,7 @@ emissionFactors:
       - _comment: used non-null storage values
         datetime: '2025-01-01'
         source: Electricity Maps, 2025 zone average
-        value: 288.75
+        value: 288.81
     biomass:
       - datetime: '2020-01-01'
         source: BEIS 2021
@@ -335,7 +335,7 @@ emissionFactors:
       - _comment: used non-null storage values
         datetime: '2025-01-01'
         source: Electricity Maps, 2025 zone average; National Laboratory of the Rockies
-        value: 321.75
+        value: 321.81
     biomass:
       - _comment: Mean of all US zones
         datetime: '2020-01-01'
@@ -592,6 +592,8 @@ isLowCarbon:
   battery discharge:
     - datetime: '2022-01-01'
       value: 0.2687
+    - datetime: '2025-01-01'
+      value: 0.4999
   hydro discharge:
     - datetime: '2020-01-01'
       value: 0.3464
@@ -599,16 +601,22 @@ isLowCarbon:
       value: 0.4423
     - datetime: '2022-01-01'
       value: 1.0
+    - datetime: '2025-01-01'
+      value: 1.0
 isRenewable:
   battery discharge:
     - datetime: '2022-01-01'
       value: 0.1886
+    - datetime: '2025-01-01'
+      value: 0.4503
   hydro discharge:
     - datetime: '2020-01-01'
       value: 0.325
     - datetime: '2021-01-01'
       value: 0.3961
     - datetime: '2022-01-01'
+      value: 1.0
+    - datetime: '2025-01-01'
       value: 1.0
 parsers:
   consumption: EIA.fetch_consumption

--- a/config/zones/US-CAL-LDWP.yaml
+++ b/config/zones/US-CAL-LDWP.yaml
@@ -589,17 +589,27 @@ fallbackZoneMixes:
 has_day_ahead_price_license: false
 hide_day_ahead_price: false
 isLowCarbon:
+  battery discharge:
+    - datetime: '2022-01-01'
+      value: 0.2687
   hydro discharge:
     - datetime: '2020-01-01'
       value: 0.3464
     - datetime: '2021-01-01'
       value: 0.4423
+    - datetime: '2022-01-01'
+      value: 1.0
 isRenewable:
+  battery discharge:
+    - datetime: '2022-01-01'
+      value: 0.1886
   hydro discharge:
     - datetime: '2020-01-01'
       value: 0.325
     - datetime: '2021-01-01'
       value: 0.3961
+    - datetime: '2022-01-01'
+      value: 1.0
 parsers:
   consumption: EIA.fetch_consumption
   consumptionForecast: EIA.fetch_consumption_forecast

--- a/config/zones/US-CAL-TIDC.yaml
+++ b/config/zones/US-CAL-TIDC.yaml
@@ -394,6 +394,14 @@ fallbackZoneMixes:
         wind: 0.025510983164008797
 has_day_ahead_price_license: false
 hide_day_ahead_price: false
+isLowCarbon:
+  hydro discharge:
+    - datetime: '2022-01-01'
+      value: 1.0
+isRenewable:
+  hydro discharge:
+    - datetime: '2022-01-01'
+      value: 1.0
 parsers:
   consumption: EIA.fetch_consumption
   consumptionForecast: EIA.fetch_consumption_forecast

--- a/config/zones/US-CAR-CPLE.yaml
+++ b/config/zones/US-CAR-CPLE.yaml
@@ -264,7 +264,7 @@ emissionFactors:
       - _comment: used storage values greater than zero.
         datetime: '2025-01-01'
         source: Electricity Maps, 2025 zone average
-        value: 303.58
+        value: 310.96
     biomass:
       - datetime: '2020-01-01'
         source: BEIS 2021
@@ -325,7 +325,7 @@ emissionFactors:
       - _comment: used storage values greater than zero.
         datetime: '2020-01-01'
         source: Electricity Maps, 2020 zone average
-        value: 249.64
+        value: 249.77
       - _comment: used storage values greater than zero.
         datetime: '2021-01-01'
         source: Electricity Maps, 2021 zone average
@@ -333,7 +333,7 @@ emissionFactors:
       - _comment: used storage values greater than zero.
         datetime: '2022-01-01'
         source: Electricity Maps, 2022 zone average
-        value: 195.85
+        value: 195.22
       - _comment: used storage values greater than zero.
         datetime: '2023-01-01'
         source: Electricity Maps, 2023 zone average
@@ -341,7 +341,7 @@ emissionFactors:
       - _comment: used storage values greater than zero.
         datetime: '2025-01-01'
         source: Electricity Maps, 2025 zone average
-        value: 283.66
+        value: 284.82
     oil:
       - _comment: Mean of all US zones
         datetime: '2020-01-01'
@@ -364,7 +364,7 @@ emissionFactors:
       - _comment: used storage values greater than zero.
         datetime: '2025-01-01'
         source: Electricity Maps, 2025 zone average; National Laboratory of the Rockies
-        value: 336.58
+        value: 343.96
     biomass:
       - _comment: Mean of all US zones
         datetime: '2020-01-01'
@@ -429,7 +429,7 @@ emissionFactors:
       - _comment: used storage values greater than zero.
         datetime: '2020-01-01'
         source: Electricity Maps, 2020 zone average; IPCC 2014
-        value: 273.64
+        value: 273.77
       - _comment: used storage values greater than zero.
         datetime: '2021-01-01'
         source: Electricity Maps, 2021 zone average; IPCC 2014
@@ -437,7 +437,7 @@ emissionFactors:
       - _comment: used storage values greater than zero.
         datetime: '2022-01-01'
         source: Electricity Maps, 2022 zone average; IPCC 2014
-        value: 219.85
+        value: 219.22
       - _comment: used storage values greater than zero.
         datetime: '2023-01-01'
         source: Electricity Maps, 2023 zone average; IPCC 2014
@@ -445,7 +445,7 @@ emissionFactors:
       - _comment: used storage values greater than zero.
         datetime: '2025-01-01'
         source: Electricity Maps, 2025 zone average; IPCC 2014
-        value: 307.66
+        value: 308.82
     oil:
       - _comment: Mean of all US zones
         datetime: '2020-01-01'
@@ -624,33 +624,33 @@ hide_day_ahead_price: false
 isLowCarbon:
   battery discharge:
     - datetime: '2025-01-01'
-      value: 0.5248
+      value: 0.5179
   hydro discharge:
     - datetime: '2020-01-01'
       value: 0.5802
     - datetime: '2021-01-01'
       value: 0.7716
     - datetime: '2022-01-01'
-      value: 0.6096
+      value: 0.6106
     - datetime: '2023-01-01'
       value: 0.5894
     - datetime: '2025-01-01'
-      value: 0.5377
+      value: 0.5331
 isRenewable:
   battery discharge:
     - datetime: '2025-01-01'
-      value: 0.0739
+      value: 0.0729
   hydro discharge:
     - datetime: '2020-01-01'
-      value: 0.0712
+      value: 0.0714
     - datetime: '2021-01-01'
       value: 0.2827
     - datetime: '2022-01-01'
-      value: 0.1374
+      value: 0.1393
     - datetime: '2023-01-01'
       value: 0.0003
     - datetime: '2025-01-01'
-      value: 0.1111
+      value: 0.1105
 parsers:
   consumption: EIA.fetch_consumption
   consumptionForecast: EIA.fetch_consumption_forecast

--- a/config/zones/US-CAR-CPLE.yaml
+++ b/config/zones/US-CAR-CPLE.yaml
@@ -627,12 +627,16 @@ isLowCarbon:
       value: 0.5802
     - datetime: '2021-01-01'
       value: 0.7716
+    - datetime: '2022-01-01'
+      value: 0.6096
 isRenewable:
   hydro discharge:
     - datetime: '2020-01-01'
       value: 0.0712
     - datetime: '2021-01-01'
       value: 0.2827
+    - datetime: '2022-01-01'
+      value: 0.1374
 parsers:
   consumption: EIA.fetch_consumption
   consumptionForecast: EIA.fetch_consumption_forecast

--- a/config/zones/US-CAR-CPLE.yaml
+++ b/config/zones/US-CAR-CPLE.yaml
@@ -325,7 +325,7 @@ emissionFactors:
       - _comment: used storage values greater than zero.
         datetime: '2020-01-01'
         source: Electricity Maps, 2020 zone average
-        value: 243.81
+        value: 249.64
       - _comment: used storage values greater than zero.
         datetime: '2021-01-01'
         source: Electricity Maps, 2021 zone average
@@ -429,7 +429,7 @@ emissionFactors:
       - _comment: used storage values greater than zero.
         datetime: '2020-01-01'
         source: Electricity Maps, 2020 zone average; IPCC 2014
-        value: 267.81
+        value: 273.64
       - _comment: used storage values greater than zero.
         datetime: '2021-01-01'
         source: Electricity Maps, 2021 zone average; IPCC 2014
@@ -621,6 +621,14 @@ fallbackZoneMixes:
         wind: 0.00029901388079216223
 has_day_ahead_price_license: false
 hide_day_ahead_price: false
+isLowCarbon:
+  hydro discharge:
+    - datetime: '2020-01-01'
+      value: 0.5802
+isRenewable:
+  hydro discharge:
+    - datetime: '2020-01-01'
+      value: 0.0712
 parsers:
   consumption: EIA.fetch_consumption
   consumptionForecast: EIA.fetch_consumption_forecast
@@ -628,12 +636,12 @@ parsers:
   productionCapacity: EIA.fetch_production_capacity
 region: Americas
 sources:
-  National Laboratory of the Rockies:
-    link: https://docs.nrel.gov/docs/fy21osti/80580.pdf
   INCER ACV:
     link: https://docs.google.com/spreadsheets/d/1w5DJ7sPen6axIHU8TCVcuzNCjlct4I6JAbhUlw-ZXu8/edit?usp=sharing
   IPCC 2014:
     link: https://www.ipcc.ch/site/assets/uploads/2018/02/ipcc_wg3_ar5_annex-iii.pdf#page=7
+  National Laboratory of the Rockies:
+    link: https://docs.nrel.gov/docs/fy21osti/80580.pdf
   eGrid 2020:
     link: https://drive.google.com/file/d/1_FAAuTtIdMuORZKsqHnd9vMNHlQgYarh/view?usp=sharing
   eGrid 2021:

--- a/config/zones/US-CAR-CPLE.yaml
+++ b/config/zones/US-CAR-CPLE.yaml
@@ -264,7 +264,7 @@ emissionFactors:
       - _comment: used storage values greater than zero.
         datetime: '2025-01-01'
         source: Electricity Maps, 2025 zone average
-        value: 304.58
+        value: 303.58
     biomass:
       - datetime: '2020-01-01'
         source: BEIS 2021
@@ -337,11 +337,11 @@ emissionFactors:
       - _comment: used storage values greater than zero.
         datetime: '2023-01-01'
         source: Electricity Maps, 2023 zone average
-        value: 228.69
+        value: 229.29
       - _comment: used storage values greater than zero.
         datetime: '2025-01-01'
         source: Electricity Maps, 2025 zone average
-        value: 283.85
+        value: 283.66
     oil:
       - _comment: Mean of all US zones
         datetime: '2020-01-01'
@@ -364,7 +364,7 @@ emissionFactors:
       - _comment: used storage values greater than zero.
         datetime: '2025-01-01'
         source: Electricity Maps, 2025 zone average; National Laboratory of the Rockies
-        value: 337.58
+        value: 336.58
     biomass:
       - _comment: Mean of all US zones
         datetime: '2020-01-01'
@@ -441,11 +441,11 @@ emissionFactors:
       - _comment: used storage values greater than zero.
         datetime: '2023-01-01'
         source: Electricity Maps, 2023 zone average; IPCC 2014
-        value: 252.69
+        value: 253.29
       - _comment: used storage values greater than zero.
         datetime: '2025-01-01'
         source: Electricity Maps, 2025 zone average; IPCC 2014
-        value: 307.85
+        value: 307.66
     oil:
       - _comment: Mean of all US zones
         datetime: '2020-01-01'
@@ -622,6 +622,9 @@ fallbackZoneMixes:
 has_day_ahead_price_license: false
 hide_day_ahead_price: false
 isLowCarbon:
+  battery discharge:
+    - datetime: '2025-01-01'
+      value: 0.5248
   hydro discharge:
     - datetime: '2020-01-01'
       value: 0.5802
@@ -629,7 +632,14 @@ isLowCarbon:
       value: 0.7716
     - datetime: '2022-01-01'
       value: 0.6096
+    - datetime: '2023-01-01'
+      value: 0.5894
+    - datetime: '2025-01-01'
+      value: 0.5377
 isRenewable:
+  battery discharge:
+    - datetime: '2025-01-01'
+      value: 0.0739
   hydro discharge:
     - datetime: '2020-01-01'
       value: 0.0712
@@ -637,6 +647,10 @@ isRenewable:
       value: 0.2827
     - datetime: '2022-01-01'
       value: 0.1374
+    - datetime: '2023-01-01'
+      value: 0.0003
+    - datetime: '2025-01-01'
+      value: 0.1111
 parsers:
   consumption: EIA.fetch_consumption
   consumptionForecast: EIA.fetch_consumption_forecast

--- a/config/zones/US-CAR-CPLE.yaml
+++ b/config/zones/US-CAR-CPLE.yaml
@@ -625,10 +625,14 @@ isLowCarbon:
   hydro discharge:
     - datetime: '2020-01-01'
       value: 0.5802
+    - datetime: '2021-01-01'
+      value: 0.7716
 isRenewable:
   hydro discharge:
     - datetime: '2020-01-01'
       value: 0.0712
+    - datetime: '2021-01-01'
+      value: 0.2827
 parsers:
   consumption: EIA.fetch_consumption
   consumptionForecast: EIA.fetch_consumption_forecast

--- a/config/zones/US-CAR-CPLW.yaml
+++ b/config/zones/US-CAR-CPLW.yaml
@@ -158,7 +158,7 @@ emissionFactors:
       - _comment: used storage values greater than zero.
         datetime: '2021-01-01'
         source: Electricity Maps, 2021 zone average
-        value: 418.32
+        value: 418.72
       - _comment: used storage values greater than zero.
         datetime: '2022-01-01'
         source: Electricity Maps, 2022 zone average
@@ -272,7 +272,7 @@ emissionFactors:
       - _comment: used storage values greater than zero.
         datetime: '2021-01-01'
         source: Electricity Maps, 2021 zone average; IPCC 2014
-        value: 442.32
+        value: 442.72
       - _comment: used storage values greater than zero.
         datetime: '2022-01-01'
         source: Electricity Maps, 2022 zone average; IPCC 2014
@@ -468,10 +468,14 @@ isLowCarbon:
   hydro discharge:
     - datetime: '2020-01-01'
       value: 0.3559
+    - datetime: '2021-01-01'
+      value: 0.0952
 isRenewable:
   hydro discharge:
     - datetime: '2020-01-01'
       value: 0.0087
+    - datetime: '2021-01-01'
+      value: 0.0154
 parsers:
   consumption: EIA.fetch_consumption
   consumptionForecast: EIA.fetch_consumption_forecast

--- a/config/zones/US-CAR-CPLW.yaml
+++ b/config/zones/US-CAR-CPLW.yaml
@@ -162,7 +162,7 @@ emissionFactors:
       - _comment: used storage values greater than zero.
         datetime: '2022-01-01'
         source: Electricity Maps, 2022 zone average
-        value: 418.59
+        value: 418.78
       - _comment: used storage values greater than zero.
         datetime: '2023-01-01'
         source: Electricity Maps, 2023 zone average
@@ -276,7 +276,7 @@ emissionFactors:
       - _comment: used storage values greater than zero.
         datetime: '2022-01-01'
         source: Electricity Maps, 2022 zone average; IPCC 2014
-        value: 442.59
+        value: 442.78
       - _comment: used storage values greater than zero.
         datetime: '2023-01-01'
         source: Electricity Maps, 2023 zone average; IPCC 2014
@@ -470,12 +470,16 @@ isLowCarbon:
       value: 0.3559
     - datetime: '2021-01-01'
       value: 0.0952
+    - datetime: '2022-01-01'
+      value: 0.1405
 isRenewable:
   hydro discharge:
     - datetime: '2020-01-01'
       value: 0.0087
     - datetime: '2021-01-01'
       value: 0.0154
+    - datetime: '2022-01-01'
+      value: 0.0135
 parsers:
   consumption: EIA.fetch_consumption
   consumptionForecast: EIA.fetch_consumption_forecast

--- a/config/zones/US-CAR-CPLW.yaml
+++ b/config/zones/US-CAR-CPLW.yaml
@@ -154,7 +154,7 @@ emissionFactors:
       - _comment: used storage values greater than zero.
         datetime: '2020-01-01'
         source: Electricity Maps, 2020 zone average
-        value: 298.58
+        value: 298.9
       - _comment: used storage values greater than zero.
         datetime: '2021-01-01'
         source: Electricity Maps, 2021 zone average
@@ -268,7 +268,7 @@ emissionFactors:
       - _comment: used storage values greater than zero.
         datetime: '2020-01-01'
         source: Electricity Maps, 2020 zone average; IPCC 2014
-        value: 322.58
+        value: 322.9
       - _comment: used storage values greater than zero.
         datetime: '2021-01-01'
         source: Electricity Maps, 2021 zone average; IPCC 2014
@@ -464,6 +464,14 @@ fallbackZoneMixes:
         wind: 0.003138998527429385
 has_day_ahead_price_license: false
 hide_day_ahead_price: false
+isLowCarbon:
+  hydro discharge:
+    - datetime: '2020-01-01'
+      value: 0.3559
+isRenewable:
+  hydro discharge:
+    - datetime: '2020-01-01'
+      value: 0.0087
 parsers:
   consumption: EIA.fetch_consumption
   consumptionForecast: EIA.fetch_consumption_forecast

--- a/config/zones/US-CAR-CPLW.yaml
+++ b/config/zones/US-CAR-CPLW.yaml
@@ -158,23 +158,23 @@ emissionFactors:
       - _comment: used storage values greater than zero.
         datetime: '2021-01-01'
         source: Electricity Maps, 2021 zone average
-        value: 418.72
+        value: 418.55
       - _comment: used storage values greater than zero.
         datetime: '2022-01-01'
         source: Electricity Maps, 2022 zone average
-        value: 418.78
+        value: 418.81
       - _comment: used storage values greater than zero.
         datetime: '2023-01-01'
         source: Electricity Maps, 2023 zone average
-        value: 452.17
+        value: 452.14
       - _comment: used storage values greater than zero.
         datetime: '2024-01-01'
         source: Electricity Maps, 2024 zone average
-        value: 407.45
+        value: 412.87
       - _comment: used storage values greater than zero.
         datetime: '2025-01-01'
         source: Electricity Maps, 2025 zone average
-        value: 437.82
+        value: 462.03
     oil:
       - _comment: Mean of all US zones
         datetime: '2020-01-01'
@@ -272,23 +272,23 @@ emissionFactors:
       - _comment: used storage values greater than zero.
         datetime: '2021-01-01'
         source: Electricity Maps, 2021 zone average; IPCC 2014
-        value: 442.72
+        value: 442.55
       - _comment: used storage values greater than zero.
         datetime: '2022-01-01'
         source: Electricity Maps, 2022 zone average; IPCC 2014
-        value: 442.78
+        value: 442.81
       - _comment: used storage values greater than zero.
         datetime: '2023-01-01'
         source: Electricity Maps, 2023 zone average; IPCC 2014
-        value: 476.17
+        value: 476.14
       - _comment: used storage values greater than zero.
         datetime: '2024-01-01'
         source: Electricity Maps, 2024 zone average; IPCC 2014
-        value: 431.45
+        value: 436.87
       - _comment: used storage values greater than zero.
         datetime: '2025-01-01'
         source: Electricity Maps, 2025 zone average; IPCC 2014
-        value: 461.82
+        value: 486.03
     oil:
       - _comment: Mean of all US zones
         datetime: '2020-01-01'
@@ -469,15 +469,15 @@ isLowCarbon:
     - datetime: '2020-01-01'
       value: 0.3559
     - datetime: '2021-01-01'
-      value: 0.0952
+      value: 0.0954
     - datetime: '2022-01-01'
-      value: 0.1405
+      value: 0.1404
     - datetime: '2023-01-01'
       value: 0.0067
     - datetime: '2024-01-01'
-      value: 0.1671
+      value: 0.154
     - datetime: '2025-01-01'
-      value: 0.1069
+      value: 0.0973
 isRenewable:
   hydro discharge:
     - datetime: '2020-01-01'
@@ -485,13 +485,13 @@ isRenewable:
     - datetime: '2021-01-01'
       value: 0.0154
     - datetime: '2022-01-01'
-      value: 0.0135
+      value: 0.0136
     - datetime: '2023-01-01'
       value: 0.0009
     - datetime: '2024-01-01'
-      value: 0.0616
+      value: 0.0601
     - datetime: '2025-01-01'
-      value: 0.0161
+      value: 0.0141
 parsers:
   consumption: EIA.fetch_consumption
   consumptionForecast: EIA.fetch_consumption_forecast

--- a/config/zones/US-CAR-CPLW.yaml
+++ b/config/zones/US-CAR-CPLW.yaml
@@ -166,15 +166,15 @@ emissionFactors:
       - _comment: used storage values greater than zero.
         datetime: '2023-01-01'
         source: Electricity Maps, 2023 zone average
-        value: 449.0
+        value: 452.17
       - _comment: used storage values greater than zero.
         datetime: '2024-01-01'
         source: Electricity Maps, 2024 zone average
-        value: 404.87
+        value: 407.45
       - _comment: used storage values greater than zero.
         datetime: '2025-01-01'
         source: Electricity Maps, 2025 zone average
-        value: 435.05
+        value: 437.82
     oil:
       - _comment: Mean of all US zones
         datetime: '2020-01-01'
@@ -280,15 +280,15 @@ emissionFactors:
       - _comment: used storage values greater than zero.
         datetime: '2023-01-01'
         source: Electricity Maps, 2023 zone average; IPCC 2014
-        value: 473.0
+        value: 476.17
       - _comment: used storage values greater than zero.
         datetime: '2024-01-01'
         source: Electricity Maps, 2024 zone average; IPCC 2014
-        value: 428.87
+        value: 431.45
       - _comment: used storage values greater than zero.
         datetime: '2025-01-01'
         source: Electricity Maps, 2025 zone average; IPCC 2014
-        value: 459.05
+        value: 461.82
     oil:
       - _comment: Mean of all US zones
         datetime: '2020-01-01'
@@ -472,6 +472,12 @@ isLowCarbon:
       value: 0.0952
     - datetime: '2022-01-01'
       value: 0.1405
+    - datetime: '2023-01-01'
+      value: 0.0067
+    - datetime: '2024-01-01'
+      value: 0.1671
+    - datetime: '2025-01-01'
+      value: 0.1069
 isRenewable:
   hydro discharge:
     - datetime: '2020-01-01'
@@ -480,6 +486,12 @@ isRenewable:
       value: 0.0154
     - datetime: '2022-01-01'
       value: 0.0135
+    - datetime: '2023-01-01'
+      value: 0.0009
+    - datetime: '2024-01-01'
+      value: 0.0616
+    - datetime: '2025-01-01'
+      value: 0.0161
 parsers:
   consumption: EIA.fetch_consumption
   consumptionForecast: EIA.fetch_consumption_forecast

--- a/config/zones/US-CAR-DUK.yaml
+++ b/config/zones/US-CAR-DUK.yaml
@@ -715,10 +715,14 @@ isLowCarbon:
   hydro discharge:
     - datetime: '2020-01-01'
       value: 0.6319
+    - datetime: '2021-01-01'
+      value: 0.6033
 isRenewable:
   hydro discharge:
     - datetime: '2020-01-01'
       value: 0.0274
+    - datetime: '2021-01-01'
+      value: 0.0227
 parsers:
   consumption: EIA.fetch_consumption
   consumptionForecast: EIA.fetch_consumption_forecast

--- a/config/zones/US-CAR-DUK.yaml
+++ b/config/zones/US-CAR-DUK.yaml
@@ -711,6 +711,14 @@ fallbackZoneMixes:
         wind: 0.00017802609034428662
 has_day_ahead_price_license: false
 hide_day_ahead_price: false
+isLowCarbon:
+  hydro discharge:
+    - datetime: '2020-01-01'
+      value: 0.6319
+isRenewable:
+  hydro discharge:
+    - datetime: '2020-01-01'
+      value: 0.0274
 parsers:
   consumption: EIA.fetch_consumption
   consumptionForecast: EIA.fetch_consumption_forecast
@@ -718,12 +726,12 @@ parsers:
   productionCapacity: EIA.fetch_production_capacity
 region: Americas
 sources:
-  National Laboratory of the Rockies:
-    link: https://docs.nrel.gov/docs/fy21osti/80580.pdf
   INCER ACV:
     link: https://docs.google.com/spreadsheets/d/1w5DJ7sPen6axIHU8TCVcuzNCjlct4I6JAbhUlw-ZXu8/edit?usp=sharing
   IPCC 2014:
     link: https://www.ipcc.ch/site/assets/uploads/2018/02/ipcc_wg3_ar5_annex-iii.pdf#page=7
+  National Laboratory of the Rockies:
+    link: https://docs.nrel.gov/docs/fy21osti/80580.pdf
   eGrid 2020:
     link: https://drive.google.com/file/d/1_FAAuTtIdMuORZKsqHnd9vMNHlQgYarh/view?usp=sharing
   eGrid 2021:

--- a/config/zones/US-CAR-DUK.yaml
+++ b/config/zones/US-CAR-DUK.yaml
@@ -424,7 +424,7 @@ emissionFactors:
       - _comment: used storage values greater than zero.
         datetime: '2022-01-01'
         source: Electricity Maps, 2022 zone average
-        value: 299.81
+        value: 299.82
       - _comment: used storage values greater than zero.
         datetime: '2023-01-01'
         source: Electricity Maps, 2023 zone average
@@ -528,7 +528,7 @@ emissionFactors:
       - _comment: used storage values greater than zero.
         datetime: '2022-01-01'
         source: Electricity Maps, 2022 zone average; IPCC 2014
-        value: 323.81
+        value: 323.82
       - _comment: used storage values greater than zero.
         datetime: '2023-01-01'
         source: Electricity Maps, 2023 zone average; IPCC 2014
@@ -717,12 +717,16 @@ isLowCarbon:
       value: 0.6319
     - datetime: '2021-01-01'
       value: 0.6033
+    - datetime: '2022-01-01'
+      value: 0.59
 isRenewable:
   hydro discharge:
     - datetime: '2020-01-01'
       value: 0.0274
     - datetime: '2021-01-01'
       value: 0.0227
+    - datetime: '2022-01-01'
+      value: 0.0296
 parsers:
   consumption: EIA.fetch_consumption
   consumptionForecast: EIA.fetch_consumption_forecast

--- a/config/zones/US-CAR-DUK.yaml
+++ b/config/zones/US-CAR-DUK.yaml
@@ -354,7 +354,7 @@ emissionFactors:
       - _comment: used storage values greater than zero.
         datetime: '2025-01-01'
         source: Electricity Maps, 2025 zone average
-        value: 253.43
+        value: 253.48
     biomass:
       - datetime: '2020-01-01'
         source: BEIS 2021
@@ -420,19 +420,23 @@ emissionFactors:
       - _comment: used storage values greater than zero.
         datetime: '2021-01-01'
         source: Electricity Maps, 2021 zone average
-        value: 225.37
+        value: 225.29
       - _comment: used storage values greater than zero.
         datetime: '2022-01-01'
         source: Electricity Maps, 2022 zone average
-        value: 299.82
+        value: 300.31
       - _comment: used storage values greater than zero.
         datetime: '2023-01-01'
         source: Electricity Maps, 2023 zone average
-        value: 247.69
+        value: 238.61
+      - _comment: used storage values greater than zero.
+        datetime: '2024-01-01'
+        source: Electricity Maps, 2024 zone average
+        value: 249.02
       - _comment: used storage values greater than zero.
         datetime: '2025-01-01'
         source: Electricity Maps, 2025 zone average
-        value: 248.81
+        value: 249.72
     oil:
       - _comment: Mean of all US zones
         datetime: '2020-01-01'
@@ -454,7 +458,7 @@ emissionFactors:
       - _comment: used storage values greater than zero.
         datetime: '2025-01-01'
         source: Electricity Maps, 2025 zone average; National Laboratory of the Rockies
-        value: 286.43
+        value: 286.48
     biomass:
       - _comment: Mean of all US zones
         datetime: '2020-01-01'
@@ -524,19 +528,23 @@ emissionFactors:
       - _comment: used storage values greater than zero.
         datetime: '2021-01-01'
         source: Electricity Maps, 2021 zone average; IPCC 2014
-        value: 249.37
+        value: 249.29
       - _comment: used storage values greater than zero.
         datetime: '2022-01-01'
         source: Electricity Maps, 2022 zone average; IPCC 2014
-        value: 323.82
+        value: 324.31
       - _comment: used storage values greater than zero.
         datetime: '2023-01-01'
         source: Electricity Maps, 2023 zone average; IPCC 2014
-        value: 271.69
+        value: 262.61
+      - _comment: used storage values greater than zero.
+        datetime: '2024-01-01'
+        source: Electricity Maps, 2024 zone average; IPCC 2014
+        value: 273.02
       - _comment: used storage values greater than zero.
         datetime: '2025-01-01'
         source: Electricity Maps, 2025 zone average; IPCC 2014
-        value: 272.81
+        value: 273.72
     oil:
       - _comment: Mean of all US zones
         datetime: '2020-01-01'
@@ -714,22 +722,24 @@ hide_day_ahead_price: false
 isLowCarbon:
   battery discharge:
     - datetime: '2025-01-01'
-      value: 0.5815
+      value: 0.5813
   hydro discharge:
     - datetime: '2020-01-01'
       value: 0.6319
     - datetime: '2021-01-01'
-      value: 0.6033
+      value: 0.6026
     - datetime: '2022-01-01'
       value: 0.59
     - datetime: '2023-01-01'
-      value: 0.5951
+      value: 0.6088
+    - datetime: '2024-01-01'
+      value: 0.5933
     - datetime: '2025-01-01'
-      value: 0.591
+      value: 0.5905
 isRenewable:
   battery discharge:
     - datetime: '2025-01-01'
-      value: 0.042
+      value: 0.0417
   hydro discharge:
     - datetime: '2020-01-01'
       value: 0.0274
@@ -738,9 +748,11 @@ isRenewable:
     - datetime: '2022-01-01'
       value: 0.0296
     - datetime: '2023-01-01'
-      value: 0.0431
+      value: 0.035
+    - datetime: '2024-01-01'
+      value: 0.0348
     - datetime: '2025-01-01'
-      value: 0.0391
+      value: 0.0402
 parsers:
   consumption: EIA.fetch_consumption
   consumptionForecast: EIA.fetch_consumption_forecast

--- a/config/zones/US-CAR-DUK.yaml
+++ b/config/zones/US-CAR-DUK.yaml
@@ -354,7 +354,7 @@ emissionFactors:
       - _comment: used storage values greater than zero.
         datetime: '2025-01-01'
         source: Electricity Maps, 2025 zone average
-        value: 253.47
+        value: 253.43
     biomass:
       - datetime: '2020-01-01'
         source: BEIS 2021
@@ -428,11 +428,11 @@ emissionFactors:
       - _comment: used storage values greater than zero.
         datetime: '2023-01-01'
         source: Electricity Maps, 2023 zone average
-        value: 247.62
+        value: 247.69
       - _comment: used storage values greater than zero.
         datetime: '2025-01-01'
         source: Electricity Maps, 2025 zone average
-        value: 248.78
+        value: 248.81
     oil:
       - _comment: Mean of all US zones
         datetime: '2020-01-01'
@@ -454,7 +454,7 @@ emissionFactors:
       - _comment: used storage values greater than zero.
         datetime: '2025-01-01'
         source: Electricity Maps, 2025 zone average; National Laboratory of the Rockies
-        value: 286.47
+        value: 286.43
     biomass:
       - _comment: Mean of all US zones
         datetime: '2020-01-01'
@@ -532,11 +532,11 @@ emissionFactors:
       - _comment: used storage values greater than zero.
         datetime: '2023-01-01'
         source: Electricity Maps, 2023 zone average; IPCC 2014
-        value: 271.62
+        value: 271.69
       - _comment: used storage values greater than zero.
         datetime: '2025-01-01'
         source: Electricity Maps, 2025 zone average; IPCC 2014
-        value: 272.78
+        value: 272.81
     oil:
       - _comment: Mean of all US zones
         datetime: '2020-01-01'
@@ -712,6 +712,9 @@ fallbackZoneMixes:
 has_day_ahead_price_license: false
 hide_day_ahead_price: false
 isLowCarbon:
+  battery discharge:
+    - datetime: '2025-01-01'
+      value: 0.5815
   hydro discharge:
     - datetime: '2020-01-01'
       value: 0.6319
@@ -719,7 +722,14 @@ isLowCarbon:
       value: 0.6033
     - datetime: '2022-01-01'
       value: 0.59
+    - datetime: '2023-01-01'
+      value: 0.5951
+    - datetime: '2025-01-01'
+      value: 0.591
 isRenewable:
+  battery discharge:
+    - datetime: '2025-01-01'
+      value: 0.042
   hydro discharge:
     - datetime: '2020-01-01'
       value: 0.0274
@@ -727,6 +737,10 @@ isRenewable:
       value: 0.0227
     - datetime: '2022-01-01'
       value: 0.0296
+    - datetime: '2023-01-01'
+      value: 0.0431
+    - datetime: '2025-01-01'
+      value: 0.0391
 parsers:
   consumption: EIA.fetch_consumption
   consumptionForecast: EIA.fetch_consumption_forecast

--- a/config/zones/US-CAR-SC.yaml
+++ b/config/zones/US-CAR-SC.yaml
@@ -462,6 +462,14 @@ fallbackZoneMixes:
         wind: 0.00013469670798902004
 has_day_ahead_price_license: false
 hide_day_ahead_price: false
+isLowCarbon:
+  hydro discharge:
+    - datetime: '2021-01-01'
+      value: 0.1903
+isRenewable:
+  hydro discharge:
+    - datetime: '2021-01-01'
+      value: 0.0147
 parsers:
   consumption: EIA.fetch_consumption
   consumptionForecast: EIA.fetch_consumption_forecast

--- a/config/zones/US-CAR-SC.yaml
+++ b/config/zones/US-CAR-SC.yaml
@@ -466,10 +466,14 @@ isLowCarbon:
   hydro discharge:
     - datetime: '2021-01-01'
       value: 0.1903
+    - datetime: '2022-01-01'
+      value: 0.2805
 isRenewable:
   hydro discharge:
     - datetime: '2021-01-01'
       value: 0.0147
+    - datetime: '2022-01-01'
+      value: 0.086
 parsers:
   consumption: EIA.fetch_consumption
   consumptionForecast: EIA.fetch_consumption_forecast

--- a/config/zones/US-CAR-SC.yaml
+++ b/config/zones/US-CAR-SC.yaml
@@ -468,12 +468,24 @@ isLowCarbon:
       value: 0.1903
     - datetime: '2022-01-01'
       value: 0.2805
+    - datetime: '2023-01-01'
+      value: 0.2568
+    - datetime: '2024-01-01'
+      value: 0.241
+    - datetime: '2025-01-01'
+      value: 0.2137
 isRenewable:
   hydro discharge:
     - datetime: '2021-01-01'
       value: 0.0147
     - datetime: '2022-01-01'
       value: 0.086
+    - datetime: '2023-01-01'
+      value: 0.0454
+    - datetime: '2024-01-01'
+      value: 0.0427
+    - datetime: '2025-01-01'
+      value: 0.0324
 parsers:
   consumption: EIA.fetch_consumption
   consumptionForecast: EIA.fetch_consumption_forecast

--- a/config/zones/US-CAR-SCEG.yaml
+++ b/config/zones/US-CAR-SCEG.yaml
@@ -524,6 +524,14 @@ fallbackZoneMixes:
         wind: 0.00011411094674027499
 has_day_ahead_price_license: false
 hide_day_ahead_price: false
+isLowCarbon:
+  hydro discharge:
+    - datetime: '2022-01-01'
+      value: 1.0
+isRenewable:
+  hydro discharge:
+    - datetime: '2022-01-01'
+      value: 1.0
 parsers:
   consumption: EIA.fetch_consumption
   consumptionForecast: EIA.fetch_consumption_forecast

--- a/config/zones/US-FLA-FPC.yaml
+++ b/config/zones/US-FLA-FPC.yaml
@@ -214,13 +214,17 @@ emissionFactors:
   direct:
     battery discharge:
       - _comment: used storage values greater than zero.
+        datetime: '2021-01-01'
+        source: Electricity Maps, 2021 zone average
+        value: 425.17
+      - _comment: used storage values greater than zero.
         datetime: '2022-01-01'
         source: Electricity Maps, 2022 zone average
-        value: 430.87
+        value: 425.35
       - _comment: used storage values greater than zero.
         datetime: '2025-01-01'
         source: Electricity Maps, 2025 zone average
-        value: 464.87
+        value: 464.86
     biomass:
       - datetime: '2020-01-01'
         source: BEIS 2021
@@ -280,6 +284,10 @@ emissionFactors:
         value: 28.739435464835893
     hydro discharge:
       - _comment: used default IPCC 2014 value of 0.0
+        datetime: '2021-01-01'
+        source: Electricity Maps, 2021 zone average
+        value: 0.0
+      - _comment: used default IPCC 2014 value of 0.0
         datetime: '2022-01-01'
         source: Electricity Maps, 2022 zone average
         value: 0.0
@@ -299,13 +307,17 @@ emissionFactors:
   lifecycle:
     battery discharge:
       - _comment: used storage values greater than zero.
+        datetime: '2021-01-01'
+        source: Electricity Maps, 2021 zone average; National Laboratory of the Rockies
+        value: 458.17
+      - _comment: used storage values greater than zero.
         datetime: '2022-01-01'
         source: Electricity Maps, 2022 zone average; National Laboratory of the Rockies
-        value: 463.87
+        value: 458.35
       - _comment: used storage values greater than zero.
         datetime: '2025-01-01'
         source: Electricity Maps, 2025 zone average; National Laboratory of the Rockies
-        value: 497.87
+        value: 497.86
     biomass:
       - _comment: Mean of all US zones
         datetime: '2020-01-01'
@@ -368,6 +380,10 @@ emissionFactors:
         source: eGrid 2023; IPCC 2014
         value: 66.73943546483589
     hydro discharge:
+      - _comment: used default IPCC 2014 value of 24.0
+        datetime: '2021-01-01'
+        source: Electricity Maps, 2021 zone average; IPCC 2014
+        value: 24.0
       - _comment: used default IPCC 2014 value of 24.0
         datetime: '2022-01-01'
         source: Electricity Maps, 2022 zone average; IPCC 2014
@@ -545,20 +561,28 @@ has_day_ahead_price_license: false
 hide_day_ahead_price: false
 isLowCarbon:
   battery discharge:
+    - datetime: '2021-01-01'
+      value: 0.0391
     - datetime: '2022-01-01'
-      value: 0.045
+      value: 0.0506
     - datetime: '2025-01-01'
-      value: 0.0987
+      value: 0.0984
   hydro discharge:
+    - datetime: '2021-01-01'
+      value: 1.0
     - datetime: '2022-01-01'
       value: 1.0
 isRenewable:
   battery discharge:
+    - datetime: '2021-01-01'
+      value: 0.0135
     - datetime: '2022-01-01'
-      value: 0.0228
+      value: 0.0256
     - datetime: '2025-01-01'
-      value: 0.0756
+      value: 0.0754
   hydro discharge:
+    - datetime: '2021-01-01'
+      value: 1.0
     - datetime: '2022-01-01'
       value: 1.0
 parsers:

--- a/config/zones/US-FLA-FPC.yaml
+++ b/config/zones/US-FLA-FPC.yaml
@@ -220,7 +220,7 @@ emissionFactors:
       - _comment: used storage values greater than zero.
         datetime: '2025-01-01'
         source: Electricity Maps, 2025 zone average
-        value: 464.73
+        value: 464.87
     biomass:
       - datetime: '2020-01-01'
         source: BEIS 2021
@@ -305,7 +305,7 @@ emissionFactors:
       - _comment: used storage values greater than zero.
         datetime: '2025-01-01'
         source: Electricity Maps, 2025 zone average; National Laboratory of the Rockies
-        value: 497.73
+        value: 497.87
     biomass:
       - _comment: Mean of all US zones
         datetime: '2020-01-01'
@@ -547,6 +547,8 @@ isLowCarbon:
   battery discharge:
     - datetime: '2022-01-01'
       value: 0.045
+    - datetime: '2025-01-01'
+      value: 0.0987
   hydro discharge:
     - datetime: '2022-01-01'
       value: 1.0
@@ -554,6 +556,8 @@ isRenewable:
   battery discharge:
     - datetime: '2022-01-01'
       value: 0.0228
+    - datetime: '2025-01-01'
+      value: 0.0756
   hydro discharge:
     - datetime: '2022-01-01'
       value: 1.0

--- a/config/zones/US-FLA-FPC.yaml
+++ b/config/zones/US-FLA-FPC.yaml
@@ -543,6 +543,20 @@ fallbackZoneMixes:
         wind: 2.9803827190777754e-06
 has_day_ahead_price_license: false
 hide_day_ahead_price: false
+isLowCarbon:
+  battery discharge:
+    - datetime: '2022-01-01'
+      value: 0.045
+  hydro discharge:
+    - datetime: '2022-01-01'
+      value: 1.0
+isRenewable:
+  battery discharge:
+    - datetime: '2022-01-01'
+      value: 0.0228
+  hydro discharge:
+    - datetime: '2022-01-01'
+      value: 1.0
 parsers:
   consumption: EIA.fetch_consumption
   consumptionForecast: EIA.fetch_consumption_forecast
@@ -550,12 +564,12 @@ parsers:
   productionCapacity: EIA.fetch_production_capacity
 region: Americas
 sources:
-  National Laboratory of the Rockies:
-    link: https://docs.nrel.gov/docs/fy21osti/80580.pdf
   INCER ACV:
     link: https://docs.google.com/spreadsheets/d/1w5DJ7sPen6axIHU8TCVcuzNCjlct4I6JAbhUlw-ZXu8/edit?usp=sharing
   IPCC 2014:
     link: https://www.ipcc.ch/site/assets/uploads/2018/02/ipcc_wg3_ar5_annex-iii.pdf#page=7
+  National Laboratory of the Rockies:
+    link: https://docs.nrel.gov/docs/fy21osti/80580.pdf
   eGrid 2020:
     link: https://drive.google.com/file/d/1_FAAuTtIdMuORZKsqHnd9vMNHlQgYarh/view?usp=sharing
   eGrid 2021:

--- a/config/zones/US-FLA-FPL.yaml
+++ b/config/zones/US-FLA-FPL.yaml
@@ -216,7 +216,7 @@ emissionFactors:
       - _comment: used storage values greater than zero.
         datetime: '2025-01-01'
         source: Electricity Maps, 2025 zone average
-        value: 249.66
+        value: 248.89
     biomass:
       - datetime: '2020-01-01'
         source: BEIS 2021
@@ -295,7 +295,7 @@ emissionFactors:
       - _comment: used storage values greater than zero.
         datetime: '2025-01-01'
         source: Electricity Maps, 2025 zone average; National Laboratory of the Rockies
-        value: 282.66
+        value: 281.89
     biomass:
       - _comment: Mean of all US zones
         datetime: '2020-01-01'
@@ -534,11 +534,11 @@ hide_day_ahead_price: false
 isLowCarbon:
   battery discharge:
     - datetime: '2025-01-01'
-      value: 0.3614
+      value: 0.3638
 isRenewable:
   battery discharge:
     - datetime: '2025-01-01'
-      value: 0.1189
+      value: 0.1193
 parsers:
   consumption: EIA.fetch_consumption
   consumptionForecast: EIA.fetch_consumption_forecast

--- a/config/zones/US-FLA-FPL.yaml
+++ b/config/zones/US-FLA-FPL.yaml
@@ -216,7 +216,7 @@ emissionFactors:
       - _comment: used storage values greater than zero.
         datetime: '2025-01-01'
         source: Electricity Maps, 2025 zone average
-        value: 248.88
+        value: 249.66
     biomass:
       - datetime: '2020-01-01'
         source: BEIS 2021
@@ -295,7 +295,7 @@ emissionFactors:
       - _comment: used storage values greater than zero.
         datetime: '2025-01-01'
         source: Electricity Maps, 2025 zone average; National Laboratory of the Rockies
-        value: 281.88
+        value: 282.66
     biomass:
       - _comment: Mean of all US zones
         datetime: '2020-01-01'
@@ -531,6 +531,14 @@ fallbackZoneMixes:
         wind: 6.811091115586069e-06
 has_day_ahead_price_license: false
 hide_day_ahead_price: false
+isLowCarbon:
+  battery discharge:
+    - datetime: '2025-01-01'
+      value: 0.3614
+isRenewable:
+  battery discharge:
+    - datetime: '2025-01-01'
+      value: 0.1189
 parsers:
   consumption: EIA.fetch_consumption
   consumptionForecast: EIA.fetch_consumption_forecast
@@ -538,12 +546,12 @@ parsers:
   productionCapacity: EIA.fetch_production_capacity
 region: Americas
 sources:
-  National Laboratory of the Rockies:
-    link: https://docs.nrel.gov/docs/fy21osti/80580.pdf
   INCER ACV:
     link: https://docs.google.com/spreadsheets/d/1w5DJ7sPen6axIHU8TCVcuzNCjlct4I6JAbhUlw-ZXu8/edit?usp=sharing
   IPCC 2014:
     link: https://www.ipcc.ch/site/assets/uploads/2018/02/ipcc_wg3_ar5_annex-iii.pdf#page=7
+  National Laboratory of the Rockies:
+    link: https://docs.nrel.gov/docs/fy21osti/80580.pdf
   eGrid 2020:
     link: https://drive.google.com/file/d/1_FAAuTtIdMuORZKsqHnd9vMNHlQgYarh/view?usp=sharing
   eGrid 2021:

--- a/config/zones/US-MIDA-PJM.yaml
+++ b/config/zones/US-MIDA-PJM.yaml
@@ -1163,15 +1163,15 @@ emissionFactors:
       - _comment: used storage values greater than zero.
         datetime: '2023-01-01'
         source: Electricity Maps, 2023 zone average
-        value: 329.11
+        value: 331.24
       - _comment: used storage values greater than zero.
         datetime: '2024-01-01'
         source: Electricity Maps, 2024 zone average
-        value: 337.04
+        value: 339.21
       - _comment: used storage values greater than zero.
         datetime: '2025-01-01'
         source: Electricity Maps, 2025 zone average
-        value: 387.65
+        value: 389.71
     biomass:
       - datetime: '2020-01-01'
         source: BEIS 2021
@@ -1258,15 +1258,15 @@ emissionFactors:
       - _comment: used storage values greater than zero.
         datetime: '2023-01-01'
         source: Electricity Maps, 2023 zone average; National Laboratory of the Rockies
-        value: 362.11
+        value: 364.24
       - _comment: used storage values greater than zero.
         datetime: '2024-01-01'
         source: Electricity Maps, 2024 zone average; National Laboratory of the Rockies
-        value: 370.04
+        value: 372.21
       - _comment: used storage values greater than zero.
         datetime: '2025-01-01'
         source: Electricity Maps, 2025 zone average; National Laboratory of the Rockies
-        value: 420.65
+        value: 422.71
     biomass:
       - _comment: Mean of all US zones
         datetime: '2020-01-01'
@@ -1506,6 +1506,12 @@ isLowCarbon:
       value: 0.3904
     - datetime: '2022-01-01'
       value: 0.3909
+    - datetime: '2023-01-01'
+      value: 0.403
+    - datetime: '2024-01-01'
+      value: 0.3869
+    - datetime: '2025-01-01'
+      value: 0.3639
 isRenewable:
   battery discharge:
     - datetime: '2020-01-01'
@@ -1514,6 +1520,12 @@ isRenewable:
       value: 0.0611
     - datetime: '2022-01-01'
       value: 0.0664
+    - datetime: '2023-01-01'
+      value: 0.0739
+    - datetime: '2024-01-01'
+      value: 0.0837
+    - datetime: '2025-01-01'
+      value: 0.073
 parsers:
   consumption: EIA.fetch_consumption
   consumptionForecast: US_PJM.fetch_consumption_forecast

--- a/config/zones/US-MIDA-PJM.yaml
+++ b/config/zones/US-MIDA-PJM.yaml
@@ -1159,7 +1159,7 @@ emissionFactors:
       - _comment: used non-null storage values
         datetime: '2022-01-01'
         source: Electricity Maps, 2022 zone average
-        value: 367.08
+        value: 367.45
       - _comment: used storage values greater than zero.
         datetime: '2023-01-01'
         source: Electricity Maps, 2023 zone average
@@ -1254,7 +1254,7 @@ emissionFactors:
       - _comment: used non-null storage values
         datetime: '2022-01-01'
         source: Electricity Maps, 2022 zone average; National Laboratory of the Rockies
-        value: 400.08
+        value: 400.45
       - _comment: used storage values greater than zero.
         datetime: '2023-01-01'
         source: Electricity Maps, 2023 zone average; National Laboratory of the Rockies
@@ -1504,12 +1504,16 @@ isLowCarbon:
       value: 0.3997
     - datetime: '2021-01-01'
       value: 0.3904
+    - datetime: '2022-01-01'
+      value: 0.3909
 isRenewable:
   battery discharge:
     - datetime: '2020-01-01'
       value: 0.0571
     - datetime: '2021-01-01'
       value: 0.0611
+    - datetime: '2022-01-01'
+      value: 0.0664
 parsers:
   consumption: EIA.fetch_consumption
   consumptionForecast: US_PJM.fetch_consumption_forecast

--- a/config/zones/US-MIDA-PJM.yaml
+++ b/config/zones/US-MIDA-PJM.yaml
@@ -1155,7 +1155,7 @@ emissionFactors:
       - _comment: used non-null storage values
         datetime: '2021-01-01'
         source: Electricity Maps, 2021 zone average
-        value: 373.76
+        value: 373.92
       - _comment: used non-null storage values
         datetime: '2022-01-01'
         source: Electricity Maps, 2022 zone average
@@ -1250,7 +1250,7 @@ emissionFactors:
       - _comment: used non-null storage values
         datetime: '2021-01-01'
         source: Electricity Maps, 2021 zone average; National Laboratory of the Rockies
-        value: 406.76
+        value: 406.92
       - _comment: used non-null storage values
         datetime: '2022-01-01'
         source: Electricity Maps, 2022 zone average; National Laboratory of the Rockies
@@ -1502,10 +1502,14 @@ isLowCarbon:
   battery discharge:
     - datetime: '2020-01-01'
       value: 0.3997
+    - datetime: '2021-01-01'
+      value: 0.3904
 isRenewable:
   battery discharge:
     - datetime: '2020-01-01'
       value: 0.0571
+    - datetime: '2021-01-01'
+      value: 0.0611
 parsers:
   consumption: EIA.fetch_consumption
   consumptionForecast: US_PJM.fetch_consumption_forecast

--- a/config/zones/US-MIDA-PJM.yaml
+++ b/config/zones/US-MIDA-PJM.yaml
@@ -1151,7 +1151,7 @@ emissionFactors:
       - _comment: used non-null storage values
         datetime: '2020-01-01'
         source: Electricity Maps, 2020 zone average
-        value: 353.73
+        value: 354.0
       - _comment: used non-null storage values
         datetime: '2021-01-01'
         source: Electricity Maps, 2021 zone average
@@ -1246,7 +1246,7 @@ emissionFactors:
       - _comment: used non-null storage values
         datetime: '2020-01-01'
         source: Electricity Maps, 2020 zone average; National Laboratory of the Rockies
-        value: 386.73
+        value: 387.0
       - _comment: used non-null storage values
         datetime: '2021-01-01'
         source: Electricity Maps, 2021 zone average; National Laboratory of the Rockies
@@ -1498,6 +1498,14 @@ fallbackZoneMixes:
         wind: 0.03655739992719188
 has_day_ahead_price_license: false
 hide_day_ahead_price: false
+isLowCarbon:
+  battery discharge:
+    - datetime: '2020-01-01'
+      value: 0.3997
+isRenewable:
+  battery discharge:
+    - datetime: '2020-01-01'
+      value: 0.0571
 parsers:
   consumption: EIA.fetch_consumption
   consumptionForecast: US_PJM.fetch_consumption_forecast
@@ -1507,12 +1515,12 @@ parsers:
   productionPerModeForecast: US_PJM.fetch_wind_solar_forecasts
 region: Americas
 sources:
-  National Laboratory of the Rockies:
-    link: https://docs.nrel.gov/docs/fy21osti/80580.pdf
   INCER ACV:
     link: https://docs.google.com/spreadsheets/d/1w5DJ7sPen6axIHU8TCVcuzNCjlct4I6JAbhUlw-ZXu8/edit?usp=sharing
   IPCC 2014:
     link: https://www.ipcc.ch/site/assets/uploads/2018/02/ipcc_wg3_ar5_annex-iii.pdf#page=7
+  National Laboratory of the Rockies:
+    link: https://docs.nrel.gov/docs/fy21osti/80580.pdf
   eGrid 2020:
     link: https://drive.google.com/file/d/1_FAAuTtIdMuORZKsqHnd9vMNHlQgYarh/view?usp=sharing
   eGrid 2021:

--- a/config/zones/US-MIDA-PJM.yaml
+++ b/config/zones/US-MIDA-PJM.yaml
@@ -1155,23 +1155,23 @@ emissionFactors:
       - _comment: used non-null storage values
         datetime: '2021-01-01'
         source: Electricity Maps, 2021 zone average
-        value: 373.92
+        value: 373.88
       - _comment: used non-null storage values
         datetime: '2022-01-01'
         source: Electricity Maps, 2022 zone average
-        value: 367.45
+        value: 367.39
       - _comment: used storage values greater than zero.
         datetime: '2023-01-01'
         source: Electricity Maps, 2023 zone average
-        value: 331.24
+        value: 331.11
       - _comment: used storage values greater than zero.
         datetime: '2024-01-01'
         source: Electricity Maps, 2024 zone average
-        value: 339.21
+        value: 339.25
       - _comment: used storage values greater than zero.
         datetime: '2025-01-01'
         source: Electricity Maps, 2025 zone average
-        value: 389.71
+        value: 363.05
     biomass:
       - datetime: '2020-01-01'
         source: BEIS 2021
@@ -1250,23 +1250,23 @@ emissionFactors:
       - _comment: used non-null storage values
         datetime: '2021-01-01'
         source: Electricity Maps, 2021 zone average; National Laboratory of the Rockies
-        value: 406.92
+        value: 406.88
       - _comment: used non-null storage values
         datetime: '2022-01-01'
         source: Electricity Maps, 2022 zone average; National Laboratory of the Rockies
-        value: 400.45
+        value: 400.39
       - _comment: used storage values greater than zero.
         datetime: '2023-01-01'
         source: Electricity Maps, 2023 zone average; National Laboratory of the Rockies
-        value: 364.24
+        value: 364.11
       - _comment: used storage values greater than zero.
         datetime: '2024-01-01'
         source: Electricity Maps, 2024 zone average; National Laboratory of the Rockies
-        value: 372.21
+        value: 372.25
       - _comment: used storage values greater than zero.
         datetime: '2025-01-01'
         source: Electricity Maps, 2025 zone average; National Laboratory of the Rockies
-        value: 422.71
+        value: 396.05
     biomass:
       - _comment: Mean of all US zones
         datetime: '2020-01-01'
@@ -1503,15 +1503,15 @@ isLowCarbon:
     - datetime: '2020-01-01'
       value: 0.3997
     - datetime: '2021-01-01'
-      value: 0.3904
+      value: 0.3905
     - datetime: '2022-01-01'
-      value: 0.3909
+      value: 0.391
     - datetime: '2023-01-01'
-      value: 0.403
+      value: 0.4031
     - datetime: '2024-01-01'
       value: 0.3869
     - datetime: '2025-01-01'
-      value: 0.3639
+      value: 0.3994
 isRenewable:
   battery discharge:
     - datetime: '2020-01-01'
@@ -1519,13 +1519,13 @@ isRenewable:
     - datetime: '2021-01-01'
       value: 0.0611
     - datetime: '2022-01-01'
-      value: 0.0664
+      value: 0.0665
     - datetime: '2023-01-01'
-      value: 0.0739
+      value: 0.0738
     - datetime: '2024-01-01'
       value: 0.0837
     - datetime: '2025-01-01'
-      value: 0.073
+      value: 0.0871
 parsers:
   consumption: EIA.fetch_consumption
   consumptionForecast: US_PJM.fetch_consumption_forecast

--- a/config/zones/US-MIDW-LGEE.yaml
+++ b/config/zones/US-MIDW-LGEE.yaml
@@ -450,9 +450,13 @@ isLowCarbon:
   hydro discharge:
     - datetime: '2020-01-01'
       value: 1.0
+    - datetime: '2021-01-01'
+      value: 1.0
 isRenewable:
   hydro discharge:
     - datetime: '2020-01-01'
+      value: 1.0
+    - datetime: '2021-01-01'
       value: 1.0
 parsers:
   consumption: EIA.fetch_consumption

--- a/config/zones/US-MIDW-LGEE.yaml
+++ b/config/zones/US-MIDW-LGEE.yaml
@@ -446,6 +446,14 @@ fallbackZoneMixes:
         wind: 0.013273336745387228
 has_day_ahead_price_license: false
 hide_day_ahead_price: false
+isLowCarbon:
+  hydro discharge:
+    - datetime: '2020-01-01'
+      value: 1.0
+isRenewable:
+  hydro discharge:
+    - datetime: '2020-01-01'
+      value: 1.0
 parsers:
   consumption: EIA.fetch_consumption
   consumptionForecast: EIA.fetch_consumption_forecast

--- a/config/zones/US-MIDW-LGEE.yaml
+++ b/config/zones/US-MIDW-LGEE.yaml
@@ -454,6 +454,8 @@ isLowCarbon:
       value: 1.0
     - datetime: '2022-01-01'
       value: 1.0
+    - datetime: '2025-01-01'
+      value: 0.0775
 isRenewable:
   hydro discharge:
     - datetime: '2020-01-01'
@@ -462,6 +464,8 @@ isRenewable:
       value: 1.0
     - datetime: '2022-01-01'
       value: 1.0
+    - datetime: '2025-01-01'
+      value: 0.0563
 parsers:
   consumption: EIA.fetch_consumption
   consumptionForecast: EIA.fetch_consumption_forecast

--- a/config/zones/US-MIDW-LGEE.yaml
+++ b/config/zones/US-MIDW-LGEE.yaml
@@ -452,11 +452,15 @@ isLowCarbon:
       value: 1.0
     - datetime: '2021-01-01'
       value: 1.0
+    - datetime: '2022-01-01'
+      value: 1.0
 isRenewable:
   hydro discharge:
     - datetime: '2020-01-01'
       value: 1.0
     - datetime: '2021-01-01'
+      value: 1.0
+    - datetime: '2022-01-01'
       value: 1.0
 parsers:
   consumption: EIA.fetch_consumption

--- a/config/zones/US-MIDW-MISO.yaml
+++ b/config/zones/US-MIDW-MISO.yaml
@@ -1232,7 +1232,7 @@ emissionFactors:
       - _comment: used storage values greater than zero.
         datetime: '2025-01-01'
         source: Electricity Maps, 2025 zone average
-        value: 428.36
+        value: 428.67
     biomass:
       - datetime: '2020-01-01'
         source: BEIS 2021
@@ -1307,7 +1307,7 @@ emissionFactors:
       - _comment: used storage values greater than zero.
         datetime: '2025-01-01'
         source: Electricity Maps, 2025 zone average; National Laboratory of the Rockies
-        value: 461.36
+        value: 461.67
     biomass:
       - _comment: Mean of all US zones
         datetime: '2020-01-01'
@@ -1542,11 +1542,11 @@ hide_day_ahead_price: false
 isLowCarbon:
   battery discharge:
     - datetime: '2025-01-01'
-      value: 0.3687
+      value: 0.3682
 isRenewable:
   battery discharge:
     - datetime: '2025-01-01'
-      value: 0.2171
+      value: 0.2165
 parsers:
   consumption: EIA.fetch_consumption
   consumptionForecast: US_MISO.fetch_consumption_forecast

--- a/config/zones/US-MIDW-MISO.yaml
+++ b/config/zones/US-MIDW-MISO.yaml
@@ -1232,7 +1232,7 @@ emissionFactors:
       - _comment: used storage values greater than zero.
         datetime: '2025-01-01'
         source: Electricity Maps, 2025 zone average
-        value: 419.95
+        value: 428.36
     biomass:
       - datetime: '2020-01-01'
         source: BEIS 2021
@@ -1307,7 +1307,7 @@ emissionFactors:
       - _comment: used storage values greater than zero.
         datetime: '2025-01-01'
         source: Electricity Maps, 2025 zone average; National Laboratory of the Rockies
-        value: 452.95
+        value: 461.36
     biomass:
       - _comment: Mean of all US zones
         datetime: '2020-01-01'
@@ -1539,6 +1539,14 @@ fallbackZoneMixes:
         wind: 0.14722782107459684
 has_day_ahead_price_license: false
 hide_day_ahead_price: false
+isLowCarbon:
+  battery discharge:
+    - datetime: '2025-01-01'
+      value: 0.3687
+isRenewable:
+  battery discharge:
+    - datetime: '2025-01-01'
+      value: 0.2171
 parsers:
   consumption: EIA.fetch_consumption
   consumptionForecast: US_MISO.fetch_consumption_forecast
@@ -1548,12 +1556,12 @@ parsers:
   productionPerModeForecast: US_MISO.fetch_wind_solar_forecasts
 region: Americas
 sources:
-  National Laboratory of the Rockies:
-    link: https://docs.nrel.gov/docs/fy21osti/80580.pdf
   INCER ACV:
     link: https://docs.google.com/spreadsheets/d/1w5DJ7sPen6axIHU8TCVcuzNCjlct4I6JAbhUlw-ZXu8/edit?usp=sharing
   IPCC 2014:
     link: https://www.ipcc.ch/site/assets/uploads/2018/02/ipcc_wg3_ar5_annex-iii.pdf#page=7
+  National Laboratory of the Rockies:
+    link: https://docs.nrel.gov/docs/fy21osti/80580.pdf
   eGrid 2020:
     link: https://drive.google.com/file/d/1_FAAuTtIdMuORZKsqHnd9vMNHlQgYarh/view?usp=sharing
   eGrid 2021:

--- a/config/zones/US-NE-ISNE.yaml
+++ b/config/zones/US-NE-ISNE.yaml
@@ -855,7 +855,7 @@ emissionFactors:
       - _comment: used non-null storage values
         datetime: '2020-01-01'
         source: Electricity Maps, 2020 zone average
-        value: 183.0
+        value: 183.01
       - _comment: used non-null storage values
         datetime: '2021-01-01'
         source: Electricity Maps, 2021 zone average
@@ -863,19 +863,19 @@ emissionFactors:
       - _comment: used non-null storage values
         datetime: '2022-01-01'
         source: Electricity Maps, 2022 zone average
-        value: 202.41
+        value: 202.42
       - _comment: used non-null storage values
         datetime: '2023-01-01'
         source: Electricity Maps, 2023 zone average
-        value: 204.26
+        value: 204.25
       - _comment: used non-null storage values
         datetime: '2024-01-01'
         source: Electricity Maps, 2024 zone average
-        value: 214.87
+        value: 214.88
       - _comment: used non-null storage values
         datetime: '2025-01-01'
         source: Electricity Maps, 2025 zone average
-        value: 223.57
+        value: 223.55
     biomass:
       - datetime: '2020-01-01'
         source: BEIS 2021
@@ -950,7 +950,7 @@ emissionFactors:
       - _comment: used non-null storage values
         datetime: '2020-01-01'
         source: Electricity Maps, 2020 zone average; National Laboratory of the Rockies
-        value: 216.0
+        value: 216.01
       - _comment: used non-null storage values
         datetime: '2021-01-01'
         source: Electricity Maps, 2021 zone average; National Laboratory of the Rockies
@@ -958,19 +958,19 @@ emissionFactors:
       - _comment: used non-null storage values
         datetime: '2022-01-01'
         source: Electricity Maps, 2022 zone average; National Laboratory of the Rockies
-        value: 235.41
+        value: 235.42
       - _comment: used non-null storage values
         datetime: '2023-01-01'
         source: Electricity Maps, 2023 zone average; National Laboratory of the Rockies
-        value: 237.26
+        value: 237.25
       - _comment: used non-null storage values
         datetime: '2024-01-01'
         source: Electricity Maps, 2024 zone average; National Laboratory of the Rockies
-        value: 247.87
+        value: 247.88
       - _comment: used non-null storage values
         datetime: '2025-01-01'
         source: Electricity Maps, 2025 zone average; National Laboratory of the Rockies
-        value: 256.57
+        value: 256.55
     biomass:
       - _comment: Mean of all US zones
         datetime: '2020-01-01'
@@ -1211,9 +1211,9 @@ isLowCarbon:
     - datetime: '2022-01-01'
       value: 0.5136
     - datetime: '2023-01-01'
-      value: 0.4845
+      value: 0.4846
     - datetime: '2024-01-01'
-      value: 0.4567
+      value: 0.4568
     - datetime: '2025-01-01'
       value: 0.4474
 isRenewable:
@@ -1225,11 +1225,11 @@ isRenewable:
     - datetime: '2022-01-01'
       value: 0.2718
     - datetime: '2023-01-01'
-      value: 0.2651
+      value: 0.2652
     - datetime: '2024-01-01'
-      value: 0.2145
+      value: 0.2146
     - datetime: '2025-01-01'
-      value: 0.1969
+      value: 0.197
 parsers:
   consumption: EIA.fetch_consumption
   consumptionForecast: US_NEISO.fetch_consumption_forecast

--- a/config/zones/US-NE-ISNE.yaml
+++ b/config/zones/US-NE-ISNE.yaml
@@ -1206,10 +1206,14 @@ isLowCarbon:
   battery discharge:
     - datetime: '2020-01-01'
       value: 0.5393
+    - datetime: '2021-01-01'
+      value: 0.5179
 isRenewable:
   battery discharge:
     - datetime: '2020-01-01'
       value: 0.2936
+    - datetime: '2021-01-01'
+      value: 0.2755
 parsers:
   consumption: EIA.fetch_consumption
   consumptionForecast: US_NEISO.fetch_consumption_forecast

--- a/config/zones/US-NE-ISNE.yaml
+++ b/config/zones/US-NE-ISNE.yaml
@@ -1202,6 +1202,14 @@ fallbackZoneMixes:
         wind: 0.035357632711841926
 has_day_ahead_price_license: false
 hide_day_ahead_price: false
+isLowCarbon:
+  battery discharge:
+    - datetime: '2020-01-01'
+      value: 0.5393
+isRenewable:
+  battery discharge:
+    - datetime: '2020-01-01'
+      value: 0.2936
 parsers:
   consumption: EIA.fetch_consumption
   consumptionForecast: US_NEISO.fetch_consumption_forecast
@@ -1211,12 +1219,12 @@ parsers:
   productionPerModeForecast: US_NEISO.fetch_wind_solar_forecasts
 region: Americas
 sources:
-  National Laboratory of the Rockies:
-    link: https://docs.nrel.gov/docs/fy21osti/80580.pdf
   INCER ACV:
     link: https://docs.google.com/spreadsheets/d/1w5DJ7sPen6axIHU8TCVcuzNCjlct4I6JAbhUlw-ZXu8/edit?usp=sharing
   IPCC 2014:
     link: https://www.ipcc.ch/site/assets/uploads/2018/02/ipcc_wg3_ar5_annex-iii.pdf#page=7
+  National Laboratory of the Rockies:
+    link: https://docs.nrel.gov/docs/fy21osti/80580.pdf
   eGrid 2020:
     link: https://drive.google.com/file/d/1_FAAuTtIdMuORZKsqHnd9vMNHlQgYarh/view?usp=sharing
   eGrid 2021:

--- a/config/zones/US-NE-ISNE.yaml
+++ b/config/zones/US-NE-ISNE.yaml
@@ -867,15 +867,15 @@ emissionFactors:
       - _comment: used non-null storage values
         datetime: '2023-01-01'
         source: Electricity Maps, 2023 zone average
-        value: 204.17
+        value: 204.26
       - _comment: used non-null storage values
         datetime: '2024-01-01'
         source: Electricity Maps, 2024 zone average
-        value: 214.78
+        value: 214.87
       - _comment: used non-null storage values
         datetime: '2025-01-01'
         source: Electricity Maps, 2025 zone average
-        value: 223.34
+        value: 223.57
     biomass:
       - datetime: '2020-01-01'
         source: BEIS 2021
@@ -962,15 +962,15 @@ emissionFactors:
       - _comment: used non-null storage values
         datetime: '2023-01-01'
         source: Electricity Maps, 2023 zone average; National Laboratory of the Rockies
-        value: 237.17
+        value: 237.26
       - _comment: used non-null storage values
         datetime: '2024-01-01'
         source: Electricity Maps, 2024 zone average; National Laboratory of the Rockies
-        value: 247.78
+        value: 247.87
       - _comment: used non-null storage values
         datetime: '2025-01-01'
         source: Electricity Maps, 2025 zone average; National Laboratory of the Rockies
-        value: 256.34
+        value: 256.57
     biomass:
       - _comment: Mean of all US zones
         datetime: '2020-01-01'
@@ -1210,6 +1210,12 @@ isLowCarbon:
       value: 0.5179
     - datetime: '2022-01-01'
       value: 0.5136
+    - datetime: '2023-01-01'
+      value: 0.4845
+    - datetime: '2024-01-01'
+      value: 0.4567
+    - datetime: '2025-01-01'
+      value: 0.4474
 isRenewable:
   battery discharge:
     - datetime: '2020-01-01'
@@ -1218,6 +1224,12 @@ isRenewable:
       value: 0.2755
     - datetime: '2022-01-01'
       value: 0.2718
+    - datetime: '2023-01-01'
+      value: 0.2651
+    - datetime: '2024-01-01'
+      value: 0.2145
+    - datetime: '2025-01-01'
+      value: 0.1969
 parsers:
   consumption: EIA.fetch_consumption
   consumptionForecast: US_NEISO.fetch_consumption_forecast

--- a/config/zones/US-NE-ISNE.yaml
+++ b/config/zones/US-NE-ISNE.yaml
@@ -1208,12 +1208,16 @@ isLowCarbon:
       value: 0.5393
     - datetime: '2021-01-01'
       value: 0.5179
+    - datetime: '2022-01-01'
+      value: 0.5136
 isRenewable:
   battery discharge:
     - datetime: '2020-01-01'
       value: 0.2936
     - datetime: '2021-01-01'
       value: 0.2755
+    - datetime: '2022-01-01'
+      value: 0.2718
 parsers:
   consumption: EIA.fetch_consumption
   consumptionForecast: US_NEISO.fetch_consumption_forecast

--- a/config/zones/US-NW-AVA.yaml
+++ b/config/zones/US-NW-AVA.yaml
@@ -156,7 +156,7 @@ emissionFactors:
       - _comment: used storage values greater than zero.
         datetime: '2025-01-01'
         source: Electricity Maps, 2025 zone average
-        value: 183.93
+        value: 184.06
     oil:
       - _comment: Mean of all US zones
         datetime: '2020-01-01'
@@ -243,7 +243,7 @@ emissionFactors:
       - _comment: used storage values greater than zero.
         datetime: '2025-01-01'
         source: Electricity Maps, 2025 zone average; IPCC 2014
-        value: 207.93
+        value: 208.06
     oil:
       - _comment: Mean of all US zones
         datetime: '2020-01-01'
@@ -400,6 +400,14 @@ fallbackZoneMixes:
         wind: 0.1020901076480728
 has_day_ahead_price_license: false
 hide_day_ahead_price: false
+isLowCarbon:
+  hydro discharge:
+    - datetime: '2025-01-01'
+      value: 0.6535
+isRenewable:
+  hydro discharge:
+    - datetime: '2025-01-01'
+      value: 0.6224
 parsers:
   consumption: EIA.fetch_consumption
   consumptionForecast: EIA.fetch_consumption_forecast

--- a/config/zones/US-NW-IPCO.yaml
+++ b/config/zones/US-NW-IPCO.yaml
@@ -207,7 +207,7 @@ emissionFactors:
       - _comment: used storage values greater than zero.
         datetime: '2025-01-01'
         source: Electricity Maps, 2025 zone average
-        value: 246.91
+        value: 248.2
     biomass:
       - datetime: '2020-01-01'
         source: BEIS 2021
@@ -286,7 +286,7 @@ emissionFactors:
       - _comment: used storage values greater than zero.
         datetime: '2025-01-01'
         source: Electricity Maps, 2025 zone average; National Laboratory of the Rockies
-        value: 279.91
+        value: 281.2
     biomass:
       - _comment: Mean of all US zones
         datetime: '2020-01-01'
@@ -525,11 +525,11 @@ hide_day_ahead_price: false
 isLowCarbon:
   battery discharge:
     - datetime: '2025-01-01'
-      value: 0.6306
+      value: 0.6298
 isRenewable:
   battery discharge:
     - datetime: '2025-01-01'
-      value: 0.6291
+      value: 0.6283
 parsers:
   consumption: EIA.fetch_consumption
   consumptionForecast: EIA.fetch_consumption_forecast

--- a/config/zones/US-NW-IPCO.yaml
+++ b/config/zones/US-NW-IPCO.yaml
@@ -207,7 +207,7 @@ emissionFactors:
       - _comment: used storage values greater than zero.
         datetime: '2025-01-01'
         source: Electricity Maps, 2025 zone average
-        value: 246.68
+        value: 246.91
     biomass:
       - datetime: '2020-01-01'
         source: BEIS 2021
@@ -286,7 +286,7 @@ emissionFactors:
       - _comment: used storage values greater than zero.
         datetime: '2025-01-01'
         source: Electricity Maps, 2025 zone average; National Laboratory of the Rockies
-        value: 279.68
+        value: 279.91
     biomass:
       - _comment: Mean of all US zones
         datetime: '2020-01-01'
@@ -522,6 +522,14 @@ fallbackZoneMixes:
         wind: 0.13662238355509054
 has_day_ahead_price_license: false
 hide_day_ahead_price: false
+isLowCarbon:
+  battery discharge:
+    - datetime: '2025-01-01'
+      value: 0.6306
+isRenewable:
+  battery discharge:
+    - datetime: '2025-01-01'
+      value: 0.6291
 parsers:
   consumption: EIA.fetch_consumption
   consumptionForecast: EIA.fetch_consumption_forecast
@@ -529,12 +537,12 @@ parsers:
   productionCapacity: EIA.fetch_production_capacity
 region: Americas
 sources:
-  National Laboratory of the Rockies:
-    link: https://docs.nrel.gov/docs/fy21osti/80580.pdf
   INCER ACV:
     link: https://docs.google.com/spreadsheets/d/1w5DJ7sPen6axIHU8TCVcuzNCjlct4I6JAbhUlw-ZXu8/edit?usp=sharing
   IPCC 2014:
     link: https://www.ipcc.ch/site/assets/uploads/2018/02/ipcc_wg3_ar5_annex-iii.pdf#page=7
+  National Laboratory of the Rockies:
+    link: https://docs.nrel.gov/docs/fy21osti/80580.pdf
   eGrid 2020:
     link: https://drive.google.com/file/d/1_FAAuTtIdMuORZKsqHnd9vMNHlQgYarh/view?usp=sharing
   eGrid 2021:

--- a/config/zones/US-NW-NEVP.yaml
+++ b/config/zones/US-NW-NEVP.yaml
@@ -269,6 +269,15 @@ delays:
   production: 48
 emissionFactors:
   direct:
+    battery discharge:
+      - _comment: used non-null storage values
+        datetime: '2024-01-01'
+        source: Electricity Maps, 2024 zone average
+        value: 368.88
+      - _comment: used non-null storage values
+        datetime: '2025-01-01'
+        source: Electricity Maps, 2025 zone average
+        value: 409.65
     biomass:
       - datetime: '2020-01-01'
         source: BEIS 2021
@@ -344,6 +353,15 @@ emissionFactors:
         source: eGrid 2023
         value: 757.3688858307635
   lifecycle:
+    battery discharge:
+      - _comment: used non-null storage values
+        datetime: '2024-01-01'
+        source: Electricity Maps, 2024 zone average; National Laboratory of the Rockies
+        value: 401.88
+      - _comment: used non-null storage values
+        datetime: '2025-01-01'
+        source: Electricity Maps, 2025 zone average; National Laboratory of the Rockies
+        value: 442.65
     biomass:
       - _comment: Mean of all US zones
         datetime: '2020-01-01'
@@ -566,10 +584,20 @@ fallbackZoneMixes:
 has_day_ahead_price_license: false
 hide_day_ahead_price: false
 isLowCarbon:
+  battery discharge:
+    - datetime: '2024-01-01'
+      value: 0.3196
+    - datetime: '2025-01-01'
+      value: 0.201
   hydro discharge:
     - datetime: '2022-01-01'
       value: 1.0
 isRenewable:
+  battery discharge:
+    - datetime: '2024-01-01'
+      value: 0.2996
+    - datetime: '2025-01-01'
+      value: 0.1879
   hydro discharge:
     - datetime: '2022-01-01'
       value: 1.0

--- a/config/zones/US-NW-NEVP.yaml
+++ b/config/zones/US-NW-NEVP.yaml
@@ -620,5 +620,7 @@ sources:
     link: https://www.epa.gov/egrid/historical-egrid-data
   eGrid 2023:
     link: https://www.epa.gov/egrid/detailed-data
+  National Laboratory of the Rockies:
+    link: https://docs.nrel.gov/docs/fy21osti/80580.pdf
 timezone: US/Pacific
 zone_name: Nevada Power Company

--- a/config/zones/US-NW-NEVP.yaml
+++ b/config/zones/US-NW-NEVP.yaml
@@ -565,6 +565,14 @@ fallbackZoneMixes:
         wind: 0.030996482747352047
 has_day_ahead_price_license: false
 hide_day_ahead_price: false
+isLowCarbon:
+  hydro discharge:
+    - datetime: '2022-01-01'
+      value: 1.0
+isRenewable:
+  hydro discharge:
+    - datetime: '2022-01-01'
+      value: 1.0
 parsers:
   consumption: EIA.fetch_consumption
   consumptionForecast: EIA.fetch_consumption_forecast

--- a/config/zones/US-NW-NWMT.yaml
+++ b/config/zones/US-NW-NWMT.yaml
@@ -471,6 +471,14 @@ fallbackZoneMixes:
         wind: 0.24723499458575396
 has_day_ahead_price_license: false
 hide_day_ahead_price: false
+isLowCarbon:
+  hydro discharge:
+    - datetime: '2024-01-01'
+      value: 0.139
+isRenewable:
+  hydro discharge:
+    - datetime: '2024-01-01'
+      value: 0.139
 parsers:
   consumption: EIA.fetch_consumption
   consumptionForecast: EIA.fetch_consumption_forecast

--- a/config/zones/US-NW-PACW.yaml
+++ b/config/zones/US-NW-PACW.yaml
@@ -263,7 +263,7 @@ emissionFactors:
       - _comment: used storage values greater than zero.
         datetime: '2021-01-01'
         source: Electricity Maps, 2021 zone average
-        value: 395.81
+        value: 395.8
     oil:
       - _comment: Mean of all US zones
         datetime: '2020-01-01'
@@ -354,7 +354,7 @@ emissionFactors:
       - _comment: used storage values greater than zero.
         datetime: '2021-01-01'
         source: Electricity Maps, 2021 zone average; IPCC 2014
-        value: 419.81
+        value: 419.8
     oil:
       - _comment: Mean of all US zones
         datetime: '2020-01-01'
@@ -520,7 +520,7 @@ isLowCarbon:
     - datetime: '2020-01-01'
       value: 0.7924
     - datetime: '2021-01-01'
-      value: 0.5025
+      value: 0.5026
 isRenewable:
   hydro discharge:
     - datetime: '2020-01-01'

--- a/config/zones/US-NW-PACW.yaml
+++ b/config/zones/US-NW-PACW.yaml
@@ -263,7 +263,7 @@ emissionFactors:
       - _comment: used storage values greater than zero.
         datetime: '2021-01-01'
         source: Electricity Maps, 2021 zone average
-        value: 395.79
+        value: 395.81
     oil:
       - _comment: Mean of all US zones
         datetime: '2020-01-01'
@@ -354,7 +354,7 @@ emissionFactors:
       - _comment: used storage values greater than zero.
         datetime: '2021-01-01'
         source: Electricity Maps, 2021 zone average; IPCC 2014
-        value: 419.79
+        value: 419.81
     oil:
       - _comment: Mean of all US zones
         datetime: '2020-01-01'
@@ -519,10 +519,14 @@ isLowCarbon:
   hydro discharge:
     - datetime: '2020-01-01'
       value: 0.7924
+    - datetime: '2021-01-01'
+      value: 0.5025
 isRenewable:
   hydro discharge:
     - datetime: '2020-01-01'
       value: 0.762
+    - datetime: '2021-01-01'
+      value: 0.4888
 parsers:
   consumption: EIA.fetch_consumption
   consumptionForecast: EIA.fetch_consumption_forecast

--- a/config/zones/US-NW-PACW.yaml
+++ b/config/zones/US-NW-PACW.yaml
@@ -259,7 +259,7 @@ emissionFactors:
       - _comment: used storage values greater than zero.
         datetime: '2020-01-01'
         source: Electricity Maps, 2020 zone average
-        value: 187.81
+        value: 187.89
       - _comment: used storage values greater than zero.
         datetime: '2021-01-01'
         source: Electricity Maps, 2021 zone average
@@ -350,7 +350,7 @@ emissionFactors:
       - _comment: used storage values greater than zero.
         datetime: '2020-01-01'
         source: Electricity Maps, 2020 zone average; IPCC 2014
-        value: 211.81
+        value: 211.89
       - _comment: used storage values greater than zero.
         datetime: '2021-01-01'
         source: Electricity Maps, 2021 zone average; IPCC 2014
@@ -515,6 +515,14 @@ fallbackZoneMixes:
         wind: 0.14522387099354464
 has_day_ahead_price_license: false
 hide_day_ahead_price: false
+isLowCarbon:
+  hydro discharge:
+    - datetime: '2020-01-01'
+      value: 0.7924
+isRenewable:
+  hydro discharge:
+    - datetime: '2020-01-01'
+      value: 0.762
 parsers:
   consumption: EIA.fetch_consumption
   consumptionForecast: EIA.fetch_consumption_forecast

--- a/config/zones/US-NW-PGE.yaml
+++ b/config/zones/US-NW-PGE.yaml
@@ -189,7 +189,7 @@ emissionFactors:
       - _comment: used storage values greater than zero.
         datetime: '2025-01-01'
         source: Electricity Maps, 2025 zone average
-        value: 213.12
+        value: 213.42
     biomass:
       - datetime: '2020-01-01'
         source: BEIS 2021
@@ -271,7 +271,7 @@ emissionFactors:
       - _comment: used storage values greater than zero.
         datetime: '2025-01-01'
         source: Electricity Maps, 2025 zone average; National Laboratory of the Rockies
-        value: 246.12
+        value: 246.42
     biomass:
       - _comment: Mean of all US zones
         datetime: '2020-01-01'
@@ -495,6 +495,14 @@ fallbackZoneMixes:
         wind: 0.07587504128718962
 has_day_ahead_price_license: false
 hide_day_ahead_price: false
+isLowCarbon:
+  battery discharge:
+    - datetime: '2025-01-01'
+      value: 0.5848
+isRenewable:
+  battery discharge:
+    - datetime: '2025-01-01'
+      value: 0.5467
 parsers:
   consumption: EIA.fetch_consumption
   consumptionForecast: EIA.fetch_consumption_forecast
@@ -502,12 +510,12 @@ parsers:
   productionCapacity: EIA.fetch_production_capacity
 region: Americas
 sources:
-  National Laboratory of the Rockies:
-    link: https://docs.nrel.gov/docs/fy21osti/80580.pdf
   INCER ACV:
     link: https://docs.google.com/spreadsheets/d/1w5DJ7sPen6axIHU8TCVcuzNCjlct4I6JAbhUlw-ZXu8/edit?usp=sharing
   IPCC 2014:
     link: https://www.ipcc.ch/site/assets/uploads/2018/02/ipcc_wg3_ar5_annex-iii.pdf#page=7
+  National Laboratory of the Rockies:
+    link: https://docs.nrel.gov/docs/fy21osti/80580.pdf
   eGrid 2020:
     link: https://drive.google.com/file/d/1_FAAuTtIdMuORZKsqHnd9vMNHlQgYarh/view?usp=sharing
   eGrid 2021:

--- a/config/zones/US-NW-PGE.yaml
+++ b/config/zones/US-NW-PGE.yaml
@@ -186,10 +186,14 @@ delays:
 emissionFactors:
   direct:
     battery discharge:
+      - _comment: used non-null storage values
+        datetime: '2024-01-01'
+        source: Electricity Maps, 2024 zone average
+        value: 127.37
       - _comment: used storage values greater than zero.
         datetime: '2025-01-01'
         source: Electricity Maps, 2025 zone average
-        value: 213.42
+        value: 214.57
     biomass:
       - datetime: '2020-01-01'
         source: BEIS 2021
@@ -268,10 +272,14 @@ emissionFactors:
         value: 757.3688858307635
   lifecycle:
     battery discharge:
+      - _comment: used non-null storage values
+        datetime: '2024-01-01'
+        source: Electricity Maps, 2024 zone average; National Laboratory of the Rockies
+        value: 160.37
       - _comment: used storage values greater than zero.
         datetime: '2025-01-01'
         source: Electricity Maps, 2025 zone average; National Laboratory of the Rockies
-        value: 246.42
+        value: 247.57
     biomass:
       - _comment: Mean of all US zones
         datetime: '2020-01-01'
@@ -497,12 +505,16 @@ has_day_ahead_price_license: false
 hide_day_ahead_price: false
 isLowCarbon:
   battery discharge:
+    - datetime: '2024-01-01'
+      value: 0.7585
     - datetime: '2025-01-01'
-      value: 0.5848
+      value: 0.5843
 isRenewable:
   battery discharge:
+    - datetime: '2024-01-01'
+      value: 0.7585
     - datetime: '2025-01-01'
-      value: 0.5467
+      value: 0.5458
 parsers:
   consumption: EIA.fetch_consumption
   consumptionForecast: EIA.fetch_consumption_forecast

--- a/config/zones/US-NW-PSCO.yaml
+++ b/config/zones/US-NW-PSCO.yaml
@@ -312,7 +312,7 @@ emissionFactors:
       - _comment: used storage values greater than zero.
         datetime: '2025-01-01'
         source: Electricity Maps, 2025 zone average
-        value: 324.14
+        value: 324.2
     biomass:
       - datetime: '2020-01-01'
         source: BEIS 2021
@@ -391,7 +391,7 @@ emissionFactors:
       - _comment: used storage values greater than zero.
         datetime: '2025-01-01'
         source: Electricity Maps, 2025 zone average; National Laboratory of the Rockies
-        value: 357.14
+        value: 357.2
     biomass:
       - _comment: Mean of all US zones
         datetime: '2020-01-01'
@@ -612,6 +612,14 @@ fallbackZoneMixes:
         wind: 0.3064469544491784
 has_day_ahead_price_license: false
 hide_day_ahead_price: false
+isLowCarbon:
+  battery discharge:
+    - datetime: '2025-01-01'
+      value: 0.5079
+isRenewable:
+  battery discharge:
+    - datetime: '2025-01-01'
+      value: 0.5062
 parsers:
   consumption: EIA.fetch_consumption
   consumptionForecast: EIA.fetch_consumption_forecast
@@ -619,12 +627,12 @@ parsers:
   productionCapacity: EIA.fetch_production_capacity
 region: Americas
 sources:
-  National Laboratory of the Rockies:
-    link: https://docs.nrel.gov/docs/fy21osti/80580.pdf
   INCER ACV:
     link: https://docs.google.com/spreadsheets/d/1w5DJ7sPen6axIHU8TCVcuzNCjlct4I6JAbhUlw-ZXu8/edit?usp=sharing
   IPCC 2014:
     link: https://www.ipcc.ch/site/assets/uploads/2018/02/ipcc_wg3_ar5_annex-iii.pdf#page=7
+  National Laboratory of the Rockies:
+    link: https://docs.nrel.gov/docs/fy21osti/80580.pdf
   eGrid 2020:
     link: https://drive.google.com/file/d/1_FAAuTtIdMuORZKsqHnd9vMNHlQgYarh/view?usp=sharing
   eGrid 2021:

--- a/config/zones/US-NW-PSCO.yaml
+++ b/config/zones/US-NW-PSCO.yaml
@@ -312,7 +312,7 @@ emissionFactors:
       - _comment: used storage values greater than zero.
         datetime: '2025-01-01'
         source: Electricity Maps, 2025 zone average
-        value: 324.2
+        value: 323.94
     biomass:
       - datetime: '2020-01-01'
         source: BEIS 2021
@@ -391,7 +391,7 @@ emissionFactors:
       - _comment: used storage values greater than zero.
         datetime: '2025-01-01'
         source: Electricity Maps, 2025 zone average; National Laboratory of the Rockies
-        value: 357.2
+        value: 356.94
     biomass:
       - _comment: Mean of all US zones
         datetime: '2020-01-01'
@@ -615,11 +615,11 @@ hide_day_ahead_price: false
 isLowCarbon:
   battery discharge:
     - datetime: '2025-01-01'
-      value: 0.5079
+      value: 0.5081
 isRenewable:
   battery discharge:
     - datetime: '2025-01-01'
-      value: 0.5062
+      value: 0.5064
 parsers:
   consumption: EIA.fetch_consumption
   consumptionForecast: EIA.fetch_consumption_forecast

--- a/config/zones/US-NW-WACM.yaml
+++ b/config/zones/US-NW-WACM.yaml
@@ -604,6 +604,14 @@ fallbackZoneMixes:
         wind: 0.1680123086368647
 has_day_ahead_price_license: false
 hide_day_ahead_price: false
+isLowCarbon:
+  hydro discharge:
+    - datetime: '2025-01-01'
+      value: 0.3325
+isRenewable:
+  hydro discharge:
+    - datetime: '2025-01-01'
+      value: 0.3325
 parsers:
   consumption: EIA.fetch_consumption
   consumptionForecast: EIA.fetch_consumption_forecast

--- a/config/zones/US-NW-WACM.yaml
+++ b/config/zones/US-NW-WACM.yaml
@@ -351,6 +351,10 @@ emissionFactors:
         value: 28.739435464835893
     hydro discharge:
       - _comment: used storage values greater than zero.
+        datetime: '2023-01-01'
+        source: Electricity Maps, 2023 zone average
+        value: 695.25
+      - _comment: used storage values greater than zero.
         datetime: '2025-01-01'
         source: Electricity Maps, 2025 zone average
         value: 671.46
@@ -429,6 +433,10 @@ emissionFactors:
         source: eGrid 2023; IPCC 2014
         value: 66.73943546483589
     hydro discharge:
+      - _comment: used storage values greater than zero.
+        datetime: '2023-01-01'
+        source: Electricity Maps, 2023 zone average; IPCC 2014
+        value: 719.25
       - _comment: used storage values greater than zero.
         datetime: '2025-01-01'
         source: Electricity Maps, 2025 zone average; IPCC 2014
@@ -606,10 +614,14 @@ has_day_ahead_price_license: false
 hide_day_ahead_price: false
 isLowCarbon:
   hydro discharge:
+    - datetime: '2023-01-01'
+      value: 0.3102
     - datetime: '2025-01-01'
       value: 0.3325
 isRenewable:
   hydro discharge:
+    - datetime: '2023-01-01'
+      value: 0.3041
     - datetime: '2025-01-01'
       value: 0.3325
 parsers:

--- a/config/zones/US-SE-SOCO.yaml
+++ b/config/zones/US-SE-SOCO.yaml
@@ -469,7 +469,7 @@ emissionFactors:
       - _comment: used storage values greater than zero.
         datetime: '2025-01-01'
         source: Electricity Maps, 2025 zone average
-        value: 387.49
+        value: 385.57
     biomass:
       - datetime: '2020-01-01'
         source: BEIS 2021
@@ -530,7 +530,7 @@ emissionFactors:
       - _comment: used storage values greater than zero.
         datetime: '2025-01-01'
         source: Electricity Maps, 2025 zone average
-        value: 388.14
+        value: 387.01
     oil:
       - datetime: '2020-01-01'
         source: eGrid 2020
@@ -549,7 +549,7 @@ emissionFactors:
       - _comment: used storage values greater than zero.
         datetime: '2025-01-01'
         source: Electricity Maps, 2025 zone average; National Laboratory of the Rockies
-        value: 420.49
+        value: 418.57
     biomass:
       - _comment: Mean of all US zones
         datetime: '2020-01-01'
@@ -614,7 +614,7 @@ emissionFactors:
       - _comment: used storage values greater than zero.
         datetime: '2025-01-01'
         source: Electricity Maps, 2025 zone average; IPCC 2014
-        value: 412.14
+        value: 411.01
     oil:
       - datetime: '2020-01-01'
         source: eGrid 2020; IPCC 2014
@@ -774,17 +774,17 @@ hide_day_ahead_price: false
 isLowCarbon:
   battery discharge:
     - datetime: '2025-01-01'
-      value: 0.3358
+      value: 0.3413
   hydro discharge:
     - datetime: '2025-01-01'
-      value: 0.3382
+      value: 0.3422
 isRenewable:
   battery discharge:
     - datetime: '2025-01-01'
-      value: 0.0571
+      value: 0.0659
   hydro discharge:
     - datetime: '2025-01-01'
-      value: 0.0537
+      value: 0.0605
 parsers:
   consumption: EIA.fetch_consumption
   consumptionForecast: EIA.fetch_consumption_forecast

--- a/config/zones/US-SE-SOCO.yaml
+++ b/config/zones/US-SE-SOCO.yaml
@@ -530,7 +530,7 @@ emissionFactors:
       - _comment: used storage values greater than zero.
         datetime: '2025-01-01'
         source: Electricity Maps, 2025 zone average
-        value: 388.15
+        value: 388.14
     oil:
       - datetime: '2020-01-01'
         source: eGrid 2020
@@ -614,7 +614,7 @@ emissionFactors:
       - _comment: used storage values greater than zero.
         datetime: '2025-01-01'
         source: Electricity Maps, 2025 zone average; IPCC 2014
-        value: 412.15
+        value: 412.14
     oil:
       - datetime: '2020-01-01'
         source: eGrid 2020; IPCC 2014
@@ -771,6 +771,20 @@ fallbackZoneMixes:
         wind: 0.00037636503223176254
 has_day_ahead_price_license: false
 hide_day_ahead_price: false
+isLowCarbon:
+  battery discharge:
+    - datetime: '2025-01-01'
+      value: 0.3358
+  hydro discharge:
+    - datetime: '2025-01-01'
+      value: 0.3382
+isRenewable:
+  battery discharge:
+    - datetime: '2025-01-01'
+      value: 0.0571
+  hydro discharge:
+    - datetime: '2025-01-01'
+      value: 0.0537
 parsers:
   consumption: EIA.fetch_consumption
   consumptionForecast: EIA.fetch_consumption_forecast
@@ -778,12 +792,12 @@ parsers:
   productionCapacity: EIA.fetch_production_capacity
 region: Americas
 sources:
-  National Laboratory of the Rockies:
-    link: https://docs.nrel.gov/docs/fy21osti/80580.pdf
   INCER ACV:
     link: https://docs.google.com/spreadsheets/d/1w5DJ7sPen6axIHU8TCVcuzNCjlct4I6JAbhUlw-ZXu8/edit?usp=sharing
   IPCC 2014:
     link: https://www.ipcc.ch/site/assets/uploads/2018/02/ipcc_wg3_ar5_annex-iii.pdf#page=7
+  National Laboratory of the Rockies:
+    link: https://docs.nrel.gov/docs/fy21osti/80580.pdf
   eGrid 2020:
     link: https://drive.google.com/file/d/1_FAAuTtIdMuORZKsqHnd9vMNHlQgYarh/view?usp=sharing
   eGrid 2021:

--- a/config/zones/US-SW-AZPS.yaml
+++ b/config/zones/US-SW-AZPS.yaml
@@ -190,10 +190,14 @@ delays:
 emissionFactors:
   direct:
     battery discharge:
+      - _comment: used non-null storage values
+        datetime: '2024-01-01'
+        source: Electricity Maps, 2024 zone average
+        value: 406.44
       - _comment: used storage values greater than zero.
         datetime: '2025-01-01'
         source: Electricity Maps, 2025 zone average
-        value: 261.44
+        value: 266.98
     biomass:
       - datetime: '2020-01-01'
         source: BEIS 2021
@@ -269,10 +273,14 @@ emissionFactors:
         value: 757.3688858307635
   lifecycle:
     battery discharge:
+      - _comment: used non-null storage values
+        datetime: '2024-01-01'
+        source: Electricity Maps, 2024 zone average; National Laboratory of the Rockies
+        value: 439.44
       - _comment: used storage values greater than zero.
         datetime: '2025-01-01'
         source: Electricity Maps, 2025 zone average; National Laboratory of the Rockies
-        value: 294.44
+        value: 299.98
     biomass:
       - _comment: Mean of all US zones
         datetime: '2020-01-01'
@@ -495,12 +503,16 @@ has_day_ahead_price_license: false
 hide_day_ahead_price: false
 isLowCarbon:
   battery discharge:
+    - datetime: '2024-01-01'
+      value: 0.2665
     - datetime: '2025-01-01'
-      value: 0.5547
+      value: 0.5676
 isRenewable:
   battery discharge:
+    - datetime: '2024-01-01'
+      value: 0.0196
     - datetime: '2025-01-01'
-      value: 0.2588
+      value: 0.2838
 parsers:
   consumption: EIA.fetch_consumption
   consumptionForecast: EIA.fetch_consumption_forecast

--- a/config/zones/US-SW-AZPS.yaml
+++ b/config/zones/US-SW-AZPS.yaml
@@ -493,6 +493,14 @@ fallbackZoneMixes:
         wind: 0.05223583306779387
 has_day_ahead_price_license: false
 hide_day_ahead_price: false
+isLowCarbon:
+  battery discharge:
+    - datetime: '2025-01-01'
+      value: 0.5547
+isRenewable:
+  battery discharge:
+    - datetime: '2025-01-01'
+      value: 0.2588
 parsers:
   consumption: EIA.fetch_consumption
   consumptionForecast: EIA.fetch_consumption_forecast
@@ -500,12 +508,12 @@ parsers:
   productionCapacity: EIA.fetch_production_capacity
 region: Americas
 sources:
-  National Laboratory of the Rockies:
-    link: https://docs.nrel.gov/docs/fy21osti/80580.pdf
   INCER ACV:
     link: https://docs.google.com/spreadsheets/d/1w5DJ7sPen6axIHU8TCVcuzNCjlct4I6JAbhUlw-ZXu8/edit?usp=sharing
   IPCC 2014:
     link: https://www.ipcc.ch/site/assets/uploads/2018/02/ipcc_wg3_ar5_annex-iii.pdf#page=7
+  National Laboratory of the Rockies:
+    link: https://docs.nrel.gov/docs/fy21osti/80580.pdf
   eGrid 2020:
     link: https://drive.google.com/file/d/1_FAAuTtIdMuORZKsqHnd9vMNHlQgYarh/view?usp=sharing
   eGrid 2021:

--- a/config/zones/US-SW-PNM.yaml
+++ b/config/zones/US-SW-PNM.yaml
@@ -606,6 +606,14 @@ fallbackZoneMixes:
         wind: 0.3386034024377126
 has_day_ahead_price_license: false
 hide_day_ahead_price: false
+isLowCarbon:
+  hydro discharge:
+    - datetime: '2022-01-01'
+      value: 0.276
+isRenewable:
+  hydro discharge:
+    - datetime: '2022-01-01'
+      value: 0.2628
 parsers:
   consumption: EIA.fetch_consumption
   consumptionForecast: EIA.fetch_consumption_forecast
@@ -613,12 +621,12 @@ parsers:
   productionCapacity: EIA.fetch_production_capacity
 region: Americas
 sources:
-  National Laboratory of the Rockies:
-    link: https://docs.nrel.gov/docs/fy21osti/80580.pdf
   INCER ACV:
     link: https://docs.google.com/spreadsheets/d/1w5DJ7sPen6axIHU8TCVcuzNCjlct4I6JAbhUlw-ZXu8/edit?usp=sharing
   IPCC 2014:
     link: https://www.ipcc.ch/site/assets/uploads/2018/02/ipcc_wg3_ar5_annex-iii.pdf#page=7
+  National Laboratory of the Rockies:
+    link: https://docs.nrel.gov/docs/fy21osti/80580.pdf
   eGrid 2020:
     link: https://drive.google.com/file/d/1_FAAuTtIdMuORZKsqHnd9vMNHlQgYarh/view?usp=sharing
   eGrid 2021:

--- a/config/zones/US-SW-PNM.yaml
+++ b/config/zones/US-SW-PNM.yaml
@@ -270,7 +270,7 @@ emissionFactors:
       - _comment: used storage values greater than zero.
         datetime: '2025-01-01'
         source: Electricity Maps, 2025 zone average
-        value: 185.79
+        value: 185.67
     biomass:
       - datetime: '2020-01-01'
         source: BEIS 2021
@@ -371,7 +371,7 @@ emissionFactors:
       - _comment: used storage values greater than zero.
         datetime: '2025-01-01'
         source: Electricity Maps, 2025 zone average; National Laboratory of the Rockies
-        value: 218.79
+        value: 218.67
     biomass:
       - _comment: Mean of all US zones
         datetime: '2020-01-01'
@@ -628,7 +628,7 @@ isRenewable:
     - datetime: '2024-01-01'
       value: 0.5288
     - datetime: '2025-01-01'
-      value: 0.7217
+      value: 0.7218
   hydro discharge:
     - datetime: '2022-01-01'
       value: 0.2628

--- a/config/zones/US-SW-PNM.yaml
+++ b/config/zones/US-SW-PNM.yaml
@@ -262,15 +262,15 @@ emissionFactors:
       - _comment: used storage values greater than zero.
         datetime: '2023-01-01'
         source: Electricity Maps, 2023 zone average
-        value: 350.94
+        value: 351.27
       - _comment: used storage values greater than zero.
         datetime: '2024-01-01'
         source: Electricity Maps, 2024 zone average
-        value: 281.11
+        value: 281.32
       - _comment: used storage values greater than zero.
         datetime: '2025-01-01'
         source: Electricity Maps, 2025 zone average
-        value: 185.62
+        value: 185.79
     biomass:
       - datetime: '2020-01-01'
         source: BEIS 2021
@@ -336,11 +336,11 @@ emissionFactors:
       - _comment: used storage values greater than zero.
         datetime: '2023-01-01'
         source: Electricity Maps, 2023 zone average
-        value: 356.66
+        value: 356.98
       - _comment: used storage values greater than zero.
         datetime: '2024-01-01'
         source: Electricity Maps, 2024 zone average
-        value: 161.54
+        value: 161.72
     oil:
       - _comment: Mean of all US zones
         datetime: '2020-01-01'
@@ -363,15 +363,15 @@ emissionFactors:
       - _comment: used storage values greater than zero.
         datetime: '2023-01-01'
         source: Electricity Maps, 2023 zone average; National Laboratory of the Rockies
-        value: 383.94
+        value: 384.27
       - _comment: used storage values greater than zero.
         datetime: '2024-01-01'
         source: Electricity Maps, 2024 zone average; National Laboratory of the Rockies
-        value: 314.11
+        value: 314.32
       - _comment: used storage values greater than zero.
         datetime: '2025-01-01'
         source: Electricity Maps, 2025 zone average; National Laboratory of the Rockies
-        value: 218.62
+        value: 218.79
     biomass:
       - _comment: Mean of all US zones
         datetime: '2020-01-01'
@@ -441,11 +441,11 @@ emissionFactors:
       - _comment: used storage values greater than zero.
         datetime: '2023-01-01'
         source: Electricity Maps, 2023 zone average; IPCC 2014
-        value: 380.66
+        value: 380.98
       - _comment: used storage values greater than zero.
         datetime: '2024-01-01'
         source: Electricity Maps, 2024 zone average; IPCC 2014
-        value: 185.54
+        value: 185.72
     oil:
       - _comment: Mean of all US zones
         datetime: '2020-01-01'
@@ -607,13 +607,35 @@ fallbackZoneMixes:
 has_day_ahead_price_license: false
 hide_day_ahead_price: false
 isLowCarbon:
+  battery discharge:
+    - datetime: '2023-01-01'
+      value: 0.4919
+    - datetime: '2024-01-01'
+      value: 0.5511
+    - datetime: '2025-01-01'
+      value: 0.7346
   hydro discharge:
     - datetime: '2022-01-01'
       value: 0.276
+    - datetime: '2023-01-01'
+      value: 0.4728
+    - datetime: '2024-01-01'
+      value: 0.7807
 isRenewable:
+  battery discharge:
+    - datetime: '2023-01-01'
+      value: 0.4825
+    - datetime: '2024-01-01'
+      value: 0.5288
+    - datetime: '2025-01-01'
+      value: 0.7217
   hydro discharge:
     - datetime: '2022-01-01'
       value: 0.2628
+    - datetime: '2023-01-01'
+      value: 0.464
+    - datetime: '2024-01-01'
+      value: 0.7806
 parsers:
   consumption: EIA.fetch_consumption
   consumptionForecast: EIA.fetch_consumption_forecast

--- a/config/zones/US-SW-SRP.yaml
+++ b/config/zones/US-SW-SRP.yaml
@@ -169,17 +169,21 @@ emissionFactors:
   direct:
     battery discharge:
       - _comment: used storage values greater than zero.
+        datetime: '2022-01-01'
+        source: Electricity Maps, 2022 zone average
+        value: 184.26
+      - _comment: used storage values greater than zero.
         datetime: '2023-01-01'
         source: Electricity Maps, 2023 zone average
         value: 250.01
       - _comment: used storage values greater than zero.
         datetime: '2024-01-01'
         source: Electricity Maps, 2024 zone average
-        value: 242.56
+        value: 284.05
       - _comment: used storage values greater than zero.
         datetime: '2025-01-01'
         source: Electricity Maps, 2025 zone average
-        value: 241.86
+        value: 243.17
     biomass:
       - datetime: '2020-01-01'
         source: BEIS 2021
@@ -244,23 +248,23 @@ emissionFactors:
       - _comment: used storage values greater than zero.
         datetime: '2021-01-01'
         source: Electricity Maps, 2021 zone average
-        value: 214.07
+        value: 214.36
       - _comment: used storage values greater than zero.
         datetime: '2022-01-01'
         source: Electricity Maps, 2022 zone average
-        value: 206.8
+        value: 205.58
       - _comment: used storage values greater than zero.
         datetime: '2023-01-01'
         source: Electricity Maps, 2023 zone average
-        value: 267.21
+        value: 262.97
       - _comment: used storage values greater than zero.
         datetime: '2024-01-01'
         source: Electricity Maps, 2024 zone average
-        value: 235.1
+        value: 240.66
       - _comment: used storage values greater than zero.
         datetime: '2025-01-01'
         source: Electricity Maps, 2025 zone average
-        value: 243.92
+        value: 240.2
     oil:
       - _comment: Mean of all US zones
         datetime: '2020-01-01'
@@ -281,17 +285,21 @@ emissionFactors:
   lifecycle:
     battery discharge:
       - _comment: used storage values greater than zero.
+        datetime: '2022-01-01'
+        source: Electricity Maps, 2022 zone average; National Laboratory of the Rockies
+        value: 217.26
+      - _comment: used storage values greater than zero.
         datetime: '2023-01-01'
         source: Electricity Maps, 2023 zone average; National Laboratory of the Rockies
         value: 283.01
       - _comment: used storage values greater than zero.
         datetime: '2024-01-01'
         source: Electricity Maps, 2024 zone average; National Laboratory of the Rockies
-        value: 275.56
+        value: 317.05
       - _comment: used storage values greater than zero.
         datetime: '2025-01-01'
         source: Electricity Maps, 2025 zone average; National Laboratory of the Rockies
-        value: 274.86
+        value: 276.17
     biomass:
       - _comment: Mean of all US zones
         datetime: '2020-01-01'
@@ -360,23 +368,23 @@ emissionFactors:
       - _comment: used storage values greater than zero.
         datetime: '2021-01-01'
         source: Electricity Maps, 2021 zone average; IPCC 2014
-        value: 238.07
+        value: 238.36
       - _comment: used storage values greater than zero.
         datetime: '2022-01-01'
         source: Electricity Maps, 2022 zone average; IPCC 2014
-        value: 230.8
+        value: 229.58
       - _comment: used storage values greater than zero.
         datetime: '2023-01-01'
         source: Electricity Maps, 2023 zone average; IPCC 2014
-        value: 291.21
+        value: 286.97
       - _comment: used storage values greater than zero.
         datetime: '2024-01-01'
         source: Electricity Maps, 2024 zone average; IPCC 2014
-        value: 259.1
+        value: 264.66
       - _comment: used storage values greater than zero.
         datetime: '2025-01-01'
         source: Electricity Maps, 2025 zone average; IPCC 2014
-        value: 267.92
+        value: 264.2
     oil:
       - _comment: Mean of all US zones
         datetime: '2020-01-01'
@@ -539,46 +547,50 @@ has_day_ahead_price_license: false
 hide_day_ahead_price: false
 isLowCarbon:
   battery discharge:
+    - datetime: '2022-01-01'
+      value: 0.6476
     - datetime: '2023-01-01'
       value: 0.5527
     - datetime: '2024-01-01'
-      value: 0.5969
+      value: 0.5374
     - datetime: '2025-01-01'
-      value: 0.5503
+      value: 0.5469
   hydro discharge:
     - datetime: '2020-01-01'
       value: 0.4802
     - datetime: '2021-01-01'
-      value: 0.5684
+      value: 0.5686
     - datetime: '2022-01-01'
-      value: 0.5921
+      value: 0.5954
     - datetime: '2023-01-01'
-      value: 0.5137
+      value: 0.5272
     - datetime: '2024-01-01'
-      value: 0.592
+      value: 0.5775
     - datetime: '2025-01-01'
-      value: 0.5891
+      value: 0.5884
 isRenewable:
   battery discharge:
+    - datetime: '2022-01-01'
+      value: 0.0356
     - datetime: '2023-01-01'
       value: 0.0565
     - datetime: '2024-01-01'
-      value: 0.0762
+      value: 0.0366
     - datetime: '2025-01-01'
-      value: 0.0958
+      value: 0.0964
   hydro discharge:
     - datetime: '2020-01-01'
       value: 0.035
     - datetime: '2021-01-01'
-      value: 0.0334
+      value: 0.0336
     - datetime: '2022-01-01'
-      value: 0.0443
+      value: 0.0437
     - datetime: '2023-01-01'
-      value: 0.0405
+      value: 0.0376
     - datetime: '2024-01-01'
-      value: 0.0698
+      value: 0.0603
     - datetime: '2025-01-01'
-      value: 0.0733
+      value: 0.0912
 parsers:
   consumption: EIA.fetch_consumption
   consumptionForecast: EIA.fetch_consumption_forecast

--- a/config/zones/US-SW-SRP.yaml
+++ b/config/zones/US-SW-SRP.yaml
@@ -543,12 +543,16 @@ isLowCarbon:
       value: 0.4802
     - datetime: '2021-01-01'
       value: 0.5684
+    - datetime: '2022-01-01'
+      value: 0.5921
 isRenewable:
   hydro discharge:
     - datetime: '2020-01-01'
       value: 0.035
     - datetime: '2021-01-01'
       value: 0.0334
+    - datetime: '2022-01-01'
+      value: 0.0443
 parsers:
   consumption: EIA.fetch_consumption
   consumptionForecast: EIA.fetch_consumption_forecast

--- a/config/zones/US-SW-SRP.yaml
+++ b/config/zones/US-SW-SRP.yaml
@@ -541,10 +541,14 @@ isLowCarbon:
   hydro discharge:
     - datetime: '2020-01-01'
       value: 0.4802
+    - datetime: '2021-01-01'
+      value: 0.5684
 isRenewable:
   hydro discharge:
     - datetime: '2020-01-01'
       value: 0.035
+    - datetime: '2021-01-01'
+      value: 0.0334
 parsers:
   consumption: EIA.fetch_consumption
   consumptionForecast: EIA.fetch_consumption_forecast

--- a/config/zones/US-SW-SRP.yaml
+++ b/config/zones/US-SW-SRP.yaml
@@ -537,6 +537,14 @@ fallbackZoneMixes:
         wind: 0.008596420205364573
 has_day_ahead_price_license: false
 hide_day_ahead_price: false
+isLowCarbon:
+  hydro discharge:
+    - datetime: '2020-01-01'
+      value: 0.4802
+isRenewable:
+  hydro discharge:
+    - datetime: '2020-01-01'
+      value: 0.035
 parsers:
   consumption: EIA.fetch_consumption
   consumptionForecast: EIA.fetch_consumption_forecast
@@ -544,12 +552,12 @@ parsers:
   productionCapacity: EIA.fetch_production_capacity
 region: Americas
 sources:
-  National Laboratory of the Rockies:
-    link: https://docs.nrel.gov/docs/fy21osti/80580.pdf
   INCER ACV:
     link: https://docs.google.com/spreadsheets/d/1w5DJ7sPen6axIHU8TCVcuzNCjlct4I6JAbhUlw-ZXu8/edit?usp=sharing
   IPCC 2014:
     link: https://www.ipcc.ch/site/assets/uploads/2018/02/ipcc_wg3_ar5_annex-iii.pdf#page=7
+  National Laboratory of the Rockies:
+    link: https://docs.nrel.gov/docs/fy21osti/80580.pdf
   eGrid 2020:
     link: https://drive.google.com/file/d/1_FAAuTtIdMuORZKsqHnd9vMNHlQgYarh/view?usp=sharing
   eGrid 2021:

--- a/config/zones/US-SW-SRP.yaml
+++ b/config/zones/US-SW-SRP.yaml
@@ -179,7 +179,7 @@ emissionFactors:
       - _comment: used storage values greater than zero.
         datetime: '2025-01-01'
         source: Electricity Maps, 2025 zone average
-        value: 241.85
+        value: 241.86
     biomass:
       - datetime: '2020-01-01'
         source: BEIS 2021
@@ -260,7 +260,7 @@ emissionFactors:
       - _comment: used storage values greater than zero.
         datetime: '2025-01-01'
         source: Electricity Maps, 2025 zone average
-        value: 242.94
+        value: 243.92
     oil:
       - _comment: Mean of all US zones
         datetime: '2020-01-01'
@@ -291,7 +291,7 @@ emissionFactors:
       - _comment: used storage values greater than zero.
         datetime: '2025-01-01'
         source: Electricity Maps, 2025 zone average; National Laboratory of the Rockies
-        value: 274.85
+        value: 274.86
     biomass:
       - _comment: Mean of all US zones
         datetime: '2020-01-01'
@@ -376,7 +376,7 @@ emissionFactors:
       - _comment: used storage values greater than zero.
         datetime: '2025-01-01'
         source: Electricity Maps, 2025 zone average; IPCC 2014
-        value: 266.94
+        value: 267.92
     oil:
       - _comment: Mean of all US zones
         datetime: '2020-01-01'
@@ -538,6 +538,13 @@ fallbackZoneMixes:
 has_day_ahead_price_license: false
 hide_day_ahead_price: false
 isLowCarbon:
+  battery discharge:
+    - datetime: '2023-01-01'
+      value: 0.5527
+    - datetime: '2024-01-01'
+      value: 0.5969
+    - datetime: '2025-01-01'
+      value: 0.5503
   hydro discharge:
     - datetime: '2020-01-01'
       value: 0.4802
@@ -545,7 +552,20 @@ isLowCarbon:
       value: 0.5684
     - datetime: '2022-01-01'
       value: 0.5921
+    - datetime: '2023-01-01'
+      value: 0.5137
+    - datetime: '2024-01-01'
+      value: 0.592
+    - datetime: '2025-01-01'
+      value: 0.5891
 isRenewable:
+  battery discharge:
+    - datetime: '2023-01-01'
+      value: 0.0565
+    - datetime: '2024-01-01'
+      value: 0.0762
+    - datetime: '2025-01-01'
+      value: 0.0958
   hydro discharge:
     - datetime: '2020-01-01'
       value: 0.035
@@ -553,6 +573,12 @@ isRenewable:
       value: 0.0334
     - datetime: '2022-01-01'
       value: 0.0443
+    - datetime: '2023-01-01'
+      value: 0.0405
+    - datetime: '2024-01-01'
+      value: 0.0698
+    - datetime: '2025-01-01'
+      value: 0.0733
 parsers:
   consumption: EIA.fetch_consumption
   consumptionForecast: EIA.fetch_consumption_forecast

--- a/config/zones/US-SW-TEPC.yaml
+++ b/config/zones/US-SW-TEPC.yaml
@@ -138,7 +138,7 @@ emissionFactors:
       - _comment: used storage values greater than zero.
         datetime: '2025-01-01'
         source: Electricity Maps, 2025 zone average
-        value: 406.82
+        value: 406.83
     biomass:
       - datetime: '2020-01-01'
         source: BEIS 2021
@@ -217,7 +217,7 @@ emissionFactors:
       - _comment: used storage values greater than zero.
         datetime: '2025-01-01'
         source: Electricity Maps, 2025 zone average; National Laboratory of the Rockies
-        value: 439.82
+        value: 439.83
     biomass:
       - _comment: Mean of all US zones
         datetime: '2020-01-01'
@@ -438,6 +438,14 @@ fallbackZoneMixes:
         wind: 0.10338034646937623
 has_day_ahead_price_license: false
 hide_day_ahead_price: false
+isLowCarbon:
+  battery discharge:
+    - datetime: '2025-01-01'
+      value: 0.2587
+isRenewable:
+  battery discharge:
+    - datetime: '2025-01-01'
+      value: 0.224
 parsers:
   consumption: EIA.fetch_consumption
   consumptionForecast: EIA.fetch_consumption_forecast
@@ -445,12 +453,12 @@ parsers:
   productionCapacity: EIA.fetch_production_capacity
 region: Americas
 sources:
-  National Laboratory of the Rockies:
-    link: https://docs.nrel.gov/docs/fy21osti/80580.pdf
   INCER ACV:
     link: https://docs.google.com/spreadsheets/d/1w5DJ7sPen6axIHU8TCVcuzNCjlct4I6JAbhUlw-ZXu8/edit?usp=sharing
   IPCC 2014:
     link: https://www.ipcc.ch/site/assets/uploads/2018/02/ipcc_wg3_ar5_annex-iii.pdf#page=7
+  National Laboratory of the Rockies:
+    link: https://docs.nrel.gov/docs/fy21osti/80580.pdf
   eGrid 2020:
     link: https://drive.google.com/file/d/1_FAAuTtIdMuORZKsqHnd9vMNHlQgYarh/view?usp=sharing
   eGrid 2021:

--- a/config/zones/US-SW-TEPC.yaml
+++ b/config/zones/US-SW-TEPC.yaml
@@ -138,7 +138,7 @@ emissionFactors:
       - _comment: used storage values greater than zero.
         datetime: '2025-01-01'
         source: Electricity Maps, 2025 zone average
-        value: 406.83
+        value: 404.51
     biomass:
       - datetime: '2020-01-01'
         source: BEIS 2021
@@ -217,7 +217,7 @@ emissionFactors:
       - _comment: used storage values greater than zero.
         datetime: '2025-01-01'
         source: Electricity Maps, 2025 zone average; National Laboratory of the Rockies
-        value: 439.83
+        value: 437.51
     biomass:
       - _comment: Mean of all US zones
         datetime: '2020-01-01'
@@ -441,11 +441,11 @@ hide_day_ahead_price: false
 isLowCarbon:
   battery discharge:
     - datetime: '2025-01-01'
-      value: 0.2587
+      value: 0.2633
 isRenewable:
   battery discharge:
     - datetime: '2025-01-01'
-      value: 0.224
+      value: 0.2268
 parsers:
   consumption: EIA.fetch_consumption
   consumptionForecast: EIA.fetch_consumption_forecast

--- a/config/zones/US-SW-WALC.yaml
+++ b/config/zones/US-SW-WALC.yaml
@@ -450,6 +450,18 @@ fallbackZoneMixes:
         wind: 0.06749767730316335
 has_day_ahead_price_license: false
 hide_day_ahead_price: false
+isLowCarbon:
+  hydro discharge:
+    - datetime: '2024-01-01'
+      value: 0.4499
+    - datetime: '2025-01-01'
+      value: 0.1686
+isRenewable:
+  hydro discharge:
+    - datetime: '2024-01-01'
+      value: 0.322
+    - datetime: '2025-01-01'
+      value: 0.126
 parsers:
   consumption: EIA.fetch_consumption
   consumptionForecast: EIA.fetch_consumption_forecast

--- a/config/zones/US-TEN-TVA.yaml
+++ b/config/zones/US-TEN-TVA.yaml
@@ -345,7 +345,7 @@ emissionFactors:
       - _comment: used storage values greater than zero.
         datetime: '2021-01-01'
         source: Electricity Maps, 2021 zone average
-        value: 331.87
+        value: 332.71
       - _comment: used storage values greater than zero.
         datetime: '2022-01-01'
         source: Electricity Maps, 2022 zone average
@@ -456,7 +456,7 @@ emissionFactors:
       - _comment: used storage values greater than zero.
         datetime: '2021-01-01'
         source: Electricity Maps, 2021 zone average; IPCC 2014
-        value: 355.87
+        value: 356.71
       - _comment: used storage values greater than zero.
         datetime: '2022-01-01'
         source: Electricity Maps, 2022 zone average; IPCC 2014
@@ -636,10 +636,14 @@ isLowCarbon:
   hydro discharge:
     - datetime: '2020-01-01'
       value: 1.0
+    - datetime: '2021-01-01'
+      value: 0.5012
 isRenewable:
   hydro discharge:
     - datetime: '2020-01-01'
       value: 1.0
+    - datetime: '2021-01-01'
+      value: 0.0288
 parsers:
   consumption: EIA.fetch_consumption
   consumptionForecast: EIA.fetch_consumption_forecast

--- a/config/zones/US-TEN-TVA.yaml
+++ b/config/zones/US-TEN-TVA.yaml
@@ -632,6 +632,14 @@ fallbackZoneMixes:
         wind: 0.01264416307073402
 has_day_ahead_price_license: false
 hide_day_ahead_price: false
+isLowCarbon:
+  hydro discharge:
+    - datetime: '2020-01-01'
+      value: 1.0
+isRenewable:
+  hydro discharge:
+    - datetime: '2020-01-01'
+      value: 1.0
 parsers:
   consumption: EIA.fetch_consumption
   consumptionForecast: EIA.fetch_consumption_forecast
@@ -639,12 +647,12 @@ parsers:
   productionCapacity: EIA.fetch_production_capacity
 region: Americas
 sources:
-  National Laboratory of the Rockies:
-    link: https://docs.nrel.gov/docs/fy21osti/80580.pdf
   INCER ACV:
     link: https://docs.google.com/spreadsheets/d/1w5DJ7sPen6axIHU8TCVcuzNCjlct4I6JAbhUlw-ZXu8/edit?usp=sharing
   IPCC 2014:
     link: https://www.ipcc.ch/site/assets/uploads/2018/02/ipcc_wg3_ar5_annex-iii.pdf#page=7
+  National Laboratory of the Rockies:
+    link: https://docs.nrel.gov/docs/fy21osti/80580.pdf
   eGrid 2020:
     link: https://drive.google.com/file/d/1_FAAuTtIdMuORZKsqHnd9vMNHlQgYarh/view?usp=sharing
   eGrid 2021:

--- a/config/zones/US-TEN-TVA.yaml
+++ b/config/zones/US-TEN-TVA.yaml
@@ -276,11 +276,11 @@ emissionFactors:
       - _comment: used non-null storage values
         datetime: '2024-01-01'
         source: Electricity Maps, 2024 zone average
-        value: 366.24
+        value: 367.24
       - _comment: used non-null storage values
         datetime: '2025-01-01'
         source: Electricity Maps, 2025 zone average
-        value: 342.17
+        value: 342.92
     biomass:
       - datetime: '2020-01-01'
         source: BEIS 2021
@@ -353,15 +353,15 @@ emissionFactors:
       - _comment: used storage values greater than zero.
         datetime: '2023-01-01'
         source: Electricity Maps, 2023 zone average
-        value: 325.56
+        value: 326.29
       - _comment: used storage values greater than zero.
         datetime: '2024-01-01'
         source: Electricity Maps, 2024 zone average
-        value: 365.26
+        value: 366.24
       - _comment: used storage values greater than zero.
         datetime: '2025-01-01'
         source: Electricity Maps, 2025 zone average
-        value: 341.53
+        value: 342.28
     oil:
       - datetime: '2020-01-01'
         source: eGrid 2020
@@ -383,11 +383,11 @@ emissionFactors:
       - _comment: used non-null storage values
         datetime: '2024-01-01'
         source: Electricity Maps, 2024 zone average; National Laboratory of the Rockies
-        value: 399.24
+        value: 400.24
       - _comment: used non-null storage values
         datetime: '2025-01-01'
         source: Electricity Maps, 2025 zone average; National Laboratory of the Rockies
-        value: 375.17
+        value: 375.92
     biomass:
       - _comment: Mean of all US zones
         datetime: '2020-01-01'
@@ -464,15 +464,15 @@ emissionFactors:
       - _comment: used storage values greater than zero.
         datetime: '2023-01-01'
         source: Electricity Maps, 2023 zone average; IPCC 2014
-        value: 349.56
+        value: 350.29
       - _comment: used storage values greater than zero.
         datetime: '2024-01-01'
         source: Electricity Maps, 2024 zone average; IPCC 2014
-        value: 389.26
+        value: 390.24
       - _comment: used storage values greater than zero.
         datetime: '2025-01-01'
         source: Electricity Maps, 2025 zone average; IPCC 2014
-        value: 365.53
+        value: 366.28
     oil:
       - datetime: '2020-01-01'
         source: eGrid 2020; IPCC 2014
@@ -633,6 +633,11 @@ fallbackZoneMixes:
 has_day_ahead_price_license: false
 hide_day_ahead_price: false
 isLowCarbon:
+  battery discharge:
+    - datetime: '2024-01-01'
+      value: 0.3954
+    - datetime: '2025-01-01'
+      value: 0.4818
   hydro discharge:
     - datetime: '2020-01-01'
       value: 1.0
@@ -640,7 +645,18 @@ isLowCarbon:
       value: 0.5012
     - datetime: '2022-01-01'
       value: 0.4541
+    - datetime: '2023-01-01'
+      value: 0.5081
+    - datetime: '2024-01-01'
+      value: 0.4013
+    - datetime: '2025-01-01'
+      value: 0.4849
 isRenewable:
+  battery discharge:
+    - datetime: '2024-01-01'
+      value: 0.0536
+    - datetime: '2025-01-01'
+      value: 0.1245
   hydro discharge:
     - datetime: '2020-01-01'
       value: 1.0
@@ -648,6 +664,12 @@ isRenewable:
       value: 0.0288
     - datetime: '2022-01-01'
       value: 0.0267
+    - datetime: '2023-01-01'
+      value: 0.0212
+    - datetime: '2024-01-01'
+      value: 0.0503
+    - datetime: '2025-01-01'
+      value: 0.1143
 parsers:
   consumption: EIA.fetch_consumption
   consumptionForecast: EIA.fetch_consumption_forecast

--- a/config/zones/US-TEN-TVA.yaml
+++ b/config/zones/US-TEN-TVA.yaml
@@ -638,12 +638,16 @@ isLowCarbon:
       value: 1.0
     - datetime: '2021-01-01'
       value: 0.5012
+    - datetime: '2022-01-01'
+      value: 0.4541
 isRenewable:
   hydro discharge:
     - datetime: '2020-01-01'
       value: 1.0
     - datetime: '2021-01-01'
       value: 0.0288
+    - datetime: '2022-01-01'
+      value: 0.0267
 parsers:
   consumption: EIA.fetch_consumption
   consumptionForecast: EIA.fetch_consumption_forecast

--- a/config/zones/US-TEN-TVA.yaml
+++ b/config/zones/US-TEN-TVA.yaml
@@ -276,11 +276,11 @@ emissionFactors:
       - _comment: used non-null storage values
         datetime: '2024-01-01'
         source: Electricity Maps, 2024 zone average
-        value: 367.24
+        value: 367.12
       - _comment: used non-null storage values
         datetime: '2025-01-01'
         source: Electricity Maps, 2025 zone average
-        value: 342.92
+        value: 342.89
     biomass:
       - datetime: '2020-01-01'
         source: BEIS 2021
@@ -345,23 +345,23 @@ emissionFactors:
       - _comment: used storage values greater than zero.
         datetime: '2021-01-01'
         source: Electricity Maps, 2021 zone average
-        value: 332.71
+        value: 332.72
       - _comment: used storage values greater than zero.
         datetime: '2022-01-01'
         source: Electricity Maps, 2022 zone average
-        value: 364.52
+        value: 365.32
       - _comment: used storage values greater than zero.
         datetime: '2023-01-01'
         source: Electricity Maps, 2023 zone average
-        value: 326.29
+        value: 325.6
       - _comment: used storage values greater than zero.
         datetime: '2024-01-01'
         source: Electricity Maps, 2024 zone average
-        value: 366.24
+        value: 366.13
       - _comment: used storage values greater than zero.
         datetime: '2025-01-01'
         source: Electricity Maps, 2025 zone average
-        value: 342.28
+        value: 343.06
     oil:
       - datetime: '2020-01-01'
         source: eGrid 2020
@@ -383,11 +383,11 @@ emissionFactors:
       - _comment: used non-null storage values
         datetime: '2024-01-01'
         source: Electricity Maps, 2024 zone average; National Laboratory of the Rockies
-        value: 400.24
+        value: 400.12
       - _comment: used non-null storage values
         datetime: '2025-01-01'
         source: Electricity Maps, 2025 zone average; National Laboratory of the Rockies
-        value: 375.92
+        value: 375.89
     biomass:
       - _comment: Mean of all US zones
         datetime: '2020-01-01'
@@ -456,23 +456,23 @@ emissionFactors:
       - _comment: used storage values greater than zero.
         datetime: '2021-01-01'
         source: Electricity Maps, 2021 zone average; IPCC 2014
-        value: 356.71
+        value: 356.72
       - _comment: used storage values greater than zero.
         datetime: '2022-01-01'
         source: Electricity Maps, 2022 zone average; IPCC 2014
-        value: 388.52
+        value: 389.32
       - _comment: used storage values greater than zero.
         datetime: '2023-01-01'
         source: Electricity Maps, 2023 zone average; IPCC 2014
-        value: 350.29
+        value: 349.6
       - _comment: used storage values greater than zero.
         datetime: '2024-01-01'
         source: Electricity Maps, 2024 zone average; IPCC 2014
-        value: 390.24
+        value: 390.13
       - _comment: used storage values greater than zero.
         datetime: '2025-01-01'
         source: Electricity Maps, 2025 zone average; IPCC 2014
-        value: 366.28
+        value: 367.06
     oil:
       - datetime: '2020-01-01'
         source: eGrid 2020; IPCC 2014
@@ -644,19 +644,19 @@ isLowCarbon:
     - datetime: '2021-01-01'
       value: 0.5012
     - datetime: '2022-01-01'
-      value: 0.4541
+      value: 0.4537
     - datetime: '2023-01-01'
-      value: 0.5081
+      value: 0.509
     - datetime: '2024-01-01'
-      value: 0.4013
+      value: 0.4014
     - datetime: '2025-01-01'
-      value: 0.4849
+      value: 0.4834
 isRenewable:
   battery discharge:
     - datetime: '2024-01-01'
-      value: 0.0536
+      value: 0.0535
     - datetime: '2025-01-01'
-      value: 0.1245
+      value: 0.1246
   hydro discharge:
     - datetime: '2020-01-01'
       value: 1.0
@@ -665,11 +665,11 @@ isRenewable:
     - datetime: '2022-01-01'
       value: 0.0267
     - datetime: '2023-01-01'
-      value: 0.0212
+      value: 0.0211
     - datetime: '2024-01-01'
       value: 0.0503
     - datetime: '2025-01-01'
-      value: 0.1143
+      value: 0.114
 parsers:
   consumption: EIA.fetch_consumption
   consumptionForecast: EIA.fetch_consumption_forecast

--- a/config/zones/US-TEX-ERCO.yaml
+++ b/config/zones/US-TEX-ERCO.yaml
@@ -845,7 +845,7 @@ emissionFactors:
       - _comment: used storage values greater than zero.
         datetime: '2025-01-01'
         source: Electricity Maps, 2025 zone average
-        value: 268.59
+        value: 268.74
     biomass:
       - datetime: '2020-01-01'
         source: BEIS 2021
@@ -920,7 +920,7 @@ emissionFactors:
       - _comment: used storage values greater than zero.
         datetime: '2025-01-01'
         source: Electricity Maps, 2025 zone average; National Laboratory of the Rockies
-        value: 301.59
+        value: 301.74
     biomass:
       - _comment: Mean of all US zones
         datetime: '2020-01-01'
@@ -1137,6 +1137,14 @@ fallbackZoneMixes:
         wind: 0.24233286045039404
 has_day_ahead_price_license: false
 hide_day_ahead_price: false
+isLowCarbon:
+  battery discharge:
+    - datetime: '2025-01-01'
+      value: 0.5241
+isRenewable:
+  battery discharge:
+    - datetime: '2025-01-01'
+      value: 0.4362
 parsers:
   consumption: US_ERCOT.fetch_consumption
   consumptionForecast: US_ERCOT.fetch_consumption_forecast
@@ -1148,12 +1156,12 @@ parsers:
   realtimeLocationalMarginalPrice: US_ERCOT.fetch_realtime_locational_marginal_price
 region: Americas
 sources:
-  National Laboratory of the Rockies:
-    link: https://docs.nrel.gov/docs/fy21osti/80580.pdf
   INCER ACV:
     link: https://docs.google.com/spreadsheets/d/1w5DJ7sPen6axIHU8TCVcuzNCjlct4I6JAbhUlw-ZXu8/edit?usp=sharing
   IPCC 2014:
     link: https://www.ipcc.ch/site/assets/uploads/2018/02/ipcc_wg3_ar5_annex-iii.pdf#page=7
+  National Laboratory of the Rockies:
+    link: https://docs.nrel.gov/docs/fy21osti/80580.pdf
   eGrid 2020:
     link: https://drive.google.com/file/d/1_FAAuTtIdMuORZKsqHnd9vMNHlQgYarh/view?usp=sharing
   eGrid 2021:

--- a/config/zones/US.yaml
+++ b/config/zones/US.yaml
@@ -459,18 +459,32 @@ fallbackZoneMixes:
         solar: 0.036972927459937105
         unknown: 0.017414508337906885
         wind: 0.10517083862296002
-has_day_ahead_price_license: False
-hide_day_ahead_price: False
+has_day_ahead_price_license: false
+hide_day_ahead_price: false
+isLowCarbon:
+  battery discharge:
+    - datetime: '2020-01-01'
+      value: 0.4048
+  hydro discharge:
+    - datetime: '2020-01-01'
+      value: 0.4173
+isRenewable:
+  battery discharge:
+    - datetime: '2020-01-01'
+      value: 0.1972
+  hydro discharge:
+    - datetime: '2020-01-01'
+      value: 0.1971
 parsers:
   productionCapacity: EMBER.fetch_production_capacity
 region: Americas
 sources:
-  National Laboratory of the Rockies:
-    link: https://docs.nrel.gov/docs/fy21osti/80580.pdf
   INCER ACV:
     link: https://docs.google.com/spreadsheets/d/1w5DJ7sPen6axIHU8TCVcuzNCjlct4I6JAbhUlw-ZXu8/edit?usp=sharing
   IPCC 2014:
     link: https://www.ipcc.ch/site/assets/uploads/2018/02/ipcc_wg3_ar5_annex-iii.pdf#page=7
+  National Laboratory of the Rockies:
+    link: https://docs.nrel.gov/docs/fy21osti/80580.pdf
   eGrid 2020:
     link: https://drive.google.com/file/d/1_FAAuTtIdMuORZKsqHnd9vMNHlQgYarh/view?usp=sharing
   eGrid 2021:

--- a/config/zones/US.yaml
+++ b/config/zones/US.yaml
@@ -465,16 +465,24 @@ isLowCarbon:
   battery discharge:
     - datetime: '2020-01-01'
       value: 0.4048
+    - datetime: '2021-01-01'
+      value: 0.3947
   hydro discharge:
     - datetime: '2020-01-01'
       value: 0.4173
+    - datetime: '2021-01-01'
+      value: 0.406
 isRenewable:
   battery discharge:
     - datetime: '2020-01-01'
       value: 0.1972
+    - datetime: '2021-01-01'
+      value: 0.2006
   hydro discharge:
     - datetime: '2020-01-01'
       value: 0.1971
+    - datetime: '2021-01-01'
+      value: 0.2012
 parsers:
   productionCapacity: EMBER.fetch_production_capacity
 region: Americas

--- a/config/zones/US.yaml
+++ b/config/zones/US.yaml
@@ -467,22 +467,30 @@ isLowCarbon:
       value: 0.4048
     - datetime: '2021-01-01'
       value: 0.3947
+    - datetime: '2022-01-01'
+      value: 0.4081
   hydro discharge:
     - datetime: '2020-01-01'
       value: 0.4173
     - datetime: '2021-01-01'
       value: 0.406
+    - datetime: '2022-01-01'
+      value: 0.4175
 isRenewable:
   battery discharge:
     - datetime: '2020-01-01'
       value: 0.1972
     - datetime: '2021-01-01'
       value: 0.2006
+    - datetime: '2022-01-01'
+      value: 0.2195
   hydro discharge:
     - datetime: '2020-01-01'
       value: 0.1971
     - datetime: '2021-01-01'
       value: 0.2012
+    - datetime: '2022-01-01'
+      value: 0.2166
 parsers:
   productionCapacity: EMBER.fetch_production_capacity
 region: Americas

--- a/config/zones/US.yaml
+++ b/config/zones/US.yaml
@@ -469,6 +469,12 @@ isLowCarbon:
       value: 0.3947
     - datetime: '2022-01-01'
       value: 0.4081
+    - datetime: '2023-01-01'
+      value: 0.4116
+    - datetime: '2024-01-01'
+      value: 0.4237
+    - datetime: '2025-01-01'
+      value: 0.4392
   hydro discharge:
     - datetime: '2020-01-01'
       value: 0.4173
@@ -476,6 +482,12 @@ isLowCarbon:
       value: 0.406
     - datetime: '2022-01-01'
       value: 0.4175
+    - datetime: '2023-01-01'
+      value: 0.4077
+    - datetime: '2024-01-01'
+      value: 0.4205
+    - datetime: '2025-01-01'
+      value: 0.4334
 isRenewable:
   battery discharge:
     - datetime: '2020-01-01'
@@ -484,6 +496,12 @@ isRenewable:
       value: 0.2006
     - datetime: '2022-01-01'
       value: 0.2195
+    - datetime: '2023-01-01'
+      value: 0.2213
+    - datetime: '2024-01-01'
+      value: 0.2402
+    - datetime: '2025-01-01'
+      value: 0.2586
   hydro discharge:
     - datetime: '2020-01-01'
       value: 0.1971
@@ -491,6 +509,12 @@ isRenewable:
       value: 0.2012
     - datetime: '2022-01-01'
       value: 0.2166
+    - datetime: '2023-01-01'
+      value: 0.2088
+    - datetime: '2024-01-01'
+      value: 0.2217
+    - datetime: '2025-01-01'
+      value: 0.2359
 parsers:
   productionCapacity: EMBER.fetch_production_capacity
 region: Americas

--- a/config/zones/US.yaml
+++ b/config/zones/US.yaml
@@ -230,23 +230,23 @@ emissionFactors:
       - _comment: used storage values greater than zero.
         datetime: '2021-01-01'
         source: Electricity Maps, 2021 zone average
-        value: 381.29
+        value: 377.97
       - _comment: used storage values greater than zero.
         datetime: '2022-01-01'
         source: Electricity Maps, 2022 zone average
-        value: 363.26
+        value: 361.05
       - _comment: used storage values greater than zero.
         datetime: '2023-01-01'
         source: Electricity Maps, 2023 zone average
-        value: 340.62
+        value: 340.32
       - _comment: used storage values greater than zero.
         datetime: '2024-01-01'
         source: Electricity Maps, 2024 zone average
-        value: 329.42
+        value: 328.47
       - _comment: used storage values greater than zero.
         datetime: '2025-01-01'
         source: Electricity Maps, 2025 zone average
-        value: 330.63
+        value: 330.7
     biomass:
       datetime: '2020-01-01'
       source: eGrid 2020
@@ -267,27 +267,27 @@ emissionFactors:
       - _comment: used storage values greater than zero.
         datetime: '2020-01-01'
         source: Electricity Maps, 2020 zone average
-        value: 353.42
+        value: 353.31
       - _comment: used storage values greater than zero.
         datetime: '2021-01-01'
         source: Electricity Maps, 2021 zone average
-        value: 378.82
+        value: 374.73
       - _comment: used storage values greater than zero.
         datetime: '2022-01-01'
         source: Electricity Maps, 2022 zone average
-        value: 360.64
+        value: 359.12
       - _comment: used storage values greater than zero.
         datetime: '2023-01-01'
         source: Electricity Maps, 2023 zone average
-        value: 343.72
+        value: 339.4
       - _comment: used storage values greater than zero.
         datetime: '2024-01-01'
         source: Electricity Maps, 2024 zone average
-        value: 332.64
+        value: 327.53
       - _comment: used storage values greater than zero.
         datetime: '2025-01-01'
         source: Electricity Maps, 2025 zone average
-        value: 335.24
+        value: 334.83
     oil:
       datetime: '2021-01-01'
       source: eGrid 2020
@@ -301,23 +301,23 @@ emissionFactors:
       - _comment: used storage values greater than zero.
         datetime: '2021-01-01'
         source: Electricity Maps, 2021 zone average; National Laboratory of the Rockies
-        value: 414.29
+        value: 410.97
       - _comment: used storage values greater than zero.
         datetime: '2022-01-01'
         source: Electricity Maps, 2022 zone average; National Laboratory of the Rockies
-        value: 396.26
+        value: 394.05
       - _comment: used storage values greater than zero.
         datetime: '2023-01-01'
         source: Electricity Maps, 2023 zone average; National Laboratory of the Rockies
-        value: 373.62
+        value: 373.32
       - _comment: used storage values greater than zero.
         datetime: '2024-01-01'
         source: Electricity Maps, 2024 zone average; National Laboratory of the Rockies
-        value: 362.42
+        value: 361.47
       - _comment: used storage values greater than zero.
         datetime: '2025-01-01'
         source: Electricity Maps, 2025 zone average; National Laboratory of the Rockies
-        value: 363.63
+        value: 363.7
     biomass:
       datetime: '2020-01-01'
       source: eGrid 2020
@@ -338,27 +338,27 @@ emissionFactors:
       - _comment: used storage values greater than zero.
         datetime: '2020-01-01'
         source: Electricity Maps, 2020 zone average; IPCC 2014
-        value: 377.42
+        value: 377.31
       - _comment: used storage values greater than zero.
         datetime: '2021-01-01'
         source: Electricity Maps, 2021 zone average; IPCC 2014
-        value: 402.82
+        value: 398.73
       - _comment: used storage values greater than zero.
         datetime: '2022-01-01'
         source: Electricity Maps, 2022 zone average; IPCC 2014
-        value: 384.64
+        value: 383.12
       - _comment: used storage values greater than zero.
         datetime: '2023-01-01'
         source: Electricity Maps, 2023 zone average; IPCC 2014
-        value: 367.72
+        value: 363.4
       - _comment: used storage values greater than zero.
         datetime: '2024-01-01'
         source: Electricity Maps, 2024 zone average; IPCC 2014
-        value: 356.64
+        value: 351.53
       - _comment: used storage values greater than zero.
         datetime: '2025-01-01'
         source: Electricity Maps, 2025 zone average; IPCC 2014
-        value: 359.24
+        value: 358.83
     oil:
       datetime: '2021-01-01'
       source: eGrid 2020; IPCC 2014
@@ -466,55 +466,55 @@ isLowCarbon:
     - datetime: '2020-01-01'
       value: 0.4048
     - datetime: '2021-01-01'
-      value: 0.3947
+      value: 0.3991
     - datetime: '2022-01-01'
-      value: 0.4081
+      value: 0.4122
     - datetime: '2023-01-01'
-      value: 0.4116
+      value: 0.4112
     - datetime: '2024-01-01'
-      value: 0.4237
+      value: 0.4255
     - datetime: '2025-01-01'
       value: 0.4392
   hydro discharge:
     - datetime: '2020-01-01'
-      value: 0.4173
+      value: 0.4174
     - datetime: '2021-01-01'
-      value: 0.406
+      value: 0.4112
     - datetime: '2022-01-01'
-      value: 0.4175
+      value: 0.4202
     - datetime: '2023-01-01'
-      value: 0.4077
+      value: 0.4139
     - datetime: '2024-01-01'
-      value: 0.4205
+      value: 0.4264
     - datetime: '2025-01-01'
-      value: 0.4334
+      value: 0.4348
 isRenewable:
   battery discharge:
     - datetime: '2020-01-01'
       value: 0.1972
     - datetime: '2021-01-01'
-      value: 0.2006
+      value: 0.2025
     - datetime: '2022-01-01'
-      value: 0.2195
+      value: 0.2221
     - datetime: '2023-01-01'
-      value: 0.2213
+      value: 0.22
     - datetime: '2024-01-01'
-      value: 0.2402
+      value: 0.2411
     - datetime: '2025-01-01'
-      value: 0.2586
+      value: 0.2585
   hydro discharge:
     - datetime: '2020-01-01'
       value: 0.1971
     - datetime: '2021-01-01'
-      value: 0.2012
+      value: 0.2036
     - datetime: '2022-01-01'
-      value: 0.2166
+      value: 0.2186
     - datetime: '2023-01-01'
-      value: 0.2088
+      value: 0.2102
     - datetime: '2024-01-01'
-      value: 0.2217
+      value: 0.2243
     - datetime: '2025-01-01'
-      value: 0.2359
+      value: 0.2371
 parsers:
   productionCapacity: EMBER.fetch_production_capacity
 region: Americas

--- a/config/zones/ZA.yaml
+++ b/config/zones/ZA.yaml
@@ -308,22 +308,28 @@ fallbackZoneMixes:
         solar: 0.031763672924306964
         unknown: 0.0
         wind: 0.05303024755245981
-has_day_ahead_price_license: False
-hide_day_ahead_price: False
+has_day_ahead_price_license: false
+hide_day_ahead_price: false
 isLowCarbon:
+  hydro discharge:
+    - datetime: '2020-01-01'
+      value: 0.1307
   unknown:
     value: 1
 isRenewable:
+  hydro discharge:
+    - datetime: '2020-01-01'
+      value: 0.078
   unknown:
     value: 1
 parsers:
   production: ESKOM.fetch_production
   productionCapacity: EMBER.fetch_production_capacity
 region: Africa
-timezone: Africa/Johannesburg
-zone_name: South Africa
 sources:
   IPCC 2014:
     link: https://www.ipcc.ch/site/assets/uploads/2018/02/ipcc_wg3_ar5_annex-iii.pdf#page=7
   National Laboratory of the Rockies:
     link: https://docs.nrel.gov/docs/fy21osti/80580.pdf
+timezone: Africa/Johannesburg
+zone_name: South Africa

--- a/config/zones/ZA.yaml
+++ b/config/zones/ZA.yaml
@@ -314,12 +314,16 @@ isLowCarbon:
   hydro discharge:
     - datetime: '2020-01-01'
       value: 0.1307
+    - datetime: '2021-01-01'
+      value: 0.1472
   unknown:
     value: 1
 isRenewable:
   hydro discharge:
     - datetime: '2020-01-01'
       value: 0.078
+    - datetime: '2021-01-01'
+      value: 0.0932
   unknown:
     value: 1
 parsers:

--- a/config/zones/ZA.yaml
+++ b/config/zones/ZA.yaml
@@ -316,6 +316,8 @@ isLowCarbon:
       value: 0.1307
     - datetime: '2021-01-01'
       value: 0.1472
+    - datetime: '2022-01-01'
+      value: 0.1504
   unknown:
     value: 1
 isRenewable:
@@ -324,6 +326,8 @@ isRenewable:
       value: 0.078
     - datetime: '2021-01-01'
       value: 0.0932
+    - datetime: '2022-01-01'
+      value: 0.1039
   unknown:
     value: 1
 parsers:

--- a/config/zones/ZA.yaml
+++ b/config/zones/ZA.yaml
@@ -129,7 +129,7 @@ emissionFactors:
       - _comment: used storage values greater than zero.
         datetime: '2025-01-01'
         source: Electricity Maps, 2025 zone average
-        value: 644.62
+        value: 644.38
   lifecycle:
     hydro discharge:
       - _comment: used storage values greater than zero.
@@ -155,7 +155,7 @@ emissionFactors:
       - _comment: used storage values greater than zero.
         datetime: '2025-01-01'
         source: Electricity Maps, 2025 zone average; IPCC 2014
-        value: 668.62
+        value: 668.38
 fallbackZoneMixes:
   powerOriginRatios:
     - _source: Electricity Maps, 2015 average
@@ -318,6 +318,12 @@ isLowCarbon:
       value: 0.1472
     - datetime: '2022-01-01'
       value: 0.1504
+    - datetime: '2023-01-01'
+      value: 0.1532
+    - datetime: '2024-01-01'
+      value: 0.1281
+    - datetime: '2025-01-01'
+      value: 0.1465
   unknown:
     value: 1
 isRenewable:
@@ -328,6 +334,12 @@ isRenewable:
       value: 0.0932
     - datetime: '2022-01-01'
       value: 0.1039
+    - datetime: '2023-01-01'
+      value: 0.1136
+    - datetime: '2024-01-01'
+      value: 0.0878
+    - datetime: '2025-01-01'
+      value: 0.0923
   unknown:
     value: 1
 parsers:

--- a/config/zones/ZA.yaml
+++ b/config/zones/ZA.yaml
@@ -113,23 +113,23 @@ emissionFactors:
       - _comment: used storage values greater than zero.
         datetime: '2021-01-01'
         source: Electricity Maps, 2021 zone average
-        value: 641.08
+        value: 641.14
       - _comment: used storage values greater than zero.
         datetime: '2022-01-01'
         source: Electricity Maps, 2022 zone average
-        value: 637.55
+        value: 637.6
       - _comment: used storage values greater than zero.
         datetime: '2023-01-01'
         source: Electricity Maps, 2023 zone average
-        value: 631.99
+        value: 636.0
       - _comment: used storage values greater than zero.
         datetime: '2024-01-01'
         source: Electricity Maps, 2024 zone average
-        value: 658.28
+        value: 658.32
       - _comment: used storage values greater than zero.
         datetime: '2025-01-01'
         source: Electricity Maps, 2025 zone average
-        value: 644.38
+        value: 646.53
   lifecycle:
     hydro discharge:
       - _comment: used storage values greater than zero.
@@ -139,23 +139,23 @@ emissionFactors:
       - _comment: used storage values greater than zero.
         datetime: '2021-01-01'
         source: Electricity Maps, 2021 zone average; IPCC 2014
-        value: 665.08
+        value: 665.14
       - _comment: used storage values greater than zero.
         datetime: '2022-01-01'
         source: Electricity Maps, 2022 zone average; IPCC 2014
-        value: 661.55
+        value: 661.6
       - _comment: used storage values greater than zero.
         datetime: '2023-01-01'
         source: Electricity Maps, 2023 zone average; IPCC 2014
-        value: 655.99
+        value: 660.0
       - _comment: used storage values greater than zero.
         datetime: '2024-01-01'
         source: Electricity Maps, 2024 zone average; IPCC 2014
-        value: 682.28
+        value: 682.32
       - _comment: used storage values greater than zero.
         datetime: '2025-01-01'
         source: Electricity Maps, 2025 zone average; IPCC 2014
-        value: 668.38
+        value: 670.53
 fallbackZoneMixes:
   powerOriginRatios:
     - _source: Electricity Maps, 2015 average
@@ -319,11 +319,11 @@ isLowCarbon:
     - datetime: '2022-01-01'
       value: 0.1504
     - datetime: '2023-01-01'
-      value: 0.1532
+      value: 0.1503
     - datetime: '2024-01-01'
       value: 0.1281
     - datetime: '2025-01-01'
-      value: 0.1465
+      value: 0.1435
   unknown:
     value: 1
 isRenewable:
@@ -335,11 +335,11 @@ isRenewable:
     - datetime: '2022-01-01'
       value: 0.1039
     - datetime: '2023-01-01'
-      value: 0.1136
+      value: 0.1091
     - datetime: '2024-01-01'
       value: 0.0878
     - datetime: '2025-01-01'
-      value: 0.0923
+      value: 0.0907
   unknown:
     value: 1
 parsers:

--- a/electricitymap/contrib/parsers/tests/__snapshots__/test_config.ambr
+++ b/electricitymap/contrib/parsers/tests/__snapshots__/test_config.ambr
@@ -9,7 +9,7 @@
         }),
         'battery discharge': dict({
           'source': 'IPCC 2014',
-          'value': 50.04,
+          'value': 48.2,
         }),
         'biomass': dict({
           'source': 'IPCC 2014',
@@ -37,7 +37,7 @@
         }),
         'hydro discharge': dict({
           'source': 'IPCC 2014',
-          'value': 22.3,
+          'value': 21.06,
         }),
         'nuclear': dict({
           'source': 'IPCC 2014',
@@ -103,7 +103,7 @@
         }),
         'hydro discharge': dict({
           'source': 'IPCC 2014',
-          'value': 377.41,
+          'value': 377.42,
         }),
         'nuclear': dict({
           'source': 'IPCC 2014',

--- a/electricitymap/contrib/parsers/tests/__snapshots__/test_config.ambr
+++ b/electricitymap/contrib/parsers/tests/__snapshots__/test_config.ambr
@@ -9,7 +9,7 @@
         }),
         'battery discharge': dict({
           'source': 'IPCC 2014',
-          'value': 48.2,
+          'value': 48.13,
         }),
         'biomass': dict({
           'source': 'IPCC 2014',
@@ -103,7 +103,7 @@
         }),
         'hydro discharge': dict({
           'source': 'IPCC 2014',
-          'value': 377.42,
+          'value': 377.43,
         }),
         'nuclear': dict({
           'source': 'IPCC 2014',


### PR DESCRIPTION
Note that some of the emission factors have also changed (if only slightly). This is because both these numbers are calculated by the same script due to them both having the same source data. I think it's better that these numbers are always in-sync.

The only noticeable change is battery discharge for HR - that is because it had a global number before while now it has a zonal number for battery discharge in 2025 -> when a zone gets a specific factor that factor is used for all emission calculation the for that mode. In practice this has little effect outside the year the factor is defined for because the fuel doesn't show up outside that year.

Also I'm skipping impact analysis for this change because the numbers are "more correct" by definition and because cfe% and re% are less important from our clients perspective (edited)