### PR TITLE
feat(config): add can_have_zero_production in zone_config

### DIFF
--- a/config/zones/AX.yaml
+++ b/config/zones/AX.yaml
@@ -3,6 +3,7 @@ bounding_box:
     - 59.40448639500012
   - - 21.59669030000012
     - 60.98078034100014
+can_have_zero_production: true
 capacity:
   coal: 0
   gas: 0

--- a/config/zones/CA-PE.yaml
+++ b/config/zones/CA-PE.yaml
@@ -3,6 +3,7 @@ bounding_box:
     - 45.4507510440001
   - - -61.47695878799993
     - 47.567328192000076
+can_have_zero_production: true
 capacity:
   oil: 179
   wind: 203.6

--- a/config/zones/DK-BHM.yaml
+++ b/config/zones/DK-BHM.yaml
@@ -3,6 +3,7 @@ bounding_box:
     - 54.9
   - - 15.2
     - 55.2
+can_have_zero_production: true
 capacity:
   wind: 30
 contributors:

--- a/config/zones/ES-IB-FO.yaml
+++ b/config/zones/ES-IB-FO.yaml
@@ -3,6 +3,7 @@ bounding_box:
     - 38.1386463070001
   - - 2.082367384000122
     - 39.25535716400017
+can_have_zero_production: true
 contributors:
   - hectorespert
   - systemcatch

--- a/config/zones/ES-IB-IZ.yaml
+++ b/config/zones/ES-IB-IZ.yaml
@@ -3,6 +3,7 @@ bounding_box:
     - 38.33180940700015
   - - 2.123057488000086
     - 39.618882554000066
+can_have_zero_production: true
 contributors:
   - hectorespert
   - systemcatch

--- a/config/zones/ME.yaml
+++ b/config/zones/ME.yaml
@@ -3,6 +3,7 @@ bounding_box:
     - 41.87755
   - - 20.3398
     - 43.52384
+can_have_zero_production: true
 capacity:
   coal:
     - datetime: '2017-01-01'

--- a/config/zones/US-CAR-YAD.yaml
+++ b/config/zones/US-CAR-YAD.yaml
@@ -3,6 +3,7 @@ bounding_box:
     - 34.797960281
   - - -79.4523525239999
     - 36.2042064670001
+can_have_zero_production: true
 capacity:
   battery storage:
     - datetime: '2017-01-01'

--- a/config/zones/US-FLA-HST.yaml
+++ b/config/zones/US-FLA-HST.yaml
@@ -3,6 +3,7 @@ bounding_box:
     - 24.6374500000001
   - - -79.61802
     - 26.47902
+can_have_zero_production: true
 capacity:
   battery storage:
     - datetime: '2017-01-01'

--- a/config/zones/US-NW-GRID.yaml
+++ b/config/zones/US-NW-GRID.yaml
@@ -3,6 +3,7 @@ bounding_box:
     - 44.7463779450001
   - - -118.363136292
     - 46.366308212
+can_have_zero_production: true
 capacity:
   battery storage:
     - datetime: '2021-01-01'

--- a/config/zones/US-SE-SEPA.yaml
+++ b/config/zones/US-SE-SEPA.yaml
@@ -3,6 +3,7 @@ bounding_box:
     - 30.211187
   - - -83.357543
     - 33.075117
+can_have_zero_production: true
 capacity:
   battery storage:
     - datetime: '2017-01-01'

--- a/electricitymap/contrib/config/model.py
+++ b/electricitymap/contrib/config/model.py
@@ -136,6 +136,7 @@ class Zone(StrictBaseModelWithAlias):
     disclaimer: str | None
     parsers: Parsers = Parsers()
     generation_only: bool | None
+    can_have_zero_production: bool | None
     has_day_ahead_price_license: bool | None
     hide_day_ahead_price: bool | None
     sub_zone_names: list[ZoneKey] | None = Field(None, alias="subZoneNames")


### PR DESCRIPTION
## Description

We have an internal list of zones for which we allow 0 production. Let's move this information here to keep things centralized. 

See PR https://github.com/electricitymaps/electricitymaps-contrib/issues/2483 for details about some of those zones. 
US-FLA-HST imports all of its needs from US-FLA-FPL and on rare occasions they use gas turbines if the import is insufficient.
See internal change here : https://github.com/electricitymaps/electricitymaps/pull/11364

### Preview

<!-- Please add screenshots and/or gif that shows visual changes (if applicable) -->

### Double check

- [ ] I have tested my parser changes locally with `uv run test_parser "zone_key"`
- [x] I have run `pnpx prettier@2 --write .` and `uv run format` in the top level directory to format my changes.
