### PR TITLE
Create NESO parser and make gb use it

### DIFF
--- a/config/zones/GB.yaml
+++ b/config/zones/GB.yaml
@@ -450,7 +450,7 @@ parsers:
   consumptionForecast: ENTSOE.fetch_consumption_forecast
   generationForecast: ENTSOE.fetch_generation_forecast
   price: NORDPOOL.fetch_price
-  production: ELEXON.fetch_production
+  production: NESO.fetch_production
   productionCapacity: GB.fetch_production_capacity
   productionPerModeForecast: ENTSOE.fetch_wind_solar_forecasts
 region: Europe

--- a/electricitymap/contrib/parsers/NESO.py
+++ b/electricitymap/contrib/parsers/NESO.py
@@ -68,8 +68,8 @@ def fetch_production(
 
     obj = res.json()["result"]["records"]
 
+    production_list = ProductionBreakdownList(logger=logger)
     for row in obj:
-        production_list = ProductionBreakdownList(logger=logger)
         production_mix = ProductionMix()
 
         for neso_key, emaps_key in NESO_TO_PRODUCTION_MIX_MAPPING.items():

--- a/electricitymap/contrib/parsers/NESO.py
+++ b/electricitymap/contrib/parsers/NESO.py
@@ -17,7 +17,7 @@ NESO_GENERATION_DATASET_ID = "f93d1835-75bc-43e5-84ad-12472b180a98"
 
 def fetch_production(
     zone_key: ZoneKey,
-    session: Session = Session(),
+    session: Session | None = None,
     target_datetime: datetime | None = None,
     logger: Logger = getLogger(__name__),
 ) -> list[dict] | dict:

--- a/electricitymap/contrib/parsers/NESO.py
+++ b/electricitymap/contrib/parsers/NESO.py
@@ -2,7 +2,6 @@ from datetime import datetime, timedelta
 from logging import Logger, getLogger
 from zoneinfo import ZoneInfo
 
-# The request library is used to fetch content through HTTP
 from requests import Response, Session
 
 from electricitymap.contrib.lib.models.event_lists import (
@@ -13,6 +12,7 @@ from electricitymap.contrib.lib.types import ZoneKey
 from electricitymap.contrib.parsers.lib.exceptions import ParserException
 
 NESO_API = "https://api.neso.energy/api/3/action/datastore_search_sql"
+NESO_GENERATION_DATASET_ID = "f93d1835-75bc-43e5-84ad-12472b180a98"
 
 
 def fetch_production(
@@ -21,63 +21,23 @@ def fetch_production(
     target_datetime: datetime | None = None,
     logger: Logger = getLogger(__name__),
 ) -> list[dict] | dict:
-    """
-        Requests the last known production mix (in MW) of a given country.
-
-        Arguments:
-        ----------
-        zone_key: used in case a parser is able to fetch multiple countries
-        session: request session passed in order to re-use an existing session
-        target_datetime: the datetime for which we want production data. If not
-          provided, we should default it to now. If past data is not available,
-          raise a ParserException. Beware that the provided target_datetime is
-          UTC. To convert to local timezone, you can use
-          `target_datetime = target_datetime.astimezone(tz=ZoneInfo('America/New_York'))`.
-        logger: an instance of a `logging.Logger` that will be passed by the
-          backend. Information logged will be publicly available so that correct
-          execution of the logger can be checked. All Exceptions will automatically
-          be logged, so when something's wrong, simply raise an Exception (with an
-          explicit text). Use `logger.warning` or `logger.info` for information
-          that can useful to check if the parser is working correctly. A default
-          logger is used so that logger output can be seen when coding / debugging.
-
-        Returns:
-        --------
-        If no data can be fetched, any falsy value (None, [], False) will be
-          ignored by the backend. If there is no data because the source may have
-          changed or is not available, raise an ParserException.
-
-        A  ProductionBreakdownList should be returned containing all ProductionBreakdown
-        events. Each ProductionBreakdown event should contain a datetime, a zoneKey,
-        a ProductionMix, a source and optionally a StorageMix.
-        The ProductionMix should contain the production breakdown for each fuel type.
-
-    -     A  ProductionBreakdownList contains all ProductionBreakdown events.
-    -     Each ProductionBreakdown event contains a datetime, a zoneKey,
-       a ProductionMix, a source and optionally a StorageMix.
-    -     The ProductionMix contains the production breakdown for each fuel type.
-    -     The StorageMix contains the storage breakdown for each storage type.
-
-
-    """
-
     if target_datetime is None:
-        target_datetime = datetime.now(tz=ZoneInfo("UTC"))
+        start_datetime = datetime.now(tz=ZoneInfo("UTC")) - timedelta(hours=24)
+        sql_query = f"""SELECT * FROM "{NESO_GENERATION_DATASET_ID}" WHERE "DATETIME" >= '{start_datetime.strftime("%Y-%m-%d")}' ORDER BY "DATETIME" ASC"""
+
     elif target_datetime > datetime(year=2009, month=1, day=1):
-        # WHEN HISTORICAL DATA IS AVAILABLE
-        # convert target datetime to local datetime
-        target_datetime = target_datetime.astimezone(ZoneInfo("London"))
+        target_datetime = target_datetime.astimezone(ZoneInfo("Europe/London"))
+        start_datetime = target_datetime - timedelta(hours=24)
+        end_datetime = target_datetime + timedelta(hours=24)
+
+        sql_query = f"""SELECT * FROM "{NESO_GENERATION_DATASET_ID}" WHERE "DATETIME" >= '{start_datetime.strftime("%Y-%m-%d")}' AND "DATETIME" <= '{end_datetime.strftime("%Y-%m-%d")}' ORDER BY "DATETIME" ASC"""
     else:
-        # WHEN HISTORICAL DATA IS NOT AVAILABLE
         raise ParserException(
             "example_parser.py",
             "This parser is not yet able to parse dates before 2009-01-01",
             zone_key,
         )
 
-    start_datetime = target_datetime - timedelta(days=1)
-
-    sql_query = f"""SELECT * FROM  "f93d1835-75bc-43e5-84ad-12472b180a98" WHERE "DATETIME" >= '{start_datetime.strftime("%Y-%m-%d")}' AND "DATETIME" < '{target_datetime.strftime("%Y-%m-%d")}' ORDER BY "DATETIME" ASC"""
     params = {"sql": sql_query}
 
     res: Response = session.get(NESO_API, params=params)
@@ -88,49 +48,26 @@ def fetch_production(
             zone_key,
         )
 
-    obj = res.json()
-
+    obj = res.json()["result"]["records"]
     production_list = ProductionBreakdownList(logger=logger)
 
-    for item in obj["productionMix"]:
-        # You can create the production mix directly
+    for item in obj:
         production_list.append(
             zoneKey=zone_key,
-            datetime=datetime.fromisoformat(item["datetime"]),
-            production=ProductionMix(
-                biomass=item["biomass"],
-                coal=item["coal"],
-                gas=item["gas"],
-                hydro=item["hydro"],
-                nuclear=item["nuclear"],
-                oil=item["oil"],
-                solar=item["solar"],
-                wind=item["wind"],
-                geothermal=item["geothermal"],
-                unknown=(
-                    item["unknown"]
-                    if item["unknown"] > 0
-                    else 0 + item["other"]
-                    if item["other"] > 0
-                    else 0
-                ),
+            datetime=datetime.fromisoformat(item["DATETIME"]).replace(
+                tzinfo=ZoneInfo("UTC")
             ),
-            storage=StorageMix(hydro=item["hydroStorage"] * -1),
-            source="someservice.com",
+            production=ProductionMix(
+                biomass=float(item["BIOMASS"]),
+                coal=float(item["COAL"]),
+                gas=float(item["GAS"]),
+                hydro=float(item["HYDRO"]),
+                nuclear=float(item["NUCLEAR"]),
+                solar=float(item["SOLAR"]),
+                wind=float(item["WIND"]) + float(item["WIND_EMB"]),
+                unknown=(float(item["OTHER"])),
+            ),
+            storage=StorageMix(hydro=float(item["STORAGE"]) * -1),
+            source="neso.energy",
         )
-        # Or you can create the production mix and fill it later.
-        production_mix = ProductionMix()
-        for mode, value in item.items():
-            production_mix.add_value(mode, value)
-        production_list.append(
-            zoneKey=zone_key,
-            datetime=datetime.fromisoformat(item["datetime"]),
-            production=production_mix,
-            storage=StorageMix(hydro=item["hydroStorage"] * -1),
-            source="someservice.com",
-        )
-    # For now we should return a list of dictionaries
-    # and therefore we convert the ProductionBreakdownList to a list
-    # using the to_list() method.
-    # In the future we will return a ProductionBreakdownList directly.
     return production_list.to_list()

--- a/electricitymap/contrib/parsers/NESO.py
+++ b/electricitymap/contrib/parsers/NESO.py
@@ -1,0 +1,136 @@
+from datetime import datetime, timedelta
+from logging import Logger, getLogger
+from zoneinfo import ZoneInfo
+
+# The request library is used to fetch content through HTTP
+from requests import Response, Session
+
+from electricitymap.contrib.lib.models.event_lists import (
+    ProductionBreakdownList,
+)
+from electricitymap.contrib.lib.models.events import ProductionMix, StorageMix
+from electricitymap.contrib.lib.types import ZoneKey
+from electricitymap.contrib.parsers.lib.exceptions import ParserException
+
+NESO_API = "https://api.neso.energy/api/3/action/datastore_search_sql"
+
+
+def fetch_production(
+    zone_key: ZoneKey,
+    session: Session = Session(),
+    target_datetime: datetime | None = None,
+    logger: Logger = getLogger(__name__),
+) -> list[dict] | dict:
+    """
+        Requests the last known production mix (in MW) of a given country.
+
+        Arguments:
+        ----------
+        zone_key: used in case a parser is able to fetch multiple countries
+        session: request session passed in order to re-use an existing session
+        target_datetime: the datetime for which we want production data. If not
+          provided, we should default it to now. If past data is not available,
+          raise a ParserException. Beware that the provided target_datetime is
+          UTC. To convert to local timezone, you can use
+          `target_datetime = target_datetime.astimezone(tz=ZoneInfo('America/New_York'))`.
+        logger: an instance of a `logging.Logger` that will be passed by the
+          backend. Information logged will be publicly available so that correct
+          execution of the logger can be checked. All Exceptions will automatically
+          be logged, so when something's wrong, simply raise an Exception (with an
+          explicit text). Use `logger.warning` or `logger.info` for information
+          that can useful to check if the parser is working correctly. A default
+          logger is used so that logger output can be seen when coding / debugging.
+
+        Returns:
+        --------
+        If no data can be fetched, any falsy value (None, [], False) will be
+          ignored by the backend. If there is no data because the source may have
+          changed or is not available, raise an ParserException.
+
+        A  ProductionBreakdownList should be returned containing all ProductionBreakdown
+        events. Each ProductionBreakdown event should contain a datetime, a zoneKey,
+        a ProductionMix, a source and optionally a StorageMix.
+        The ProductionMix should contain the production breakdown for each fuel type.
+
+    -     A  ProductionBreakdownList contains all ProductionBreakdown events.
+    -     Each ProductionBreakdown event contains a datetime, a zoneKey,
+       a ProductionMix, a source and optionally a StorageMix.
+    -     The ProductionMix contains the production breakdown for each fuel type.
+    -     The StorageMix contains the storage breakdown for each storage type.
+
+
+    """
+
+    if target_datetime is None:
+        target_datetime = datetime.now(tz=ZoneInfo("UTC"))
+    elif target_datetime > datetime(year=2009, month=1, day=1):
+        # WHEN HISTORICAL DATA IS AVAILABLE
+        # convert target datetime to local datetime
+        target_datetime = target_datetime.astimezone(ZoneInfo("London"))
+    else:
+        # WHEN HISTORICAL DATA IS NOT AVAILABLE
+        raise ParserException(
+            "example_parser.py",
+            "This parser is not yet able to parse dates before 2009-01-01",
+            zone_key,
+        )
+
+    start_datetime = target_datetime - timedelta(days=1)
+
+    sql_query = f"""SELECT * FROM  "f93d1835-75bc-43e5-84ad-12472b180a98" WHERE "DATETIME" >= '{start_datetime.strftime("%Y-%m-%d")}' AND "DATETIME" < '{target_datetime.strftime("%Y-%m-%d")}' ORDER BY "DATETIME" ASC"""
+    params = {"sql": sql_query}
+
+    res: Response = session.get(NESO_API, params=params)
+    if not res.status_code == 200:
+        raise ParserException(
+            "example_parser.py",
+            f"Exception when fetching production error code: {res.status_code}: {res.text}",
+            zone_key,
+        )
+
+    obj = res.json()
+
+    production_list = ProductionBreakdownList(logger=logger)
+
+    for item in obj["productionMix"]:
+        # You can create the production mix directly
+        production_list.append(
+            zoneKey=zone_key,
+            datetime=datetime.fromisoformat(item["datetime"]),
+            production=ProductionMix(
+                biomass=item["biomass"],
+                coal=item["coal"],
+                gas=item["gas"],
+                hydro=item["hydro"],
+                nuclear=item["nuclear"],
+                oil=item["oil"],
+                solar=item["solar"],
+                wind=item["wind"],
+                geothermal=item["geothermal"],
+                unknown=(
+                    item["unknown"]
+                    if item["unknown"] > 0
+                    else 0 + item["other"]
+                    if item["other"] > 0
+                    else 0
+                ),
+            ),
+            storage=StorageMix(hydro=item["hydroStorage"] * -1),
+            source="someservice.com",
+        )
+        # Or you can create the production mix and fill it later.
+        production_mix = ProductionMix()
+        for mode, value in item.items():
+            production_mix.add_value(mode, value)
+        production_list.append(
+            zoneKey=zone_key,
+            datetime=datetime.fromisoformat(item["datetime"]),
+            production=production_mix,
+            storage=StorageMix(hydro=item["hydroStorage"] * -1),
+            source="someservice.com",
+        )
+    # For now we should return a list of dictionaries
+    # and therefore we convert the ProductionBreakdownList to a list
+    # using the to_list() method.
+    # In the future we will return a ProductionBreakdownList directly.
+    return production_list.to_list()

--- a/electricitymap/contrib/parsers/NESO.py
+++ b/electricitymap/contrib/parsers/NESO.py
@@ -14,6 +14,22 @@ from electricitymap.contrib.parsers.lib.exceptions import ParserException
 NESO_API = "https://api.neso.energy/api/3/action/datastore_search_sql"
 NESO_GENERATION_DATASET_ID = "f93d1835-75bc-43e5-84ad-12472b180a98"
 
+NESO_TO_PRODUCTION_MIX_MAPPING = {
+    "BIOMASS": "biomass",
+    "COAL": "coal",
+    "GAS": "gas",
+    "HYDRO": "hydro",
+    "NUCLEAR": "nuclear",
+    "SOLAR": "solar",
+    "WIND": "wind",
+    "WIND_EMB": "wind",
+    "OTHER": "unknown",
+}
+
+NESO_TO_STORAGE_MIX_MAPPING = {
+    "STORAGE": "hydro",
+}
+
 
 def fetch_production(
     zone_key: ZoneKey,
@@ -21,6 +37,8 @@ def fetch_production(
     target_datetime: datetime | None = None,
     logger: Logger = getLogger(__name__),
 ) -> list[dict] | dict:
+    session = session or Session()
+
     if target_datetime is None:
         start_datetime = datetime.now(tz=ZoneInfo("UTC")) - timedelta(hours=24)
         sql_query = f"""SELECT * FROM "{NESO_GENERATION_DATASET_ID}" WHERE "DATETIME" >= '{start_datetime.strftime("%Y-%m-%d")}' ORDER BY "DATETIME" ASC"""
@@ -33,7 +51,7 @@ def fetch_production(
         sql_query = f"""SELECT * FROM "{NESO_GENERATION_DATASET_ID}" WHERE "DATETIME" >= '{start_datetime.strftime("%Y-%m-%d")}' AND "DATETIME" <= '{end_datetime.strftime("%Y-%m-%d")}' ORDER BY "DATETIME" ASC"""
     else:
         raise ParserException(
-            "example_parser.py",
+            "NESO.py",
             "This parser is not yet able to parse dates before 2009-01-01",
             zone_key,
         )
@@ -43,33 +61,35 @@ def fetch_production(
     res: Response = session.get(NESO_API, params=params)
     if not res.status_code == 200:
         raise ParserException(
-            "example_parser.py",
+            "NESO.py",
             f"Exception when fetching production error code: {res.status_code}: {res.text}",
             zone_key,
         )
 
     obj = res.json()["result"]["records"]
-    production_list = ProductionBreakdownList(logger=logger)
 
-    for item in obj:
+    for row in obj:
+        production_list = ProductionBreakdownList(logger=logger)
+        production_mix = ProductionMix()
+
+        for neso_key, emaps_key in NESO_TO_PRODUCTION_MIX_MAPPING.items():
+            production_mix.add_value(emaps_key, float(row[neso_key]))
+
+        storage_mix = StorageMix()
+        for neso_key, emaps_key in NESO_TO_STORAGE_MIX_MAPPING.items():
+            storage_mix.add_value(
+                emaps_key,
+                float(row[neso_key]) * -1 if float(row[neso_key]) != 0 else 0,
+            )
+
         production_list.append(
             zoneKey=zone_key,
-            datetime=datetime.fromisoformat(item["DATETIME"]).replace(
+            datetime=datetime.fromisoformat(row["DATETIME"]).replace(
                 tzinfo=ZoneInfo("UTC")
             ),
-            production=ProductionMix(
-                biomass=float(item["BIOMASS"]),
-                coal=float(item["COAL"]),
-                gas=float(item["GAS"]),
-                hydro=float(item["HYDRO"]),
-                nuclear=float(item["NUCLEAR"]),
-                solar=float(item["SOLAR"]),
-                wind=float(item["WIND"]) + float(item["WIND_EMB"]),
-                unknown=(float(item["OTHER"])),
-            ),
-            storage=StorageMix(
-                hydro=float(item["STORAGE"]) * -1 if float(item["STORAGE"]) != 0 else 0
-            ),  # Classify storage as hydro storage since ELEXON uses this mapping and because NESO demand data is also hydro storage
+            production=production_mix,
+            storage=storage_mix,
             source="neso.energy",
         )
+
     return production_list.to_list()

--- a/electricitymap/contrib/parsers/NESO.py
+++ b/electricitymap/contrib/parsers/NESO.py
@@ -68,7 +68,7 @@ def fetch_production(
                 unknown=(float(item["OTHER"])),
             ),
             storage=StorageMix(
-                hydro=float(item["STORAGE"]) * -1
+                hydro=float(item["STORAGE"]) * -1 if float(item["STORAGE"]) != 0 else 0
             ),  # Classify storage as hydro storage since ELEXON uses this mapping and because NESO demand data is also hydro storage
             source="neso.energy",
         )

--- a/electricitymap/contrib/parsers/NESO.py
+++ b/electricitymap/contrib/parsers/NESO.py
@@ -27,7 +27,7 @@ NESO_TO_PRODUCTION_MIX_MAPPING = {
 }
 
 NESO_TO_STORAGE_MIX_MAPPING = {
-    "STORAGE": "hydro",
+    "STORAGE": "hydro",  # Classify storage as hydro storage since ELEXON uses this mapping
 }
 
 

--- a/electricitymap/contrib/parsers/NESO.py
+++ b/electricitymap/contrib/parsers/NESO.py
@@ -67,7 +67,9 @@ def fetch_production(
                 wind=float(item["WIND"]) + float(item["WIND_EMB"]),
                 unknown=(float(item["OTHER"])),
             ),
-            storage=StorageMix(hydro=float(item["STORAGE"]) * -1),
+            storage=StorageMix(
+                hydro=float(item["STORAGE"]) * -1
+            ),  # Classify storage as hydro storage since ELEXON uses this mapping and because NESO demand data is also hydro storage
             source="neso.energy",
         )
     return production_list.to_list()

--- a/electricitymap/contrib/parsers/tests/__snapshots__/test_NESO.ambr
+++ b/electricitymap/contrib/parsers/tests/__snapshots__/test_NESO.ambr
@@ -1,0 +1,47 @@
+# serializer version: 1
+# name: test_fetch_production
+  list([
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 12, 15, 10, 0, tzinfo=zoneinfo.ZoneInfo(key='UTC')),
+      'production': dict({
+        'biomass': 5.0,
+        'coal': 0.0,
+        'gas': 10.5,
+        'hydro': 2.0,
+        'nuclear': 8.0,
+        'solar': 3.5,
+        'unknown': 0.0,
+        'wind': 13.5,
+      }),
+      'source': 'neso.energy',
+      'sourceType': <EventSourceType.measured: 'measured'>,
+      'storage': dict({
+        'hydro': 0,
+      }),
+      'zoneKey': 'GB',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 12, 15, 10, 30, tzinfo=zoneinfo.ZoneInfo(key='UTC')),
+      'production': dict({
+        'biomass': 6.0,
+        'coal': 1.0,
+        'gas': 11.0,
+        'hydro': 2.5,
+        'nuclear': 8.0,
+        'solar': 4.0,
+        'unknown': 0.5,
+        'wind': 15.0,
+      }),
+      'source': 'neso.energy',
+      'sourceType': <EventSourceType.measured: 'measured'>,
+      'storage': dict({
+        'hydro': -5.0,
+      }),
+      'zoneKey': 'GB',
+    }),
+  ])
+# ---

--- a/electricitymap/contrib/parsers/tests/mocks/NESO/production.json
+++ b/electricitymap/contrib/parsers/tests/mocks/NESO/production.json
@@ -1,0 +1,34 @@
+{
+    "help": "Mock NESO generation data",
+    "success": true,
+    "result": {
+      "records": [
+        {
+          "DATETIME": "2024-12-15T10:00:00",
+          "BIOMASS": 5.0,
+          "COAL": 0.0,
+          "GAS": 10.5,
+          "HYDRO": 2.0,
+          "NUCLEAR": 8.0,
+          "SOLAR": 3.5,
+          "WIND": 12.0,
+          "WIND_EMB": 1.5,
+          "OTHER": 0.0,
+          "STORAGE": 0.0
+        },
+        {
+          "DATETIME": "2024-12-15T10:30:00",
+          "BIOMASS": 6.0,
+          "COAL": 1.0,
+          "GAS": 11.0,
+          "HYDRO": 2.5,
+          "NUCLEAR": 8.0,
+          "SOLAR": 4.0,
+          "WIND": 13.0,
+          "WIND_EMB": 2.0,
+          "OTHER": 0.5,
+          "STORAGE": 5.0
+        }
+      ]
+    }
+  }

--- a/electricitymap/contrib/parsers/tests/test_NESO.py
+++ b/electricitymap/contrib/parsers/tests/test_NESO.py
@@ -1,0 +1,24 @@
+import json
+from importlib import resources
+
+from requests_mock import ANY, GET
+
+from electricitymap.contrib.parsers.NESO import fetch_production
+from electricitymap.contrib.types import ZoneKey
+
+
+def test_fetch_production(adapter, session, snapshot):
+    adapter.register_uri(
+        GET,
+        ANY,
+        json=json.loads(
+            resources.files("electricitymap.contrib.parsers.tests.mocks.NESO")
+            .joinpath("production.json")
+            .read_text()
+        ),
+    )
+
+    assert snapshot == fetch_production(
+        zone_key=ZoneKey("GB"),
+        session=session,
+    )


### PR DESCRIPTION
## Issue

<!-- If you want to close an issue automatically when your PR is merged, write "Closes X" where X is the issue number. For example: Closes #000 -->
[GMM-1470](https://linear.app/electricitymaps/issue/GMM-1470/create-neso-parser-and-make-gb-use-it)

## Description

<!-- Explains the goal of this PR -->
GB currently use the ELEXON parser which is a mix of ELEXON production data and NESO demand data. This PR creates a new NESO parser which fetches NESO generation data and makes GB use it for production mix. 

### Preview

<!-- Please add screenshots and/or gif that shows visual changes (if applicable) -->
```
...
{'correctedModes': [],
  'datetime': datetime.datetime(2026, 1, 30, 12, 30, tzinfo=zoneinfo.ZoneInfo(key='UTC')),
  'production': {'biomass': 3207.0,
                 'coal': 0.0,
                 'gas': 8313.0,
                 'hydro': 368.0,
                 'nuclear': 4022.0,
                 'solar': 2823.0,
                 'unknown': 643.0,
                 'wind': 18743.0},
  'source': 'neso.energy',
  'sourceType': <EventSourceType.measured: 'measured'>,
  'storage': {'hydro': 0},
  'zoneKey': 'GB'}]
---------------------
took 0.32s
min returned datetime: 2026-01-29 00:00:00+00:00 UTC
max returned datetime: 2026-01-30 12:30:00+00:00 UTC  -- OK, <2h from now :) (now=2026-01-30T14:01:48+00:00 UTC)
```
### Double check

- [x] I have tested my parser changes locally with `uv run test_parser "zone_key"`
- [x] I have run `pnpx prettier@2 --write .` and `uv run format` in the top level directory to format my changes.
