### PR TITLE
feat(MN): add battery storage (Songino BESS) to Mongolia parser

### DIFF
--- a/electricitymap/contrib/parsers/tests/mocks/MN/response.json
+++ b/electricitymap/contrib/parsers/tests/mocks/MN/response.json
@@ -1,0 +1,1 @@
+{"date":"2025-01-14 03:00:00","syssum":"1351.8","dts":1061,"sumnar":-0.5,"sumsalhit":128.6,"energyimport":"162.7","t":"-20.2","Songino":-23.9,"Taishir":"-20.2"}

--- a/electricitymap/contrib/parsers/tests/test_MN.py
+++ b/electricitymap/contrib/parsers/tests/test_MN.py
@@ -1,0 +1,29 @@
+import json
+from importlib import resources
+
+import pytest
+from requests_mock import ANY, GET
+
+from electricitymap.contrib.parsers.MN import fetch_consumption, fetch_production
+from electricitymap.contrib.types import ZoneKey
+
+
+@pytest.fixture(autouse=True)
+def mock_response(adapter):
+    adapter.register_uri(
+        GET,
+        ANY,
+        json=json.loads(
+            resources.files("electricitymap.contrib.parsers.tests.mocks.MN")
+            .joinpath("response.json")
+            .read_text()
+        ),
+    )
+
+
+def test_production(session, snapshot):
+    assert snapshot == fetch_production(ZoneKey("MN"), session=session)
+
+
+def test_consumption(session, snapshot):
+    assert snapshot == fetch_consumption(ZoneKey("MN"), session=session)


### PR DESCRIPTION
## Summary

Adds battery storage support to the Mongolia (MN) parser by mapping the `Songino` field from the NDC API response to `StorageMix.battery`.

## Changes

- **MN.py**: Added `Songino` → `battery_storage` to the JSON API mapping and included a `StorageMix` in the production breakdown output
- **test_MN.py**: Added tests for both `fetch_production` and `fetch_consumption` with mock API responses
- **mocks/MN/response.json**: Mock API response for testing

## Context

The [Songino Battery Energy Storage System](https://ndc.energy.mn/) is displayed on the NDC dashboard alongside other generation sources. The API at `https://disnews.energy.mn/convertt.php` returns a `Songino` field with:
- **Positive values**: battery is charging (consuming power)
- **Negative values**: battery is discharging (generating power)

This aligns with the `StorageMix` convention where positive = storing and negative = discharging.

Closes #8355