### PR TITLE
use and return model for datacenters

### DIFF
--- a/electricitymap/contrib/config/data_center_model.py
+++ b/electricitymap/contrib/config/data_center_model.py
@@ -1,0 +1,70 @@
+"""Data Center model definitions."""
+from pydantic.v1 import BaseModel, validator
+
+from electricitymap.contrib.types import ZoneKey
+
+
+class StrictBaseModel(BaseModel):
+    class Config:
+        extra = "forbid"
+
+
+class DataCenter(BaseModel):
+    provider: str
+    lonlat: tuple[float, float]
+    displayName: str
+    region: str
+    zoneKey: ZoneKey
+    operationalSince: str | None
+    operationalUntil: str | None
+    status: str | None
+    source: str | None
+
+    @property
+    def ID(self) -> str:
+        return f"{self.provider}-{self.region}"
+
+    @validator("provider", "region", "displayName")
+    def string_not_empty(cls, v):
+        if not v or v.strip() == "":
+            raise ValueError("Value must be a non-empty string")
+        return v
+
+    @validator("lonlat")
+    def lonlat_valid(cls, v):
+        lon, lat = v
+        if not (-180 <= lon <= 180):
+            raise ValueError("Longitude must be between -180 and 180")
+        if not (-90 <= lat <= 90):
+            raise ValueError("Latitude must be between -90 and 90")
+        return v
+
+    @validator("zoneKey")
+    def zone_key_exists(cls, v):
+        # Import here to avoid circular dependency
+        from electricitymap.contrib.config import ZONES_CONFIG
+
+        if v not in ZONES_CONFIG:
+            raise ValueError(
+                f"Data center zone key {v} is not one of the allowed zone keys: {ZONES_CONFIG.keys()}"
+            )
+        return v
+
+
+class DataCenters(BaseModel):
+    """Container for data centers."""
+
+    data_centers: list[DataCenter]
+
+    class Config:
+        extra = "forbid"
+
+    # check that the ID for each data center is unique
+    @validator("data_centers")
+    def ids_are_unique(cls, v):
+        ids = set()
+        for data_center in v:
+            if data_center.ID in ids:
+                raise ValueError(f"Duplicate data center ID found: {data_center.ID}")
+            ids.add(data_center.ID)
+        return v

--- a/electricitymap/contrib/config/data_center_model.py
+++ b/electricitymap/contrib/config/data_center_model.py
@@ -1,4 +1,5 @@
 """Data Center model definitions."""
+
 from pydantic.v1 import BaseModel, validator
 
 from electricitymap.contrib.types import ZoneKey

--- a/electricitymap/contrib/config/reading.py
+++ b/electricitymap/contrib/config/reading.py
@@ -44,13 +44,11 @@ def read_exchanges_config(config_dir) -> dict[ZoneKey, Any]:
     return exchanges_config
 
 
-def read_data_centers_config(config_dir) -> dict[str, Any]:
-    data_centers_config = {}
-    for data_center_path in config_dir.joinpath("data_centers").glob("*.json"):
-        with open(data_center_path, encoding="utf-8") as file:
-            data_centers_config[data_center_path.stem] = json.load(file)
-    # Flatten
-    all_data_centers = {}
-    for data_centers in data_centers_config.values():
-        all_data_centers.update(data_centers)
-    return all_data_centers
+def read_data_centers_config(config_dir):
+    """Reads the data centers config file."""
+    from electricitymap.contrib.config.data_center_model import DataCenters
+
+    data_centers_path = config_dir.joinpath("data_centers", "data_centers.json")
+    with open(data_centers_path, encoding="utf-8") as file:
+        data_centers_dict = json.load(file)
+    return DataCenters(data_centers=list(data_centers_dict.values()))

--- a/tests/config/__snapshots__/test_config.ambr
+++ b/tests/config/__snapshots__/test_config.ambr
@@ -1,0 +1,4 @@
+# serializer version: 1
+# name: test_data_centers_config
+  DataCenter(provider='gcp', lonlat=(-80.088472, 33.105486), displayName='Berkeley County', region='us-east1', zoneKey='US-CAR-SCEG', operationalSince=None, operationalUntil=None, status='operational', source='https://cloud.google.com/compute/docs/regions-zones')
+# ---

--- a/tests/config/test_config.py
+++ b/tests/config/test_config.py
@@ -53,10 +53,9 @@ class ConfigTestcase(unittest.TestCase):
         self.assertGreater(factors["gas"], 0)
 
 
-class DataCentersConfigTestcase(unittest.TestCase):
-    def test_data_centers_config_contains_basic_data_centers(self):
-        self.assertIn("gcp-europe-west1", config.DATA_CENTERS_CONFIG.keys())
 
+def test_data_centers_config(snapshot):
+    assert snapshot == config.DATA_CENTERS_CONFIG.data_centers[1]
 
 if __name__ == "__main__":
     unittest.main(buffer=True)

--- a/tests/config/test_config.py
+++ b/tests/config/test_config.py
@@ -53,9 +53,9 @@ class ConfigTestcase(unittest.TestCase):
         self.assertGreater(factors["gas"], 0)
 
 
-
 def test_data_centers_config(snapshot):
     assert snapshot == config.DATA_CENTERS_CONFIG.data_centers[1]
+
 
 if __name__ == "__main__":
     unittest.main(buffer=True)


### PR DESCRIPTION
## Issue

To clean up https://github.com/electricitymaps/electricitymaps/pull/11563 a bit we should just use the models directly.

## Description

Updates the model and validators.
Moved them to their own file so there was no circular imports.

### Double check

- [x] I have tested my parser changes locally with `uv run test_parser "zone_key"`
- [x] I have run `pnpx prettier@2 --write .` and `uv run format` in the top level directory to format my changes.
