### PR TITLE
Make the actual dates dates in datacenters

### DIFF
--- a/tests/config/test_data_center_model.py
+++ b/tests/config/test_data_center_model.py
@@ -136,7 +136,9 @@ class TestDateValid:
         ["not-a-date", "21", "2021/06/15", "2021-6", "2021-06-1", "06-2021"],
     )
     def test_invalid_format_rejected(self, field: str, value: str):
-        with pytest.raises(ValidationError, match="must be in YYYY, YYYY-MM, or YYYY-MM-DD format"):
+        with pytest.raises(
+            ValidationError, match="must be in YYYY, YYYY-MM, or YYYY-MM-DD format"
+        ):
             make_data_center(**{field: value})  # type: ignore[arg-type]
 
     @pytest.mark.parametrize("field", ["operationalSince", "operationalUntil"])


### PR DESCRIPTION
## Issue
This failed to resolve to valid dates in the sync job, so let's put the logic here instead of potentially duplicating it downstream.

ref: GMM-1511


### Double check

- [x] I have tested my parser changes locally with `uv run test_parser "zone_key"`
- [x] I have run `pnpx prettier@2 --write .` and `uv run format` in the top level directory to format my changes.
