### PR TITLE
Change DK-DK1 and DK-DK2 parser to use energinet instead of ENTSOE

### DIFF
--- a/config/zones/DK-DK1.yaml
+++ b/config/zones/DK-DK1.yaml
@@ -437,7 +437,7 @@ parsers:
   consumptionForecast: ENTSOE.fetch_consumption_forecast
   generationForecast: ENTSOE.fetch_generation_forecast
   price: NORDPOOL.fetch_price
-  production: ENTSOE.fetch_production
+  production: Energinet.fetch_production
   productionCapacity: ENTSOE.fetch_production_capacity
   productionPerModeForecast: DK.fetch_wind_solar_forecasts
 region: Europe

--- a/config/zones/DK-DK2.yaml
+++ b/config/zones/DK-DK2.yaml
@@ -422,7 +422,7 @@ parsers:
   consumptionForecast: ENTSOE.fetch_consumption_forecast
   generationForecast: ENTSOE.fetch_generation_forecast
   price: NORDPOOL.fetch_price
-  production: ENTSOE.fetch_production
+  production: Energinet.fetch_production
   productionCapacity: ENTSOE.fetch_production_capacity
   productionPerModeForecast: DK.fetch_wind_solar_forecasts
 region: Europe

--- a/electricitymap/contrib/parsers/Energinet.py
+++ b/electricitymap/contrib/parsers/Energinet.py
@@ -1,0 +1,80 @@
+from datetime import datetime, timedelta
+from logging import Logger, getLogger
+from zoneinfo import ZoneInfo
+
+from requests import Session
+
+from electricitymap.contrib.lib.models.event_lists import (
+    ProductionBreakdownList,
+)
+from electricitymap.contrib.lib.models.events import ProductionMix
+from electricitymap.contrib.lib.types import ZoneKey
+
+ENERGINET_API = "https://api.energidataservice.dk/dataset/GenerationProdTypeExchange"
+
+ZONE_KEY_TO_PRICE_AREA = {
+    ZoneKey("DK-DK1"): "DK1",
+    ZoneKey("DK-DK2"): "DK2",
+}
+
+ENERGINET_TO_PRODUCTION_MIX_MAPPING = {
+    "OffshoreWindPower": "wind",
+    "OnshoreWindPower": "wind",
+    "HydroPower": "hydro",
+    "SolarPower": "solar",
+    "SolarPowerSelfCon": "solar",
+    "Biomass": "biomass",
+    "Biogas": "gas",
+    "Waste": "biomass",
+    "FossilGas": "gas",
+    "FossilOil": "oil",
+    "FossilHardCoal": "coal",
+}
+
+
+def fetch_production(
+    zone_key: ZoneKey,
+    session: Session | None = None,
+    target_datetime: datetime | None = None,
+    logger: Logger = getLogger(__name__),
+) -> list[dict] | dict:
+    session = session or Session()
+
+    if target_datetime is None:
+        target_datetime = datetime.now(tz=ZoneInfo("Europe/Copenhagen"))
+    else:
+        target_datetime = target_datetime.astimezone(ZoneInfo("Europe/Copenhagen"))
+
+    start_datetime = target_datetime - timedelta(hours=24)
+    end_datetime = target_datetime + timedelta(hours=24)
+
+    response = session.get(
+        url=ENERGINET_API,
+        params={
+            "filter": f'{{"PriceArea":"{ZONE_KEY_TO_PRICE_AREA[zone_key]}"}}',
+            "start": start_datetime.strftime("%Y-%m-%dT%H:%M"),
+            "end": end_datetime.strftime("%Y-%m-%dT%H:%M"),
+        },
+    )
+
+    obj = response.json()
+
+    records = obj.get("records", [])
+
+    production_list = ProductionBreakdownList(logger=logger)
+    for record in records:
+        production_mix = ProductionMix()
+
+        for key, value in ENERGINET_TO_PRODUCTION_MIX_MAPPING.items():
+            production_mix.add_value(value, record[key])
+
+        production_list.append(
+            zoneKey=zone_key,
+            datetime=datetime.fromisoformat(record["TimeUTC"]).replace(
+                tzinfo=ZoneInfo("UTC")
+            ),
+            production=production_mix,
+            source="energinet.dk",
+        )
+
+    return production_list.to_list()


### PR DESCRIPTION
## Issue

<!-- If you want to close an issue automatically when your PR is merged, write "Closes X" where X is the issue number. For example: Closes #000 -->
[GMM-1507](https://linear.app/electricitymaps/issue/GMM-1507/change-dk-parser-to-use-energinet-instead-of-entsoe)

## Description

<!-- Explains the goal of this PR -->
This PR changes the DK-DK1 and DK-DK2 parser to use energinet hourly values instead of ENTSOE. The reason for this is that ENTSOE currently does not have accurate values, and for DK-DK2 ENTSOE has a ~4 week delay on wind offshore, which makes up approximately 50% of DK-DK2's total production.

### Preview

<!-- Please add screenshots and/or gif that shows visual changes (if applicable) -->

### Double check

- [x] I have tested my parser changes locally with `uv run test_parser "zone_key"`
- [x] I have run `pnpx prettier@2 --write .` and `uv run format` in the top level directory to format my changes.
