### PR TITLE
add exchangeCapacityForecast to ENTSOE exchange yaml files

### DIFF
--- a/config/exchanges/AL_GR.yaml
+++ b/config/exchanges/AL_GR.yaml
@@ -6,4 +6,8 @@ lonlat:
   - 40.198219
 parsers:
   exchange: ENTSOE.fetch_exchange
+  exchangeCapacityForecastDayAhead: ENTSOE.fetch_exchange_capacity_forecasts_day_ahead
+  exchangeCapacityForecastWeekAhead: ENTSOE.fetch_exchange_capacity_forecasts_week_ahead
+  exchangeCapacityForecastMonthAhead: ENTSOE.fetch_exchange_capacity_forecasts_month_ahead
+  exchangeForecast: ENTSOE.fetch_exchange_forecast
 rotation: 135

--- a/config/exchanges/AL_ME.yaml
+++ b/config/exchanges/AL_ME.yaml
@@ -3,4 +3,8 @@ lonlat:
   - 42.428871
 parsers:
   exchange: ENTSOE.fetch_exchange
+  exchangeCapacityForecastDayAhead: ENTSOE.fetch_exchange_capacity_forecasts_day_ahead
+  exchangeCapacityForecastWeekAhead: ENTSOE.fetch_exchange_capacity_forecasts_week_ahead
+  exchangeCapacityForecastMonthAhead: ENTSOE.fetch_exchange_capacity_forecasts_month_ahead
+  exchangeForecast: ENTSOE.fetch_exchange_forecast
 rotation: -45

--- a/config/exchanges/AL_RS.yaml
+++ b/config/exchanges/AL_RS.yaml
@@ -3,4 +3,8 @@ lonlat:
   - 42.323472
 parsers:
   exchange: ENTSOE.fetch_exchange
+  exchangeCapacityForecastDayAhead: ENTSOE.fetch_exchange_capacity_forecasts_day_ahead
+  exchangeCapacityForecastWeekAhead: ENTSOE.fetch_exchange_capacity_forecasts_week_ahead
+  exchangeCapacityForecastMonthAhead: ENTSOE.fetch_exchange_capacity_forecasts_month_ahead
+  exchangeForecast: ENTSOE.fetch_exchange_forecast
 rotation: 45

--- a/config/exchanges/AL_XK.yaml
+++ b/config/exchanges/AL_XK.yaml
@@ -3,4 +3,8 @@ lonlat:
   - 42.408
 parsers:
   exchange: ENTSOE.fetch_exchange
+  exchangeCapacityForecastDayAhead: ENTSOE.fetch_exchange_capacity_forecasts_day_ahead
+  exchangeCapacityForecastWeekAhead: ENTSOE.fetch_exchange_capacity_forecasts_week_ahead
+  exchangeCapacityForecastMonthAhead: ENTSOE.fetch_exchange_capacity_forecasts_month_ahead
+  exchangeForecast: ENTSOE.fetch_exchange_forecast
 rotation: 45

--- a/config/exchanges/AM_GE.yaml
+++ b/config/exchanges/AM_GE.yaml
@@ -3,5 +3,8 @@ lonlat:
   - 41.205
 parsers:
   exchange: ENTSOE.fetch_exchange
+  exchangeCapacityForecastDayAhead: ENTSOE.fetch_exchange_capacity_forecasts_day_ahead
+  exchangeCapacityForecastWeekAhead: ENTSOE.fetch_exchange_capacity_forecasts_week_ahead
+  exchangeCapacityForecastMonthAhead: ENTSOE.fetch_exchange_capacity_forecasts_month_ahead
   exchangeForecast: ENTSOE.fetch_exchange_forecast
 rotation: 0

--- a/config/exchanges/AT_CH.yaml
+++ b/config/exchanges/AT_CH.yaml
@@ -3,5 +3,8 @@ lonlat:
   - 47.079455
 parsers:
   exchange: ENTSOE.fetch_exchange
+  exchangeCapacityForecastDayAhead: ENTSOE.fetch_exchange_capacity_forecasts_day_ahead
+  exchangeCapacityForecastWeekAhead: ENTSOE.fetch_exchange_capacity_forecasts_week_ahead
+  exchangeCapacityForecastMonthAhead: ENTSOE.fetch_exchange_capacity_forecasts_month_ahead
   exchangeForecast: ENTSOE.fetch_exchange_forecast
 rotation: -90

--- a/config/exchanges/AT_DE.yaml
+++ b/config/exchanges/AT_DE.yaml
@@ -3,5 +3,8 @@ lonlat:
   - 47.696804
 parsers:
   exchange: ENTSOE.fetch_exchange
+  exchangeCapacityForecastDayAhead: ENTSOE.fetch_exchange_capacity_forecasts_day_ahead
+  exchangeCapacityForecastWeekAhead: ENTSOE.fetch_exchange_capacity_forecasts_week_ahead
+  exchangeCapacityForecastMonthAhead: ENTSOE.fetch_exchange_capacity_forecasts_month_ahead
   exchangeForecast: ENTSOE.fetch_exchange_forecast
 rotation: -30

--- a/config/exchanges/AT_HU.yaml
+++ b/config/exchanges/AT_HU.yaml
@@ -3,5 +3,8 @@ lonlat:
   - 47.444264
 parsers:
   exchange: ENTSOE.fetch_exchange
+  exchangeCapacityForecastDayAhead: ENTSOE.fetch_exchange_capacity_forecasts_day_ahead
+  exchangeCapacityForecastWeekAhead: ENTSOE.fetch_exchange_capacity_forecasts_week_ahead
+  exchangeCapacityForecastMonthAhead: ENTSOE.fetch_exchange_capacity_forecasts_month_ahead
   exchangeForecast: ENTSOE.fetch_exchange_forecast
 rotation: 120

--- a/config/exchanges/AT_IT-NO.yaml
+++ b/config/exchanges/AT_IT-NO.yaml
@@ -6,5 +6,8 @@ lonlat:
   - 46.741723
 parsers:
   exchange: ENTSOE.fetch_exchange
+  exchangeCapacityForecastDayAhead: ENTSOE.fetch_exchange_capacity_forecasts_day_ahead
+  exchangeCapacityForecastWeekAhead: ENTSOE.fetch_exchange_capacity_forecasts_week_ahead
+  exchangeCapacityForecastMonthAhead: ENTSOE.fetch_exchange_capacity_forecasts_month_ahead
   exchangeForecast: ENTSOE.fetch_exchange_forecast
 rotation: -140

--- a/config/exchanges/AT_SI.yaml
+++ b/config/exchanges/AT_SI.yaml
@@ -3,4 +3,8 @@ lonlat:
   - 46.613582
 parsers:
   exchange: ENTSOE.fetch_exchange
+  exchangeCapacityForecastDayAhead: ENTSOE.fetch_exchange_capacity_forecasts_day_ahead
+  exchangeCapacityForecastWeekAhead: ENTSOE.fetch_exchange_capacity_forecasts_week_ahead
+  exchangeCapacityForecastMonthAhead: ENTSOE.fetch_exchange_capacity_forecasts_month_ahead
+  exchangeForecast: ENTSOE.fetch_exchange_forecast
 rotation: 180

--- a/config/exchanges/AZ_GE.yaml
+++ b/config/exchanges/AZ_GE.yaml
@@ -3,5 +3,8 @@ lonlat:
   - 41.398
 parsers:
   exchange: ENTSOE.fetch_exchange
+  exchangeCapacityForecastDayAhead: ENTSOE.fetch_exchange_capacity_forecasts_day_ahead
+  exchangeCapacityForecastWeekAhead: ENTSOE.fetch_exchange_capacity_forecasts_week_ahead
+  exchangeCapacityForecastMonthAhead: ENTSOE.fetch_exchange_capacity_forecasts_month_ahead
   exchangeForecast: ENTSOE.fetch_exchange_forecast
 rotation: -35

--- a/config/exchanges/BA_HR.yaml
+++ b/config/exchanges/BA_HR.yaml
@@ -6,5 +6,8 @@ lonlat:
   - 45.205
 parsers:
   exchange: ENTSOE.fetch_exchange
+  exchangeCapacityForecastDayAhead: ENTSOE.fetch_exchange_capacity_forecasts_day_ahead
+  exchangeCapacityForecastWeekAhead: ENTSOE.fetch_exchange_capacity_forecasts_week_ahead
+  exchangeCapacityForecastMonthAhead: ENTSOE.fetch_exchange_capacity_forecasts_month_ahead
   exchangeForecast: ENTSOE.fetch_exchange_forecast
 rotation: 0

--- a/config/exchanges/BA_ME.yaml
+++ b/config/exchanges/BA_ME.yaml
@@ -3,4 +3,8 @@ lonlat:
   - 43.042137
 parsers:
   exchange: ENTSOE.fetch_exchange
+  exchangeCapacityForecastDayAhead: ENTSOE.fetch_exchange_capacity_forecasts_day_ahead
+  exchangeCapacityForecastWeekAhead: ENTSOE.fetch_exchange_capacity_forecasts_week_ahead
+  exchangeCapacityForecastMonthAhead: ENTSOE.fetch_exchange_capacity_forecasts_month_ahead
+  exchangeForecast: ENTSOE.fetch_exchange_forecast
 rotation: 120

--- a/config/exchanges/BA_RS.yaml
+++ b/config/exchanges/BA_RS.yaml
@@ -3,4 +3,8 @@ lonlat:
   - 44.377951
 parsers:
   exchange: ENTSOE.fetch_exchange
+  exchangeCapacityForecastDayAhead: ENTSOE.fetch_exchange_capacity_forecasts_day_ahead
+  exchangeCapacityForecastWeekAhead: ENTSOE.fetch_exchange_capacity_forecasts_week_ahead
+  exchangeCapacityForecastMonthAhead: ENTSOE.fetch_exchange_capacity_forecasts_month_ahead
+  exchangeForecast: ENTSOE.fetch_exchange_forecast
 rotation: 90

--- a/config/exchanges/BE_DE.yaml
+++ b/config/exchanges/BE_DE.yaml
@@ -6,5 +6,8 @@ lonlat:
   - 50.4
 parsers:
   exchange: ENTSOE.fetch_exchange
+  exchangeCapacityForecastDayAhead: ENTSOE.fetch_exchange_capacity_forecasts_day_ahead
+  exchangeCapacityForecastWeekAhead: ENTSOE.fetch_exchange_capacity_forecasts_week_ahead
+  exchangeCapacityForecastMonthAhead: ENTSOE.fetch_exchange_capacity_forecasts_month_ahead
   exchangeForecast: ENTSOE.fetch_exchange_forecast
 rotation: 90

--- a/config/exchanges/BE_FR.yaml
+++ b/config/exchanges/BE_FR.yaml
@@ -3,5 +3,8 @@ lonlat:
   - 50.255806
 parsers:
   exchange: ENTSOE.fetch_exchange
+  exchangeCapacityForecastDayAhead: ENTSOE.fetch_exchange_capacity_forecasts_day_ahead
+  exchangeCapacityForecastWeekAhead: ENTSOE.fetch_exchange_capacity_forecasts_week_ahead
+  exchangeCapacityForecastMonthAhead: ENTSOE.fetch_exchange_capacity_forecasts_month_ahead
   exchangeForecast: ENTSOE.fetch_exchange_forecast
 rotation: -135

--- a/config/exchanges/BE_GB.yaml
+++ b/config/exchanges/BE_GB.yaml
@@ -6,5 +6,8 @@ lonlat:
   - 51.659015
 parsers:
   exchange: ENTSOE.fetch_exchange
+  exchangeCapacityForecastDayAhead: ENTSOE.fetch_exchange_capacity_forecasts_day_ahead
+  exchangeCapacityForecastWeekAhead: ENTSOE.fetch_exchange_capacity_forecasts_week_ahead
+  exchangeCapacityForecastMonthAhead: ENTSOE.fetch_exchange_capacity_forecasts_month_ahead
   exchangeForecast: ENTSOE.fetch_exchange_forecast
 rotation: -45

--- a/config/exchanges/BE_LU.yaml
+++ b/config/exchanges/BE_LU.yaml
@@ -3,5 +3,8 @@ lonlat:
   - 49.990503
 parsers:
   exchange: ENTSOE.fetch_exchange
+  exchangeCapacityForecastDayAhead: ENTSOE.fetch_exchange_capacity_forecasts_day_ahead
+  exchangeCapacityForecastWeekAhead: ENTSOE.fetch_exchange_capacity_forecasts_week_ahead
+  exchangeCapacityForecastMonthAhead: ENTSOE.fetch_exchange_capacity_forecasts_month_ahead
   exchangeForecast: ENTSOE.fetch_exchange_forecast
 rotation: 100

--- a/config/exchanges/BE_NL.yaml
+++ b/config/exchanges/BE_NL.yaml
@@ -3,5 +3,8 @@ lonlat:
   - 51.425174
 parsers:
   exchange: ENTSOE.fetch_exchange
+  exchangeCapacityForecastDayAhead: ENTSOE.fetch_exchange_capacity_forecasts_day_ahead
+  exchangeCapacityForecastWeekAhead: ENTSOE.fetch_exchange_capacity_forecasts_week_ahead
+  exchangeCapacityForecastMonthAhead: ENTSOE.fetch_exchange_capacity_forecasts_month_ahead
   exchangeForecast: ENTSOE.fetch_exchange_forecast
 rotation: 0

--- a/config/exchanges/BG_GR.yaml
+++ b/config/exchanges/BG_GR.yaml
@@ -6,4 +6,8 @@ lonlat:
   - 41.558088
 parsers:
   exchange: ENTSOE.fetch_exchange
+  exchangeCapacityForecastDayAhead: ENTSOE.fetch_exchange_capacity_forecasts_day_ahead
+  exchangeCapacityForecastWeekAhead: ENTSOE.fetch_exchange_capacity_forecasts_week_ahead
+  exchangeCapacityForecastMonthAhead: ENTSOE.fetch_exchange_capacity_forecasts_month_ahead
+  exchangeForecast: ENTSOE.fetch_exchange_forecast
 rotation: 180

--- a/config/exchanges/BG_MK.yaml
+++ b/config/exchanges/BG_MK.yaml
@@ -6,4 +6,8 @@ lonlat:
   - 41.86784
 parsers:
   exchange: ENTSOE.fetch_exchange
+  exchangeCapacityForecastDayAhead: ENTSOE.fetch_exchange_capacity_forecasts_day_ahead
+  exchangeCapacityForecastWeekAhead: ENTSOE.fetch_exchange_capacity_forecasts_week_ahead
+  exchangeCapacityForecastMonthAhead: ENTSOE.fetch_exchange_capacity_forecasts_month_ahead
+  exchangeForecast: ENTSOE.fetch_exchange_forecast
 rotation: -90

--- a/config/exchanges/BG_RO.yaml
+++ b/config/exchanges/BG_RO.yaml
@@ -3,4 +3,8 @@ lonlat:
   - 43.674878
 parsers:
   exchange: ENTSOE.fetch_exchange
+  exchangeCapacityForecastDayAhead: ENTSOE.fetch_exchange_capacity_forecasts_day_ahead
+  exchangeCapacityForecastWeekAhead: ENTSOE.fetch_exchange_capacity_forecasts_week_ahead
+  exchangeCapacityForecastMonthAhead: ENTSOE.fetch_exchange_capacity_forecasts_month_ahead
+  exchangeForecast: ENTSOE.fetch_exchange_forecast
 rotation: 0

--- a/config/exchanges/BG_RS.yaml
+++ b/config/exchanges/BG_RS.yaml
@@ -6,4 +6,8 @@ lonlat:
   - 43.131375
 parsers:
   exchange: ENTSOE.fetch_exchange
+  exchangeCapacityForecastDayAhead: ENTSOE.fetch_exchange_capacity_forecasts_day_ahead
+  exchangeCapacityForecastWeekAhead: ENTSOE.fetch_exchange_capacity_forecasts_week_ahead
+  exchangeCapacityForecastMonthAhead: ENTSOE.fetch_exchange_capacity_forecasts_month_ahead
+  exchangeForecast: ENTSOE.fetch_exchange_forecast
 rotation: -90

--- a/config/exchanges/BG_TR.yaml
+++ b/config/exchanges/BG_TR.yaml
@@ -6,4 +6,8 @@ lonlat:
   - 42.002181
 parsers:
   exchange: ENTSOE.fetch_exchange
+  exchangeCapacityForecastDayAhead: ENTSOE.fetch_exchange_capacity_forecasts_day_ahead
+  exchangeCapacityForecastWeekAhead: ENTSOE.fetch_exchange_capacity_forecasts_week_ahead
+  exchangeCapacityForecastMonthAhead: ENTSOE.fetch_exchange_capacity_forecasts_month_ahead
+  exchangeForecast: ENTSOE.fetch_exchange_forecast
 rotation: 135

--- a/config/exchanges/BY_LT.yaml
+++ b/config/exchanges/BY_LT.yaml
@@ -6,5 +6,8 @@ lonlat:
   - 54.789457
 parsers:
   exchange: ENTSOE.fetch_exchange
+  exchangeCapacityForecastDayAhead: ENTSOE.fetch_exchange_capacity_forecasts_day_ahead
+  exchangeCapacityForecastWeekAhead: ENTSOE.fetch_exchange_capacity_forecasts_week_ahead
+  exchangeCapacityForecastMonthAhead: ENTSOE.fetch_exchange_capacity_forecasts_month_ahead
   exchangeForecast: ENTSOE.fetch_exchange_forecast
 rotation: -90

--- a/config/exchanges/BY_UA.yaml
+++ b/config/exchanges/BY_UA.yaml
@@ -6,4 +6,8 @@ lonlat:
   - 51.468916
 parsers:
   exchange: ENTSOE.fetch_exchange
+  exchangeCapacityForecastDayAhead: ENTSOE.fetch_exchange_capacity_forecasts_day_ahead
+  exchangeCapacityForecastWeekAhead: ENTSOE.fetch_exchange_capacity_forecasts_week_ahead
+  exchangeCapacityForecastMonthAhead: ENTSOE.fetch_exchange_capacity_forecasts_month_ahead
+  exchangeForecast: ENTSOE.fetch_exchange_forecast
 rotation: 180

--- a/config/exchanges/CH_DE.yaml
+++ b/config/exchanges/CH_DE.yaml
@@ -3,5 +3,8 @@ lonlat:
   - 47.667048
 parsers:
   exchange: ENTSOE.fetch_exchange
+  exchangeCapacityForecastDayAhead: ENTSOE.fetch_exchange_capacity_forecasts_day_ahead
+  exchangeCapacityForecastWeekAhead: ENTSOE.fetch_exchange_capacity_forecasts_week_ahead
+  exchangeCapacityForecastMonthAhead: ENTSOE.fetch_exchange_capacity_forecasts_month_ahead
   exchangeForecast: ENTSOE.fetch_exchange_forecast
 rotation: 0

--- a/config/exchanges/CH_FR.yaml
+++ b/config/exchanges/CH_FR.yaml
@@ -3,5 +3,8 @@ lonlat:
   - 46.7
 parsers:
   exchange: ENTSOE.fetch_exchange
+  exchangeCapacityForecastDayAhead: ENTSOE.fetch_exchange_capacity_forecasts_day_ahead
+  exchangeCapacityForecastWeekAhead: ENTSOE.fetch_exchange_capacity_forecasts_week_ahead
+  exchangeCapacityForecastMonthAhead: ENTSOE.fetch_exchange_capacity_forecasts_month_ahead
   exchangeForecast: ENTSOE.fetch_exchange_forecast
 rotation: -90

--- a/config/exchanges/CH_IT-NO.yaml
+++ b/config/exchanges/CH_IT-NO.yaml
@@ -6,5 +6,8 @@ lonlat:
   - 46.113596
 parsers:
   exchange: ENTSOE.fetch_exchange
+  exchangeCapacityForecastDayAhead: ENTSOE.fetch_exchange_capacity_forecasts_day_ahead
+  exchangeCapacityForecastWeekAhead: ENTSOE.fetch_exchange_capacity_forecasts_week_ahead
+  exchangeCapacityForecastMonthAhead: ENTSOE.fetch_exchange_capacity_forecasts_month_ahead
   exchangeForecast: ENTSOE.fetch_exchange_forecast
 rotation: 180

--- a/config/exchanges/DE_LU.yaml
+++ b/config/exchanges/DE_LU.yaml
@@ -3,5 +3,8 @@ lonlat:
   - 49.847692
 parsers:
   exchange: ENTSOE.fetch_exchange
+  exchangeCapacityForecastDayAhead: ENTSOE.fetch_exchange_capacity_forecasts_day_ahead
+  exchangeCapacityForecastWeekAhead: ENTSOE.fetch_exchange_capacity_forecasts_week_ahead
+  exchangeCapacityForecastMonthAhead: ENTSOE.fetch_exchange_capacity_forecasts_month_ahead
   exchangeForecast: ENTSOE.fetch_exchange_forecast
 rotation: -90

--- a/config/exchanges/DE_NL.yaml
+++ b/config/exchanges/DE_NL.yaml
@@ -3,5 +3,8 @@ lonlat:
   - 52.159037
 parsers:
   exchange: ENTSOE.fetch_exchange
+  exchangeCapacityForecastDayAhead: ENTSOE.fetch_exchange_capacity_forecasts_day_ahead
+  exchangeCapacityForecastWeekAhead: ENTSOE.fetch_exchange_capacity_forecasts_week_ahead
+  exchangeCapacityForecastMonthAhead: ENTSOE.fetch_exchange_capacity_forecasts_month_ahead
   exchangeForecast: ENTSOE.fetch_exchange_forecast
 rotation: -90

--- a/config/exchanges/DE_NO-NO2.yaml
+++ b/config/exchanges/DE_NO-NO2.yaml
@@ -6,5 +6,8 @@ lonlat:
   - 55.9
 parsers:
   exchange: ENTSOE.fetch_exchange
+  exchangeCapacityForecastDayAhead: ENTSOE.fetch_exchange_capacity_forecasts_day_ahead
+  exchangeCapacityForecastWeekAhead: ENTSOE.fetch_exchange_capacity_forecasts_week_ahead
+  exchangeCapacityForecastMonthAhead: ENTSOE.fetch_exchange_capacity_forecasts_month_ahead
   exchangeForecast: ENTSOE.fetch_exchange_forecast
 rotation: -10

--- a/config/exchanges/DE_PL.yaml
+++ b/config/exchanges/DE_PL.yaml
@@ -3,5 +3,8 @@ lonlat:
   - 52.410625
 parsers:
   exchange: ENTSOE.fetch_exchange
+  exchangeCapacityForecastDayAhead: ENTSOE.fetch_exchange_capacity_forecasts_day_ahead
+  exchangeCapacityForecastWeekAhead: ENTSOE.fetch_exchange_capacity_forecasts_week_ahead
+  exchangeCapacityForecastMonthAhead: ENTSOE.fetch_exchange_capacity_forecasts_month_ahead
   exchangeForecast: ENTSOE.fetch_exchange_forecast
 rotation: 90

--- a/config/exchanges/DE_SE-SE4.yaml
+++ b/config/exchanges/DE_SE-SE4.yaml
@@ -6,5 +6,8 @@ lonlat:
   - 54.925814
 parsers:
   exchange: ENTSOE.fetch_exchange
+  exchangeCapacityForecastDayAhead: ENTSOE.fetch_exchange_capacity_forecasts_day_ahead
+  exchangeCapacityForecastWeekAhead: ENTSOE.fetch_exchange_capacity_forecasts_week_ahead
+  exchangeCapacityForecastMonthAhead: ENTSOE.fetch_exchange_capacity_forecasts_month_ahead
   exchangeForecast: ENTSOE.fetch_exchange_forecast
 rotation: 0

--- a/config/exchanges/DK-DK1_GB.yaml
+++ b/config/exchanges/DK-DK1_GB.yaml
@@ -6,5 +6,8 @@ lonlat:
   - 55
 parsers:
   exchange: ENTSOE.fetch_exchange
+  exchangeCapacityForecastDayAhead: ENTSOE.fetch_exchange_capacity_forecasts_day_ahead
+  exchangeCapacityForecastWeekAhead: ENTSOE.fetch_exchange_capacity_forecasts_week_ahead
+  exchangeCapacityForecastMonthAhead: ENTSOE.fetch_exchange_capacity_forecasts_month_ahead
   exchangeForecast: ENTSOE.fetch_exchange_forecast
 rotation: -105

--- a/config/exchanges/DK-DK1_SE-SE3.yaml
+++ b/config/exchanges/DK-DK1_SE-SE3.yaml
@@ -6,5 +6,8 @@ lonlat:
   - 56.857802
 parsers:
   exchange: ENTSOE.fetch_exchange
+  exchangeCapacityForecastDayAhead: ENTSOE.fetch_exchange_capacity_forecasts_day_ahead
+  exchangeCapacityForecastWeekAhead: ENTSOE.fetch_exchange_capacity_forecasts_week_ahead
+  exchangeCapacityForecastMonthAhead: ENTSOE.fetch_exchange_capacity_forecasts_month_ahead
   exchangeForecast: ENTSOE.fetch_exchange_forecast
 rotation: 70

--- a/config/exchanges/DK-DK2_SE-SE4.yaml
+++ b/config/exchanges/DK-DK2_SE-SE4.yaml
@@ -6,5 +6,8 @@ lonlat:
   - 55.952282
 parsers:
   exchange: ENTSOE.fetch_exchange
+  exchangeCapacityForecastDayAhead: ENTSOE.fetch_exchange_capacity_forecasts_day_ahead
+  exchangeCapacityForecastWeekAhead: ENTSOE.fetch_exchange_capacity_forecasts_week_ahead
+  exchangeCapacityForecastMonthAhead: ENTSOE.fetch_exchange_capacity_forecasts_month_ahead
   exchangeForecast: ENTSOE.fetch_exchange_forecast
 rotation: 70

--- a/config/exchanges/EE_FI.yaml
+++ b/config/exchanges/EE_FI.yaml
@@ -6,5 +6,8 @@ lonlat:
   - 59.923241
 parsers:
   exchange: ENTSOE.fetch_exchange
+  exchangeCapacityForecastDayAhead: ENTSOE.fetch_exchange_capacity_forecasts_day_ahead
+  exchangeCapacityForecastWeekAhead: ENTSOE.fetch_exchange_capacity_forecasts_week_ahead
+  exchangeCapacityForecastMonthAhead: ENTSOE.fetch_exchange_capacity_forecasts_month_ahead
   exchangeForecast: ENTSOE.fetch_exchange_forecast
 rotation: -35

--- a/config/exchanges/EE_LV.yaml
+++ b/config/exchanges/EE_LV.yaml
@@ -6,5 +6,8 @@ lonlat:
   - 57.810982
 parsers:
   exchange: ENTSOE.fetch_exchange
+  exchangeCapacityForecastDayAhead: ENTSOE.fetch_exchange_capacity_forecasts_day_ahead
+  exchangeCapacityForecastWeekAhead: ENTSOE.fetch_exchange_capacity_forecasts_week_ahead
+  exchangeCapacityForecastMonthAhead: ENTSOE.fetch_exchange_capacity_forecasts_month_ahead
   exchangeForecast: ENTSOE.fetch_exchange_forecast
 rotation: 180

--- a/config/exchanges/EE_RU-1.yaml
+++ b/config/exchanges/EE_RU-1.yaml
@@ -6,5 +6,8 @@ lonlat:
   - 58.545189
 parsers:
   exchange: ENTSOE.fetch_exchange
+  exchangeCapacityForecastDayAhead: ENTSOE.fetch_exchange_capacity_forecasts_day_ahead
+  exchangeCapacityForecastWeekAhead: ENTSOE.fetch_exchange_capacity_forecasts_week_ahead
+  exchangeCapacityForecastMonthAhead: ENTSOE.fetch_exchange_capacity_forecasts_month_ahead
   exchangeForecast: ENTSOE.fetch_exchange_forecast
 rotation: 90

--- a/config/exchanges/ES_PT.yaml
+++ b/config/exchanges/ES_PT.yaml
@@ -6,5 +6,8 @@ lonlat:
   - 40
 parsers:
   exchange: ENTSOE.fetch_exchange
+  exchangeCapacityForecastDayAhead: ENTSOE.fetch_exchange_capacity_forecasts_day_ahead
+  exchangeCapacityForecastWeekAhead: ENTSOE.fetch_exchange_capacity_forecasts_week_ahead
+  exchangeCapacityForecastMonthAhead: ENTSOE.fetch_exchange_capacity_forecasts_month_ahead
   exchangeForecast: ENTSOE.fetch_exchange_forecast
 rotation: -90

--- a/config/exchanges/FI_NO-NO4.yaml
+++ b/config/exchanges/FI_NO-NO4.yaml
@@ -6,5 +6,8 @@ lonlat:
   - 68.862684
 parsers:
   exchange: ENTSOE.fetch_exchange
+  exchangeCapacityForecastDayAhead: ENTSOE.fetch_exchange_capacity_forecasts_day_ahead
+  exchangeCapacityForecastWeekAhead: ENTSOE.fetch_exchange_capacity_forecasts_week_ahead
+  exchangeCapacityForecastMonthAhead: ENTSOE.fetch_exchange_capacity_forecasts_month_ahead
   exchangeForecast: ENTSOE.fetch_exchange_forecast
 rotation: -30

--- a/config/exchanges/FI_RU-1.yaml
+++ b/config/exchanges/FI_RU-1.yaml
@@ -6,5 +6,8 @@ lonlat:
   - 60.878
 parsers:
   exchange: ENTSOE.fetch_exchange
+  exchangeCapacityForecastDayAhead: ENTSOE.fetch_exchange_capacity_forecasts_day_ahead
+  exchangeCapacityForecastWeekAhead: ENTSOE.fetch_exchange_capacity_forecasts_week_ahead
+  exchangeCapacityForecastMonthAhead: ENTSOE.fetch_exchange_capacity_forecasts_month_ahead
   exchangeForecast: ENTSOE.fetch_exchange_forecast
 rotation: 135

--- a/config/exchanges/FI_SE-SE1.yaml
+++ b/config/exchanges/FI_SE-SE1.yaml
@@ -6,5 +6,8 @@ lonlat:
   - 66.921
 parsers:
   exchange: ENTSOE.fetch_exchange
+  exchangeCapacityForecastDayAhead: ENTSOE.fetch_exchange_capacity_forecasts_day_ahead
+  exchangeCapacityForecastWeekAhead: ENTSOE.fetch_exchange_capacity_forecasts_week_ahead
+  exchangeCapacityForecastMonthAhead: ENTSOE.fetch_exchange_capacity_forecasts_month_ahead
   exchangeForecast: ENTSOE.fetch_exchange_forecast
 rotation: -90

--- a/config/exchanges/FI_SE-SE3.yaml
+++ b/config/exchanges/FI_SE-SE3.yaml
@@ -6,5 +6,8 @@ lonlat:
   - 60.628
 parsers:
   exchange: ENTSOE.fetch_exchange
+  exchangeCapacityForecastDayAhead: ENTSOE.fetch_exchange_capacity_forecasts_day_ahead
+  exchangeCapacityForecastWeekAhead: ENTSOE.fetch_exchange_capacity_forecasts_week_ahead
+  exchangeCapacityForecastMonthAhead: ENTSOE.fetch_exchange_capacity_forecasts_month_ahead
   exchangeForecast: ENTSOE.fetch_exchange_forecast
 rotation: -110

--- a/config/exchanges/FR-COR_IT-CNO.yaml
+++ b/config/exchanges/FR-COR_IT-CNO.yaml
@@ -6,5 +6,8 @@ lonlat:
   - 42.686804
 parsers:
   exchange: ENTSOE.fetch_exchange
+  exchangeCapacityForecastDayAhead: ENTSOE.fetch_exchange_capacity_forecasts_day_ahead
+  exchangeCapacityForecastWeekAhead: ENTSOE.fetch_exchange_capacity_forecasts_week_ahead
+  exchangeCapacityForecastMonthAhead: ENTSOE.fetch_exchange_capacity_forecasts_month_ahead
   exchangeForecast: ENTSOE.fetch_exchange_forecast
 rotation: 45

--- a/config/exchanges/FR-COR_IT-SAR.yaml
+++ b/config/exchanges/FR-COR_IT-SAR.yaml
@@ -6,5 +6,8 @@ lonlat:
   - 41.293785
 parsers:
   exchange: ENTSOE.fetch_exchange
+  exchangeCapacityForecastDayAhead: ENTSOE.fetch_exchange_capacity_forecasts_day_ahead
+  exchangeCapacityForecastWeekAhead: ENTSOE.fetch_exchange_capacity_forecasts_week_ahead
+  exchangeCapacityForecastMonthAhead: ENTSOE.fetch_exchange_capacity_forecasts_month_ahead
   exchangeForecast: ENTSOE.fetch_exchange_forecast
 rotation: 180

--- a/config/exchanges/FR_IT-NO.yaml
+++ b/config/exchanges/FR_IT-NO.yaml
@@ -6,5 +6,8 @@ lonlat:
   - 44.4
 parsers:
   exchange: ENTSOE.fetch_exchange
+  exchangeCapacityForecastDayAhead: ENTSOE.fetch_exchange_capacity_forecasts_day_ahead
+  exchangeCapacityForecastWeekAhead: ENTSOE.fetch_exchange_capacity_forecasts_week_ahead
+  exchangeCapacityForecastMonthAhead: ENTSOE.fetch_exchange_capacity_forecasts_month_ahead
   exchangeForecast: ENTSOE.fetch_exchange_forecast
 rotation: 70

--- a/config/exchanges/GB_NO-NO2.yaml
+++ b/config/exchanges/GB_NO-NO2.yaml
@@ -6,5 +6,8 @@ lonlat:
   - 57.266334
 parsers:
   exchange: ENTSOE.fetch_exchange
+  exchangeCapacityForecastDayAhead: ENTSOE.fetch_exchange_capacity_forecasts_day_ahead
+  exchangeCapacityForecastWeekAhead: ENTSOE.fetch_exchange_capacity_forecasts_week_ahead
+  exchangeCapacityForecastMonthAhead: ENTSOE.fetch_exchange_capacity_forecasts_month_ahead
   exchangeForecast: ENTSOE.fetch_exchange_forecast
 rotation: 50

--- a/config/exchanges/GE_RU-1.yaml
+++ b/config/exchanges/GE_RU-1.yaml
@@ -3,5 +3,8 @@ lonlat:
   - 43.158267
 parsers:
   exchange: ENTSOE.fetch_exchange
+  exchangeCapacityForecastDayAhead: ENTSOE.fetch_exchange_capacity_forecasts_day_ahead
+  exchangeCapacityForecastWeekAhead: ENTSOE.fetch_exchange_capacity_forecasts_week_ahead
+  exchangeCapacityForecastMonthAhead: ENTSOE.fetch_exchange_capacity_forecasts_month_ahead
   exchangeForecast: ENTSOE.fetch_exchange_forecast
 rotation: 0

--- a/config/exchanges/GE_TR.yaml
+++ b/config/exchanges/GE_TR.yaml
@@ -6,5 +6,8 @@ lonlat:
   - 41.562
 parsers:
   exchange: ENTSOE.fetch_exchange
+  exchangeCapacityForecastDayAhead: ENTSOE.fetch_exchange_capacity_forecasts_day_ahead
+  exchangeCapacityForecastWeekAhead: ENTSOE.fetch_exchange_capacity_forecasts_week_ahead
+  exchangeCapacityForecastMonthAhead: ENTSOE.fetch_exchange_capacity_forecasts_month_ahead
   exchangeForecast: ENTSOE.fetch_exchange_forecast
 rotation: -135

--- a/config/exchanges/GR_IT-SO.yaml
+++ b/config/exchanges/GR_IT-SO.yaml
@@ -6,5 +6,8 @@ lonlat:
   - 38.902132
 parsers:
   exchange: ENTSOE.fetch_exchange
+  exchangeCapacityForecastDayAhead: ENTSOE.fetch_exchange_capacity_forecasts_day_ahead
+  exchangeCapacityForecastWeekAhead: ENTSOE.fetch_exchange_capacity_forecasts_week_ahead
+  exchangeCapacityForecastMonthAhead: ENTSOE.fetch_exchange_capacity_forecasts_month_ahead
   exchangeForecast: ENTSOE.fetch_exchange_forecast
 rotation: -90

--- a/config/exchanges/GR_MK.yaml
+++ b/config/exchanges/GR_MK.yaml
@@ -6,4 +6,8 @@ lonlat:
   - 41.160374
 parsers:
   exchange: ENTSOE.fetch_exchange
+  exchangeCapacityForecastDayAhead: ENTSOE.fetch_exchange_capacity_forecasts_day_ahead
+  exchangeCapacityForecastWeekAhead: ENTSOE.fetch_exchange_capacity_forecasts_week_ahead
+  exchangeCapacityForecastMonthAhead: ENTSOE.fetch_exchange_capacity_forecasts_month_ahead
+  exchangeForecast: ENTSOE.fetch_exchange_forecast
 rotation: 0

--- a/config/exchanges/GR_TR.yaml
+++ b/config/exchanges/GR_TR.yaml
@@ -6,4 +6,8 @@ lonlat:
   - 41.1262
 parsers:
   exchange: ENTSOE.fetch_exchange
+  exchangeCapacityForecastDayAhead: ENTSOE.fetch_exchange_capacity_forecasts_day_ahead
+  exchangeCapacityForecastWeekAhead: ENTSOE.fetch_exchange_capacity_forecasts_week_ahead
+  exchangeCapacityForecastMonthAhead: ENTSOE.fetch_exchange_capacity_forecasts_month_ahead
+  exchangeForecast: ENTSOE.fetch_exchange_forecast
 rotation: 90

--- a/config/exchanges/HR_HU.yaml
+++ b/config/exchanges/HR_HU.yaml
@@ -3,5 +3,8 @@ lonlat:
   - 45.967775
 parsers:
   exchange: ENTSOE.fetch_exchange
+  exchangeCapacityForecastDayAhead: ENTSOE.fetch_exchange_capacity_forecasts_day_ahead
+  exchangeCapacityForecastWeekAhead: ENTSOE.fetch_exchange_capacity_forecasts_week_ahead
+  exchangeCapacityForecastMonthAhead: ENTSOE.fetch_exchange_capacity_forecasts_month_ahead
   exchangeForecast: ENTSOE.fetch_exchange_forecast
 rotation: 30

--- a/config/exchanges/HR_RS.yaml
+++ b/config/exchanges/HR_RS.yaml
@@ -6,5 +6,8 @@ lonlat:
   - 45.354302
 parsers:
   exchange: ENTSOE.fetch_exchange
+  exchangeCapacityForecastDayAhead: ENTSOE.fetch_exchange_capacity_forecasts_day_ahead
+  exchangeCapacityForecastWeekAhead: ENTSOE.fetch_exchange_capacity_forecasts_week_ahead
+  exchangeCapacityForecastMonthAhead: ENTSOE.fetch_exchange_capacity_forecasts_month_ahead
   exchangeForecast: ENTSOE.fetch_exchange_forecast
 rotation: 90

--- a/config/exchanges/HR_SI.yaml
+++ b/config/exchanges/HR_SI.yaml
@@ -3,5 +3,8 @@ lonlat:
   - 45.583
 parsers:
   exchange: ENTSOE.fetch_exchange
+  exchangeCapacityForecastDayAhead: ENTSOE.fetch_exchange_capacity_forecasts_day_ahead
+  exchangeCapacityForecastWeekAhead: ENTSOE.fetch_exchange_capacity_forecasts_week_ahead
+  exchangeCapacityForecastMonthAhead: ENTSOE.fetch_exchange_capacity_forecasts_month_ahead
   exchangeForecast: ENTSOE.fetch_exchange_forecast
 rotation: -90

--- a/config/exchanges/HU_RO.yaml
+++ b/config/exchanges/HU_RO.yaml
@@ -3,5 +3,8 @@ lonlat:
   - 47.1141229
 parsers:
   exchange: ENTSOE.fetch_exchange
+  exchangeCapacityForecastDayAhead: ENTSOE.fetch_exchange_capacity_forecasts_day_ahead
+  exchangeCapacityForecastWeekAhead: ENTSOE.fetch_exchange_capacity_forecasts_week_ahead
+  exchangeCapacityForecastMonthAhead: ENTSOE.fetch_exchange_capacity_forecasts_month_ahead
   exchangeForecast: ENTSOE.fetch_exchange_forecast
 rotation: 110

--- a/config/exchanges/HU_RS.yaml
+++ b/config/exchanges/HU_RS.yaml
@@ -6,5 +6,8 @@ lonlat:
   - 46.112673
 parsers:
   exchange: ENTSOE.fetch_exchange
+  exchangeCapacityForecastDayAhead: ENTSOE.fetch_exchange_capacity_forecasts_day_ahead
+  exchangeCapacityForecastWeekAhead: ENTSOE.fetch_exchange_capacity_forecasts_week_ahead
+  exchangeCapacityForecastMonthAhead: ENTSOE.fetch_exchange_capacity_forecasts_month_ahead
   exchangeForecast: ENTSOE.fetch_exchange_forecast
 rotation: 180

--- a/config/exchanges/HU_SI.yaml
+++ b/config/exchanges/HU_SI.yaml
@@ -3,5 +3,8 @@ lonlat:
   - 46.69
 parsers:
   exchange: ENTSOE.fetch_exchange
+  exchangeCapacityForecastDayAhead: ENTSOE.fetch_exchange_capacity_forecasts_day_ahead
+  exchangeCapacityForecastWeekAhead: ENTSOE.fetch_exchange_capacity_forecasts_week_ahead
+  exchangeCapacityForecastMonthAhead: ENTSOE.fetch_exchange_capacity_forecasts_month_ahead
   exchangeForecast: ENTSOE.fetch_exchange_forecast
 rotation: -125

--- a/config/exchanges/HU_SK.yaml
+++ b/config/exchanges/HU_SK.yaml
@@ -3,4 +3,8 @@ lonlat:
   - 48.204006
 parsers:
   exchange: ENTSOE.fetch_exchange
+  exchangeCapacityForecastDayAhead: ENTSOE.fetch_exchange_capacity_forecasts_day_ahead
+  exchangeCapacityForecastWeekAhead: ENTSOE.fetch_exchange_capacity_forecasts_week_ahead
+  exchangeCapacityForecastMonthAhead: ENTSOE.fetch_exchange_capacity_forecasts_month_ahead
+  exchangeForecast: ENTSOE.fetch_exchange_forecast
 rotation: 0

--- a/config/exchanges/HU_UA.yaml
+++ b/config/exchanges/HU_UA.yaml
@@ -6,5 +6,8 @@ lonlat:
   - 48.240603
 parsers:
   exchange: ENTSOE.fetch_exchange
+  exchangeCapacityForecastDayAhead: ENTSOE.fetch_exchange_capacity_forecasts_day_ahead
+  exchangeCapacityForecastWeekAhead: ENTSOE.fetch_exchange_capacity_forecasts_week_ahead
+  exchangeCapacityForecastMonthAhead: ENTSOE.fetch_exchange_capacity_forecasts_month_ahead
   exchangeForecast: ENTSOE.fetch_exchange_forecast
 rotation: 35

--- a/config/exchanges/IT-CNO_IT-CSO.yaml
+++ b/config/exchanges/IT-CNO_IT-CSO.yaml
@@ -6,5 +6,8 @@ lonlat:
   - 42.6
 parsers:
   exchange: ENTSOE.fetch_exchange
+  exchangeCapacityForecastDayAhead: ENTSOE.fetch_exchange_capacity_forecasts_day_ahead
+  exchangeCapacityForecastWeekAhead: ENTSOE.fetch_exchange_capacity_forecasts_week_ahead
+  exchangeCapacityForecastMonthAhead: ENTSOE.fetch_exchange_capacity_forecasts_month_ahead
   exchangeForecast: ENTSOE.fetch_exchange_forecast
 rotation: 135

--- a/config/exchanges/IT-CNO_IT-NO.yaml
+++ b/config/exchanges/IT-CNO_IT-NO.yaml
@@ -6,5 +6,8 @@ lonlat:
   - 44.1
 parsers:
   exchange: ENTSOE.fetch_exchange
+  exchangeCapacityForecastDayAhead: ENTSOE.fetch_exchange_capacity_forecasts_day_ahead
+  exchangeCapacityForecastWeekAhead: ENTSOE.fetch_exchange_capacity_forecasts_week_ahead
+  exchangeCapacityForecastMonthAhead: ENTSOE.fetch_exchange_capacity_forecasts_month_ahead
   exchangeForecast: ENTSOE.fetch_exchange_forecast
 rotation: 0

--- a/config/exchanges/IT-CSO_IT-SAR.yaml
+++ b/config/exchanges/IT-CSO_IT-SAR.yaml
@@ -6,5 +6,8 @@ lonlat:
   - 41.042731
 parsers:
   exchange: ENTSOE.fetch_exchange
+  exchangeCapacityForecastDayAhead: ENTSOE.fetch_exchange_capacity_forecasts_day_ahead
+  exchangeCapacityForecastWeekAhead: ENTSOE.fetch_exchange_capacity_forecasts_week_ahead
+  exchangeCapacityForecastMonthAhead: ENTSOE.fetch_exchange_capacity_forecasts_month_ahead
   exchangeForecast: ENTSOE.fetch_exchange_forecast
 rotation: -135

--- a/config/exchanges/IT-CSO_IT-SO.yaml
+++ b/config/exchanges/IT-CSO_IT-SO.yaml
@@ -6,5 +6,8 @@ lonlat:
   - 41.0
 parsers:
   exchange: ENTSOE.fetch_exchange
+  exchangeCapacityForecastDayAhead: ENTSOE.fetch_exchange_capacity_forecasts_day_ahead
+  exchangeCapacityForecastWeekAhead: ENTSOE.fetch_exchange_capacity_forecasts_week_ahead
+  exchangeCapacityForecastMonthAhead: ENTSOE.fetch_exchange_capacity_forecasts_month_ahead
   exchangeForecast: ENTSOE.fetch_exchange_forecast
 rotation: 90

--- a/config/exchanges/IT-CSO_ME.yaml
+++ b/config/exchanges/IT-CSO_ME.yaml
@@ -6,5 +6,8 @@ lonlat:
   - 42.4
 parsers:
   exchange: ENTSOE.fetch_exchange
+  exchangeCapacityForecastDayAhead: ENTSOE.fetch_exchange_capacity_forecasts_day_ahead
+  exchangeCapacityForecastWeekAhead: ENTSOE.fetch_exchange_capacity_forecasts_week_ahead
+  exchangeCapacityForecastMonthAhead: ENTSOE.fetch_exchange_capacity_forecasts_month_ahead
   exchangeForecast: ENTSOE.fetch_exchange_forecast
 rotation: 90

--- a/config/exchanges/IT-NO_SI.yaml
+++ b/config/exchanges/IT-NO_SI.yaml
@@ -6,5 +6,8 @@ lonlat:
   - 46.105418
 parsers:
   exchange: ENTSOE.fetch_exchange
+  exchangeCapacityForecastDayAhead: ENTSOE.fetch_exchange_capacity_forecasts_day_ahead
+  exchangeCapacityForecastWeekAhead: ENTSOE.fetch_exchange_capacity_forecasts_week_ahead
+  exchangeCapacityForecastMonthAhead: ENTSOE.fetch_exchange_capacity_forecasts_month_ahead
   exchangeForecast: ENTSOE.fetch_exchange_forecast
 rotation: 90

--- a/config/exchanges/IT-SIC_IT-SO.yaml
+++ b/config/exchanges/IT-SIC_IT-SO.yaml
@@ -6,5 +6,8 @@ lonlat:
   - 38.1
 parsers:
   exchange: ENTSOE.fetch_exchange
+  exchangeCapacityForecastDayAhead: ENTSOE.fetch_exchange_capacity_forecasts_day_ahead
+  exchangeCapacityForecastWeekAhead: ENTSOE.fetch_exchange_capacity_forecasts_week_ahead
+  exchangeCapacityForecastMonthAhead: ENTSOE.fetch_exchange_capacity_forecasts_month_ahead
   exchangeForecast: ENTSOE.fetch_exchange_forecast
 rotation: 90

--- a/config/exchanges/IT-SIC_MT.yaml
+++ b/config/exchanges/IT-SIC_MT.yaml
@@ -6,5 +6,8 @@ lonlat:
   - 36.264287
 parsers:
   exchange: ENTSOE.fetch_exchange
+  exchangeCapacityForecastDayAhead: ENTSOE.fetch_exchange_capacity_forecasts_day_ahead
+  exchangeCapacityForecastWeekAhead: ENTSOE.fetch_exchange_capacity_forecasts_week_ahead
+  exchangeCapacityForecastMonthAhead: ENTSOE.fetch_exchange_capacity_forecasts_month_ahead
   exchangeForecast: ENTSOE.fetch_exchange_forecast
 rotation: -160

--- a/config/exchanges/IT_ME.yaml
+++ b/config/exchanges/IT_ME.yaml
@@ -6,5 +6,8 @@ lonlat:
   - 42.4
 parsers:
   exchange: ENTSOE.fetch_exchange
+  exchangeCapacityForecastDayAhead: ENTSOE.fetch_exchange_capacity_forecasts_day_ahead
+  exchangeCapacityForecastWeekAhead: ENTSOE.fetch_exchange_capacity_forecasts_week_ahead
+  exchangeCapacityForecastMonthAhead: ENTSOE.fetch_exchange_capacity_forecasts_month_ahead
   exchangeForecast: ENTSOE.fetch_exchange_forecast
 rotation: 90

--- a/config/exchanges/LT_LV.yaml
+++ b/config/exchanges/LT_LV.yaml
@@ -6,5 +6,8 @@ lonlat:
   - 56.287428
 parsers:
   exchange: ENTSOE.fetch_exchange
+  exchangeCapacityForecastDayAhead: ENTSOE.fetch_exchange_capacity_forecasts_day_ahead
+  exchangeCapacityForecastWeekAhead: ENTSOE.fetch_exchange_capacity_forecasts_week_ahead
+  exchangeCapacityForecastMonthAhead: ENTSOE.fetch_exchange_capacity_forecasts_month_ahead
   exchangeForecast: ENTSOE.fetch_exchange_forecast
 rotation: 0

--- a/config/exchanges/LT_PL.yaml
+++ b/config/exchanges/LT_PL.yaml
@@ -6,5 +6,8 @@ lonlat:
   - 54.247411
 parsers:
   exchange: ENTSOE.fetch_exchange
+  exchangeCapacityForecastDayAhead: ENTSOE.fetch_exchange_capacity_forecasts_day_ahead
+  exchangeCapacityForecastWeekAhead: ENTSOE.fetch_exchange_capacity_forecasts_week_ahead
+  exchangeCapacityForecastMonthAhead: ENTSOE.fetch_exchange_capacity_forecasts_month_ahead
   exchangeForecast: ENTSOE.fetch_exchange_forecast
 rotation: 180

--- a/config/exchanges/LT_RU-KGD.yaml
+++ b/config/exchanges/LT_RU-KGD.yaml
@@ -6,5 +6,8 @@ lonlat:
   - 55.080726
 parsers:
   exchange: ENTSOE.fetch_exchange
+  exchangeCapacityForecastDayAhead: ENTSOE.fetch_exchange_capacity_forecasts_day_ahead
+  exchangeCapacityForecastWeekAhead: ENTSOE.fetch_exchange_capacity_forecasts_week_ahead
+  exchangeCapacityForecastMonthAhead: ENTSOE.fetch_exchange_capacity_forecasts_month_ahead
   exchangeForecast: ENTSOE.fetch_exchange_forecast
 rotation: -180

--- a/config/exchanges/LT_SE-SE4.yaml
+++ b/config/exchanges/LT_SE-SE4.yaml
@@ -6,5 +6,8 @@ lonlat:
   - 55.910978
 parsers:
   exchange: ENTSOE.fetch_exchange
+  exchangeCapacityForecastDayAhead: ENTSOE.fetch_exchange_capacity_forecasts_day_ahead
+  exchangeCapacityForecastWeekAhead: ENTSOE.fetch_exchange_capacity_forecasts_week_ahead
+  exchangeCapacityForecastMonthAhead: ENTSOE.fetch_exchange_capacity_forecasts_month_ahead
   exchangeForecast: ENTSOE.fetch_exchange_forecast
 rotation: -90

--- a/config/exchanges/LV_RU-1.yaml
+++ b/config/exchanges/LV_RU-1.yaml
@@ -6,5 +6,8 @@ lonlat:
   - 56.87436
 parsers:
   exchange: ENTSOE.fetch_exchange
+  exchangeCapacityForecastDayAhead: ENTSOE.fetch_exchange_capacity_forecasts_day_ahead
+  exchangeCapacityForecastWeekAhead: ENTSOE.fetch_exchange_capacity_forecasts_week_ahead
+  exchangeCapacityForecastMonthAhead: ENTSOE.fetch_exchange_capacity_forecasts_month_ahead
   exchangeForecast: ENTSOE.fetch_exchange_forecast
 rotation: 45

--- a/config/exchanges/MD_RO.yaml
+++ b/config/exchanges/MD_RO.yaml
@@ -3,5 +3,8 @@ lonlat:
   - 47.003312
 parsers:
   exchange: ENTSOE.fetch_exchange
+  exchangeCapacityForecastDayAhead: ENTSOE.fetch_exchange_capacity_forecasts_day_ahead
+  exchangeCapacityForecastWeekAhead: ENTSOE.fetch_exchange_capacity_forecasts_week_ahead
+  exchangeCapacityForecastMonthAhead: ENTSOE.fetch_exchange_capacity_forecasts_month_ahead
   exchangeForecast: MD.fetch_exchange_forecast
 rotation: -120

--- a/config/exchanges/MD_UA.yaml
+++ b/config/exchanges/MD_UA.yaml
@@ -6,5 +6,8 @@ lonlat:
   - 47.646939
 parsers:
   exchange: ENTSOE.fetch_exchange
+  exchangeCapacityForecastDayAhead: ENTSOE.fetch_exchange_capacity_forecasts_day_ahead
+  exchangeCapacityForecastWeekAhead: ENTSOE.fetch_exchange_capacity_forecasts_week_ahead
+  exchangeCapacityForecastMonthAhead: ENTSOE.fetch_exchange_capacity_forecasts_month_ahead
   exchangeForecast: MD.fetch_exchange_forecast
 rotation: 50

--- a/config/exchanges/ME_RS.yaml
+++ b/config/exchanges/ME_RS.yaml
@@ -3,4 +3,8 @@ lonlat:
   - 43.242543
 parsers:
   exchange: ENTSOE.fetch_exchange
+  exchangeCapacityForecastDayAhead: ENTSOE.fetch_exchange_capacity_forecasts_day_ahead
+  exchangeCapacityForecastWeekAhead: ENTSOE.fetch_exchange_capacity_forecasts_week_ahead
+  exchangeCapacityForecastMonthAhead: ENTSOE.fetch_exchange_capacity_forecasts_month_ahead
+  exchangeForecast: ENTSOE.fetch_exchange_forecast
 rotation: 45

--- a/config/exchanges/ME_XK.yaml
+++ b/config/exchanges/ME_XK.yaml
@@ -3,4 +3,8 @@ lonlat:
   - 42.784
 parsers:
   exchange: ENTSOE.fetch_exchange
+  exchangeCapacityForecastDayAhead: ENTSOE.fetch_exchange_capacity_forecasts_day_ahead
+  exchangeCapacityForecastWeekAhead: ENTSOE.fetch_exchange_capacity_forecasts_week_ahead
+  exchangeCapacityForecastMonthAhead: ENTSOE.fetch_exchange_capacity_forecasts_month_ahead
+  exchangeForecast: ENTSOE.fetch_exchange_forecast
 rotation: 135

--- a/config/exchanges/MK_RS.yaml
+++ b/config/exchanges/MK_RS.yaml
@@ -3,4 +3,8 @@ lonlat:
   - 42.31702
 parsers:
   exchange: ENTSOE.fetch_exchange
+  exchangeCapacityForecastDayAhead: ENTSOE.fetch_exchange_capacity_forecasts_day_ahead
+  exchangeCapacityForecastWeekAhead: ENTSOE.fetch_exchange_capacity_forecasts_week_ahead
+  exchangeCapacityForecastMonthAhead: ENTSOE.fetch_exchange_capacity_forecasts_month_ahead
+  exchangeForecast: ENTSOE.fetch_exchange_forecast
 rotation: 0

--- a/config/exchanges/MK_XK.yaml
+++ b/config/exchanges/MK_XK.yaml
@@ -3,4 +3,8 @@ lonlat:
   - 42.153
 parsers:
   exchange: ENTSOE.fetch_exchange
+  exchangeCapacityForecastDayAhead: ENTSOE.fetch_exchange_capacity_forecasts_day_ahead
+  exchangeCapacityForecastWeekAhead: ENTSOE.fetch_exchange_capacity_forecasts_week_ahead
+  exchangeCapacityForecastMonthAhead: ENTSOE.fetch_exchange_capacity_forecasts_month_ahead
+  exchangeForecast: ENTSOE.fetch_exchange_forecast
 rotation: 0

--- a/config/exchanges/NL_NO-NO2.yaml
+++ b/config/exchanges/NL_NO-NO2.yaml
@@ -6,5 +6,8 @@ lonlat:
   - 55.859727
 parsers:
   exchange: ENTSOE.fetch_exchange
+  exchangeCapacityForecastDayAhead: ENTSOE.fetch_exchange_capacity_forecasts_day_ahead
+  exchangeCapacityForecastWeekAhead: ENTSOE.fetch_exchange_capacity_forecasts_week_ahead
+  exchangeCapacityForecastMonthAhead: ENTSOE.fetch_exchange_capacity_forecasts_month_ahead
   exchangeForecast: ENTSOE.fetch_exchange_forecast
 rotation: 0

--- a/config/exchanges/NO-NO1_NO-NO2.yaml
+++ b/config/exchanges/NO-NO1_NO-NO2.yaml
@@ -6,5 +6,8 @@ lonlat:
   - 59.844429
 parsers:
   exchange: ENTSOE.fetch_exchange
+  exchangeCapacityForecastDayAhead: ENTSOE.fetch_exchange_capacity_forecasts_day_ahead
+  exchangeCapacityForecastWeekAhead: ENTSOE.fetch_exchange_capacity_forecasts_week_ahead
+  exchangeCapacityForecastMonthAhead: ENTSOE.fetch_exchange_capacity_forecasts_month_ahead
   exchangeForecast: ENTSOE.fetch_exchange_forecast
 rotation: -110

--- a/config/exchanges/NO-NO1_NO-NO3.yaml
+++ b/config/exchanges/NO-NO1_NO-NO3.yaml
@@ -6,5 +6,8 @@ lonlat:
   - 61.731596
 parsers:
   exchange: ENTSOE.fetch_exchange
+  exchangeCapacityForecastDayAhead: ENTSOE.fetch_exchange_capacity_forecasts_day_ahead
+  exchangeCapacityForecastWeekAhead: ENTSOE.fetch_exchange_capacity_forecasts_week_ahead
+  exchangeCapacityForecastMonthAhead: ENTSOE.fetch_exchange_capacity_forecasts_month_ahead
   exchangeForecast: ENTSOE.fetch_exchange_forecast
 rotation: -45

--- a/config/exchanges/NO-NO1_NO-NO5.yaml
+++ b/config/exchanges/NO-NO1_NO-NO5.yaml
@@ -6,5 +6,8 @@ lonlat:
   - 61.132896
 parsers:
   exchange: ENTSOE.fetch_exchange
+  exchangeCapacityForecastDayAhead: ENTSOE.fetch_exchange_capacity_forecasts_day_ahead
+  exchangeCapacityForecastWeekAhead: ENTSOE.fetch_exchange_capacity_forecasts_week_ahead
+  exchangeCapacityForecastMonthAhead: ENTSOE.fetch_exchange_capacity_forecasts_month_ahead
   exchangeForecast: ENTSOE.fetch_exchange_forecast
 rotation: -90

--- a/config/exchanges/NO-NO2_NO-NO5.yaml
+++ b/config/exchanges/NO-NO2_NO-NO5.yaml
@@ -6,5 +6,8 @@ lonlat:
   - 60.0
 parsers:
   exchange: ENTSOE.fetch_exchange
+  exchangeCapacityForecastDayAhead: ENTSOE.fetch_exchange_capacity_forecasts_day_ahead
+  exchangeCapacityForecastWeekAhead: ENTSOE.fetch_exchange_capacity_forecasts_week_ahead
+  exchangeCapacityForecastMonthAhead: ENTSOE.fetch_exchange_capacity_forecasts_month_ahead
   exchangeForecast: ENTSOE.fetch_exchange_forecast
 rotation: -10

--- a/config/exchanges/NO-NO3_NO-NO4.yaml
+++ b/config/exchanges/NO-NO3_NO-NO4.yaml
@@ -6,5 +6,8 @@ lonlat:
   - 64.745638
 parsers:
   exchange: ENTSOE.fetch_exchange
+  exchangeCapacityForecastDayAhead: ENTSOE.fetch_exchange_capacity_forecasts_day_ahead
+  exchangeCapacityForecastWeekAhead: ENTSOE.fetch_exchange_capacity_forecasts_week_ahead
+  exchangeCapacityForecastMonthAhead: ENTSOE.fetch_exchange_capacity_forecasts_month_ahead
   exchangeForecast: ENTSOE.fetch_exchange_forecast
 rotation: 30

--- a/config/exchanges/NO-NO3_NO-NO5.yaml
+++ b/config/exchanges/NO-NO3_NO-NO5.yaml
@@ -7,5 +7,8 @@ lonlat:
   - 61.194118
 parsers:
   exchange: ENTSOE.fetch_exchange
+  exchangeCapacityForecastDayAhead: ENTSOE.fetch_exchange_capacity_forecasts_day_ahead
+  exchangeCapacityForecastWeekAhead: ENTSOE.fetch_exchange_capacity_forecasts_week_ahead
+  exchangeCapacityForecastMonthAhead: ENTSOE.fetch_exchange_capacity_forecasts_month_ahead
   exchangeForecast: ENTSOE.fetch_exchange_forecast
 rotation: 140

--- a/config/exchanges/NO-NO3_SE-SE2.yaml
+++ b/config/exchanges/NO-NO3_SE-SE2.yaml
@@ -6,5 +6,8 @@ lonlat:
   - 63.462916
 parsers:
   exchange: ENTSOE.fetch_exchange
+  exchangeCapacityForecastDayAhead: ENTSOE.fetch_exchange_capacity_forecasts_day_ahead
+  exchangeCapacityForecastWeekAhead: ENTSOE.fetch_exchange_capacity_forecasts_week_ahead
+  exchangeCapacityForecastMonthAhead: ENTSOE.fetch_exchange_capacity_forecasts_month_ahead
   exchangeForecast: ENTSOE.fetch_exchange_forecast
 rotation: 90

--- a/config/exchanges/NO-NO4_SE-SE1.yaml
+++ b/config/exchanges/NO-NO4_SE-SE1.yaml
@@ -6,5 +6,8 @@ lonlat:
   - 66.609
 parsers:
   exchange: ENTSOE.fetch_exchange
+  exchangeCapacityForecastDayAhead: ENTSOE.fetch_exchange_capacity_forecasts_day_ahead
+  exchangeCapacityForecastWeekAhead: ENTSOE.fetch_exchange_capacity_forecasts_week_ahead
+  exchangeCapacityForecastMonthAhead: ENTSOE.fetch_exchange_capacity_forecasts_month_ahead
   exchangeForecast: ENTSOE.fetch_exchange_forecast
 rotation: 130

--- a/config/exchanges/NO-NO4_SE-SE2.yaml
+++ b/config/exchanges/NO-NO4_SE-SE2.yaml
@@ -6,5 +6,8 @@ lonlat:
   - 64.913
 parsers:
   exchange: ENTSOE.fetch_exchange
+  exchangeCapacityForecastDayAhead: ENTSOE.fetch_exchange_capacity_forecasts_day_ahead
+  exchangeCapacityForecastWeekAhead: ENTSOE.fetch_exchange_capacity_forecasts_week_ahead
+  exchangeCapacityForecastMonthAhead: ENTSOE.fetch_exchange_capacity_forecasts_month_ahead
   exchangeForecast: ENTSOE.fetch_exchange_forecast
 rotation: 130

--- a/config/exchanges/PL_SE-SE4.yaml
+++ b/config/exchanges/PL_SE-SE4.yaml
@@ -6,5 +6,8 @@ lonlat:
   - 55.215172
 parsers:
   exchange: ENTSOE.fetch_exchange
+  exchangeCapacityForecastDayAhead: ENTSOE.fetch_exchange_capacity_forecasts_day_ahead
+  exchangeCapacityForecastWeekAhead: ENTSOE.fetch_exchange_capacity_forecasts_week_ahead
+  exchangeCapacityForecastMonthAhead: ENTSOE.fetch_exchange_capacity_forecasts_month_ahead
   exchangeForecast: ENTSOE.fetch_exchange_forecast
 rotation: -20

--- a/config/exchanges/PL_SK.yaml
+++ b/config/exchanges/PL_SK.yaml
@@ -3,4 +3,8 @@ lonlat:
   - 49.359467
 parsers:
   exchange: ENTSOE.fetch_exchange
+  exchangeCapacityForecastDayAhead: ENTSOE.fetch_exchange_capacity_forecasts_day_ahead
+  exchangeCapacityForecastWeekAhead: ENTSOE.fetch_exchange_capacity_forecasts_week_ahead
+  exchangeCapacityForecastMonthAhead: ENTSOE.fetch_exchange_capacity_forecasts_month_ahead
+  exchangeForecast: ENTSOE.fetch_exchange_forecast
 rotation: 180

--- a/config/exchanges/PL_UA.yaml
+++ b/config/exchanges/PL_UA.yaml
@@ -6,4 +6,8 @@ lonlat:
   - 50.664587
 parsers:
   exchange: ENTSOE.fetch_exchange
+  exchangeCapacityForecastDayAhead: ENTSOE.fetch_exchange_capacity_forecasts_day_ahead
+  exchangeCapacityForecastWeekAhead: ENTSOE.fetch_exchange_capacity_forecasts_week_ahead
+  exchangeCapacityForecastMonthAhead: ENTSOE.fetch_exchange_capacity_forecasts_month_ahead
+  exchangeForecast: ENTSOE.fetch_exchange_forecast
 rotation: 90

--- a/config/exchanges/RO_RS.yaml
+++ b/config/exchanges/RO_RS.yaml
@@ -6,4 +6,8 @@ lonlat:
   - 44.947107
 parsers:
   exchange: ENTSOE.fetch_exchange
+  exchangeCapacityForecastDayAhead: ENTSOE.fetch_exchange_capacity_forecasts_day_ahead
+  exchangeCapacityForecastWeekAhead: ENTSOE.fetch_exchange_capacity_forecasts_week_ahead
+  exchangeCapacityForecastMonthAhead: ENTSOE.fetch_exchange_capacity_forecasts_month_ahead
+  exchangeForecast: ENTSOE.fetch_exchange_forecast
 rotation: -140

--- a/config/exchanges/RO_UA.yaml
+++ b/config/exchanges/RO_UA.yaml
@@ -6,4 +6,8 @@ lonlat:
   - 47.768595
 parsers:
   exchange: ENTSOE.fetch_exchange
+  exchangeCapacityForecastDayAhead: ENTSOE.fetch_exchange_capacity_forecasts_day_ahead
+  exchangeCapacityForecastWeekAhead: ENTSOE.fetch_exchange_capacity_forecasts_week_ahead
+  exchangeCapacityForecastMonthAhead: ENTSOE.fetch_exchange_capacity_forecasts_month_ahead
+  exchangeForecast: ENTSOE.fetch_exchange_forecast
 rotation: 0

--- a/config/exchanges/RS_XK.yaml
+++ b/config/exchanges/RS_XK.yaml
@@ -3,4 +3,8 @@ lonlat:
   - 43.011
 parsers:
   exchange: ENTSOE.fetch_exchange
+  exchangeCapacityForecastDayAhead: ENTSOE.fetch_exchange_capacity_forecasts_day_ahead
+  exchangeCapacityForecastWeekAhead: ENTSOE.fetch_exchange_capacity_forecasts_week_ahead
+  exchangeCapacityForecastMonthAhead: ENTSOE.fetch_exchange_capacity_forecasts_month_ahead
+  exchangeForecast: ENTSOE.fetch_exchange_forecast
 rotation: -135

--- a/config/exchanges/SE-SE1_SE-SE2.yaml
+++ b/config/exchanges/SE-SE1_SE-SE2.yaml
@@ -6,5 +6,8 @@ lonlat:
   - 65.469
 parsers:
   exchange: ENTSOE.fetch_exchange
+  exchangeCapacityForecastDayAhead: ENTSOE.fetch_exchange_capacity_forecasts_day_ahead
+  exchangeCapacityForecastWeekAhead: ENTSOE.fetch_exchange_capacity_forecasts_week_ahead
+  exchangeCapacityForecastMonthAhead: ENTSOE.fetch_exchange_capacity_forecasts_month_ahead
   exchangeForecast: ENTSOE.fetch_exchange_forecast
 rotation: 205

--- a/config/exchanges/SE-SE2_SE-SE3.yaml
+++ b/config/exchanges/SE-SE2_SE-SE3.yaml
@@ -6,5 +6,8 @@ lonlat:
   - 61.42
 parsers:
   exchange: ENTSOE.fetch_exchange
+  exchangeCapacityForecastDayAhead: ENTSOE.fetch_exchange_capacity_forecasts_day_ahead
+  exchangeCapacityForecastWeekAhead: ENTSOE.fetch_exchange_capacity_forecasts_week_ahead
+  exchangeCapacityForecastMonthAhead: ENTSOE.fetch_exchange_capacity_forecasts_month_ahead
   exchangeForecast: ENTSOE.fetch_exchange_forecast
 rotation: 180

--- a/config/exchanges/SE-SE3_SE-SE4.yaml
+++ b/config/exchanges/SE-SE3_SE-SE4.yaml
@@ -6,5 +6,8 @@ lonlat:
   - 57.2
 parsers:
   exchange: ENTSOE.fetch_exchange
+  exchangeCapacityForecastDayAhead: ENTSOE.fetch_exchange_capacity_forecasts_day_ahead
+  exchangeCapacityForecastWeekAhead: ENTSOE.fetch_exchange_capacity_forecasts_week_ahead
+  exchangeCapacityForecastMonthAhead: ENTSOE.fetch_exchange_capacity_forecasts_month_ahead
   exchangeForecast: ENTSOE.fetch_exchange_forecast
 rotation: 180

--- a/config/exchanges/SK_UA.yaml
+++ b/config/exchanges/SK_UA.yaml
@@ -6,4 +6,8 @@ lonlat:
   - 48.820578
 parsers:
   exchange: ENTSOE.fetch_exchange
+  exchangeCapacityForecastDayAhead: ENTSOE.fetch_exchange_capacity_forecasts_day_ahead
+  exchangeCapacityForecastWeekAhead: ENTSOE.fetch_exchange_capacity_forecasts_week_ahead
+  exchangeCapacityForecastMonthAhead: ENTSOE.fetch_exchange_capacity_forecasts_month_ahead
+  exchangeForecast: ENTSOE.fetch_exchange_forecast
 rotation: 90


### PR DESCRIPTION
## Issue

<!-- If you want to close an issue automatically when your PR is merged, write "Closes X" where X is the issue number. For example: Closes #000 -->

[GMM-1682](https://linear.app/electricitymaps/issue/GMM-1682/add-functions-to-all-exchange-yaml-files)

## Description

<!-- Explains the goal of this PR -->
This PR adds exchangeCapacityForecast to ENTSOE exchange yaml files.

### Preview

<!-- Please add screenshots and/or gif that shows visual changes (if applicable) -->

### Double check

- [ ] I have tested my parser changes locally with `uv run test_parser "zone_key"`
- [x] I have run `pnpx prettier@2 --write .` and `uv run format` in the top level directory to format my changes.
