### PR TITLE
chore: remove delays config from zone YAML files

### DIFF
--- a/config/zones/AR.yaml
+++ b/config/zones/AR.yaml
@@ -166,8 +166,6 @@ contributors:
 country: AR
 country_name: Argentina
 currency: ARS
-delays:
-  production: 5
 disclaimer: Unknown production is the aggregation of thermal production, mainly gas.
 emissionFactors:
   direct:

--- a/config/zones/AT.yaml
+++ b/config/zones/AT.yaml
@@ -237,8 +237,6 @@ contributors:
 country: AT
 country_name: Austria
 currency: EUR
-delays:
-  production: 6
 emissionFactors:
   direct:
     biomass:

--- a/config/zones/AU-NSW.yaml
+++ b/config/zones/AU-NSW.yaml
@@ -99,8 +99,6 @@ contributors:
 country: AU
 country_name: Australia
 currency: AUD
-delays:
-  production: 96
 emissionFactors:
   direct:
     battery discharge:

--- a/config/zones/AU-NT.yaml
+++ b/config/zones/AU-NT.yaml
@@ -20,10 +20,6 @@ contributors:
 country: AU
 country_name: Australia
 currency: AUD
-delays:
-  consumption: 30
-  price: 30
-  production: 96
 disclaimer: The Northern Territory power grid is not connected to the (Australian) National Electricity Market or Western Australia's grid.
 emissionFactors:
   lifecycle: {}

--- a/config/zones/AU-QLD.yaml
+++ b/config/zones/AU-QLD.yaml
@@ -87,8 +87,6 @@ contributors:
 country: AU
 country_name: Australia
 currency: AUD
-delays:
-  production: 96
 emissionFactors:
   direct:
     battery discharge:

--- a/config/zones/AU-SA.yaml
+++ b/config/zones/AU-SA.yaml
@@ -85,8 +85,6 @@ contributors:
 country: AU
 country_name: Australia
 currency: AUD
-delays:
-  production: 96
 emissionFactors:
   direct:
     battery discharge:

--- a/config/zones/AU-TAS.yaml
+++ b/config/zones/AU-TAS.yaml
@@ -48,8 +48,6 @@ contributors:
 country: AU
 country_name: Australia
 currency: AUD
-delays:
-  production: 96
 emissionFactors:
   direct:
     battery discharge:

--- a/config/zones/AU-VIC.yaml
+++ b/config/zones/AU-VIC.yaml
@@ -84,8 +84,6 @@ contributors:
 country: AU
 country_name: Australia
 currency: AUD
-delays:
-  production: 96
 emissionFactors:
   direct:
     battery discharge:

--- a/config/zones/AU-WA.yaml
+++ b/config/zones/AU-WA.yaml
@@ -73,8 +73,6 @@ contributors:
 country: AU
 country_name: Australia
 currency: AUD
-delays:
-  production: 96
 disclaimer: Western Australia's power grid is not connected to the (Australian) National
   Electricity Market or the Northern Territory grid.
 emissionFactors:

--- a/config/zones/AX.yaml
+++ b/config/zones/AX.yaml
@@ -24,8 +24,6 @@ contributors:
 country: AX
 country_name: "\xC5land Islands"
 currency: EUR
-delays:
-  production: 5
 emissionFactors:
   direct:
     biomass:

--- a/config/zones/BA.yaml
+++ b/config/zones/BA.yaml
@@ -66,8 +66,6 @@ contributors:
 country: BA
 country_name: Bosnia and Herzegovina
 currency: BAM
-delays:
-  production: 72
 emissionFactors:
   direct:
     hydro discharge:

--- a/config/zones/BD.yaml
+++ b/config/zones/BD.yaml
@@ -123,8 +123,6 @@ contributors:
 country: BD
 country_name: Bangladesh
 currency: BDT
-delays:
-  production: 10
 emissionFactors:
   lifecycle: {}
 fallbackZoneMixes:

--- a/config/zones/BE.yaml
+++ b/config/zones/BE.yaml
@@ -209,8 +209,6 @@ contributors:
 country: BE
 country_name: Belgium
 currency: EUR
-delays:
-  production: 6
 emissionFactors:
   direct:
     battery discharge:

--- a/config/zones/BG.yaml
+++ b/config/zones/BG.yaml
@@ -155,8 +155,6 @@ contributors:
 country: BG
 country_name: Bulgaria
 currency: EUR
-delays:
-  production: 5
 emissionFactors:
   direct:
     biomass:

--- a/config/zones/BR-CS.yaml
+++ b/config/zones/BR-CS.yaml
@@ -34,8 +34,6 @@ contributors:
 country: BR
 country_name: Brazil
 currency: BRL
-delays:
-  production: 5
 disclaimer: Unknown production is the aggregation of thermal production, mainly gas, coal and oil.
 fallbackZoneMixes:
   powerOriginRatios:

--- a/config/zones/BR-N.yaml
+++ b/config/zones/BR-N.yaml
@@ -34,8 +34,6 @@ contributors:
 country: BR
 country_name: Brazil
 currency: BRL
-delays:
-  production: 5
 disclaimer: Unknown production is the aggregation of thermal production, mainly gas, coal and oil.
 fallbackZoneMixes:
   powerOriginRatios:

--- a/config/zones/BR-NE.yaml
+++ b/config/zones/BR-NE.yaml
@@ -34,8 +34,6 @@ contributors:
 country: BR
 country_name: Brazil
 currency: BRL
-delays:
-  production: 5
 disclaimer: Unknown production is the aggregation of thermal production, mainly gas, coal and oil.
 fallbackZoneMixes:
   powerOriginRatios:

--- a/config/zones/BR-S.yaml
+++ b/config/zones/BR-S.yaml
@@ -34,8 +34,6 @@ contributors:
 country: BR
 country_name: Brazil
 currency: BRL
-delays:
-  production: 5
 disclaimer: Unknown production is the aggregation of thermal production, mainly gas, coal and oil.
 fallbackZoneMixes:
   powerOriginRatios:

--- a/config/zones/CA-AB.yaml
+++ b/config/zones/CA-AB.yaml
@@ -15,8 +15,6 @@ contributors:
 country: CA
 country_name: Canada
 currency: CAD
-delays:
-  production: 5
 emissionFactors:
   direct:
     battery discharge:

--- a/config/zones/CA-NB.yaml
+++ b/config/zones/CA-NB.yaml
@@ -24,8 +24,6 @@ contributors:
 country: CA
 country_name: Canada
 currency: CAD
-delays:
-  production: 5
 emissionFactors:
   direct:
     unknown:

--- a/config/zones/CA-ON.yaml
+++ b/config/zones/CA-ON.yaml
@@ -57,8 +57,6 @@ contributors:
 country: CA
 country_name: Canada
 currency: CAD
-delays:
-  production: 6
 emissionFactors:
   direct: {}
   lifecycle:

--- a/config/zones/CA-QC.yaml
+++ b/config/zones/CA-QC.yaml
@@ -28,8 +28,6 @@ contributors:
 country: CA
 country_name: Canada
 currency: CAD
-delays:
-  production: 6
 fallbackZoneMixes:
   powerOriginRatios:
     - _source: Electricity Maps, 2015 average

--- a/config/zones/CH.yaml
+++ b/config/zones/CH.yaml
@@ -116,8 +116,6 @@ contributors:
 country: CH
 country_name: Switzerland
 currency: EUR
-delays:
-  production: 7
 disclaimer: Data for the electricity consumption and generation mix is based on estimates stemming from different data sources. As such, it may diverge from aggregated public statistics of the Swiss Federal Office for Energy.
 emissionFactors:
   direct:

--- a/config/zones/CL-SEN.yaml
+++ b/config/zones/CL-SEN.yaml
@@ -51,8 +51,6 @@ contributors:
 country: CL
 country_name: Chile
 currency: CLP
-delays:
-  production: 22
 disclaimer: Unknown production is the aggregation of thermal production, mainly gas, coal and oil.
 emissionFactors:
   direct:

--- a/config/zones/CO.yaml
+++ b/config/zones/CO.yaml
@@ -133,8 +133,6 @@ contributors:
 country: CO
 country_name: Colombia
 currency: COP
-delays:
-  production: 84
 emissionFactors:
   lifecycle: {}
 fallbackZoneMixes:

--- a/config/zones/CR.yaml
+++ b/config/zones/CR.yaml
@@ -108,8 +108,6 @@ contributors:
 country: CR
 country_name: Costa Rica
 currency: CRC
-delays:
-  production: 7
 emissionFactors:
   direct:
     unknown:

--- a/config/zones/CY.yaml
+++ b/config/zones/CY.yaml
@@ -55,8 +55,6 @@ contributors:
 country: CY
 country_name: Cyprus
 currency: EUR
-delays:
-  production: 5
 emissionFactors:
   direct:
     biomass:

--- a/config/zones/CZ.yaml
+++ b/config/zones/CZ.yaml
@@ -152,8 +152,6 @@ contributors:
 country: CZ
 country_name: Czechia
 currency: EUR
-delays:
-  production: 7
 emissionFactors:
   direct:
     biomass:

--- a/config/zones/DE.yaml
+++ b/config/zones/DE.yaml
@@ -290,8 +290,6 @@ contributors:
 country: DE
 country_name: Germany
 currency: EUR
-delays:
-  production: 7
 emissionFactors:
   direct:
     biomass:

--- a/config/zones/DK-BHM.yaml
+++ b/config/zones/DK-BHM.yaml
@@ -17,8 +17,6 @@ contributors:
 country: DK
 country_name: Denmark
 currency: EUR
-delays:
-  production: 6
 emissionFactors:
   direct:
     biomass:

--- a/config/zones/DK-DK1.yaml
+++ b/config/zones/DK-DK1.yaml
@@ -171,8 +171,6 @@ contributors:
 country: DK
 country_name: Denmark
 currency: EUR
-delays:
-  production: 7
 emissionFactors:
   direct:
     biomass:

--- a/config/zones/DK-DK2.yaml
+++ b/config/zones/DK-DK2.yaml
@@ -156,8 +156,6 @@ contributors:
 country: DK
 country_name: Denmark
 currency: EUR
-delays:
-  production: 7
 emissionFactors:
   direct:
     biomass:

--- a/config/zones/EE.yaml
+++ b/config/zones/EE.yaml
@@ -213,8 +213,6 @@ contributors:
 country: EE
 country_name: Estonia
 currency: EUR
-delays:
-  production: 6
 emissionFactors:
   direct:
     biomass:

--- a/config/zones/ES-IB-IZ.yaml
+++ b/config/zones/ES-IB-IZ.yaml
@@ -18,8 +18,6 @@ contributors:
 country: ES
 country_name: Spain
 currency: EUR
-delays:
-  production: 5
 emissionFactors:
   direct:
     biomass:

--- a/config/zones/ES-IB-MA.yaml
+++ b/config/zones/ES-IB-MA.yaml
@@ -16,8 +16,6 @@ contributors:
 country: ES
 country_name: Spain
 currency: EUR
-delays:
-  production: 5
 emissionFactors:
   direct:
     battery discharge:

--- a/config/zones/ES-IB-ME.yaml
+++ b/config/zones/ES-IB-ME.yaml
@@ -61,8 +61,6 @@ contributors:
 country: ES
 country_name: Spain
 currency: EUR
-delays:
-  production: 5
 emissionFactors:
   direct:
     biomass:

--- a/config/zones/ES.yaml
+++ b/config/zones/ES.yaml
@@ -237,8 +237,6 @@ contributors:
 country: ES
 country_name: Spain
 currency: EUR
-delays:
-  production: 6
 emissionFactors:
   direct:
     battery discharge:

--- a/config/zones/FI.yaml
+++ b/config/zones/FI.yaml
@@ -111,8 +111,6 @@ contributors:
 country: FI
 country_name: Finland
 currency: EUR
-delays:
-  production: 6
 emissionFactors:
   direct:
     biomass:

--- a/config/zones/FR-COR.yaml
+++ b/config/zones/FR-COR.yaml
@@ -23,8 +23,6 @@ contributors:
 country: FR
 country_name: France
 currency: EUR
-delays:
-  production: 6
 emissionFactors:
   direct:
     battery discharge:

--- a/config/zones/FR.yaml
+++ b/config/zones/FR.yaml
@@ -279,8 +279,6 @@ contributors:
 country: FR
 country_name: France
 currency: EUR
-delays:
-  production: 6
 emissionFactors:
   direct:
     battery discharge:

--- a/config/zones/GB-NIR.yaml
+++ b/config/zones/GB-NIR.yaml
@@ -29,8 +29,6 @@ contributors:
 country: GB
 country_name: Northern Ireland
 currency: EUR
-delays:
-  production: 5
 disclaimer: The complete generation mix is unavailable. It is therefore estimated
   by Electricity Maps.
 emissionFactors:

--- a/config/zones/GB-ORK.yaml
+++ b/config/zones/GB-ORK.yaml
@@ -18,8 +18,6 @@ contributors:
 country: GB
 country_name: Great Britain
 currency: GBP
-delays:
-  production: 5
 emissionFactors:
   direct:
     unknown:

--- a/config/zones/GB.yaml
+++ b/config/zones/GB.yaml
@@ -197,8 +197,6 @@ contributors:
 country: GB
 country_name: Great Britain
 currency: GBP
-delays:
-  production: 5
 emissionFactors:
   direct:
     hydro discharge:

--- a/config/zones/GE.yaml
+++ b/config/zones/GE.yaml
@@ -75,8 +75,6 @@ contributors:
 country: GE
 country_name: Georgia
 currency: GEL
-delays:
-  production: 5
 fallbackZoneMixes:
   powerOriginRatios:
     - _source: Electricity Maps, 2017 average

--- a/config/zones/GR.yaml
+++ b/config/zones/GR.yaml
@@ -172,8 +172,6 @@ contributors:
 country: GR
 country_name: Greece
 currency: EUR
-delays:
-  production: 9
 emissionFactors:
   direct:
     biomass:

--- a/config/zones/HN.yaml
+++ b/config/zones/HN.yaml
@@ -82,8 +82,6 @@ contributors:
   - VIKTORVAV99
 country: HN
 country_name: Honduras
-delays:
-  production: 5
 emissionFactors:
   direct:
     unknown:

--- a/config/zones/HR.yaml
+++ b/config/zones/HR.yaml
@@ -194,8 +194,6 @@ contributors:
 country: HR
 country_name: Croatia
 currency: EUR
-delays:
-  production: 6
 emissionFactors:
   direct:
     battery discharge:

--- a/config/zones/HU.yaml
+++ b/config/zones/HU.yaml
@@ -193,8 +193,6 @@ contributors:
 country: HU
 country_name: Hungary
 currency: EUR
-delays:
-  production: 6
 emissionFactors:
   direct:
     biomass:

--- a/config/zones/IE.yaml
+++ b/config/zones/IE.yaml
@@ -105,8 +105,6 @@ contributors:
 country: IE
 country_name: Ireland
 currency: EUR
-delays:
-  production: 5
 disclaimer: The complete generation mix is unavailable. It is therefore estimated
   by Electricity Maps.
 emissionFactors:

--- a/config/zones/IN-EA.yaml
+++ b/config/zones/IN-EA.yaml
@@ -50,8 +50,6 @@ contributors:
 country: IN
 country_name: India
 currency: INR
-delays:
-  production: 120
 emissionFactors:
   direct:
     unknown:

--- a/config/zones/IN-NE.yaml
+++ b/config/zones/IN-NE.yaml
@@ -50,8 +50,6 @@ contributors:
 country: IN
 country_name: India
 currency: INR
-delays:
-  production: 120
 emissionFactors:
   direct:
     unknown:

--- a/config/zones/IN-NO.yaml
+++ b/config/zones/IN-NO.yaml
@@ -56,8 +56,6 @@ contributors:
 country: IN
 country_name: India
 currency: INR
-delays:
-  production: 120
 emissionFactors:
   direct:
     unknown:

--- a/config/zones/IN-SO.yaml
+++ b/config/zones/IN-SO.yaml
@@ -52,8 +52,6 @@ contributors:
 country: IN
 country_name: India
 currency: INR
-delays:
-  production: 120
 emissionFactors:
   direct:
     unknown:

--- a/config/zones/IN-WE.yaml
+++ b/config/zones/IN-WE.yaml
@@ -54,8 +54,6 @@ contributors:
 country: IN
 country_name: India
 currency: INR
-delays:
-  production: 120
 emissionFactors:
   direct:
     unknown:

--- a/config/zones/IS.yaml
+++ b/config/zones/IS.yaml
@@ -58,8 +58,6 @@ contributors:
 country: IS
 country_name: Iceland
 currency: ISK
-delays:
-  production: 5
 emissionFactors:
   direct:
     biomass:

--- a/config/zones/IT-CNO.yaml
+++ b/config/zones/IT-CNO.yaml
@@ -71,8 +71,6 @@ contributors:
 country: IT
 country_name: Italy
 currency: EUR
-delays:
-  production: 7
 emissionFactors:
   direct:
     battery discharge:

--- a/config/zones/IT-CSO.yaml
+++ b/config/zones/IT-CSO.yaml
@@ -112,8 +112,6 @@ contributors:
 country: IT
 country_name: Italy
 currency: EUR
-delays:
-  production: 7
 emissionFactors:
   direct:
     battery discharge:

--- a/config/zones/IT-NO.yaml
+++ b/config/zones/IT-NO.yaml
@@ -101,8 +101,6 @@ contributors:
 country: IT
 country_name: Italy
 currency: EUR
-delays:
-  production: 7
 emissionFactors:
   direct:
     battery discharge:

--- a/config/zones/IT-SAR.yaml
+++ b/config/zones/IT-SAR.yaml
@@ -76,8 +76,6 @@ contributors:
 country: IT
 country_name: Italy
 currency: EUR
-delays:
-  production: 7
 emissionFactors:
   direct:
     battery discharge:

--- a/config/zones/IT-SIC.yaml
+++ b/config/zones/IT-SIC.yaml
@@ -81,8 +81,6 @@ contributors:
 country: IT
 country_name: Italy
 currency: EUR
-delays:
-  production: 7
 emissionFactors:
   direct:
     battery discharge:

--- a/config/zones/IT-SO.yaml
+++ b/config/zones/IT-SO.yaml
@@ -84,8 +84,6 @@ contributors:
 country: IT
 country_name: Italy
 currency: EUR
-delays:
-  production: 7
 emissionFactors:
   direct:
     biomass:

--- a/config/zones/JP-CB.yaml
+++ b/config/zones/JP-CB.yaml
@@ -29,8 +29,6 @@ contributors:
 country: JP
 country_name: Japan
 currency: JPY
-delays:
-  production: 5
 disclaimer: The data provided for solar power production is suspected to be too high
   (source; Chubu Electric Power Co.,Inc.).
 emissionFactors:

--- a/config/zones/JP-CG.yaml
+++ b/config/zones/JP-CG.yaml
@@ -28,8 +28,6 @@ contributors:
 country: JP
 country_name: Japan
 currency: JPY
-delays:
-  production: 5
 emissionFactors:
   direct:
     hydro discharge:

--- a/config/zones/JP-HKD.yaml
+++ b/config/zones/JP-HKD.yaml
@@ -31,8 +31,6 @@ contributors:
 country: JP
 country_name: Japan
 currency: JPY
-delays:
-  production: 5
 emissionFactors:
   direct:
     hydro discharge:

--- a/config/zones/JP-HR.yaml
+++ b/config/zones/JP-HR.yaml
@@ -28,8 +28,6 @@ contributors:
 country: JP
 country_name: Japan
 currency: JPY
-delays:
-  production: 5
 disclaimer: The data provider (Hokuriku Electric Power Co.,Inc.) provides live data
   only for solar and unknown. We are working on improving the data quality for this
   zone.

--- a/config/zones/JP-KN.yaml
+++ b/config/zones/JP-KN.yaml
@@ -27,8 +27,6 @@ contributors:
 country: JP
 country_name: Japan
 currency: JPY
-delays:
-  production: 5
 emissionFactors:
   direct:
     hydro discharge:

--- a/config/zones/JP-KY.yaml
+++ b/config/zones/JP-KY.yaml
@@ -24,8 +24,6 @@ contributors:
 country: JP
 country_name: Japan
 currency: JPY
-delays:
-  production: 5
 emissionFactors:
   direct:
     hydro discharge:

--- a/config/zones/JP-ON.yaml
+++ b/config/zones/JP-ON.yaml
@@ -26,8 +26,6 @@ contributors:
 country: JP
 country_name: Japan
 currency: JPY
-delays:
-  production: 5
 emissionFactors:
   direct:
     hydro discharge:

--- a/config/zones/JP-SK.yaml
+++ b/config/zones/JP-SK.yaml
@@ -29,8 +29,6 @@ contributors:
 country: JP
 country_name: Japan
 currency: JPY
-delays:
-  production: 5
 disclaimer: The data provider (Yonden Shikoku Electric Power Co.,Inc.) provides live
   data only for solar and unknown. We are working on improving the data quality for
   this zone.

--- a/config/zones/JP-TH.yaml
+++ b/config/zones/JP-TH.yaml
@@ -30,8 +30,6 @@ contributors:
 country: JP
 country_name: Japan
 currency: JPY
-delays:
-  production: 5
 emissionFactors:
   lifecycle: {}
 fallbackZoneMixes:

--- a/config/zones/JP-TK.yaml
+++ b/config/zones/JP-TK.yaml
@@ -26,8 +26,6 @@ contributors:
 country: JP
 country_name: Japan
 currency: JPY
-delays:
-  production: 5
 emissionFactors:
   direct:
     hydro discharge:

--- a/config/zones/KR.yaml
+++ b/config/zones/KR.yaml
@@ -195,8 +195,6 @@ contributors:
 country: KR
 country_name: South Korea
 currency: KRW
-delays:
-  production: 5
 emissionFactors:
   direct:
     hydro discharge:

--- a/config/zones/LK.yaml
+++ b/config/zones/LK.yaml
@@ -94,8 +94,6 @@ contributors:
 country: LK
 country_name: Sri Lanka
 currency: LKR
-delays:
-  production: 30
 emissionFactors:
   lifecycle: {}
 fallbackZoneMixes:

--- a/config/zones/LT.yaml
+++ b/config/zones/LT.yaml
@@ -178,8 +178,6 @@ contributors:
 country: LT
 country_name: Lithuania
 currency: EUR
-delays:
-  production: 6
 emissionFactors:
   direct:
     battery discharge:

--- a/config/zones/LU.yaml
+++ b/config/zones/LU.yaml
@@ -132,8 +132,6 @@ contributors:
 country: LU
 country_name: Luxembourg
 currency: EUR
-delays:
-  production: 6
 emissionFactors:
   direct:
     biomass:

--- a/config/zones/LV.yaml
+++ b/config/zones/LV.yaml
@@ -131,8 +131,6 @@ contributors:
 country: LV
 country_name: Latvia
 currency: EUR
-delays:
-  production: 6
 emissionFactors:
   direct:
     battery discharge:

--- a/config/zones/MD.yaml
+++ b/config/zones/MD.yaml
@@ -80,8 +80,6 @@ contributors:
 country: MD
 country_name: Moldova
 currency: MDL
-delays:
-  production: 12
 emissionFactors:
   direct: {}
   lifecycle:

--- a/config/zones/ME.yaml
+++ b/config/zones/ME.yaml
@@ -42,8 +42,6 @@ contributors:
 country: ME
 country_name: Montenegro
 currency: EUR
-delays:
-  production: 6
 emissionFactors:
   direct: {}
   lifecycle:

--- a/config/zones/MK.yaml
+++ b/config/zones/MK.yaml
@@ -50,13 +50,6 @@ capacity:
 country: MK
 country_name: North Macedonia
 currency: EUR
-delays:
-  consumption: 24
-  consumptionForecast: 24
-  generationForecast: 24
-  price: 24
-  production: 34
-  productionPerModeForecast: 24
 emissionFactors:
   direct: {}
   lifecycle:

--- a/config/zones/MX.yaml
+++ b/config/zones/MX.yaml
@@ -136,8 +136,6 @@ contributors:
 country: MX
 country_name: Mexico
 currency: MXN
-delays:
-  production: 1080
 emissionFactors:
   direct:
     unknown:

--- a/config/zones/MY-WM.yaml
+++ b/config/zones/MY-WM.yaml
@@ -20,8 +20,6 @@ contributors:
   - nessie2013
 country: MY
 country_name: Malaysia
-delays:
-  production: 5
 fallbackZoneMixes:
   powerOriginRatios:
     - _source: Electricity Maps, 2017 average

--- a/config/zones/NI.yaml
+++ b/config/zones/NI.yaml
@@ -48,8 +48,6 @@ contributors:
   - jarek
 country: NI
 country_name: Nicaragua
-delays:
-  production: 5
 fallbackZoneMixes:
   powerOriginRatios:
     - _source: Electricity Maps, 2015 average

--- a/config/zones/NL.yaml
+++ b/config/zones/NL.yaml
@@ -194,8 +194,6 @@ contributors:
 country: NL
 country_name: Netherlands
 currency: EUR
-delays:
-  production: 6
 disclaimer: Solar production is collected from NED.nl and can contain their own estimations.
 emissionFactors:
   direct:

--- a/config/zones/NO-NO1.yaml
+++ b/config/zones/NO-NO1.yaml
@@ -82,8 +82,6 @@ capacity:
 country: 'NO'
 country_name: Norway
 currency: EUR
-delays:
-  production: 7
 emissionFactors:
   direct:
     biomass:

--- a/config/zones/NO-NO2.yaml
+++ b/config/zones/NO-NO2.yaml
@@ -91,8 +91,6 @@ capacity:
 country: 'NO'
 country_name: Norway
 currency: EUR
-delays:
-  production: 7
 emissionFactors:
   direct:
     biomass:

--- a/config/zones/NO-NO3.yaml
+++ b/config/zones/NO-NO3.yaml
@@ -97,8 +97,6 @@ capacity:
 country: 'NO'
 country_name: Norway
 currency: EUR
-delays:
-  production: 7
 emissionFactors:
   direct:
     biomass:

--- a/config/zones/NO-NO4.yaml
+++ b/config/zones/NO-NO4.yaml
@@ -77,8 +77,6 @@ capacity:
 country: 'NO'
 country_name: Norway
 currency: EUR
-delays:
-  production: 7
 emissionFactors:
   direct:
     biomass:

--- a/config/zones/NO-NO5.yaml
+++ b/config/zones/NO-NO5.yaml
@@ -76,8 +76,6 @@ capacity:
 country: 'NO'
 country_name: Norway
 currency: EUR
-delays:
-  production: 7
 emissionFactors:
   direct:
     biomass:

--- a/config/zones/NZ.yaml
+++ b/config/zones/NZ.yaml
@@ -103,8 +103,6 @@ contributors:
 country: NZ
 country_name: New Zealand
 currency: NZD
-delays:
-  production: 6
 emissionFactors:
   direct:
     battery discharge:

--- a/config/zones/PA.yaml
+++ b/config/zones/PA.yaml
@@ -115,8 +115,6 @@ contributors:
   - r24mille
 country: PA
 country_name: Panama
-delays:
-  production: 5
 fallbackZoneMixes:
   powerOriginRatios:
     - _source: Electricity Maps, 2015 average

--- a/config/zones/PE.yaml
+++ b/config/zones/PE.yaml
@@ -131,8 +131,6 @@ contributors:
 country: PE
 country_name: Peru
 currency: PEN
-delays:
-  production: 22
 fallbackZoneMixes:
   powerOriginRatios:
     - _source: Electricity Maps, 2015 average

--- a/config/zones/PH-LU.yaml
+++ b/config/zones/PH-LU.yaml
@@ -30,8 +30,6 @@ contributors:
   - xomanuel
 country: PH
 country_name: Philippines
-delays:
-  production: 25
 emissionFactors:
   direct:
     battery discharge:

--- a/config/zones/PH-MI.yaml
+++ b/config/zones/PH-MI.yaml
@@ -28,8 +28,6 @@ contributors:
   - xomanuel
 country: PH
 country_name: Philippines
-delays:
-  production: 25
 emissionFactors:
   direct:
     battery discharge:

--- a/config/zones/PH-VI.yaml
+++ b/config/zones/PH-VI.yaml
@@ -29,8 +29,6 @@ contributors:
   - xomanuel
 country: PH
 country_name: Philippines
-delays:
-  production: 25
 emissionFactors:
   direct:
     battery discharge:

--- a/config/zones/PL.yaml
+++ b/config/zones/PL.yaml
@@ -232,8 +232,6 @@ contributors:
 country: PL
 country_name: Poland
 currency: EUR
-delays:
-  production: 7
 emissionFactors:
   direct:
     biomass:

--- a/config/zones/PT.yaml
+++ b/config/zones/PT.yaml
@@ -224,8 +224,6 @@ contributors:
 country: PT
 country_name: Portugal
 currency: EUR
-delays:
-  production: 6
 emissionFactors:
   direct:
     biomass:

--- a/config/zones/RO.yaml
+++ b/config/zones/RO.yaml
@@ -178,8 +178,6 @@ contributors:
 country: RO
 country_name: Romania
 currency: EUR
-delays:
-  production: 6
 emissionFactors:
   direct:
     battery discharge:

--- a/config/zones/RS.yaml
+++ b/config/zones/RS.yaml
@@ -159,8 +159,6 @@ contributors:
 country: RS
 country_name: Serbia
 currency: EUR
-delays:
-  production: 9
 emissionFactors:
   direct:
     hydro discharge:

--- a/config/zones/RU-1.yaml
+++ b/config/zones/RU-1.yaml
@@ -20,8 +20,6 @@ contributors:
 country: RU
 country_name: Russia
 currency: RUB
-delays:
-  production: 6
 emissionFactors:
   direct:
     unknown:

--- a/config/zones/SE-SE1.yaml
+++ b/config/zones/SE-SE1.yaml
@@ -62,8 +62,6 @@ capacity:
 country: SE
 country_name: Sweden
 currency: EUR
-delays:
-  production: 7
 emissionFactors:
   direct:
     biomass:

--- a/config/zones/SE-SE2.yaml
+++ b/config/zones/SE-SE2.yaml
@@ -62,8 +62,6 @@ capacity:
 country: SE
 country_name: Sweden
 currency: EUR
-delays:
-  production: 7
 emissionFactors:
   direct:
     biomass:

--- a/config/zones/SE-SE3.yaml
+++ b/config/zones/SE-SE3.yaml
@@ -69,8 +69,6 @@ capacity:
 country: SE
 country_name: Sweden
 currency: EUR
-delays:
-  production: 7
 emissionFactors:
   direct:
     biomass:

--- a/config/zones/SE-SE4.yaml
+++ b/config/zones/SE-SE4.yaml
@@ -62,8 +62,6 @@ capacity:
 country: SE
 country_name: Sweden
 currency: EUR
-delays:
-  production: 7
 emissionFactors:
   direct:
     biomass:

--- a/config/zones/SG.yaml
+++ b/config/zones/SG.yaml
@@ -88,8 +88,6 @@ contributors:
 country: SG
 country_name: Singapore
 currency: SGD
-delays:
-  production: 5
 fallbackZoneMixes:
   powerOriginRatios:
     - _source: Electricity Maps, 2015 average

--- a/config/zones/SI.yaml
+++ b/config/zones/SI.yaml
@@ -165,8 +165,6 @@ contributors:
 country: SI
 country_name: Slovenia
 currency: EUR
-delays:
-  production: 7
 emissionFactors:
   direct:
     biomass:

--- a/config/zones/SK.yaml
+++ b/config/zones/SK.yaml
@@ -128,8 +128,6 @@ contributors:
 country: SK
 country_name: Slovakia
 currency: EUR
-delays:
-  production: 6
 emissionFactors:
   direct:
     biomass:

--- a/config/zones/TR.yaml
+++ b/config/zones/TR.yaml
@@ -166,8 +166,6 @@ contributors:
 country: TR
 country_name: Turkey
 currency: TRY
-delays:
-  production: 8
 emissionFactors:
   direct: {}
   lifecycle:

--- a/config/zones/TW.yaml
+++ b/config/zones/TW.yaml
@@ -171,8 +171,6 @@ contributors:
 country: TW
 country_name: Taiwan
 currency: TWD
-delays:
-  production: 5
 emissionFactors:
   direct:
     battery discharge:

--- a/config/zones/US-AK-SEAPA.yaml
+++ b/config/zones/US-AK-SEAPA.yaml
@@ -13,8 +13,6 @@ contributors:
   - wrma6
 country: US
 country_name: USA
-delays:
-  production: 2
 emissionFactors:
   direct:
     biomass:

--- a/config/zones/US-CAL-BANC.yaml
+++ b/config/zones/US-CAL-BANC.yaml
@@ -146,10 +146,6 @@ contributors:
   - KabelWlan
 country: US
 country_name: USA
-delays:
-  consumption: 30
-  consumptionForecast: 30
-  production: 48
 emissionFactors:
   direct:
     biomass:

--- a/config/zones/US-CAL-CISO.yaml
+++ b/config/zones/US-CAL-CISO.yaml
@@ -1033,8 +1033,6 @@ contributors:
 country: US
 country_name: USA
 currency: USD
-delays:
-  production: 5
 emissionFactors:
   direct:
     battery discharge:

--- a/config/zones/US-CAL-IID.yaml
+++ b/config/zones/US-CAL-IID.yaml
@@ -149,10 +149,6 @@ contributors:
   - KabelWlan
 country: US
 country_name: USA
-delays:
-  consumption: 30
-  consumptionForecast: 30
-  production: 48
 emissionFactors:
   direct:
     battery discharge:

--- a/config/zones/US-CAL-LDWP.yaml
+++ b/config/zones/US-CAL-LDWP.yaml
@@ -239,10 +239,6 @@ contributors:
   - KabelWlan
 country: US
 country_name: USA
-delays:
-  consumption: 30
-  consumptionForecast: 30
-  production: 48
 emissionFactors:
   direct:
     battery discharge:

--- a/config/zones/US-CAL-TIDC.yaml
+++ b/config/zones/US-CAL-TIDC.yaml
@@ -71,10 +71,6 @@ contributors:
   - KabelWlan
 country: US
 country_name: USA
-delays:
-  consumption: 30
-  consumptionForecast: 30
-  production: 48
 emissionFactors:
   direct:
     biomass:

--- a/config/zones/US-CAR-CPLE.yaml
+++ b/config/zones/US-CAR-CPLE.yaml
@@ -269,10 +269,6 @@ contributors:
   - KabelWlan
 country: US
 country_name: USA
-delays:
-  consumption: 30
-  consumptionForecast: 30
-  production: 48
 emissionFactors:
   direct:
     battery discharge:

--- a/config/zones/US-CAR-CPLW.yaml
+++ b/config/zones/US-CAR-CPLW.yaml
@@ -86,10 +86,6 @@ contributors:
   - KabelWlan
 country: US
 country_name: USA
-delays:
-  consumption: 30
-  consumptionForecast: 30
-  production: 48
 emissionFactors:
   direct:
     biomass:

--- a/config/zones/US-CAR-DUK.yaml
+++ b/config/zones/US-CAR-DUK.yaml
@@ -362,10 +362,6 @@ contributors:
   - KabelWlan
 country: US
 country_name: USA
-delays:
-  consumption: 30
-  consumptionForecast: 30
-  production: 48
 emissionFactors:
   direct:
     battery discharge:

--- a/config/zones/US-CAR-SC.yaml
+++ b/config/zones/US-CAR-SC.yaml
@@ -110,10 +110,6 @@ contributors:
   - KabelWlan
 country: US
 country_name: USA
-delays:
-  consumption: 30
-  consumptionForecast: 30
-  production: 48
 disclaimer: This zone includes a third of the nuclear related electricity production
   from the balancing authority South Carolina Electric & Gas Company. Read more on
   the zone definition wiki page.

--- a/config/zones/US-CAR-SCEG.yaml
+++ b/config/zones/US-CAR-SCEG.yaml
@@ -209,10 +209,6 @@ contributors:
   - KabelWlan
 country: US
 country_name: USA
-delays:
-  consumption: 30
-  consumptionForecast: 30
-  production: 48
 disclaimer: A third of the nuclear-related electricity production is attributed to
   the balancing authority South Carolina Public Service Authority (US-CAR-SC) due
   to an agreement between the two balancing authorities. Read more on the zone definition

--- a/config/zones/US-CAR-YAD.yaml
+++ b/config/zones/US-CAR-YAD.yaml
@@ -60,8 +60,6 @@ contributors:
   - KabelWlan
 country: US
 country_name: USA
-delays:
-  production: 48
 emissionFactors:
   direct:
     biomass:

--- a/config/zones/US-CENT-SPA.yaml
+++ b/config/zones/US-CENT-SPA.yaml
@@ -113,10 +113,6 @@ contributors:
   - KabelWlan
 country: US
 country_name: USA
-delays:
-  consumption: 30
-  consumptionForecast: 30
-  production: 48
 emissionFactors:
   direct:
     biomass:

--- a/config/zones/US-CENT-SWPP.yaml
+++ b/config/zones/US-CENT-SWPP.yaml
@@ -699,8 +699,6 @@ contributors:
 country: US
 country_name: USA
 currency: USD
-delays:
-  production: 5
 emissionFactors:
   direct:
     biomass:

--- a/config/zones/US-FLA-FMPP.yaml
+++ b/config/zones/US-FLA-FMPP.yaml
@@ -105,10 +105,6 @@ contributors:
 country: US
 country_name: USA
 currency: USD
-delays:
-  consumption: 30
-  consumptionForecast: 30
-  production: 48
 emissionFactors:
   direct:
     biomass:

--- a/config/zones/US-FLA-FPC.yaml
+++ b/config/zones/US-FLA-FPC.yaml
@@ -227,10 +227,6 @@ contributors:
   - KabelWlan
 country: US
 country_name: USA
-delays:
-  consumption: 30
-  consumptionForecast: 30
-  production: 48
 emissionFactors:
   direct:
     battery discharge:

--- a/config/zones/US-FLA-FPL.yaml
+++ b/config/zones/US-FLA-FPL.yaml
@@ -215,10 +215,6 @@ contributors:
   - KabelWlan
 country: US
 country_name: USA
-delays:
-  consumption: 30
-  consumptionForecast: 30
-  production: 48
 emissionFactors:
   direct:
     battery discharge:

--- a/config/zones/US-FLA-GVL.yaml
+++ b/config/zones/US-FLA-GVL.yaml
@@ -89,10 +89,6 @@ contributors:
   - KabelWlan
 country: US
 country_name: USA
-delays:
-  consumption: 30
-  consumptionForecast: 30
-  production: 48
 emissionFactors:
   direct:
     biomass:

--- a/config/zones/US-FLA-HST.yaml
+++ b/config/zones/US-FLA-HST.yaml
@@ -78,10 +78,6 @@ contributors:
   - KabelWlan
 country: US
 country_name: USA
-delays:
-  consumption: 30
-  consumptionForecast: 30
-  production: 48
 emissionFactors:
   direct:
     biomass:

--- a/config/zones/US-FLA-JEA.yaml
+++ b/config/zones/US-FLA-JEA.yaml
@@ -97,10 +97,6 @@ contributors:
   - KabelWlan
 country: US
 country_name: USA
-delays:
-  consumption: 30
-  consumptionForecast: 30
-  production: 48
 emissionFactors:
   direct:
     biomass:

--- a/config/zones/US-FLA-SEC.yaml
+++ b/config/zones/US-FLA-SEC.yaml
@@ -86,10 +86,6 @@ contributors:
   - KabelWlan
 country: US
 country_name: USA
-delays:
-  consumption: 30
-  consumptionForecast: 30
-  production: 48
 emissionFactors:
   direct:
     biomass:

--- a/config/zones/US-FLA-TAL.yaml
+++ b/config/zones/US-FLA-TAL.yaml
@@ -89,10 +89,6 @@ contributors:
   - KabelWlan
 country: US
 country_name: USA
-delays:
-  consumption: 30
-  consumptionForecast: 30
-  production: 48
 emissionFactors:
   direct:
     biomass:

--- a/config/zones/US-FLA-TEC.yaml
+++ b/config/zones/US-FLA-TEC.yaml
@@ -195,10 +195,6 @@ contributors:
   - KabelWlan
 country: US
 country_name: USA
-delays:
-  consumption: 30
-  consumptionForecast: 30
-  production: 48
 emissionFactors:
   direct:
     biomass:

--- a/config/zones/US-MIDA-PJM.yaml
+++ b/config/zones/US-MIDA-PJM.yaml
@@ -1179,8 +1179,6 @@ contributors:
 country: US
 country_name: USA
 currency: USD
-delays:
-  production: 7
 emissionFactors:
   direct:
     battery discharge:

--- a/config/zones/US-MIDW-AECI.yaml
+++ b/config/zones/US-MIDW-AECI.yaml
@@ -98,10 +98,6 @@ contributors:
   - KabelWlan
 country: US
 country_name: USA
-delays:
-  consumption: 30
-  consumptionForecast: 30
-  production: 48
 emissionFactors:
   direct:
     biomass:

--- a/config/zones/US-MIDW-LGEE.yaml
+++ b/config/zones/US-MIDW-LGEE.yaml
@@ -110,10 +110,6 @@ contributors:
   - KabelWlan
 country: US
 country_name: USA
-delays:
-  consumption: 30
-  consumptionForecast: 30
-  production: 48
 emissionFactors:
   direct:
     biomass:

--- a/config/zones/US-MIDW-MISO.yaml
+++ b/config/zones/US-MIDW-MISO.yaml
@@ -1258,10 +1258,6 @@ contributors:
 country: US
 country_name: USA
 currency: USD
-delays:
-  consumption: 30
-  consumptionForecast: 30
-  production: 48
 emissionFactors:
   direct:
     battery discharge:

--- a/config/zones/US-NE-ISNE.yaml
+++ b/config/zones/US-NE-ISNE.yaml
@@ -871,8 +871,6 @@ contributors:
 country: US
 country_name: USA
 currency: USD
-delays:
-  production: 5
 emissionFactors:
   direct:
     battery discharge:

--- a/config/zones/US-NW-AVA.yaml
+++ b/config/zones/US-NW-AVA.yaml
@@ -95,10 +95,6 @@ contributors:
   - KabelWlan
 country: US
 country_name: USA
-delays:
-  consumption: 30
-  consumptionForecast: 30
-  production: 48
 emissionFactors:
   direct:
     biomass:

--- a/config/zones/US-NW-BPAT.yaml
+++ b/config/zones/US-NW-BPAT.yaml
@@ -194,10 +194,6 @@ contributors:
   - KabelWlan
 country: US
 country_name: USA
-delays:
-  consumption: 30
-  consumptionForecast: 30
-  production: 48
 disclaimer:
   This zone includes all wind related electricity production from the generation-only
   balancing authority Avangrid Renewables, LLC. Read more on the zone definition wiki

--- a/config/zones/US-NW-CHPD.yaml
+++ b/config/zones/US-NW-CHPD.yaml
@@ -86,10 +86,6 @@ contributors:
   - KabelWlan
 country: US
 country_name: USA
-delays:
-  consumption: 30
-  consumptionForecast: 30
-  production: 48
 emissionFactors:
   direct:
     biomass:

--- a/config/zones/US-NW-DOPD.yaml
+++ b/config/zones/US-NW-DOPD.yaml
@@ -83,10 +83,6 @@ contributors:
   - KabelWlan
 country: US
 country_name: USA
-delays:
-  consumption: 30
-  consumptionForecast: 30
-  production: 48
 emissionFactors:
   direct:
     biomass:

--- a/config/zones/US-NW-GCPD.yaml
+++ b/config/zones/US-NW-GCPD.yaml
@@ -77,10 +77,6 @@ contributors:
   - KabelWlan
 country: US
 country_name: USA
-delays:
-  consumption: 30
-  consumptionForecast: 30
-  production: 48
 emissionFactors:
   direct:
     biomass:

--- a/config/zones/US-NW-GRID.yaml
+++ b/config/zones/US-NW-GRID.yaml
@@ -59,8 +59,6 @@ contributors:
   - robertahunt
 country: US
 country_name: USA
-delays:
-  production: 48
 emissionFactors:
   direct:
     biomass:

--- a/config/zones/US-NW-IPCO.yaml
+++ b/config/zones/US-NW-IPCO.yaml
@@ -203,10 +203,6 @@ contributors:
   - KabelWlan
 country: US
 country_name: USA
-delays:
-  consumption: 30
-  consumptionForecast: 30
-  production: 48
 emissionFactors:
   direct:
     battery discharge:

--- a/config/zones/US-NW-NEVP.yaml
+++ b/config/zones/US-NW-NEVP.yaml
@@ -281,10 +281,6 @@ contributors:
   - KabelWlan
 country: US
 country_name: USA
-delays:
-  consumption: 30
-  consumptionForecast: 30
-  production: 48
 emissionFactors:
   direct:
     battery discharge:

--- a/config/zones/US-NW-NWMT.yaml
+++ b/config/zones/US-NW-NWMT.yaml
@@ -164,10 +164,6 @@ contributors:
   - KabelWlan
 country: US
 country_name: USA
-delays:
-  consumption: 30
-  consumptionForecast: 30
-  production: 48
 disclaimer: This zone includes all electricity production from the generation-only
   balancing authorities NaturEner Power Watch, LLC and NaturEner Wind Watch, LLC.
   Read more on the wiki page.

--- a/config/zones/US-NW-PACE.yaml
+++ b/config/zones/US-NW-PACE.yaml
@@ -290,10 +290,6 @@ contributors:
   - KabelWlan
 country: US
 country_name: USA
-delays:
-  consumption: 30
-  consumptionForecast: 30
-  production: 48
 disclaimer:
   This zone includes all gas related electricity production from the generation-only
   balancing authority Avangrid Renewables, LLC. Read more on the zone definition wiki

--- a/config/zones/US-NW-PACW.yaml
+++ b/config/zones/US-NW-PACW.yaml
@@ -201,10 +201,6 @@ contributors:
 country: US
 country_name: USA
 currency: USD
-delays:
-  consumption: 30
-  consumptionForecast: 30
-  production: 48
 emissionFactors:
   direct:
     biomass:

--- a/config/zones/US-NW-PGE.yaml
+++ b/config/zones/US-NW-PGE.yaml
@@ -194,10 +194,6 @@ contributors:
   - KabelWlan
 country: US
 country_name: USA
-delays:
-  consumption: 30
-  consumptionForecast: 30
-  production: 48
 emissionFactors:
   direct:
     battery discharge:

--- a/config/zones/US-NW-PSCO.yaml
+++ b/config/zones/US-NW-PSCO.yaml
@@ -323,10 +323,6 @@ contributors:
   - KabelWlan
 country: US
 country_name: USA
-delays:
-  consumption: 30
-  consumptionForecast: 30
-  production: 48
 emissionFactors:
   direct:
     battery discharge:

--- a/config/zones/US-NW-PSEI.yaml
+++ b/config/zones/US-NW-PSEI.yaml
@@ -96,10 +96,6 @@ contributors:
   - miniksa
 country: US
 country_name: USA
-delays:
-  consumption: 30
-  consumptionForecast: 30
-  production: 48
 emissionFactors:
   direct:
     biomass:

--- a/config/zones/US-NW-SCL.yaml
+++ b/config/zones/US-NW-SCL.yaml
@@ -86,10 +86,6 @@ contributors:
   - KabelWlan
 country: US
 country_name: USA
-delays:
-  consumption: 30
-  consumptionForecast: 30
-  production: 48
 emissionFactors:
   direct:
     biomass:

--- a/config/zones/US-NW-TPWR.yaml
+++ b/config/zones/US-NW-TPWR.yaml
@@ -68,10 +68,6 @@ contributors:
   - KabelWlan
 country: US
 country_name: USA
-delays:
-  consumption: 30
-  consumptionForecast: 30
-  production: 48
 emissionFactors:
   direct:
     biomass:

--- a/config/zones/US-NW-WACM.yaml
+++ b/config/zones/US-NW-WACM.yaml
@@ -305,10 +305,6 @@ contributors:
   - KabelWlan
 country: US
 country_name: USA
-delays:
-  consumption: 30
-  consumptionForecast: 30
-  production: 48
 emissionFactors:
   direct:
     biomass:

--- a/config/zones/US-NW-WAUW.yaml
+++ b/config/zones/US-NW-WAUW.yaml
@@ -89,10 +89,6 @@ contributors:
   - KabelWlan
 country: US
 country_name: USA
-delays:
-  consumption: 30
-  consumptionForecast: 30
-  production: 48
 emissionFactors:
   direct:
     biomass:

--- a/config/zones/US-NY-NYIS.yaml
+++ b/config/zones/US-NY-NYIS.yaml
@@ -692,8 +692,6 @@ contributors:
 country: US
 country_name: USA
 currency: USD
-delays:
-  production: 5
 emissionFactors:
   direct:
     biomass:

--- a/config/zones/US-SE-SEPA.yaml
+++ b/config/zones/US-SE-SEPA.yaml
@@ -87,8 +87,6 @@ contributors:
   - KabelWlan
 country: US
 country_name: USA
-delays:
-  production: 48
 emissionFactors:
   direct:
     biomass:

--- a/config/zones/US-SE-SOCO.yaml
+++ b/config/zones/US-SE-SOCO.yaml
@@ -471,10 +471,6 @@ contributors:
   - MisterClean
 country: US
 country_name: USA
-delays:
-  consumption: 30
-  consumptionForecast: 30
-  production: 48
 emissionFactors:
   direct:
     battery discharge:

--- a/config/zones/US-SW-AZPS.yaml
+++ b/config/zones/US-SW-AZPS.yaml
@@ -192,10 +192,6 @@ contributors:
 country: US
 country_name: USA
 currency: USD
-delays:
-  consumption: 30
-  consumptionForecast: 30
-  production: 48
 emissionFactors:
   direct:
     battery discharge:

--- a/config/zones/US-SW-EPE.yaml
+++ b/config/zones/US-SW-EPE.yaml
@@ -128,10 +128,6 @@ contributors:
   - KabelWlan
 country: US
 country_name: USA
-delays:
-  consumption: 30
-  consumptionForecast: 30
-  production: 48
 emissionFactors:
   direct:
     biomass:

--- a/config/zones/US-SW-PNM.yaml
+++ b/config/zones/US-SW-PNM.yaml
@@ -270,10 +270,6 @@ contributors:
   - brandongalbraith
 country: US
 country_name: USA
-delays:
-  consumption: 30
-  consumptionForecast: 30
-  production: 48
 emissionFactors:
   direct:
     battery discharge:

--- a/config/zones/US-SW-SRP.yaml
+++ b/config/zones/US-SW-SRP.yaml
@@ -167,10 +167,6 @@ contributors:
   - KabelWlan
 country: US
 country_name: USA
-delays:
-  consumption: 30
-  consumptionForecast: 30
-  production: 48
 disclaimer: This zone includes all electricity production from the generation-only
   balancing authorities Arlington Valley, LLC - AVBA and New Harquahala Generating
   Company, LLC - HGBA. Read more on the wiki page.

--- a/config/zones/US-SW-TEPC.yaml
+++ b/config/zones/US-SW-TEPC.yaml
@@ -134,10 +134,6 @@ contributors:
   - KabelWlan
 country: US
 country_name: USA
-delays:
-  consumption: 30
-  consumptionForecast: 30
-  production: 48
 emissionFactors:
   direct:
     battery discharge:

--- a/config/zones/US-SW-WALC.yaml
+++ b/config/zones/US-SW-WALC.yaml
@@ -149,10 +149,6 @@ contributors:
   - KabelWlan
 country: US
 country_name: USA
-delays:
-  consumption: 30
-  consumptionForecast: 30
-  production: 48
 disclaimer: This zone includes all electricity production from the generation-only
   balancing authority Griffith Energy, LLC. Read more on the zone definition wiki
   page.

--- a/config/zones/US-TEN-TVA.yaml
+++ b/config/zones/US-TEN-TVA.yaml
@@ -284,10 +284,6 @@ contributors:
   - KabelWlan
 country: US
 country_name: USA
-delays:
-  consumption: 30
-  consumptionForecast: 30
-  production: 48
 emissionFactors:
   direct:
     battery discharge:

--- a/config/zones/UY.yaml
+++ b/config/zones/UY.yaml
@@ -70,8 +70,6 @@ contributors:
 country: UY
 country_name: Uruguay
 currency: UYU
-delays:
-  production: 7
 fallbackZoneMixes:
   powerOriginRatios:
     - _source: Electricity Maps, 2015 average

--- a/config/zones/XK.yaml
+++ b/config/zones/XK.yaml
@@ -30,8 +30,6 @@ contributors:
 country: XK
 country_name: Kosovo
 currency: EUR
-delays:
-  production: 8
 fallbackZoneMixes:
   powerOriginRatios:
     - _source: Electricity Maps, 2017 average

--- a/config/zones/ZA.yaml
+++ b/config/zones/ZA.yaml
@@ -107,8 +107,6 @@ contributors:
 country: ZA
 country_name: South Africa
 currency: ZAR
-delays:
-  production: 96
 emissionFactors:
   direct:
     hydro discharge:


### PR DESCRIPTION
## Summary
- Removes the entire `delays:` section from all 167 zone YAML config files
- All delay types removed: production, consumption, price, consumptionForecast, generationForecast, productionPerModeForecast
- No consumers exist for any delay type in the main codebase

## Context
Production delays have been inlined in the metrics/parser-data service (electricitymaps/electricitymaps#11943). A codebase-wide search confirmed no other consumers of any delay type.

Ref: GMM-1616

## Related PRs
- electricitymaps/electricitymaps#11943 — Inline production delays in parser-data

## Test plan
- [x] All 167 YAML files validated as valid YAML after removal
- [x] `grep -rn "^delays:" config/zones/*.yaml` returns 0 matches

🤖 Generated with [Claude Code](https://claude.com/claude-code)