### PR TITLE
fix: update French Guiana (GF) capacity data for 2024

### DIFF
--- a/config/zones/GF.yaml
+++ b/config/zones/GF.yaml
@@ -17,10 +17,20 @@ capacity:
     - datetime: '2021-01-01'
       source: Ember, Yearly electricity data
       value: 10.0
+    - datetime: '2024-01-01'
+      source: EDF SEI, Bilan Prévisionnel 2024 Guyane Littoral, Tableau 11
+      value: 13.0
   hydro:
     - datetime: '2017-01-01'
       source: Ember, Yearly electricity data
       value: 120.0
+    - datetime: '2024-01-01'
+      source: EDF SEI, Bilan Prévisionnel 2024 Guyane Littoral, Tableau 11
+      value: 108.0
+  oil:
+    - datetime: '2024-01-01'
+      source: EDF SEI, Bilan Prévisionnel 2024 Guyane Littoral, Tableau 11
+      value: 149.0
   solar:
     - datetime: '2017-01-01'
       source: Ember, Yearly electricity data
@@ -28,6 +38,9 @@ capacity:
     - datetime: '2021-01-01'
       source: Ember, Yearly electricity data
       value: 60.0
+    - datetime: '2024-01-01'
+      source: EDF SEI, Bilan Prévisionnel 2024 Guyane Littoral, Tableau 11
+      value: 57.0
 contributors:
   - PETILLON-Sebastien
   - VIKTORVAV99


### PR DESCRIPTION
Updated capacity values for French Guiana based on current installation data. Added oil capacity (previously missing) and updated hydro, biomass, and solar to 2024 figures. 

Fixes #8025