### PR TITLE
fix(parsers):Fix timezone errors in BE parser

### DIFF
--- a/electricitymap/contrib/parsers/BE.py
+++ b/electricitymap/contrib/parsers/BE.py
@@ -1,5 +1,5 @@
 import json
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from itertools import groupby
 from logging import Logger, getLogger
 from zoneinfo import ZoneInfo
@@ -54,7 +54,9 @@ def fetch_elia(
     session = session or Session()
 
     if start_datetime is not None and end_datetime is not None:
-        url = f"{BASE_URL_ELIA}&timezone=Europe/Brussels&where=datetime >= date'{start_datetime.replace(tzinfo=None).isoformat()}' AND datetime < date'{end_datetime.replace(tzinfo=None).isoformat()}'"
+        start_brussels = start_datetime.astimezone(TIMEZONE).replace(tzinfo=None)
+        end_brussels = end_datetime.astimezone(TIMEZONE).replace(tzinfo=None)
+        url = f"{BASE_URL_ELIA}&timezone=Europe/Brussels&where=datetime >= date'{start_brussels.isoformat()}' AND datetime < date'{end_brussels.isoformat()}'"
     else:
         url = BASE_URL_ELIA
 
@@ -87,7 +89,7 @@ def fetch_elia(
 
         production_breakdown_list.append(
             zoneKey=zone_key,
-            datetime=datetime.fromisoformat(dt_key),
+            datetime=datetime.fromisoformat(dt_key).astimezone(timezone.utc),
             production=production_mix,
             storage=storage_mix,
             source=SOURCE_ELIA,

--- a/electricitymap/contrib/parsers/BE.py
+++ b/electricitymap/contrib/parsers/BE.py
@@ -79,7 +79,7 @@ def fetch_elia(
             if "storage" in fuel_type:
                 storage_mix.add_value(
                     fuel_type.removeprefix("storage_"),
-                    power,
+                    -power if power is not None else None,
                 )
             else:
                 production_mix.add_value(

--- a/electricitymap/contrib/parsers/tests/__snapshots__/test_BE/test_fetch_production.ambr
+++ b/electricitymap/contrib/parsers/tests/__snapshots__/test_BE/test_fetch_production.ambr
@@ -40,7 +40,7 @@
       'source': 'entsoe.eu, opendata.elia.be',
       'sourceType': <EventSourceType.measured: 'measured'>,
       'storage': dict({
-        'battery': -40.0,
+        'battery': 40.0,
         'hydro': 180.0,
       }),
       'zoneKey': 'BE',
@@ -62,7 +62,7 @@
       'source': 'opendata.elia.be',
       'sourceType': <EventSourceType.measured: 'measured'>,
       'storage': dict({
-        'battery': -45.0,
+        'battery': 45.0,
         'hydro': None,
       }),
       'zoneKey': 'BE',
@@ -84,7 +84,7 @@
       'source': 'opendata.elia.be',
       'sourceType': <EventSourceType.measured: 'measured'>,
       'storage': dict({
-        'battery': -50.0,
+        'battery': 50.0,
         'hydro': None,
       }),
       'zoneKey': 'BE',


### PR DESCRIPTION
## Issue
Time issues as elia use UTC+2 and entsoe use UTC. 

## Description
Entsoe is in UTC and elia in Brussels UTC+2. 

The parser contains a loop over entsoe timestamp chunks, where for each chunk it fetches the equivalent elia data (as elia can max fetch 2hrs at a time). So this loop goes over UTC time stamps, which means it will miss the last two Brussels hours as elia interprets it as UTC+2. 

So, before we gave the elia parser datetimes in utc, but it understood them as utc+2, meaning we fetched data that we missed the last 2 hours. Ex. we wanted 10UTC data, but elia parser understood as 10UTC+2 = 8UTC, meaning we only got up till 8UTC. The data was not placed in the wrong timestamps, but only last two hours would be missing from elia. 

### Solution 
Now we go from UTC to UTC+2 before feeding to elia parser. So ex: we want 10UTC —> Then the timestamp is changed such that it becomes 10UTC --> 12UTC+2 which is then fed to the elia parser, which fetches 12UTC+2 data. This is now that data we want as  12UTC+2  = 10UTC.

Also, changes Elia parser storage sign which is opposite of Entsoe. 

## Problem

- Problem with time zones
- Elia, entsoe storage sign differences 

`uv run test_parser BE --target_datetime "2026-04-07 19:00"I get this value of 16:00`
Returns: 
```
 {'correctedModes': [],
  'datetime': datetime.datetime(2026, 4, 7, 16, 0, tzinfo=datetime.timezone.utc),
  'production': {'biomass': 246.15,
                 'gas': 451.26,
                 'hydro': 4.51,
                 'nuclear': 0.0,
                 'oil': 0.0,
                 'solar': 3052.18,
                 'unknown': 330.13,
                 'wind': 1219.36},
  'source': 'entsoe.eu, opendata.elia.be',
  'sourceType': <EventSourceType.measured: 'measured'>,
  'storage': {'battery': 212.4, 'hydro': -102.5875},
  'zoneKey': 'BE'},
```

But 
`uv run test_parser BE --target_datetime "2026-04-07 17:00"`
```

 {'correctedModes': [],
  'datetime': datetime.datetime(2026, 4, 7, 16, 0, tzinfo=datetime.timezone.utc),
  'production': {'biomass': 309.4575,
                 'gas': 518.2925,
                 'hydro': 5.165,
                 'nuclear': 0.0,
                 'oil': 0.0,
                 'solar': 2412.847,
                 'unknown': 1156.214838,
                 'wind': 1164.372901},
  'source': 'entsoe.eu',
  'sourceType': <EventSourceType.measured: 'measured'>,
  'storage': {'battery': -295.515, 'hydro': -102.5875},
  'zoneKey': 'BE'}]
```



### Double check

- [x] I have tested my parser changes locally with `uv run test_parser "zone_key"`
- [x] I have run `pnpx prettier@2 --write .` and `uv run format` in the top level directory to format my changes.
