### PR TITLE
split production per mode forecasts for ENTSOE

### DIFF
--- a/electricitymap/contrib/parsers/ENTSOE.py
+++ b/electricitymap/contrib/parsers/ENTSOE.py
@@ -92,15 +92,6 @@ class EntsoeDocumentTypeEnum(str, Enum):
     ESTIMATED_NET_TRANSFER_CAPACITY = "A61"
 
 
-# The order of the forecast types is important for the parser to use the most recent data
-# This ensures that the order is consistent across all runs even if the enum is changed
-ORDERED_FORECAST_TYPES: list[EntsoeTypeEnum] = [
-    EntsoeTypeEnum.DAY_AHEAD,
-    EntsoeTypeEnum.INTRADAY,
-    EntsoeTypeEnum.CURRENT,
-]
-
-
 ENTSOE_PARAMETER_DESC = {
     "B01": "Biomass",
     "B02": "Fossil Brown coal/Lignite",
@@ -1540,6 +1531,45 @@ def fetch_consumption_forecast(
     ).to_list()
 
 
+def _fetch_wind_solar_forecasts(
+    zone_key: ZoneKey,
+    forecast_type: EntsoeTypeEnum,
+    session: Session,
+    target_datetime: datetime | None,
+    logger: Logger,
+) -> ProductionBreakdownList:
+    """Shared logic for the 3 type-specific wind/solar forecast fetchers."""
+    label = forecast_type.name.lower().replace("_", "-")
+    non_aggregated_data: list[ProductionBreakdownList] = []
+    for _zone_key in ZONE_KEY_AGGREGATES.get(zone_key, [zone_key]):
+        domain = ENTSOE_DOMAIN_MAPPINGS[_zone_key]
+        try:
+            raw_forecast = query_wind_solar_production_forecast(
+                domain,
+                session,
+                forecast_type,
+                target_datetime=target_datetime,
+            )
+        except Exception as e:
+            raise ParserException(
+                parser="ENTSOE.py",
+                message=f"Failed to fetch {label} wind and solar forecast for {_zone_key}",
+                zone_key=zone_key,
+            ) from e
+        if raw_forecast is None:
+            raise ParserException(
+                parser="ENTSOE.py",
+                message=f"No {label} wind and solar forecast data found for {_zone_key}",
+                zone_key=zone_key,
+            )
+        parsed = parse_production(raw_forecast, logger, zone_key, forecasted=True)
+        # Aggregated data are regrouped under the same zone key.
+        non_aggregated_data.append(parsed)
+    return ProductionBreakdownList.merge_production_breakdowns(
+        non_aggregated_data, logger
+    )
+
+
 @refetch_frequency(timedelta(days=1))
 def fetch_wind_solar_forecasts(
     zone_key: ZoneKey,
@@ -1551,47 +1581,84 @@ def fetch_wind_solar_forecasts(
     Gets values and corresponding datetimes for all production types in the specified zone.
     """
     session = session or Session()
-    non_aggregated_data: list[ProductionBreakdownList] = []
-    for _zone_key in ZONE_KEY_AGGREGATES.get(zone_key, [zone_key]):
-        domain = ENTSOE_DOMAIN_MAPPINGS[_zone_key]
-        raw_forecasts = {}
-
-        for data_type in ORDERED_FORECAST_TYPES:
-            try:
-                raw_forecasts[data_type.name] = query_wind_solar_production_forecast(
-                    domain, session, data_type, target_datetime=target_datetime
-                )
-            except Exception as e:
-                logger.error(
-                    f"Failed to fetch {data_type.name} wind and solar forecast for {_zone_key}: {e}",
-                    extra={"zone_key": _zone_key},
-                )
-        if raw_forecasts == {}:
-            logger.warning(
-                f"No wind and solar forecast data found for {_zone_key}",
-                extra={"zone_key": _zone_key},
+    forecast_breakdown_list = ProductionBreakdownList(logger)
+    # Order matters: later types override earlier ones at matching datetimes
+    # (intraday overrides day-ahead, current overrides intraday).
+    for forecast_type in [
+        EntsoeTypeEnum.DAY_AHEAD,
+        EntsoeTypeEnum.INTRADAY,
+        EntsoeTypeEnum.CURRENT,
+    ]:
+        try:
+            per_type = _fetch_wind_solar_forecasts(
+                zone_key, forecast_type, session, target_datetime, logger
             )
-            raise ParserException(
-                zone_key,
-                "ENTSOE.py",
-                f"No wind and solar forecast data found for {_zone_key}",
+        except ParserException as e:
+            logger.error(
+                f"Failed to fetch {forecast_type.name} wind and solar forecast for {zone_key}: {e}",
+                extra={"zone_key": zone_key},
             )
+            continue
 
-        forecast_breakdown_list = ProductionBreakdownList(logger)
-        for raw_forecast in raw_forecasts.values():
-            parsed_forecast = parse_production(
-                raw_forecast, logger, zone_key, forecasted=True
-            )
-            forecast_breakdown_list = (
-                ProductionBreakdownList.update_production_breakdowns(
-                    forecast_breakdown_list, parsed_forecast, logger
-                )
-            )
+        forecast_breakdown_list = ProductionBreakdownList.update_production_breakdowns(
+            forecast_breakdown_list,
+            per_type,
+            logger,
+        )
+    if len(forecast_breakdown_list) == 0:
+        raise ParserException(
+            parser="ENTSOE.py",
+            message=f"No wind and solar forecast data found for {zone_key}",
+            zone_key=zone_key,
+        )
+    return forecast_breakdown_list.to_list()
 
-        non_aggregated_data.append(forecast_breakdown_list)
 
-    return ProductionBreakdownList.merge_production_breakdowns(
-        non_aggregated_data, logger
+@refetch_frequency(timedelta(days=1))
+def fetch_wind_solar_forecasts_day_ahead(
+    zone_key: ZoneKey,
+    session: Session | None = None,
+    target_datetime: datetime | None = None,
+    logger: Logger = getLogger(__name__),
+) -> list:
+    return _fetch_wind_solar_forecasts(
+        zone_key,
+        EntsoeTypeEnum.DAY_AHEAD,
+        session or Session(),
+        target_datetime,
+        logger,
+    ).to_list()
+
+
+@refetch_frequency(timedelta(days=1))
+def fetch_wind_solar_forecasts_intraday(
+    zone_key: ZoneKey,
+    session: Session | None = None,
+    target_datetime: datetime | None = None,
+    logger: Logger = getLogger(__name__),
+) -> list:
+    return _fetch_wind_solar_forecasts(
+        zone_key,
+        EntsoeTypeEnum.INTRADAY,
+        session or Session(),
+        target_datetime,
+        logger,
+    ).to_list()
+
+
+@refetch_frequency(timedelta(days=1))
+def fetch_wind_solar_forecasts_current(
+    zone_key: ZoneKey,
+    session: Session | None = None,
+    target_datetime: datetime | None = None,
+    logger: Logger = getLogger(__name__),
+) -> list:
+    return _fetch_wind_solar_forecasts(
+        zone_key,
+        EntsoeTypeEnum.CURRENT,
+        session or Session(),
+        target_datetime,
+        logger,
     ).to_list()
 
 

--- a/electricitymap/contrib/parsers/tests/__snapshots__/test_ENTSOE/test_wind_and_solar_forecasts_by_type[current].ambr
+++ b/electricitymap/contrib/parsers/tests/__snapshots__/test_ENTSOE/test_wind_and_solar_forecasts_by_type[current].ambr
@@ -1,0 +1,4485 @@
+# serializer version: 1
+# name: test_wind_and_solar_forecasts_by_type[current]
+  list([
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 7, 22, 0, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 1860.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 7, 22, 15, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 1866.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 7, 22, 30, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 1876.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 7, 22, 45, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 1897.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 7, 23, 0, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 1802.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 7, 23, 15, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 1811.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 7, 23, 30, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 1825.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 7, 23, 45, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 1860.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 8, 0, 0, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 1791.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 8, 0, 15, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 1800.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 8, 0, 30, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 1815.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 8, 0, 45, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 1849.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 8, 1, 0, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 1795.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 8, 1, 15, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 1803.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 8, 1, 30, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 1816.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 8, 1, 45, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 1841.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 8, 2, 0, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 1711.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 8, 2, 15, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 1722.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 8, 2, 30, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 1742.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 8, 2, 45, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 1781.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 8, 3, 0, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 1813.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 8, 3, 15, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 1825.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 8, 3, 30, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 1845.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 8, 3, 45, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 1884.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 8, 4, 0, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 2008.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 8, 4, 15, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 2019.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 8, 4, 30, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 2039.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 8, 4, 45, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 2081.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 8, 5, 0, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 2230.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 8, 5, 15, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 2239.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 8, 5, 30, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 1.0,
+        'wind': 2253.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 8, 5, 45, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 2291.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 8, 6, 0, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 2431.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 8, 6, 15, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 2431.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 8, 6, 30, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 1.0,
+        'wind': 2431.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 8, 6, 45, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 10.0,
+        'wind': 2431.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 8, 7, 0, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 30.0,
+        'wind': 2513.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 8, 7, 15, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 33.0,
+        'wind': 2516.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 8, 7, 30, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 40.0,
+        'wind': 2511.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 8, 7, 45, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 55.0,
+        'wind': 2540.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 8, 8, 0, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 94.0,
+        'wind': 2651.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 8, 8, 15, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 97.0,
+        'wind': 2619.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 8, 8, 30, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 101.0,
+        'wind': 2561.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 8, 8, 45, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 111.0,
+        'wind': 2452.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 8, 9, 0, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 148.0,
+        'wind': 1963.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 8, 9, 15, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 149.0,
+        'wind': 1941.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 8, 9, 30, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 150.0,
+        'wind': 1904.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 8, 9, 45, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 153.0,
+        'wind': 1826.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 8, 10, 0, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 165.0,
+        'wind': 1927.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 8, 10, 15, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 165.0,
+        'wind': 1907.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 8, 10, 30, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 165.0,
+        'wind': 1876.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 8, 10, 45, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 166.0,
+        'wind': 1799.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 8, 11, 0, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 172.0,
+        'wind': 1850.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 8, 11, 15, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 170.0,
+        'wind': 1844.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 8, 11, 30, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 165.0,
+        'wind': 1836.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 8, 11, 45, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 157.0,
+        'wind': 1808.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 8, 12, 0, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 127.0,
+        'wind': 1718.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 8, 12, 15, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 124.0,
+        'wind': 1729.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 8, 12, 30, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 117.0,
+        'wind': 1750.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 8, 12, 45, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 104.0,
+        'wind': 1789.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 8, 13, 0, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 65.0,
+        'wind': 1797.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 8, 13, 15, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 62.0,
+        'wind': 1812.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 8, 13, 30, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 57.0,
+        'wind': 1840.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 8, 13, 45, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 43.0,
+        'wind': 1895.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 8, 14, 0, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 1.0,
+        'wind': 1946.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 8, 14, 15, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 1.0,
+        'wind': 1961.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 8, 14, 30, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 1.0,
+        'wind': 1986.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 8, 14, 45, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 1.0,
+        'wind': 2042.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 8, 15, 0, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 2112.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 8, 15, 15, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 2119.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 8, 15, 30, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 2131.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 8, 15, 45, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 2161.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 8, 16, 0, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 2199.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 8, 16, 15, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 2200.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 8, 16, 30, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 2201.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 8, 16, 45, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 2208.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 8, 17, 0, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 2327.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 8, 17, 15, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 2323.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 8, 17, 30, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 2315.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 8, 17, 45, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 2298.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 8, 18, 0, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 2431.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 8, 18, 15, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 2424.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 8, 18, 30, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 2411.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 8, 18, 45, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 2388.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 8, 19, 0, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 2487.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 8, 19, 15, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 2476.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 8, 19, 30, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 2457.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 8, 19, 45, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 2419.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 8, 20, 0, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 2456.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 8, 20, 15, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 2442.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 8, 20, 30, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 2418.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 8, 20, 45, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 2368.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 8, 21, 0, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 2487.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 8, 21, 15, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 2472.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 8, 21, 30, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 2447.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 8, 21, 45, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 2391.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 8, 22, 0, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 2220.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 8, 22, 15, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 2208.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 8, 22, 30, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 2187.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 8, 22, 45, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 2145.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 8, 23, 0, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 2088.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 8, 23, 15, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 2077.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 8, 23, 30, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 2059.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 8, 23, 45, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 2020.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 9, 0, 0, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 1966.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 9, 0, 15, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 1957.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 9, 0, 30, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 1941.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 9, 0, 45, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 1906.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 9, 1, 0, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 1762.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 9, 1, 15, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 1755.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 9, 1, 30, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 1742.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 9, 1, 45, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 1722.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 9, 2, 0, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 1574.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 9, 2, 15, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 1566.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 9, 2, 30, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 1552.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 9, 2, 45, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 1522.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 9, 3, 0, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 1372.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 9, 3, 15, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 1368.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 9, 3, 30, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 1361.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 9, 3, 45, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 1345.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 9, 4, 0, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 1272.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 9, 4, 15, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 1272.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 9, 4, 30, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 1271.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 9, 4, 45, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 1271.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 9, 5, 0, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 1351.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 9, 5, 15, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 1349.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 9, 5, 30, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 1.0,
+        'wind': 1345.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 9, 5, 45, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 1342.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 9, 6, 0, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 1368.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 9, 6, 15, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 1361.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 9, 6, 30, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 1.0,
+        'wind': 1348.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 9, 6, 45, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 13.0,
+        'wind': 1327.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 9, 7, 0, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 45.0,
+        'wind': 1351.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 9, 7, 15, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 49.0,
+        'wind': 1341.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 9, 7, 30, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 57.0,
+        'wind': 1326.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 9, 7, 45, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 73.0,
+        'wind': 1285.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 9, 8, 0, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 124.0,
+        'wind': 1151.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 9, 8, 15, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 128.0,
+        'wind': 1153.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 9, 8, 30, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 133.0,
+        'wind': 1157.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 9, 8, 45, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 146.0,
+        'wind': 1161.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 9, 9, 0, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 181.0,
+        'wind': 1028.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 9, 9, 15, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 182.0,
+        'wind': 1024.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 9, 9, 30, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 184.0,
+        'wind': 1019.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 9, 9, 45, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 190.0,
+        'wind': 1007.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 9, 10, 0, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 209.0,
+        'wind': 834.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 9, 10, 15, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 208.0,
+        'wind': 826.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 9, 10, 30, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 206.0,
+        'wind': 813.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 9, 10, 45, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 202.0,
+        'wind': 785.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 9, 11, 0, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 195.0,
+        'wind': 646.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 9, 11, 15, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 192.0,
+        'wind': 642.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 9, 11, 30, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 187.0,
+        'wind': 635.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 9, 11, 45, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 178.0,
+        'wind': 619.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 9, 12, 0, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 154.0,
+        'wind': 529.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 9, 12, 15, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 150.0,
+        'wind': 529.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 9, 12, 30, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 142.0,
+        'wind': 530.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 9, 12, 45, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 127.0,
+        'wind': 528.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 9, 13, 0, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 88.0,
+        'wind': 442.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 9, 13, 15, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 83.0,
+        'wind': 447.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 9, 13, 30, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 76.0,
+        'wind': 456.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 9, 13, 45, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 57.0,
+        'wind': 475.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 9, 14, 0, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 2.0,
+        'wind': 486.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 9, 14, 15, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 2.0,
+        'wind': 491.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 9, 14, 30, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 2.0,
+        'wind': 499.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 9, 14, 45, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 1.0,
+        'wind': 514.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 9, 15, 0, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 552.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 9, 15, 15, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 557.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 9, 15, 30, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 565.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 9, 15, 45, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 580.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 9, 16, 0, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 619.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 9, 16, 15, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 624.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 9, 16, 30, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 631.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 9, 16, 45, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 651.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 9, 17, 0, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 759.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 9, 17, 15, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 757.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 9, 17, 30, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 753.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 9, 17, 45, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 746.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 9, 18, 0, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 730.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 9, 18, 15, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 725.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 9, 18, 30, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 717.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 9, 18, 45, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 697.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 9, 19, 0, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 658.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 9, 19, 15, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 637.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 9, 19, 30, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 627.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 9, 19, 45, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 621.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 9, 20, 0, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 627.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 9, 20, 15, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 625.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 9, 20, 30, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 620.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 9, 20, 45, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 615.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 9, 21, 0, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 611.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 9, 21, 15, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 605.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 9, 21, 30, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 599.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 9, 21, 45, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 592.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 9, 22, 0, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 584.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 9, 22, 15, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 576.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 9, 22, 30, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 568.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 9, 22, 45, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 558.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 9, 23, 0, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 548.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 9, 23, 15, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 539.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 9, 23, 30, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 530.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 9, 23, 45, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 521.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 10, 0, 0, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 511.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 10, 0, 15, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 503.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 10, 0, 30, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 497.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 10, 0, 45, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 489.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 10, 1, 0, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 478.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 10, 1, 15, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 474.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 10, 1, 30, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 475.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 10, 1, 45, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 479.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 10, 2, 0, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 485.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 10, 2, 15, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 496.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 10, 2, 30, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 511.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 10, 2, 45, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 530.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 10, 3, 0, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 553.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 10, 3, 15, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 579.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 10, 3, 30, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 607.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 10, 3, 45, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 640.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 10, 4, 0, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 677.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 10, 4, 15, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 715.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 10, 4, 30, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 752.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 10, 4, 45, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 796.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 10, 5, 0, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 848.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 10, 5, 15, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 891.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 10, 5, 30, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 1.0,
+        'wind': 927.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 10, 5, 45, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 965.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 10, 6, 0, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 1008.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 10, 6, 15, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 1036.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 10, 6, 30, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 1.0,
+        'wind': 1053.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 10, 6, 45, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 13.0,
+        'wind': 1066.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 10, 7, 0, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 34.0,
+        'wind': 1075.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 10, 7, 15, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 49.0,
+        'wind': 1072.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 10, 7, 30, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 62.0,
+        'wind': 1063.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 10, 7, 45, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 78.0,
+        'wind': 1032.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 10, 8, 0, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 95.0,
+        'wind': 965.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 10, 8, 15, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 109.0,
+        'wind': 934.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 10, 8, 30, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 121.0,
+        'wind': 922.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 10, 8, 45, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 133.0,
+        'wind': 924.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 10, 9, 0, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 144.0,
+        'wind': 953.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 10, 9, 15, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 153.0,
+        'wind': 960.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 10, 9, 30, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 160.0,
+        'wind': 953.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 10, 9, 45, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 164.0,
+        'wind': 952.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 10, 10, 0, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 165.0,
+        'wind': 959.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 10, 10, 15, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 166.0,
+        'wind': 943.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 10, 10, 30, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 166.0,
+        'wind': 914.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 10, 10, 45, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 165.0,
+        'wind': 866.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 10, 11, 0, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 164.0,
+        'wind': 791.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 10, 11, 15, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 160.0,
+        'wind': 734.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 10, 11, 30, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 154.0,
+        'wind': 687.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 10, 11, 45, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 147.0,
+        'wind': 630.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 10, 12, 0, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 137.0,
+        'wind': 557.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 10, 12, 15, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 127.0,
+        'wind': 512.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 10, 12, 30, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 116.0,
+        'wind': 487.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 10, 12, 45, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 103.0,
+        'wind': 468.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 10, 13, 0, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 88.0,
+        'wind': 457.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 10, 13, 15, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 74.0,
+        'wind': 464.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 10, 13, 30, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 61.0,
+        'wind': 485.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 10, 13, 45, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 44.0,
+        'wind': 524.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 10, 14, 0, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 20.0,
+        'wind': 589.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 10, 14, 15, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 6.0,
+        'wind': 649.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 10, 14, 30, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 3.0,
+        'wind': 707.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 10, 14, 45, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 2.0,
+        'wind': 784.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 10, 15, 0, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 1.0,
+        'wind': 886.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 10, 15, 15, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 1.0,
+        'wind': 963.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 10, 15, 30, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 1024.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 10, 15, 45, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 1084.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 10, 16, 0, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 1137.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 10, 16, 15, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 1184.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 10, 16, 30, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 1225.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 10, 16, 45, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 1260.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 10, 17, 0, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 1288.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 10, 17, 15, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 1310.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 10, 17, 30, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 1328.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 10, 17, 45, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 1337.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 10, 18, 0, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 1334.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 10, 18, 15, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 1336.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 10, 18, 30, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 1339.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 10, 18, 45, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 1337.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 10, 19, 0, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 1327.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 10, 19, 15, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 1325.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 10, 19, 30, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 1327.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 10, 19, 45, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 1331.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 10, 20, 0, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 1339.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 10, 20, 15, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 1346.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 10, 20, 30, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 1352.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 10, 20, 45, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 1364.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 10, 21, 0, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 1384.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 10, 21, 15, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 1392.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 10, 21, 30, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 1394.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 10, 21, 45, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 1390.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 10, 22, 0, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 1380.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 10, 22, 15, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 1371.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 10, 22, 30, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 1364.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 10, 22, 45, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 1347.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 10, 23, 0, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 1315.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 10, 23, 15, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 1304.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 10, 23, 30, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 1304.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 10, 23, 45, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 1313.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 11, 0, 0, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 1335.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 11, 0, 15, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 1353.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 11, 0, 30, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 1369.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 11, 0, 45, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 1391.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 11, 1, 0, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 1419.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 11, 1, 15, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 1443.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 11, 1, 30, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 1464.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 11, 1, 45, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 1486.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 11, 2, 0, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 1509.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 11, 2, 15, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 1529.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 11, 2, 30, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 1548.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 11, 2, 45, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 1564.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 11, 3, 0, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 1578.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 11, 3, 15, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 1592.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 11, 3, 30, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 1608.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 11, 3, 45, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 1621.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 11, 4, 0, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 1631.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 11, 4, 15, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 1645.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 11, 4, 30, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 1661.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 11, 4, 45, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 1684.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 11, 5, 0, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 1718.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 11, 5, 15, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 1737.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 11, 5, 30, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 1746.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 11, 5, 45, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 1751.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+  ])
+# ---

--- a/electricitymap/contrib/parsers/tests/__snapshots__/test_ENTSOE/test_wind_and_solar_forecasts_by_type[day_ahead].ambr
+++ b/electricitymap/contrib/parsers/tests/__snapshots__/test_ENTSOE/test_wind_and_solar_forecasts_by_type[day_ahead].ambr
@@ -1,0 +1,4037 @@
+# serializer version: 1
+# name: test_wind_and_solar_forecasts_by_type[day_ahead]
+  list([
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 7, 23, 0, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 2224.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 7, 23, 15, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 2223.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 7, 23, 30, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 2221.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 7, 23, 45, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 2218.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 8, 0, 0, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 2210.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 8, 0, 15, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 2206.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 8, 0, 30, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 2205.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 8, 0, 45, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 2205.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 8, 1, 0, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 2206.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 8, 1, 15, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 2209.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 8, 1, 30, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 2213.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 8, 1, 45, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 2219.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 8, 2, 0, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 2227.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 8, 2, 15, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 2236.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 8, 2, 30, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 2244.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 8, 2, 45, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 2254.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 8, 3, 0, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 2266.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 8, 3, 15, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 2277.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 8, 3, 30, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 2287.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 8, 3, 45, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 2297.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 8, 4, 0, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 2306.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 8, 4, 15, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 2316.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 8, 4, 30, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 2328.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 8, 4, 45, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 2343.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 8, 5, 0, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 2361.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 8, 5, 15, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 2375.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 8, 5, 30, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 1.0,
+        'wind': 2385.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 8, 5, 45, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 2399.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 8, 6, 0, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 2421.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 8, 6, 15, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 2427.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 8, 6, 30, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 1.0,
+        'wind': 2425.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 8, 6, 45, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 12.0,
+        'wind': 2406.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 8, 7, 0, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 30.0,
+        'wind': 2359.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 8, 7, 15, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 45.0,
+        'wind': 2341.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 8, 7, 30, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 59.0,
+        'wind': 2349.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 8, 7, 45, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 75.0,
+        'wind': 2338.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 8, 8, 0, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 94.0,
+        'wind': 2290.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 8, 8, 15, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 110.0,
+        'wind': 2324.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 8, 8, 30, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 123.0,
+        'wind': 2397.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 8, 8, 45, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 137.0,
+        'wind': 2559.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 8, 9, 0, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 151.0,
+        'wind': 2876.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 8, 9, 15, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 161.0,
+        'wind': 3033.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 8, 9, 30, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 170.0,
+        'wind': 3092.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 8, 9, 45, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 177.0,
+        'wind': 3124.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 8, 10, 0, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 184.0,
+        'wind': 3105.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 8, 10, 15, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 187.0,
+        'wind': 3062.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 8, 10, 30, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 188.0,
+        'wind': 2994.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 8, 10, 45, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 187.0,
+        'wind': 2874.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 8, 11, 0, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 183.0,
+        'wind': 2684.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 8, 11, 15, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 178.0,
+        'wind': 2517.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 8, 11, 30, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 171.0,
+        'wind': 2363.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 8, 11, 45, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 163.0,
+        'wind': 2167.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 8, 12, 0, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 153.0,
+        'wind': 1907.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 8, 12, 15, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 141.0,
+        'wind': 1721.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 8, 12, 30, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 128.0,
+        'wind': 1587.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 8, 12, 45, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 112.0,
+        'wind': 1456.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 8, 13, 0, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 92.0,
+        'wind': 1327.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 8, 13, 15, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 75.0,
+        'wind': 1255.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 8, 13, 30, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 60.0,
+        'wind': 1222.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 8, 13, 45, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 42.0,
+        'wind': 1246.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 8, 14, 0, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 18.0,
+        'wind': 1351.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 8, 14, 15, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 4.0,
+        'wind': 1417.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 8, 14, 30, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 2.0,
+        'wind': 1464.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 8, 14, 45, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 1.0,
+        'wind': 1531.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 8, 15, 0, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 1.0,
+        'wind': 1615.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 8, 15, 15, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 1.0,
+        'wind': 1687.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 8, 15, 30, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 1749.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 8, 15, 45, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 1818.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 8, 16, 0, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 1896.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 8, 16, 15, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 1955.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 8, 16, 30, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 1999.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 8, 16, 45, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 2034.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 8, 17, 0, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 2058.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 8, 17, 15, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 2077.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 8, 17, 30, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 2091.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 8, 17, 45, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 2097.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 8, 18, 0, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 2093.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 8, 18, 15, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 2086.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 8, 18, 30, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 2076.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 8, 18, 45, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 2057.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 8, 19, 0, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 2029.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 8, 19, 15, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 2002.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 8, 19, 30, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 1975.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 8, 19, 45, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 1943.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 8, 20, 0, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 1906.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 8, 20, 15, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 1870.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 8, 20, 30, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 1834.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 8, 20, 45, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 1795.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 8, 21, 0, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 1749.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 8, 21, 15, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 1710.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 8, 21, 30, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 1677.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 8, 21, 45, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 1640.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 8, 22, 0, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 1597.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 8, 22, 15, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 1571.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 8, 22, 30, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 1557.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 8, 22, 45, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 1549.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 8, 23, 0, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 1727.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 8, 23, 15, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 1722.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 8, 23, 30, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 1712.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 8, 23, 45, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 1698.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 9, 0, 0, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 1678.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 9, 0, 15, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 1654.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 9, 0, 30, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 1626.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 9, 0, 45, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 1589.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 9, 1, 0, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 1540.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 9, 1, 15, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 1498.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 9, 1, 30, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 1460.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 9, 1, 45, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 1416.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 9, 2, 0, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 1361.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 9, 2, 15, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 1322.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 9, 2, 30, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 1294.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 9, 2, 45, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 1274.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 9, 3, 0, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 1265.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 9, 3, 15, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 1254.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 9, 3, 30, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 1241.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 9, 3, 45, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 1238.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 9, 4, 0, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 1249.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 9, 4, 15, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 1244.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 9, 4, 30, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 1228.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 9, 4, 45, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 1210.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 9, 5, 0, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 1187.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 9, 5, 15, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 1160.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 9, 5, 30, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 1.0,
+        'wind': 1131.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 9, 5, 45, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 1092.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 9, 6, 0, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 1039.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 9, 6, 15, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 1000.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 9, 6, 30, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 1.0,
+        'wind': 971.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 9, 6, 45, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 14.0,
+        'wind': 935.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 9, 7, 0, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 35.0,
+        'wind': 887.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 9, 7, 15, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 52.0,
+        'wind': 867.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 9, 7, 30, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 67.0,
+        'wind': 867.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 9, 7, 45, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 84.0,
+        'wind': 885.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 9, 8, 0, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 104.0,
+        'wind': 932.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 9, 8, 15, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 122.0,
+        'wind': 966.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 9, 8, 30, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 137.0,
+        'wind': 993.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 9, 8, 45, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 152.0,
+        'wind': 1033.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 9, 9, 0, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 169.0,
+        'wind': 1092.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 9, 9, 15, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 181.0,
+        'wind': 1127.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 9, 9, 30, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 190.0,
+        'wind': 1146.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 9, 9, 45, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 198.0,
+        'wind': 1158.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 9, 10, 0, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 204.0,
+        'wind': 1157.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 9, 10, 15, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 207.0,
+        'wind': 1156.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 9, 10, 30, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 208.0,
+        'wind': 1148.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 9, 10, 45, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 208.0,
+        'wind': 1141.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 9, 11, 0, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 205.0,
+        'wind': 1141.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 9, 11, 15, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 200.0,
+        'wind': 1114.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 9, 11, 30, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 193.0,
+        'wind': 1070.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 9, 11, 45, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 183.0,
+        'wind': 1003.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 9, 12, 0, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 170.0,
+        'wind': 897.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 9, 12, 15, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 157.0,
+        'wind': 817.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 9, 12, 30, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 143.0,
+        'wind': 754.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 9, 12, 45, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 126.0,
+        'wind': 677.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 9, 13, 0, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 106.0,
+        'wind': 579.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 9, 13, 15, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 87.0,
+        'wind': 521.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 9, 13, 30, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 71.0,
+        'wind': 488.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 9, 13, 45, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 50.0,
+        'wind': 479.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 9, 14, 0, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 22.0,
+        'wind': 505.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 9, 14, 15, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 6.0,
+        'wind': 517.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 9, 14, 30, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 3.0,
+        'wind': 522.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 9, 14, 45, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 1.0,
+        'wind': 542.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 9, 15, 0, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 1.0,
+        'wind': 582.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 9, 15, 15, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 1.0,
+        'wind': 601.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 9, 15, 30, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 609.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 9, 15, 45, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 611.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 9, 16, 0, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 603.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 9, 16, 15, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 598.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 9, 16, 30, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 595.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 9, 16, 45, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 588.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 9, 17, 0, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 577.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 9, 17, 15, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 569.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 9, 17, 30, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 563.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 9, 17, 45, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 557.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 9, 18, 0, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 554.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 9, 18, 15, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 548.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 9, 18, 30, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 542.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 9, 18, 45, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 535.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 9, 19, 0, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 527.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 9, 19, 15, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 520.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 9, 19, 30, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 515.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 9, 19, 45, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 508.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 9, 20, 0, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 501.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 9, 20, 15, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 497.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 9, 20, 30, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 494.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 9, 20, 45, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 493.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 9, 21, 0, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 496.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 9, 21, 15, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 497.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 9, 21, 30, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 496.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 9, 21, 45, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 495.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 9, 22, 0, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 493.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 9, 22, 15, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 492.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 9, 22, 30, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 492.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 9, 22, 45, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 492.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 9, 23, 0, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 542.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 9, 23, 15, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 540.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 9, 23, 30, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 537.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 9, 23, 45, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 531.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 10, 0, 0, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 521.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 10, 0, 15, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 513.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 10, 0, 30, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 507.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 10, 0, 45, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 497.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 10, 1, 0, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 482.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 10, 1, 15, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 476.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 10, 1, 30, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 476.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 10, 1, 45, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 479.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 10, 2, 0, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 486.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 10, 2, 15, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 495.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 10, 2, 30, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 508.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 10, 2, 45, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 523.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 10, 3, 0, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 538.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 10, 3, 15, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 561.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 10, 3, 30, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 589.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 10, 3, 45, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 625.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 10, 4, 0, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 671.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 10, 4, 15, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 713.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 10, 4, 30, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 752.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 10, 4, 45, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 797.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 10, 5, 0, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 850.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 10, 5, 15, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 894.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 10, 5, 30, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 1.0,
+        'wind': 930.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 10, 5, 45, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 967.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 10, 6, 0, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 1007.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 10, 6, 15, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 1035.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 10, 6, 30, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 1.0,
+        'wind': 1052.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 10, 6, 45, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 13.0,
+        'wind': 1066.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 10, 7, 0, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 33.0,
+        'wind': 1077.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 10, 7, 15, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 48.0,
+        'wind': 1075.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 10, 7, 30, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 61.0,
+        'wind': 1066.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 10, 7, 45, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 76.0,
+        'wind': 1036.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 10, 8, 0, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 94.0,
+        'wind': 971.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 10, 8, 15, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 108.0,
+        'wind': 941.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 10, 8, 30, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 120.0,
+        'wind': 929.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 10, 8, 45, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 132.0,
+        'wind': 930.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 10, 9, 0, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 145.0,
+        'wind': 957.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 10, 9, 15, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 154.0,
+        'wind': 963.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 10, 9, 30, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 161.0,
+        'wind': 955.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 10, 9, 45, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 165.0,
+        'wind': 953.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 10, 10, 0, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 166.0,
+        'wind': 958.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 10, 10, 15, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 167.0,
+        'wind': 941.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 10, 10, 30, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 167.0,
+        'wind': 911.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 10, 10, 45, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 166.0,
+        'wind': 864.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 10, 11, 0, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 164.0,
+        'wind': 790.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 10, 11, 15, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 160.0,
+        'wind': 733.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 10, 11, 30, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 155.0,
+        'wind': 687.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 10, 11, 45, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 148.0,
+        'wind': 630.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 10, 12, 0, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 140.0,
+        'wind': 557.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 10, 12, 15, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 130.0,
+        'wind': 512.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 10, 12, 30, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 119.0,
+        'wind': 487.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 10, 12, 45, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 107.0,
+        'wind': 469.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 10, 13, 0, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 92.0,
+        'wind': 458.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 10, 13, 15, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 77.0,
+        'wind': 465.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 10, 13, 30, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 63.0,
+        'wind': 486.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 10, 13, 45, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 46.0,
+        'wind': 526.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 10, 14, 0, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 20.0,
+        'wind': 591.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 10, 14, 15, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 6.0,
+        'wind': 651.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 10, 14, 30, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 3.0,
+        'wind': 710.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 10, 14, 45, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 1.0,
+        'wind': 788.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 10, 15, 0, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 1.0,
+        'wind': 891.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 10, 15, 15, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 1.0,
+        'wind': 969.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 10, 15, 30, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 1031.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 10, 15, 45, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 1090.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 10, 16, 0, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 1142.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 10, 16, 15, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 1188.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 10, 16, 30, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 1229.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 10, 16, 45, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 1264.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 10, 17, 0, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 1293.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 10, 17, 15, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 1316.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 10, 17, 30, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 1334.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 10, 17, 45, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 1343.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 10, 18, 0, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 1339.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 10, 18, 15, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 1340.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 10, 18, 30, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 1343.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 10, 18, 45, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 1340.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 10, 19, 0, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 1329.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 10, 19, 15, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 1327.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 10, 19, 30, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 1329.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 10, 19, 45, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 1333.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 10, 20, 0, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 1341.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 10, 20, 15, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 1348.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 10, 20, 30, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 1355.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 10, 20, 45, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 1367.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 10, 21, 0, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 1389.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 10, 21, 15, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 1398.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 10, 21, 30, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 1400.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 10, 21, 45, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 1394.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 10, 22, 0, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 1375.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 10, 22, 15, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 1366.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 10, 22, 30, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 1364.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 10, 22, 45, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 1362.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+  ])
+# ---

--- a/electricitymap/contrib/parsers/tests/__snapshots__/test_ENTSOE/test_wind_and_solar_forecasts_by_type[intraday].ambr
+++ b/electricitymap/contrib/parsers/tests/__snapshots__/test_ENTSOE/test_wind_and_solar_forecasts_by_type[intraday].ambr
@@ -1,0 +1,2749 @@
+# serializer version: 1
+# name: test_wind_and_solar_forecasts_by_type[intraday]
+  list([
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 7, 22, 0, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 2036.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 7, 22, 15, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 2016.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 7, 22, 30, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 2008.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 7, 22, 45, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 2004.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 7, 23, 0, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 1539.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 7, 23, 15, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 1532.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 7, 23, 30, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 1522.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 7, 23, 45, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 1490.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 8, 0, 0, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 1419.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 8, 0, 15, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 1393.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 8, 0, 30, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 1393.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 8, 0, 45, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 1407.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 8, 1, 0, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 1449.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 8, 1, 15, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 1482.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 8, 1, 30, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 1512.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 8, 1, 45, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 1548.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 8, 2, 0, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 1584.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 8, 2, 15, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 1631.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 8, 2, 30, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 1684.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 8, 2, 45, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 1752.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 8, 3, 0, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 1846.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 8, 3, 15, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 1916.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 8, 3, 30, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 1973.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 8, 3, 45, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 2028.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 8, 4, 0, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 2076.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 8, 4, 15, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 2122.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 8, 4, 30, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 2164.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 8, 4, 45, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 2197.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 8, 5, 0, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 2216.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 8, 5, 15, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 2246.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 8, 5, 30, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 1.0,
+        'wind': 2281.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 8, 5, 45, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 2326.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 8, 6, 0, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 2392.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 8, 6, 15, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 2429.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 8, 6, 30, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 1.0,
+        'wind': 2449.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 8, 6, 45, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 10.0,
+        'wind': 2454.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 8, 7, 0, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 24.0,
+        'wind': 2432.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 8, 7, 15, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 36.0,
+        'wind': 2427.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 8, 7, 30, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 48.0,
+        'wind': 2423.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 8, 7, 45, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 64.0,
+        'wind': 2446.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 8, 8, 0, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 84.0,
+        'wind': 2527.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 8, 8, 15, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 100.0,
+        'wind': 2514.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 8, 8, 30, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 114.0,
+        'wind': 2446.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 8, 8, 45, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 130.0,
+        'wind': 2322.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 8, 9, 0, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 147.0,
+        'wind': 2104.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 8, 9, 15, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 159.0,
+        'wind': 1944.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 8, 9, 30, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 169.0,
+        'wind': 1817.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 8, 9, 45, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 176.0,
+        'wind': 1668.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 8, 10, 0, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 180.0,
+        'wind': 1491.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 8, 10, 15, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 183.0,
+        'wind': 1361.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 8, 10, 30, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 185.0,
+        'wind': 1264.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 8, 10, 45, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 186.0,
+        'wind': 1184.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 8, 11, 0, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 185.0,
+        'wind': 1130.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 8, 11, 15, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 181.0,
+        'wind': 1085.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 8, 11, 30, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 175.0,
+        'wind': 1050.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 8, 11, 45, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 166.0,
+        'wind': 1034.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 8, 12, 0, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 154.0,
+        'wind': 1039.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 8, 12, 15, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 142.0,
+        'wind': 1050.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 8, 12, 30, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 128.0,
+        'wind': 1069.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 8, 12, 45, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 113.0,
+        'wind': 1100.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 8, 13, 0, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 93.0,
+        'wind': 1142.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 8, 13, 15, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 76.0,
+        'wind': 1196.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 8, 13, 30, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 61.0,
+        'wind': 1260.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 8, 13, 45, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 42.0,
+        'wind': 1345.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 8, 14, 0, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 18.0,
+        'wind': 1462.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 8, 14, 15, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 3.0,
+        'wind': 1558.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 8, 14, 30, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 1.0,
+        'wind': 1641.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 8, 14, 45, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 1.0,
+        'wind': 1731.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 8, 15, 0, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 1833.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 8, 15, 15, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 1.0,
+        'wind': 1913.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 8, 15, 30, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 1977.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 8, 15, 45, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 2033.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 8, 16, 0, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 2077.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 8, 16, 15, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 2116.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 8, 16, 30, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 2150.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 8, 16, 45, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 2174.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 8, 17, 0, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 2186.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 8, 17, 15, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 2198.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 8, 17, 30, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 2208.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 8, 17, 45, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 2211.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 8, 18, 0, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 2208.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 8, 18, 15, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 2204.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 8, 18, 30, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 2198.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 8, 18, 45, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 2188.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 8, 19, 0, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 2170.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 8, 19, 15, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 2156.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 8, 19, 30, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 2144.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 8, 19, 45, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 2134.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 8, 20, 0, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 2130.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 8, 20, 15, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 2116.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 8, 20, 30, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 2095.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 8, 20, 45, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 2068.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 8, 21, 0, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 2031.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 8, 21, 15, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 1999.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 8, 21, 30, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 1971.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 8, 21, 45, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 1933.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 8, 22, 0, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 1881.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 8, 22, 15, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 1851.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 8, 22, 30, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 1837.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 8, 22, 45, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 1828.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 8, 23, 0, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 1977.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 8, 23, 15, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 1960.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 8, 23, 30, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 1931.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 8, 23, 45, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 1869.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 9, 0, 0, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 1756.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 9, 0, 15, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 1682.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 9, 0, 30, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 1631.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 9, 0, 45, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 1579.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 9, 1, 0, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 1527.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 9, 1, 15, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 1488.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 9, 1, 30, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 1458.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 9, 1, 45, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 1436.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 9, 2, 0, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 1422.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 9, 2, 15, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 1416.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 9, 2, 30, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 1413.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 9, 2, 45, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 1429.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 9, 3, 0, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 1475.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 9, 3, 15, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 1492.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 9, 3, 30, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 1493.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 9, 3, 45, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 1486.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 9, 4, 0, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 1464.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 9, 4, 15, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 1449.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 9, 4, 30, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 1439.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 9, 4, 45, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 1424.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 9, 5, 0, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 1406.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 9, 5, 15, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 1392.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 9, 5, 30, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 1.0,
+        'wind': 1379.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 9, 5, 45, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 1372.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 9, 6, 0, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 1374.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 9, 6, 15, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 1364.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 9, 6, 30, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 1.0,
+        'wind': 1345.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 9, 6, 45, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 13.0,
+        'wind': 1322.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 9, 7, 0, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 32.0,
+        'wind': 1294.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 9, 7, 15, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 48.0,
+        'wind': 1263.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 9, 7, 30, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 63.0,
+        'wind': 1233.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 9, 7, 45, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 81.0,
+        'wind': 1189.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 9, 8, 0, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 103.0,
+        'wind': 1121.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 9, 8, 15, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 121.0,
+        'wind': 1083.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 9, 8, 30, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 136.0,
+        'wind': 1065.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 9, 8, 45, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 151.0,
+        'wind': 1055.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 9, 9, 0, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 166.0,
+        'wind': 1059.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 9, 9, 15, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 179.0,
+        'wind': 1066.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 9, 9, 30, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 188.0,
+        'wind': 1075.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 9, 9, 45, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 196.0,
+        'wind': 1103.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 9, 10, 0, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 203.0,
+        'wind': 1161.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 9, 10, 15, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 208.0,
+        'wind': 1189.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 9, 10, 30, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 209.0,
+        'wind': 1198.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 9, 10, 45, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 208.0,
+        'wind': 1207.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 9, 11, 0, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 205.0,
+        'wind': 1218.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 9, 11, 15, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 200.0,
+        'wind': 1206.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 9, 11, 30, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 193.0,
+        'wind': 1179.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 9, 11, 45, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 184.0,
+        'wind': 1134.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 9, 12, 0, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 171.0,
+        'wind': 1067.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 9, 12, 15, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 157.0,
+        'wind': 1003.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 9, 12, 30, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 143.0,
+        'wind': 942.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 9, 12, 45, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 127.0,
+        'wind': 857.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 9, 13, 0, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 107.0,
+        'wind': 733.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 9, 13, 15, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 89.0,
+        'wind': 655.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 9, 13, 30, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 72.0,
+        'wind': 606.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 9, 13, 45, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 51.0,
+        'wind': 572.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 9, 14, 0, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 23.0,
+        'wind': 562.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 9, 14, 15, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 6.0,
+        'wind': 549.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 9, 14, 30, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 3.0,
+        'wind': 537.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 9, 14, 45, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 1.0,
+        'wind': 540.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 9, 15, 0, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 1.0,
+        'wind': 561.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 9, 15, 15, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 1.0,
+        'wind': 573.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 9, 15, 30, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 579.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 9, 15, 45, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 589.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 9, 16, 0, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 602.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 9, 16, 15, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 613.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 9, 16, 30, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 621.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 9, 16, 45, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 631.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 9, 17, 0, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 643.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 9, 17, 15, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 650.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 9, 17, 30, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 651.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 9, 17, 45, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 650.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 9, 18, 0, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 643.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 9, 18, 15, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 637.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 9, 18, 30, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 630.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 9, 18, 45, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 621.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 9, 19, 0, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 610.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 9, 19, 15, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 598.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 9, 19, 30, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 586.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 9, 19, 45, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 571.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 9, 20, 0, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 552.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 9, 20, 15, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 538.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 9, 20, 30, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 526.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 9, 20, 45, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 518.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 9, 21, 0, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 514.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 9, 21, 15, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 506.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 9, 21, 30, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 497.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 9, 21, 45, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 486.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 9, 22, 0, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 470.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 9, 22, 15, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 461.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 9, 22, 30, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 457.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2024, 2, 9, 22, 45, tzinfo=datetime.timezone.utc),
+      'production': dict({
+        'solar': 0.0,
+        'wind': 454.0,
+      }),
+      'source': 'entsoe.eu',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'FI',
+    }),
+  ])
+# ---

--- a/electricitymap/contrib/parsers/tests/test_ENTSOE.py
+++ b/electricitymap/contrib/parsers/tests/test_ENTSOE.py
@@ -375,6 +375,34 @@ def test_wind_and_solar_forecasts(adapter, session, snapshot):
     assert snapshot == ENTSOE.fetch_wind_solar_forecasts(ZoneKey("FI"), session)
 
 
+@pytest.mark.parametrize(
+    ("fetcher", "mock_filename"),
+    [
+        (
+            ENTSOE.fetch_wind_solar_forecasts_day_ahead,
+            "wind_solar_forecast_FI_DAY_AHEAD.xml",
+        ),
+        (
+            ENTSOE.fetch_wind_solar_forecasts_intraday,
+            "wind_solar_forecast_FI_INTRADAY.xml",
+        ),
+        (
+            ENTSOE.fetch_wind_solar_forecasts_current,
+            "wind_solar_forecast_FI_CURRENT.xml",
+        ),
+    ],
+    ids=["day_ahead", "intraday", "current"],
+)
+def test_wind_and_solar_forecasts_by_type(
+    adapter, session, snapshot, fetcher, mock_filename
+):
+    data = base_path_to_mock / mock_filename
+    adapter.register_uri(GET, ANY, content=data.read_bytes())
+    assert snapshot(extension_class=SingleFileAmberSnapshotExtension) == fetcher(
+        ZoneKey("FI"), session
+    )
+
+
 def test_fetch_uses_normal_url(adapter, session):
     os.environ["ENTSOE_TOKEN"] = "proxy"
     with open(


### PR DESCRIPTION
## Issue

Closes: GMM-1742

## Description

To have this data split internally in the DB we need to split the fetch functions as well. Keeping the old function around while we migrate.

### Double check

- [x] I have tested my parser changes locally with `uv run test_parser "zone_key"`
- [x] I have run `pnpx prettier@2 --write .` and `uv run format` in the top level directory to format my changes.
