### PR TITLE
data: update GB solar capacity to 22126 MW (Sheffield Solar)

### DIFF
--- a/config/zones/GB.yaml
+++ b/config/zones/GB.yaml
@@ -144,6 +144,9 @@ capacity:
     - datetime: '2024-01-01'
       source: bmreports.com
       value: 15896
+    - datetime: '2025-01-01'
+      source: api.solar.sheffield.ac.uk/pvlive/capacity
+      value: 22126
   unknown:
     - datetime: '2017-01-01'
       source: Ember, Yearly electricity data


### PR DESCRIPTION
## Summary

Closes #8610. Updates GB solar capacity from 15,896 MW to 22,126 MW.

**Source:** [Sheffield Solar PVLive API](https://api.solar.sheffield.ac.uk/pvlive/capacity) (capacity report dated 2026-01-29)

**Previous source (bmreports.com/Elexon BMRS)** has been decommissioned, as noted in the issue.

## Change

`config/zones/GB.yaml` — added new entry:
```yaml
- datetime: '2025-01-01'
  source: api.solar.sheffield.ac.uk/pvlive/capacity
  value: 22126
```

Previous entries from bmreports.com are preserved for historical reference.