### PR TITLE
update swedish wind capacity

### DIFF
--- a/config/zones/SE-SE1.yaml
+++ b/config/zones/SE-SE1.yaml
@@ -59,6 +59,9 @@ capacity:
     - datetime: '2024-01-01'
       source: energimyndigheten.se
       value: 3066.87
+    - datetime: '2025-01-01'
+      source: energimyndigheten.se
+      value: 3290.87
 country: SE
 country_name: Sweden
 currency: EUR

--- a/config/zones/SE-SE2.yaml
+++ b/config/zones/SE-SE2.yaml
@@ -59,6 +59,9 @@ capacity:
     - datetime: '2024-01-01'
       source: energimyndigheten.se
       value: 7075.25
+    - datetime: '2025-01-01'
+      source: energimyndigheten.se
+      value: 7765.05
 country: SE
 country_name: Sweden
 currency: EUR

--- a/config/zones/SE-SE3.yaml
+++ b/config/zones/SE-SE3.yaml
@@ -66,6 +66,9 @@ capacity:
     - datetime: '2024-01-01'
       source: energimyndigheten.se
       value: 4233.36
+    - datetime: '2025-01-01'
+      source: energimyndigheten.se
+      value: 4493.88
 country: SE
 country_name: Sweden
 currency: EUR

--- a/config/zones/SE-SE4.yaml
+++ b/config/zones/SE-SE4.yaml
@@ -59,6 +59,9 @@ capacity:
     - datetime: '2024-01-01'
       source: energimyndigheten.se
       value: 2443.88
+    - datetime: '2025-01-01'
+      source: energimyndigheten.se
+      value: 2576.72
 country: SE
 country_name: Sweden
 currency: EUR


### PR DESCRIPTION
## Description

New wind capacity values have been published.
https://pxexternal.energimyndigheten.se/pxweb/sv/Energimyndighetens_statistikdatabas/Energimyndighetens_statistikdatabas__Officiell_energistatistik__Vindkraftsstatistik/EN0105_2.px/table/tableViewLayout2/

Added the 2025 values and double checked the values for 2023 and 2024.

### Double check

- [x] I have tested my parser changes locally with `uv run test_parser "zone_key"`
- [x] I have run `pnpx prettier@2 --write .` and `uv run format` in the top level directory to format my changes.
