### PR TITLE
feat(FO): add hydro storage from realtime API

### DIFF
--- a/config/zones/FO.yaml
+++ b/config/zones/FO.yaml
@@ -12,6 +12,7 @@ centroid:
 capacity:
   biomass: 1.3
   hydro: 40.6
+  hydro storage: 49
   oil: 99.7
   solar: 0.24
   unknown: 0.1

--- a/electricitymap/contrib/parsers/FO.py
+++ b/electricitymap/contrib/parsers/FO.py
@@ -7,7 +7,7 @@ from zoneinfo import ZoneInfo
 from requests import Session
 
 from electricitymap.contrib.lib.models.event_lists import ProductionBreakdownList
-from electricitymap.contrib.lib.models.events import ProductionMix
+from electricitymap.contrib.lib.models.events import ProductionMix, StorageMix
 from electricitymap.contrib.parsers.lib.config import refetch_frequency
 from electricitymap.contrib.parsers.lib.exceptions import ParserException
 from electricitymap.contrib.types import ZoneKey
@@ -38,6 +38,16 @@ MAP_ZONE_KEY_TO_REALTIME_API_DATA_KEY = {
     "FO-MI": "H_E",
     "FO-SI": "S_E",
 }
+
+REALTIME_STORAGE_KEYS = [
+    "Vatnid",
+    "Lomundaroyri",
+    "Heygadalur",
+    "Eidisvatn",
+    "Strandadalur",
+    "Ryskisvatn",
+    "Vatnsnesvatn",
+]
 
 VALID_ZONE_KEYS = [ZoneKey("FO"), ZoneKey("FO-MI"), ZoneKey("FO-SI")]
 
@@ -174,6 +184,15 @@ def _fetch_production_live(
         else:
             continue
 
+    # Extract hydro storage data from reservoir keys.
+    # All pumped storage infrastructure is on Main Island (FO-MI area).
+    # Positive values = pumping/charging, negative values = discharging/generating.
+    storage_mix = StorageMix()
+    if zone_key != ZoneKey("FO-SI"):
+        for key in REALTIME_STORAGE_KEYS:
+            if key in obj:
+                storage_mix.add_value("hydro", float(obj[key].replace(",", ".")))
+
     dt = (
         datetime.fromisoformat(obj["tiden"])
         # floor to hourly granularity to match historical API entries
@@ -187,6 +206,7 @@ def _fetch_production_live(
         datetime=dt,
         source="sev.fo",
         production=production_mix,
+        storage=storage_mix,
     )
 
     return production_breakdown_list

--- a/electricitymap/contrib/parsers/tests/__snapshots__/test_FO/test_fetch_production_live[FO-MI].ambr
+++ b/electricitymap/contrib/parsers/tests/__snapshots__/test_FO/test_fetch_production_live[FO-MI].ambr
@@ -543,6 +543,7 @@
       'source': 'sev.fo',
       'sourceType': <EventSourceType.measured: 'measured'>,
       'storage': dict({
+        'hydro': -19.73,
       }),
       'zoneKey': 'FO-MI',
     }),

--- a/electricitymap/contrib/parsers/tests/__snapshots__/test_FO/test_fetch_production_live[FO].ambr
+++ b/electricitymap/contrib/parsers/tests/__snapshots__/test_FO/test_fetch_production_live[FO].ambr
@@ -577,6 +577,7 @@
       'source': 'sev.fo',
       'sourceType': <EventSourceType.measured: 'measured'>,
       'storage': dict({
+        'hydro': -19.73,
       }),
       'zoneKey': 'FO',
     }),


### PR DESCRIPTION
## Summary

Implements hydro storage reporting for the Faroe Islands (FO 🇫🇴) by extracting pumped hydro storage data from the SEV realtime API.

Closes #3266

## Changes

### Parser (`electricitymap/contrib/parsers/FO.py`)
- Added `StorageMix` import
- Defined `REALTIME_STORAGE_KEYS` constant with the 7 reservoir keys: Vatnid, Lomundaroyri, Heygadalur, Eidisvatn, Strandadalur, Ryskisvatn, Vatnsnesvatn
- Modified `_fetch_production_live()` to sum reservoir values into a `StorageMix(hydro=...)` and pass it to `ProductionBreakdownList.append()`
- Storage is applied to **FO** and **FO-MI** only (all reservoirs are on Main Island); FO-SI gets an empty StorageMix

### Zone config (`config/zones/FO.yaml`)
- Added `hydro storage: 49` capacity (as noted in the issue and confirmed by ElectricityMap data)

### Sign convention
The SEV API values map directly to the StorageMix convention:
- **Positive** = pumping/charging (consuming electricity)
- **Negative** = discharging/generating (producing electricity)

No inversion is needed.

## Testing
- All 9 existing tests pass ✅
- Test snapshots updated for FO and FO-MI live tests (now include `storage` field)
- Validated against live API: `uv run test_parser FO`, `FO-MI`, `FO-SI` all return correct data
- Formatter (`uv run format`) passes with no issues