### PR TITLE
update(ES-CE,ES-ML): refresh Ceuta and Melilla capacity through 2026-05

### DIFF
--- a/config/zones/ES-CE.yaml
+++ b/config/zones/ES-CE.yaml
@@ -5,11 +5,11 @@ bounding_box:
     - 35.92262502599443
 capacity:
   gas:
-    - datetime: '2022-12-01'
+    - datetime: '2017-01-01'
       source: ree.es
       value: 13.0
   oil:
-    - datetime: '2022-12-01'
+    - datetime: '2017-01-01'
       source: ree.es
       value: 78.0
 center_point:

--- a/config/zones/ES-ML.yaml
+++ b/config/zones/ES-ML.yaml
@@ -5,23 +5,35 @@ bounding_box:
     - 35.3209422034335
 capacity:
   biomass:
-    - datetime: '2022-12-01'
+    - datetime: '2017-01-01'
       source: ree.es
       value: 1.0
   gas:
-    - datetime: '2022-12-01'
+    - datetime: '2017-01-01'
       source: ree.es
       value: 12.0
   oil:
-    - datetime: '2022-12-01'
+    - datetime: '2017-01-01'
       source: ree.es
       value: 64.0
   solar:
-    - datetime: '2022-12-01'
+    - datetime: '2017-01-01'
       source: ree.es
       value: 0.0
+    - datetime: '2024-03-01'
+      source: ree.es
+      value: 1.0
+    - datetime: '2024-11-01'
+      source: ree.es
+      value: 2.0
+    - datetime: '2025-01-01'
+      source: ree.es
+      value: 3.0
+    - datetime: '2025-02-01'
+      source: ree.es
+      value: 4.0
   unknown:
-    - datetime: '2022-12-01'
+    - datetime: '2017-01-01'
       source: ree.es
       value: 1.0
 center_point:


### PR DESCRIPTION
## Summary
Follow-up to #8720. Refreshes ES-CE (Ceuta) and ES-ML (Melilla) capacity using the same monthly REE fetch loop. Both zones had stale 2022-12-01 entries.

## Notable data changes
- **ES-CE**: gas (13 MW) and oil (78 MW) values unchanged, but verified constant since 2017-01.
- **ES-ML**: gas (12 MW), oil (64 MW), biomass (1 MW), unknown (1 MW) all unchanged since 2017-01. Surfaces a small but real new solar series: 0 → 1 → 2 → 3 → 4 MW between 2024-03 and 2025-02.

## Coverage note
The REE capacity parser supports exactly three zones in our config (ES, ES-CE, ES-ML) — REE's API only exposes electric-system aggregates, so per-island Canary (ES-CN-*) and Balearic (ES-IB-*) zones can't be populated from this source.

## Test plan
- [x] Capacity parser unit tests pass
- [x] Configs round-trip through `electricitymap.contrib.config.reading.read_zones_config` without errors
- [ ] Verify rendering on staging

🤖 Generated with [Claude Code](https://claude.com/claude-code)