### PR TITLE
hide price for MD until we have the new DayAhead market data

### DIFF
--- a/config/zones/MD.yaml
+++ b/config/zones/MD.yaml
@@ -210,7 +210,7 @@ fallbackZoneMixes:
         unknown: 0.0027065851482313144
         wind: 0.03416068856152983
 has_day_ahead_price_license: False
-hide_day_ahead_price: False
+hide_day_ahead_price: True
 parsers:
   consumption: ENTSOE.fetch_consumption
   consumptionForecast: ENTSOE.fetch_consumption_forecast


### PR DESCRIPTION
## Issue

Ref: GMM-1904

## Description

Hides the Moldovan prices until we have the data for the new Day Ahead price market. 


### Double check

- [x] I have tested my parser changes locally with `uv run test_parser "zone_key"`
- [x] I have run `pnpx prettier@2 --write .` and `uv run format` in the top level directory to format my changes.
