### PR TITLE
feat(JAO,NORDPOOL,ESIOS): retry on 429 + transient 5xx

### DIFF
--- a/electricitymap/contrib/parsers/ESIOS.py
+++ b/electricitymap/contrib/parsers/ESIOS.py
@@ -8,13 +8,12 @@ from zoneinfo import ZoneInfo
 
 import requests
 from requests import Response, Session
-from requests.adapters import HTTPAdapter
-from urllib3.util.retry import Retry
 
 from electricitymap.contrib.lib.models.event_lists import ExchangeList
 from electricitymap.contrib.types import ZoneKey
 
 from .lib.exceptions import ParserException
+from .lib.session import mount_retry
 from .lib.utils import get_token
 
 TIMEZONE = ZoneInfo("Europe/Madrid")
@@ -73,10 +72,7 @@ def fetch_exchange(
     # Get ESIOS token
     token = get_token("ESIOS_TOKEN")
 
-    # Only create a new session if one wasn't provided
-    # This allows tests to pass in a session with mock adapters
-    ses = session or Session()
-    is_new_session = session is None
+    ses = mount_retry(session or Session())
 
     if target_datetime is None:
         target_datetime = datetime.now(tz=TIMEZONE)
@@ -95,26 +91,9 @@ def fetch_exchange(
         )
     url = format_url(target_datetime, EXCHANGE_ID_MAP[zone_key])
 
-    if is_new_session:
-        # Configure retry strategy for HTTP status code errors
-        retry_strategy = Retry(
-            total=3,
-            backoff_factor=2,
-            status_forcelist=[
-                429,
-                500,
-                502,
-                503,
-                504,
-            ],
-            allowed_methods=["GET"],
-        )
-        adapter = HTTPAdapter(max_retries=retry_strategy)
-        ses.mount("https://", adapter)
-        ses.mount("http://", adapter)
-
-    # Manual retry loop with exponential backoff for connection/timeout errors
-    # This gives us better control over retry behavior for network issue
+    # Manual retry loop covers connection/timeout errors that urllib3.Retry
+    # in the mounted adapter doesn't catch (urllib3 raises them as
+    # ConnectionError before the retry counter kicks in).
     max_retries = 5
     for attempt in range(max_retries):
         try:

--- a/electricitymap/contrib/parsers/JAO.py
+++ b/electricitymap/contrib/parsers/JAO.py
@@ -47,6 +47,7 @@ from electricitymap.contrib.lib.models.events import (
 )
 from electricitymap.contrib.parsers.lib.config import refetch_frequency
 from electricitymap.contrib.parsers.lib.exceptions import ParserException
+from electricitymap.contrib.parsers.lib.session import mount_retry
 from electricitymap.contrib.types import AtcType, MarketAgreementType
 
 SOURCE = "jao.eu"
@@ -180,6 +181,7 @@ def _query_jao(
             "to_utc": params["ToUtc"],
         },
     )
+    mount_retry(session)
     response = session.get(url, params=params, timeout=REQUEST_TIMEOUT_SECONDS)
     if not response.ok:
         raise ParserException(

--- a/electricitymap/contrib/parsers/NORDPOOL.py
+++ b/electricitymap/contrib/parsers/NORDPOOL.py
@@ -5,6 +5,7 @@ from enum import Enum
 from logging import Logger, getLogger
 
 from requests import Response, Session
+from urllib3.util.retry import Retry
 
 from electricitymap.contrib.lib.models.event_lists import (
     ExchangeAtcList,
@@ -19,6 +20,7 @@ from electricitymap.contrib.parsers.lib.nordpool_intraday_schemas import (
 from electricitymap.contrib.types import AtcType, ZoneKey
 
 from .lib.config import refetch_frequency
+from .lib.session import mount_retry
 from .lib.utils import get_token
 
 """
@@ -42,6 +44,17 @@ class NordpoolToken:
 CURRENT_TOKEN: NordpoolToken | None = None
 
 SOURCE = "nordpool.com"
+
+# Nordpool needs the OAuth token endpoint (POST) retried too — replaying
+# the token POST just acquires a fresh token, no side effects — so we
+# extend the shared default's allow-list. Everything else matches
+# `lib.session.DEFAULT_RETRY` (3 retries, 0/2/4 s backoff, 429 + 5xx).
+_NORDPOOL_RETRY = Retry(
+    total=3,
+    backoff_factor=2,
+    status_forcelist=[429, 500, 502, 503, 504],
+    allowed_methods=["GET", "POST"],
+)
 
 
 class NORDPOOL_API_ENDPOINT(Enum):
@@ -217,7 +230,7 @@ def fetch_price(
     target_datetime: datetime | None = None,
     logger: Logger = getLogger(__name__),
 ) -> list:
-    session = session or Session()
+    session = mount_retry(session or Session(), retry=_NORDPOOL_RETRY)
     target_datetime = target_datetime or datetime.now()
     params = {
         "areas": f"{ZONE_MAPPING[zone_key]}",
@@ -278,7 +291,7 @@ def fetch_exchange(
     Gets exchange status between two specified zones.
     Only supports Nordpool zones.
     """
-    session = session or Session()
+    session = mount_retry(session or Session(), retry=_NORDPOOL_RETRY)
     target_datetime = target_datetime or datetime.now()
     params = {
         "areas": f"{ZONE_MAPPING[zone_key1]}",
@@ -327,7 +340,7 @@ def fetch_intraday_contract_statistics(
             f"fetch_intraday_contract_statistics is not yet implemented for zone: {zone_key}"
         )
 
-    session = session or Session()
+    session = mount_retry(session or Session(), retry=_NORDPOOL_RETRY)
     target_datetime = target_datetime or datetime.now(tz=timezone.utc)
 
     # Convert to CET date for the API call.
@@ -467,7 +480,7 @@ def fetch_exchange_available_transfer_capacity(
         )
     query_area, counterpart = border
 
-    session = session or Session()
+    session = mount_retry(session or Session(), retry=_NORDPOOL_RETRY)
     target_datetime = target_datetime or datetime.now()
 
     params = {

--- a/electricitymap/contrib/parsers/lib/session.py
+++ b/electricitymap/contrib/parsers/lib/session.py
@@ -4,16 +4,13 @@ from requests import Session
 from requests.adapters import HTTPAdapter
 from urllib3.util.retry import Retry
 
-# Default retry policy: 3 retries, exponential backoff `2 * 2^(n-1)` s
-# between attempts (0, 2, 4 s), on rate-limit (429) and transient 5xx.
-# urllib3 honours `Retry-After` automatically when the server sends it.
-# Bounded so a sustained throttle still fails the task within Cloud Run's
-# budget and lets the queue retry.
+# 3 retries on 429 + transient 5xx, 0/2/4 s exponential backoff. urllib3
+# honours `Retry-After` for free. Pass a custom `Retry` to `mount_retry`
+# to widen `allowed_methods` (e.g. POST for OAuth token endpoints).
 #
-# `allowed_methods=["GET"]` matches the urllib3 default for safe-by-default
-# behaviour; parsers that need POST retried (e.g. OAuth token endpoints
-# where a replayed request just acquires a fresh token) should build their
-# own `Retry` with a widened allow-list and pass it to `mount_retry`.
+# Does NOT reliably cover `ConnectTimeoutError` — #8616 tried `connect=N`,
+# #8617 reverted it. Parsers needing that add an app-level loop on top
+# (see ESIOS.fetch_exchange).
 DEFAULT_RETRY = Retry(
     total=3,
     backoff_factor=2,

--- a/electricitymap/contrib/parsers/lib/session.py
+++ b/electricitymap/contrib/parsers/lib/session.py
@@ -1,22 +1,36 @@
-import ssl
+"""Shared transport-layer helpers for parser HTTP sessions."""
 
-import urllib3
-from requests import Session, adapters
+from requests import Session
+from requests.adapters import HTTPAdapter
+from urllib3.util.retry import Retry
+
+# Default retry policy: 3 retries, exponential backoff `2 * 2^(n-1)` s
+# between attempts (0, 2, 4 s), on rate-limit (429) and transient 5xx.
+# urllib3 honours `Retry-After` automatically when the server sends it.
+# Bounded so a sustained throttle still fails the task within Cloud Run's
+# budget and lets the queue retry.
+#
+# `allowed_methods=["GET"]` matches the urllib3 default for safe-by-default
+# behaviour; parsers that need POST retried (e.g. OAuth token endpoints
+# where a replayed request just acquires a fresh token) should build their
+# own `Retry` with a widened allow-list and pass it to `mount_retry`.
+DEFAULT_RETRY = Retry(
+    total=3,
+    backoff_factor=2,
+    status_forcelist=[429, 500, 502, 503, 504],
+    allowed_methods=["GET"],
+)
 
 
-class LegacyHttpAdapter(adapters.HTTPAdapter):
-    def init_poolmanager(self, connections, maxsize, block=False):
-        ctx = ssl.create_default_context(ssl.Purpose.SERVER_AUTH)
-        ctx.options |= 0x4  # OP_LEGACY_SERVER_CONNECT
-        self.poolmanager = urllib3.poolmanager.PoolManager(
-            num_pools=connections, maxsize=maxsize, block=block, ssl_context=ctx
-        )
+def mount_retry(session: Session, retry: Retry = DEFAULT_RETRY) -> Session:
+    """Mount a retrying HTTPAdapter on `session` for http(s)://.
 
-
-# Use a LegacyHttpAdapter to avoid "unsafe legacy renegotiation disabled" error
-# Original code source: https://stackoverflow.com/questions/71603314/ssl-error-unsafe-legacy-renegotiation-disabled
-def get_session_with_legacy_adapter():
-    session = Session()
-    session.mount("https://", LegacyHttpAdapter())
-    session.mount("http://", LegacyHttpAdapter())
+    Idempotent — re-mounting overrides the previous adapter with one
+    carrying the same Retry config, so calling this multiple times is
+    safe (each public fetcher can call it without coordinating).
+    Returns `session` so the call composes with `session or Session()`.
+    """
+    adapter = HTTPAdapter(max_retries=retry)
+    session.mount("https://", adapter)
+    session.mount("http://", adapter)
     return session

--- a/electricitymap/contrib/parsers/tests/conftest.py
+++ b/electricitymap/contrib/parsers/tests/conftest.py
@@ -1,36 +1,22 @@
 """
-This is a configuration file for pytest that defines test fixtures available for
-use by all tests under this path.
+Pytest fixtures for parser tests.
+
+`session` is a plain `requests.Session` — production-equivalent. To
+intercept HTTP calls, tests use the `requests_mock` pytest fixture
+(auto-provided by `requests-mock`), which monkey-patches
+`Session.get_adapter` transparently. This means production code is free
+to mount HTTPAdapter / Retry / any other transport adapter on
+`session.adapters` without interfering with test interception — handy
+for parsers that want retry-on-429 behaviour.
 
 Fixtures ref: https://docs.pytest.org/en/stable/explanation/fixtures.html
+requests-mock ref: https://requests-mock.readthedocs.io/en/latest/pytest.html
 """
 
 import pytest
 from requests import Session
-from requests_mock import Adapter
 
 
 @pytest.fixture
-def adapter():
-    """
-    A `requests.Adapter` enables us to mock responses when making web requests
-    via `requests.Session`.
-
-    Adapter ref: https://requests.readthedocs.io/en/latest/user/advanced/#transport-adapters
-    """
-    adapter = Adapter()
-    yield adapter
-
-
-@pytest.fixture
-def session(adapter):
-    """
-    A `request.Session` using the adapter fixture's object whenever http:// or
-    https:// requests are made.
-
-    Session ref: https://requests.readthedocs.io/en/latest/user/advanced/#session-objects
-    """
-    session = Session()
-    session.mount("http://", adapter)
-    session.mount("https://", adapter)
-    yield session
+def session():
+    yield Session()

--- a/electricitymap/contrib/parsers/tests/test_AEMO.py
+++ b/electricitymap/contrib/parsers/tests/test_AEMO.py
@@ -16,7 +16,9 @@ BASE_PATH_TO_MOCK = Path("electricitymap/contrib/parsers/tests/mocks/AEMO")
 @pytest.mark.parametrize("zone_key", ["AU-NSW", "AU-VIC", "AU-QLD", "AU-SA", "AU-TAS"])
 # "AU-WA" is not implemented in the zones here
 
-def test_snapshot_fetch_consumption_forecast(adapter, session, snapshot, zone_key):
+def test_snapshot_fetch_consumption_forecast(
+    requests_mock, session, snapshot, zone_key
+):
     base_url = "http://nemweb.com.au/Reports/CURRENT/Operational_Demand/FORECAST_HH/"
 
     # Mock the base URL request with HTML that contains the expected link
@@ -27,7 +29,7 @@ def test_snapshot_fetch_consumption_forecast(adapter, session, snapshot, zone_ke
     </body>
     </html>
     """
-    adapter.register_uri(
+    requests_mock.register_uri(
         GET,
         base_url,
         text=html_content,
@@ -44,7 +46,7 @@ def test_snapshot_fetch_consumption_forecast(adapter, session, snapshot, zone_ke
 
     with open(data_zip_file, "rb") as zip_file:
         zip_content = zip_file.read()
-    adapter.register_uri(
+    requests_mock.register_uri(
         GET,
         re.compile(rf"{base_url}PUBLIC_FORECAST_OPERATIONAL_DEMAND_HH_\d+_\d+\.zip"),
         content=zip_content,

--- a/electricitymap/contrib/parsers/tests/test_AW.py
+++ b/electricitymap/contrib/parsers/tests/test_AW.py
@@ -7,8 +7,8 @@ from electricitymap.contrib.parsers.AW import PRODUCTION_URL, fetch_production
 from electricitymap.contrib.types import ZoneKey
 
 
-def test_fetch_production(adapter, session, snapshot):
-    adapter.register_uri(
+def test_fetch_production(requests_mock, session, snapshot):
+    requests_mock.register_uri(
         GET,
         PRODUCTION_URL,
         json=json.loads(

--- a/electricitymap/contrib/parsers/tests/test_BE.py
+++ b/electricitymap/contrib/parsers/tests/test_BE.py
@@ -18,16 +18,16 @@ def entsoe_token_env():
     os.environ["ENTSOE_TOKEN"] = "token"
 
 
-def test_fetch_production(adapter, session, snapshot):
+def test_fetch_production(requests_mock, session, snapshot):
     entsoe_data = base_path_to_mock / "entsoe_production.xml"
     elia_data = base_path_to_mock / "production.json"
 
-    adapter.register_uri(
+    requests_mock.register_uri(
         GET,
         re.compile(r"https://entsoe-proxy"),
         content=entsoe_data.read_bytes(),
     )
-    adapter.register_uri(
+    requests_mock.register_uri(
         GET,
         re.compile(r"https://opendata\.elia\.be"),
         json=json.loads(elia_data.read_text()),

--- a/electricitymap/contrib/parsers/tests/test_BG.py
+++ b/electricitymap/contrib/parsers/tests/test_BG.py
@@ -11,9 +11,9 @@ from electricitymap.contrib.parsers.lib.exceptions import ParserException
 
 
 @freeze_time("2024-01-01 12:00:00")
-def test_fetch_production(adapter, session, snapshot):
+def test_fetch_production(requests_mock, session, snapshot):
     """That we can fetch the production mix at the current time."""
-    adapter.register_uri(
+    requests_mock.register_uri(
         GET,
         ANY,
         json=json.loads(
@@ -26,9 +26,11 @@ def test_fetch_production(adapter, session, snapshot):
     assert snapshot == fetch_production(session=session)
 
 
-def test_fetch_production_raises_parser_exception_on_historical_data(adapter, session):
+def test_fetch_production_raises_parser_exception_on_historical_data(
+    requests_mock, session
+):
     """That a ParserException is raised if requesting historical data (not supported yet)."""
-    adapter.register_uri(GET, ANY, json=[])
+    requests_mock.register_uri(GET, ANY, json=[])
 
     with pytest.raises(
         ParserException, match="This parser is not yet able to parse historical data"

--- a/electricitymap/contrib/parsers/tests/test_CAMMESA.py
+++ b/electricitymap/contrib/parsers/tests/test_CAMMESA.py
@@ -14,8 +14,8 @@ from electricitymap.contrib.types import ZoneKey
 
 
 @pytest.fixture(autouse=True)
-def mock_response(adapter):
-    adapter.register_uri(
+def mock_response(requests_mock):
+    requests_mock.register_uri(
         GET,
         ANY,
         json=json.loads(
@@ -24,7 +24,7 @@ def mock_response(adapter):
             .read_text()
         ),
     )
-    adapter.register_uri(
+    requests_mock.register_uri(
         GET,
         CAMMESA_DEMANDA_ENDPOINT,
         json=json.loads(
@@ -33,7 +33,7 @@ def mock_response(adapter):
             .read_text()
         ),
     )
-    adapter.register_uri(
+    requests_mock.register_uri(
         GET,
         CAMMESA_RENEWABLES_ENDPOINT,
         json=json.loads(

--- a/electricitymap/contrib/parsers/tests/test_CA_AB.py
+++ b/electricitymap/contrib/parsers/tests/test_CA_AB.py
@@ -8,10 +8,10 @@ from electricitymap.contrib.types import ZoneKey
 base_path_to_mock = Path("electricitymap/contrib/parsers/tests/mocks/CA_AB")
 
 
-def test_fetch_wind_solar_forecasts(adapter, session, snapshot):
+def test_fetch_wind_solar_forecasts(requests_mock, session, snapshot):
     # Mock wind forecast data request
     data_wind = Path(base_path_to_mock, "wind_rpt_longterm.csv")
-    adapter.register_uri(
+    requests_mock.register_uri(
         GET,
         "http://ets.aeso.ca/Market/Reports/Manual/Operations/prodweb_reports/wind_solar_forecast/wind_rpt_longterm.csv",
         text=data_wind.read_text(),
@@ -19,7 +19,7 @@ def test_fetch_wind_solar_forecasts(adapter, session, snapshot):
 
     # Moch solar forecast data request
     data_solar = Path(base_path_to_mock, "solar_rpt_longterm.csv")
-    adapter.register_uri(
+    requests_mock.register_uri(
         GET,
         "http://ets.aeso.ca/Market/Reports/Manual/Operations/prodweb_reports/wind_solar_forecast/solar_rpt_longterm.csv",
         text=data_solar.read_text(),

--- a/electricitymap/contrib/parsers/tests/test_CA_CQ.py
+++ b/electricitymap/contrib/parsers/tests/test_CA_CQ.py
@@ -6,8 +6,8 @@ from requests_mock import ANY, GET
 from electricitymap.contrib.parsers.CA_QC import fetch_consumption, fetch_production
 
 
-def test_production(adapter, session, snapshot):
-    adapter.register_uri(
+def test_production(requests_mock, session, snapshot):
+    requests_mock.register_uri(
         GET,
         ANY,
         json=json.loads(
@@ -20,8 +20,8 @@ def test_production(adapter, session, snapshot):
     assert snapshot == fetch_production(session=session)
 
 
-def test_consumption(adapter, session, snapshot):
-    adapter.register_uri(
+def test_consumption(requests_mock, session, snapshot):
+    requests_mock.register_uri(
         GET,
         ANY,
         json=json.loads(

--- a/electricitymap/contrib/parsers/tests/test_CA_ON.py
+++ b/electricitymap/contrib/parsers/tests/test_CA_ON.py
@@ -12,12 +12,12 @@ from electricitymap.contrib.types import ZoneKey
 base_path_to_mock = Path("electricitymap/contrib/parsers/tests/mocks/CA_ON")
 
 
-def test_fetch_wind_solar_forecasts(adapter, session, snapshot):
+def test_fetch_wind_solar_forecasts(requests_mock, session, snapshot):
     # Mock VG Forecast Summary report request
     var_gen_forecast_summary_report = Path(
         base_path_to_mock, "var_gen_forecast_summary_report_20250228.xml"
     )
-    adapter.register_uri(
+    requests_mock.register_uri(
         GET,
         re.compile(
             r"https://reports-public\.ieso\.ca/public/VGForecastSummary/PUB_VGForecastSummary_\d{8}\.xml"
@@ -27,7 +27,7 @@ def test_fetch_wind_solar_forecasts(adapter, session, snapshot):
 
     # Mock Adequacy report request
     adequacy_report = Path(base_path_to_mock, "adequacy_report_20250228.xml")
-    adapter.register_uri(
+    requests_mock.register_uri(
         GET,
         re.compile(
             r"https://reports-public\.ieso\.ca/public/Adequacy2/PUB_Adequacy2_\d{8}\.xml"
@@ -42,10 +42,10 @@ def test_fetch_wind_solar_forecasts(adapter, session, snapshot):
     )
 
 
-def test_fetch_consumption_forecast(adapter, session, snapshot):
+def test_fetch_consumption_forecast(requests_mock, session, snapshot):
     # Mock Adequacy report request
     adequacy_report = Path(base_path_to_mock, "adequacy_report_20250228.xml")
-    adapter.register_uri(
+    requests_mock.register_uri(
         GET,
         re.compile(
             r"https://reports-public\.ieso\.ca/public/Adequacy2/PUB_Adequacy2_\d{8}\.xml"

--- a/electricitymap/contrib/parsers/tests/test_CEB.py
+++ b/electricitymap/contrib/parsers/tests/test_CEB.py
@@ -9,8 +9,8 @@ from electricitymap.contrib.types import ZoneKey
 
 
 @pytest.fixture(autouse=True)
-def mock_response(adapter):
-    adapter.register_uri(
+def mock_response(requests_mock):
+    requests_mock.register_uri(
         GET,
         ANY,
         json=json.loads(

--- a/electricitymap/contrib/parsers/tests/test_CENACE.py
+++ b/electricitymap/contrib/parsers/tests/test_CENACE.py
@@ -10,11 +10,11 @@ from electricitymap.contrib.types import ZoneKey
 
 
 @pytest.fixture(autouse=True)
-def mock_response(adapter):
+def mock_response(requests_mock):
     with open(
         "electricitymap/contrib/parsers/tests/mocks/CENACE/DemandaRegional.html", "rb"
     ) as data:
-        adapter.register_uri(ANY, ANY, content=data.read())
+        requests_mock.register_uri(ANY, ANY, content=data.read())
 
 
 @freezegun.freeze_time("2021-01-01 00:00:00")

--- a/electricitymap/contrib/parsers/tests/test_CL.py
+++ b/electricitymap/contrib/parsers/tests/test_CL.py
@@ -10,9 +10,9 @@ from electricitymap.contrib.types import ZoneKey
 
 
 @pytest.fixture(autouse=True)
-def mock_response(adapter):
+def mock_response(requests_mock):
     url = f"{API_BASE_URL}fecha__gte=2024-02-23&fecha__lte=2024-02-24"
-    adapter.register_uri(
+    requests_mock.register_uri(
         GET,
         url,
         json=loads(

--- a/electricitymap/contrib/parsers/tests/test_CNDC.py
+++ b/electricitymap/contrib/parsers/tests/test_CNDC.py
@@ -21,8 +21,8 @@ def target_datetime():
 
 
 @pytest.fixture(autouse=True)
-def mock_response(adapter, target_datetime):
-    adapter.register_uri(
+def mock_response(requests_mock, target_datetime):
+    requests_mock.register_uri(
         GET,
         INDEX_URL,
         text=resources.files("electricitymap.contrib.parsers.tests.mocks.CNDC")
@@ -30,7 +30,7 @@ def mock_response(adapter, target_datetime):
         .read_text(),
     )
 
-    adapter.register_uri(
+    requests_mock.register_uri(
         GET,
         DATA_URL.format(target_datetime.strftime("%Y-%m-%d")),
         json=json.loads(

--- a/electricitymap/contrib/parsers/tests/test_CO.py
+++ b/electricitymap/contrib/parsers/tests/test_CO.py
@@ -16,8 +16,8 @@ from electricitymap.contrib.parsers.CO import (
 mock_files = resources.files("electricitymap.contrib.parsers.tests.mocks.CO")
 
 
-def test_fetch_consumption_live(adapter, session, snapshot):
-    adapter.register_uri(
+def test_fetch_consumption_live(requests_mock, session, snapshot):
+    requests_mock.register_uri(
         ANY,
         CO_DEMAND_URL,
         json=loads(mock_files.joinpath("cons_live.json").read_text()),

--- a/electricitymap/contrib/parsers/tests/test_CR.py
+++ b/electricitymap/contrib/parsers/tests/test_CR.py
@@ -11,9 +11,9 @@ from electricitymap.contrib.parsers.lib.exceptions import ParserException
 
 
 @freeze_time("2024-01-01 12:00:00")
-def test_fetch_production_live(adapter, session, snapshot):
+def test_fetch_production_live(requests_mock, session, snapshot):
     """That we can fetch the production mix at the current time."""
-    adapter.register_uri(
+    requests_mock.register_uri(
         GET,
         ANY,
         json=json.loads(
@@ -26,9 +26,9 @@ def test_fetch_production_live(adapter, session, snapshot):
     assert snapshot == fetch_production(session=session)
 
 
-def test_fetch_production_historical(adapter, session, snapshot):
+def test_fetch_production_historical(requests_mock, session, snapshot):
     """That we can fetch historical energy production values."""
-    adapter.register_uri(
+    requests_mock.register_uri(
         GET,
         ANY,
         json=json.loads(
@@ -46,9 +46,9 @@ def test_fetch_production_historical(adapter, session, snapshot):
 
 
 @freeze_time("2024-01-01 12:00:00")
-def test_fetch_exchange_live(adapter, session, snapshot):
+def test_fetch_exchange_live(requests_mock, session, snapshot):
     """That we can fetch the last known power exchanges."""
-    adapter.register_uri(
+    requests_mock.register_uri(
         GET,
         ANY,
         json=json.loads(
@@ -61,9 +61,11 @@ def test_fetch_exchange_live(adapter, session, snapshot):
     assert snapshot == fetch_exchange(session=session)
 
 
-def test_fetch_exchange_raises_parser_exception_on_historical_data(adapter, session):
+def test_fetch_exchange_raises_parser_exception_on_historical_data(
+    requests_mock, session
+):
     """That a ParserException is raised if requesting historical data (not supported yet)."""
-    adapter.register_uri(GET, ANY, json=[])
+    requests_mock.register_uri(GET, ANY, json=[])
 
     with pytest.raises(
         ParserException, match="This parser is not yet able to parse historical data"

--- a/electricitymap/contrib/parsers/tests/test_CY.py
+++ b/electricitymap/contrib/parsers/tests/test_CY.py
@@ -17,19 +17,19 @@ def target_datetime():
 
 
 @pytest.fixture(autouse=True)
-def mock_response(adapter):
+def mock_response(requests_mock):
     with open(
         "electricitymap/contrib/parsers/tests/mocks/CY/response_historical_20240318.html",
         "rb",
     ) as response:
-        adapter.register_uri(
+        requests_mock.register_uri(
             GET, HISTORICAL_SOURCE.format("18-03-2024"), content=response.read()
         )
     with open(
         "electricitymap/contrib/parsers/tests/mocks/CY/response_realtime_20240401.html",
         "rb",
     ) as response:
-        adapter.register_uri(GET, REALTIME_SOURCE, content=response.read())
+        requests_mock.register_uri(GET, REALTIME_SOURCE, content=response.read())
 
 
 def test_snapshot_historical_source(session, target_datetime, snapshot):

--- a/electricitymap/contrib/parsers/tests/test_CZ.py
+++ b/electricitymap/contrib/parsers/tests/test_CZ.py
@@ -16,13 +16,13 @@ TARGET_DATETIME = datetime(2025, 10, 31, 18, 0, 0)
 
 
 @pytest.fixture
-def mock_good_response(adapter):
+def mock_good_response(requests_mock):
     """
     Mocks the CEPS API with a "good" response containing expected data.
     """
 
     data = base_path_to_mock / "CrossborderPowerFlows.xml"
-    adapter.register_uri(
+    requests_mock.register_uri(
         POST,
         CZ.url,
         content=data.read_bytes(),
@@ -30,7 +30,7 @@ def mock_good_response(adapter):
 
 
 @pytest.fixture
-def mock_no_data_response(adapter):
+def mock_no_data_response(requests_mock):
     """
     Mocks the CEPS API with a "bad" response that is missing the <data> tag.
     (This fixture is requested by the exception test)
@@ -43,7 +43,7 @@ def mock_no_data_response(adapter):
         "</root>"
     )
 
-    adapter.register_uri(POST, CZ.url, text=mock_xml_content)
+    requests_mock.register_uri(POST, CZ.url, text=mock_xml_content)
 
 
 @pytest.mark.parametrize(

--- a/electricitymap/contrib/parsers/tests/test_DK.py
+++ b/electricitymap/contrib/parsers/tests/test_DK.py
@@ -9,8 +9,8 @@ from electricitymap.contrib.parsers import DK
 
 
 @pytest.fixture(autouse=True)
-def mock_response(adapter):
-    adapter.register_uri(
+def mock_response(requests_mock):
+    requests_mock.register_uri(
         GET,
         DK.EXCHANGE_URL,
         json=loads(
@@ -20,7 +20,7 @@ def mock_response(adapter):
         ),
     )
 
-    adapter.register_uri(
+    requests_mock.register_uri(
         GET,
         DK.FORECAST_URL,
         json=loads(

--- a/electricitymap/contrib/parsers/tests/test_DO.py
+++ b/electricitymap/contrib/parsers/tests/test_DO.py
@@ -172,8 +172,8 @@ def test_correct_solar_production_prod_then_nan_then_prod(production_df):
 
 
 @freezegun.freeze_time("2025-01-15")
-def test_fetch_production(adapter, session, snapshot):
-    adapter.register_uri(
+def test_fetch_production(requests_mock, session, snapshot):
+    requests_mock.register_uri(
         ANY,
         ANY,
         content=resources.files("electricitymap.contrib.parsers.tests.mocks.DO")

--- a/electricitymap/contrib/parsers/tests/test_EIA.py
+++ b/electricitymap/contrib/parsers/tests/test_EIA.py
@@ -35,8 +35,8 @@ def test_parse_hourly_interval():
         assert result == expected
 
 
-def test_fetch_production_mix(adapter, session, snapshot):
-    adapter.register_uri(
+def test_fetch_production_mix(requests_mock, session, snapshot):
+    requests_mock.register_uri(
         GET,
         ANY,
         json=json.loads(
@@ -50,8 +50,8 @@ def test_fetch_production_mix(adapter, session, snapshot):
     assert data_list == snapshot
 
 
-def test_US_NW_AVRN_rerouting(adapter, session, snapshot):
-    adapter.register_uri(
+def test_US_NW_AVRN_rerouting(requests_mock, session, snapshot):
+    requests_mock.register_uri(
         GET,
         ANY,
         json=json.loads(
@@ -60,7 +60,7 @@ def test_US_NW_AVRN_rerouting(adapter, session, snapshot):
             .read_text()
         ),
     )
-    adapter.register_uri(
+    requests_mock.register_uri(
         GET,
         EIA.PRODUCTION_MIX.format("AVRN", "WND"),
         json=json.loads(
@@ -69,7 +69,7 @@ def test_US_NW_AVRN_rerouting(adapter, session, snapshot):
             .read_text()
         ),
     )
-    adapter.register_uri(
+    requests_mock.register_uri(
         GET,
         EIA.PRODUCTION_MIX.format("PACW", "NG"),
         json=json.loads(
@@ -78,7 +78,7 @@ def test_US_NW_AVRN_rerouting(adapter, session, snapshot):
             .read_text()
         ),
     )
-    adapter.register_uri(
+    requests_mock.register_uri(
         GET,
         EIA.PRODUCTION_MIX.format("PACW", "WAT"),
         json=json.loads(
@@ -87,7 +87,7 @@ def test_US_NW_AVRN_rerouting(adapter, session, snapshot):
             .read_text()
         ),
     )
-    adapter.register_uri(
+    requests_mock.register_uri(
         GET,
         EIA.PRODUCTION_MIX.format("PACW", "SUN"),
         json=json.loads(
@@ -96,7 +96,7 @@ def test_US_NW_AVRN_rerouting(adapter, session, snapshot):
             .read_text()
         ),
     )
-    adapter.register_uri(
+    requests_mock.register_uri(
         GET,
         EIA.PRODUCTION_MIX.format("PACW", "WND"),
         json=json.loads(
@@ -105,7 +105,7 @@ def test_US_NW_AVRN_rerouting(adapter, session, snapshot):
             .read_text()
         ),
     )
-    adapter.register_uri(
+    requests_mock.register_uri(
         GET,
         EIA.PRODUCTION_MIX.format("BPAT", "WND"),
         json=json.loads(
@@ -114,7 +114,7 @@ def test_US_NW_AVRN_rerouting(adapter, session, snapshot):
             .read_text()
         ),
     )
-    adapter.register_uri(
+    requests_mock.register_uri(
         GET,
         EIA.PRODUCTION_MIX.format("BPAT", "NG"),
         json=json.loads(
@@ -123,7 +123,7 @@ def test_US_NW_AVRN_rerouting(adapter, session, snapshot):
             .read_text()
         ),
     )
-    adapter.register_uri(
+    requests_mock.register_uri(
         GET,
         EIA.PRODUCTION_MIX.format("BPAT", "WAT"),
         json=json.loads(
@@ -132,7 +132,7 @@ def test_US_NW_AVRN_rerouting(adapter, session, snapshot):
             .read_text()
         ),
     )
-    adapter.register_uri(
+    requests_mock.register_uri(
         GET,
         EIA.PRODUCTION_MIX.format("BPAT", "NUC"),
         json=json.loads(
@@ -141,7 +141,7 @@ def test_US_NW_AVRN_rerouting(adapter, session, snapshot):
             .read_text()
         ),
     )
-    adapter.register_uri(
+    requests_mock.register_uri(
         GET,
         EIA.PRODUCTION_MIX.format("BPAT", "SUN"),
         json=json.loads(
@@ -150,7 +150,7 @@ def test_US_NW_AVRN_rerouting(adapter, session, snapshot):
             .read_text()
         ),
     )
-    adapter.register_uri(
+    requests_mock.register_uri(
         GET,
         EIA.PRODUCTION_MIX.format("AVRN", "NG"),
         json=json.loads(
@@ -166,8 +166,8 @@ def test_US_NW_AVRN_rerouting(adapter, session, snapshot):
     assert data_list == snapshot
 
 
-def test_US_CAR_SC_nuclear_split(adapter, session, snapshot):
-    adapter.register_uri(
+def test_US_CAR_SC_nuclear_split(requests_mock, session, snapshot):
+    requests_mock.register_uri(
         GET,
         ANY,
         json=json.loads(
@@ -176,7 +176,7 @@ def test_US_CAR_SC_nuclear_split(adapter, session, snapshot):
             .read_text()
         ),
     )
-    adapter.register_uri(
+    requests_mock.register_uri(
         GET,
         EIA.PRODUCTION_MIX.format("SC", "COL"),
         json=json.loads(
@@ -185,7 +185,7 @@ def test_US_CAR_SC_nuclear_split(adapter, session, snapshot):
             .read_text()
         ),
     )
-    adapter.register_uri(
+    requests_mock.register_uri(
         GET,
         EIA.PRODUCTION_MIX.format("SC", "NG"),
         json=json.loads(
@@ -194,7 +194,7 @@ def test_US_CAR_SC_nuclear_split(adapter, session, snapshot):
             .read_text()
         ),
     )
-    adapter.register_uri(
+    requests_mock.register_uri(
         GET,
         EIA.PRODUCTION_MIX.format("SC", "WAT"),
         json=json.loads(
@@ -203,7 +203,7 @@ def test_US_CAR_SC_nuclear_split(adapter, session, snapshot):
             .read_text()
         ),
     )
-    adapter.register_uri(
+    requests_mock.register_uri(
         GET,
         EIA.PRODUCTION_MIX.format("SC", "OIL"),
         json=json.loads(
@@ -212,7 +212,7 @@ def test_US_CAR_SC_nuclear_split(adapter, session, snapshot):
             .read_text()
         ),
     )
-    adapter.register_uri(
+    requests_mock.register_uri(
         GET,
         EIA.PRODUCTION_MIX.format("SC", "SUN"),
         json=json.loads(
@@ -221,7 +221,7 @@ def test_US_CAR_SC_nuclear_split(adapter, session, snapshot):
             .read_text()
         ),
     )
-    adapter.register_uri(
+    requests_mock.register_uri(
         GET,
         EIA.PRODUCTION_MIX.format("SC", "NUC"),
         json=json.loads(
@@ -230,7 +230,7 @@ def test_US_CAR_SC_nuclear_split(adapter, session, snapshot):
             .read_text()
         ),
     )
-    adapter.register_uri(
+    requests_mock.register_uri(
         GET,
         EIA.PRODUCTION_MIX.format("SCEG", "NUC"),
         json=json.loads(
@@ -239,7 +239,7 @@ def test_US_CAR_SC_nuclear_split(adapter, session, snapshot):
             .read_text()
         ),
     )
-    adapter.register_uri(
+    requests_mock.register_uri(
         GET,
         EIA.PRODUCTION_MIX.format("SCEG", "COL"),
         json=json.loads(
@@ -248,7 +248,7 @@ def test_US_CAR_SC_nuclear_split(adapter, session, snapshot):
             .read_text()
         ),
     )
-    adapter.register_uri(
+    requests_mock.register_uri(
         GET,
         EIA.PRODUCTION_MIX.format("SCEG", "NG"),
         json=json.loads(
@@ -257,7 +257,7 @@ def test_US_CAR_SC_nuclear_split(adapter, session, snapshot):
             .read_text()
         ),
     )
-    adapter.register_uri(
+    requests_mock.register_uri(
         GET,
         EIA.PRODUCTION_MIX.format("SCEG", "WAT"),
         json=json.loads(
@@ -266,7 +266,7 @@ def test_US_CAR_SC_nuclear_split(adapter, session, snapshot):
             .read_text()
         ),
     )
-    adapter.register_uri(
+    requests_mock.register_uri(
         GET,
         EIA.PRODUCTION_MIX.format("SCEG", "OIL"),
         json=json.loads(
@@ -275,7 +275,7 @@ def test_US_CAR_SC_nuclear_split(adapter, session, snapshot):
             .read_text()
         ),
     )
-    adapter.register_uri(
+    requests_mock.register_uri(
         GET,
         EIA.PRODUCTION_MIX.format("SCEG", "SUN"),
         json=json.loads(
@@ -306,13 +306,13 @@ def test_check_transfer_mixes():
                     )
 
 
-def test_hydro_transfer_mix(adapter, session, snapshot):
+def test_hydro_transfer_mix(requests_mock, session, snapshot):
     """
     Make sure that with zones that integrate production only zones
     the hydro production events are properly handled and the storage
     is accounted for on a zone by zone basis.
     """
-    adapter.register_uri(
+    requests_mock.register_uri(
         GET,
         ANY,
         json=json.loads(
@@ -321,7 +321,7 @@ def test_hydro_transfer_mix(adapter, session, snapshot):
             .read_text()
         ),
     )
-    adapter.register_uri(
+    requests_mock.register_uri(
         GET,
         EIA.PRODUCTION_MIX.format("SRP", "COL"),
         json=json.loads(
@@ -330,7 +330,7 @@ def test_hydro_transfer_mix(adapter, session, snapshot):
             .read_text()
         ),
     )
-    adapter.register_uri(
+    requests_mock.register_uri(
         GET,
         EIA.PRODUCTION_MIX.format("SRP", "NG"),
         json=json.loads(
@@ -339,7 +339,7 @@ def test_hydro_transfer_mix(adapter, session, snapshot):
             .read_text()
         ),
     )
-    adapter.register_uri(
+    requests_mock.register_uri(
         GET,
         EIA.PRODUCTION_MIX.format("SRP", "NUC"),
         json=json.loads(
@@ -348,7 +348,7 @@ def test_hydro_transfer_mix(adapter, session, snapshot):
             .read_text()
         ),
     )
-    adapter.register_uri(
+    requests_mock.register_uri(
         GET,
         EIA.PRODUCTION_MIX.format("SRP", "SUN"),
         json=json.loads(
@@ -357,7 +357,7 @@ def test_hydro_transfer_mix(adapter, session, snapshot):
             .read_text()
         ),
     )
-    adapter.register_uri(
+    requests_mock.register_uri(
         GET,
         EIA.PRODUCTION_MIX.format("SRP", "WND"),
         json=json.loads(
@@ -366,7 +366,7 @@ def test_hydro_transfer_mix(adapter, session, snapshot):
             .read_text()
         ),
     )
-    adapter.register_uri(
+    requests_mock.register_uri(
         GET,
         EIA.PRODUCTION_MIX.format("DEAA", "WAT"),
         json=json.loads(
@@ -375,7 +375,7 @@ def test_hydro_transfer_mix(adapter, session, snapshot):
             .read_text()
         ),
     )
-    adapter.register_uri(
+    requests_mock.register_uri(
         GET,
         EIA.PRODUCTION_MIX.format("HGMA", "WAT"),
         json=json.loads(
@@ -384,7 +384,7 @@ def test_hydro_transfer_mix(adapter, session, snapshot):
             .read_text()
         ),
     )
-    adapter.register_uri(
+    requests_mock.register_uri(
         GET,
         EIA.PRODUCTION_MIX.format("SRP", "WAT"),
         json=json.loads(
@@ -398,7 +398,7 @@ def test_hydro_transfer_mix(adapter, session, snapshot):
     assert data == snapshot
 
 
-def test_exchange_transfer(adapter, session):
+def test_exchange_transfer(requests_mock, session):
     exchange_key = "US-FLA-FPC->US-FLA-FPL"
     remapped_exchange_key = "US-FLA-FPC->US-FLA-NSB"
     # target_datetime = (
@@ -410,7 +410,7 @@ def test_exchange_transfer(adapter, session):
         .joinpath("US-FLA-FPC_US-FLA-FPL_exchange.json")
         .read_text()
     )
-    adapter.register_uri(
+    requests_mock.register_uri(
         GET,
         # For example:
         # https://api.eia.gov/v2/electricity/rto/interchange-data/data/?data[]=value&facets[fromba][]=FPC&facets[toba][]=FPL&frequency=hourly&api_key=token&sort[0][column]=period&sort[0][direction]=desc&length=24
@@ -422,7 +422,7 @@ def test_exchange_transfer(adapter, session):
         .joinpath("US-FLA-FPC_US-FLA-NSB_exchange.json")
         .read_text()
     )
-    adapter.register_uri(
+    requests_mock.register_uri(
         GET,
         # For example:
         # https://api.eia.gov/v2/electricity/rto/interchange-data/data/?data[]=value&facets[fromba][]=FPC&facets[toba][]=NSB&frequency=hourly&api_key=token&sort[0][column]=period&sort[0][direction]=desc&length=24
@@ -446,8 +446,8 @@ def test_exchange_transfer(adapter, session):
         assert fpl["value"] + nsb["value"] == parser["netFlow"]
 
 
-def test_fetch_production_mix_discards_null(adapter, session, snapshot):
-    adapter.register_uri(
+def test_fetch_production_mix_discards_null(requests_mock, session, snapshot):
+    requests_mock.register_uri(
         GET,
         ANY,
         json=json.loads(
@@ -466,8 +466,8 @@ def test_fetch_production_mix_discards_null(adapter, session, snapshot):
     )
 
 
-def test_fetch_exchange(adapter, session):
-    adapter.register_uri(
+def test_fetch_exchange(requests_mock, session):
+    requests_mock.register_uri(
         GET,
         ANY,
         json=json.loads(
@@ -507,8 +507,8 @@ def test_fetch_exchange(adapter, session):
         assert data["netFlow"] == expected[i]["netFlow"]
 
 
-def test_fetch_consumption(adapter, session):
-    adapter.register_uri(
+def test_fetch_consumption(requests_mock, session):
+    requests_mock.register_uri(
         GET,
         ANY,
         json=json.loads(
@@ -537,8 +537,8 @@ def test_fetch_consumption(adapter, session):
         assert data["consumption"] == expected[i]["consumption"]
 
 
-def test_fetch_forecasted_consumption(adapter, session):
-    adapter.register_uri(
+def test_fetch_forecasted_consumption(requests_mock, session):
+    requests_mock.register_uri(
         GET,
         ANY,
         json=json.loads(
@@ -568,8 +568,8 @@ def test_fetch_forecasted_consumption(adapter, session):
         assert data["sourceType"] == EventSourceType.forecasted
 
 
-def test_fetch_returns_storage(adapter, session, snapshot):
-    adapter.register_uri(
+def test_fetch_returns_storage(requests_mock, session, snapshot):
+    requests_mock.register_uri(
         GET,
         ANY,
         json=json.loads(

--- a/electricitymap/contrib/parsers/tests/test_ENERCAL.py
+++ b/electricitymap/contrib/parsers/tests/test_ENERCAL.py
@@ -6,13 +6,13 @@ from electricitymap.contrib.parsers import ENERCAL
 from electricitymap.contrib.types import ZoneKey
 
 
-def test_production_with_snapshot(adapter, session, snapshot):
+def test_production_with_snapshot(requests_mock, session, snapshot):
     raw_data = (
         resources.files("electricitymap.contrib.parsers.tests.mocks.ENERCAL")
         .joinpath("production.json")
         .read_bytes()
     )
-    adapter.register_uri(
+    requests_mock.register_uri(
         GET,
         ANY,
         content=raw_data,

--- a/electricitymap/contrib/parsers/tests/test_ENTE.py
+++ b/electricitymap/contrib/parsers/tests/test_ENTE.py
@@ -14,8 +14,8 @@ from electricitymap.contrib.types import ZoneKey
 
 
 @pytest.fixture(autouse=True)
-def mock_response(adapter):
-    adapter.register_uri(
+def mock_response(requests_mock):
+    requests_mock.register_uri(
         GET,
         DATA_URL,
         json=loads(

--- a/electricitymap/contrib/parsers/tests/test_ENTSOE.py
+++ b/electricitymap/contrib/parsers/tests/test_ENTSOE.py
@@ -28,9 +28,9 @@ def entsoe_token_env():
     os.environ["ENTSOE_TOKEN"] = "token"
 
 
-def test_fetch_consumption(adapter, session, snapshot):
+def test_fetch_consumption(requests_mock, session, snapshot):
     data = base_path_to_mock / "DK-DK1_consumption.xml"
-    adapter.register_uri(
+    requests_mock.register_uri(
         GET,
         ANY,
         content=data.read_bytes(),
@@ -39,9 +39,9 @@ def test_fetch_consumption(adapter, session, snapshot):
     assert snapshot == ENTSOE.fetch_consumption(ZoneKey("DK-DK1"), session)
 
 
-def test_fetch_consumption_forecast(adapter, session, snapshot):
+def test_fetch_consumption_forecast(requests_mock, session, snapshot):
     data = base_path_to_mock / "DK-DK2_consumption_forecast.xml"
-    adapter.register_uri(
+    requests_mock.register_uri(
         GET,
         ANY,
         content=data.read_bytes(),
@@ -89,9 +89,9 @@ def test_fetch_consumption_aggregated_zone(monkeypatch):
     ]
 
 
-def test_fetch_generation_forecast(adapter, session, snapshot):
+def test_fetch_generation_forecast(requests_mock, session, snapshot):
     data = base_path_to_mock / "SE-SE3_generation_forecast.xml"
-    adapter.register_uri(
+    requests_mock.register_uri(
         GET,
         ANY,
         content=data.read_bytes(),
@@ -141,9 +141,9 @@ def test_fetch_generation_forecast_aggregated_zone(monkeypatch):
     ]
 
 
-def test_fetch_prices_day_ahead(adapter, session, snapshot):
+def test_fetch_prices_day_ahead(requests_mock, session, snapshot):
     data = base_path_to_mock / "ES_day_ahead_price.xml"
-    adapter.register_uri(
+    requests_mock.register_uri(
         GET,
         ANY,
         content=data.read_bytes(),
@@ -152,9 +152,9 @@ def test_fetch_prices_day_ahead(adapter, session, snapshot):
     assert snapshot == ENTSOE.fetch_price(ZoneKey("ES"), session)
 
 
-def test_fetch_prices_intraday(adapter, session, snapshot):
+def test_fetch_prices_intraday(requests_mock, session, snapshot):
     data = base_path_to_mock / "ES_intraday_price.xml"
-    adapter.register_uri(
+    requests_mock.register_uri(
         GET,
         ANY,
         content=data.read_bytes(),
@@ -163,9 +163,9 @@ def test_fetch_prices_intraday(adapter, session, snapshot):
     assert snapshot == ENTSOE.fetch_price_intraday(ZoneKey("ES"), session)
 
 
-def test_fetch_prices_integrated_zone(adapter, session, snapshot):
+def test_fetch_prices_integrated_zone(requests_mock, session, snapshot):
     data = base_path_to_mock / "FR_prices.xml"
-    adapter.register_uri(
+    requests_mock.register_uri(
         GET,
         ANY,
         content=data.read_bytes(),
@@ -173,9 +173,9 @@ def test_fetch_prices_integrated_zone(adapter, session, snapshot):
     assert snapshot == ENTSOE.fetch_price(ZoneKey("AX"), session)
 
 
-def test_fetch_with_negative_values(adapter, session, snapshot):
+def test_fetch_with_negative_values(requests_mock, session, snapshot):
     data = base_path_to_mock / "NO-NO5_production-negatives.xml"
-    adapter.register_uri(
+    requests_mock.register_uri(
         GET,
         ANY,
         content=data.read_bytes(),
@@ -187,9 +187,9 @@ def test_fetch_with_negative_values(adapter, session, snapshot):
 
 
 @pytest.mark.parametrize("zone", ["FI", "LU", "NO-NO5", "SE-SE4"])
-def test_production_with_snapshot(adapter, session, snapshot, zone):
+def test_production_with_snapshot(requests_mock, session, snapshot, zone):
     raw_data = base_path_to_mock / f"{zone}_production.xml"
-    adapter.register_uri(
+    requests_mock.register_uri(
         GET,
         ANY,
         content=raw_data.read_bytes(),
@@ -199,16 +199,16 @@ def test_production_with_snapshot(adapter, session, snapshot, zone):
     ) == ENTSOE.fetch_production(ZoneKey(zone), session)
 
 
-def test_fetch_exchange(adapter, session, snapshot):
+def test_fetch_exchange(requests_mock, session, snapshot):
     imports = base_path_to_mock / "DK-DK1_GB_exchange_imports.xml"
     exports = base_path_to_mock / "DK-DK1_GB_exchange_exports.xml"
 
-    adapter.register_uri(
+    requests_mock.register_uri(
         GET,
         "?documentType=A11&in_Domain=10YDK-1--------W&out_Domain=10YGB----------A",
         content=imports.read_bytes(),
     )
-    adapter.register_uri(
+    requests_mock.register_uri(
         GET,
         "?documentType=A11&in_Domain=10YGB----------A&out_Domain=10YDK-1--------W",
         content=exports.read_bytes(),
@@ -218,28 +218,28 @@ def test_fetch_exchange(adapter, session, snapshot):
     )
 
 
-def test_fetch_exchange_with_aggregated_exchanges(adapter, session, snapshot):
+def test_fetch_exchange_with_aggregated_exchanges(requests_mock, session, snapshot):
     imports_AC = base_path_to_mock / "FR-COR_IT-SAR_AC_exchange_imports.xml"
     exports_AC = base_path_to_mock / "FR-COR_IT-SAR_AC_exchange_exports.xml"
     imports_DC = base_path_to_mock / "FR-COR_IT-SAR_DC_exchange_imports.xml"
     exports_DC = base_path_to_mock / "FR-COR_IT-SAR_DC_exchange_exports.xml"
 
-    adapter.register_uri(
+    requests_mock.register_uri(
         GET,
         "?documentType=A11&in_Domain=10Y1001A1001A885&out_Domain=10Y1001A1001A74G",
         content=imports_AC.read_bytes(),
     )
-    adapter.register_uri(
+    requests_mock.register_uri(
         GET,
         "?documentType=A11&in_Domain=10Y1001A1001A74G&out_Domain=10Y1001A1001A885",
         content=exports_AC.read_bytes(),
     )
-    adapter.register_uri(
+    requests_mock.register_uri(
         GET,
         "?documentType=A11&in_Domain=10Y1001A1001A893&out_Domain=10Y1001A1001A74G",
         content=imports_DC.read_bytes(),
     )
-    adapter.register_uri(
+    requests_mock.register_uri(
         GET,
         "?documentType=A11&in_Domain=10Y1001A1001A74G&out_Domain=10Y1001A1001A893",
         content=exports_DC.read_bytes(),
@@ -252,16 +252,16 @@ def test_fetch_exchange_with_aggregated_exchanges(adapter, session, snapshot):
     )
 
 
-def test_fetch_exchange_forecast(adapter, session, snapshot):
+def test_fetch_exchange_forecast(requests_mock, session, snapshot):
     imports = base_path_to_mock / "DK-DK2_SE-SE4_exchange_forecast_imports.xml"
     exports = base_path_to_mock / "DK-DK2_SE-SE4_exchange_forecast_exports.xml"
 
-    adapter.register_uri(
+    requests_mock.register_uri(
         GET,
         "?documentType=A09&in_Domain=10YDK-2--------M&out_Domain=10Y1001A1001A47J",
         content=imports.read_bytes(),
     )
-    adapter.register_uri(
+    requests_mock.register_uri(
         GET,
         "?documentType=A09&in_Domain=10Y1001A1001A47J&out_Domain=10YDK-2--------M",
         content=exports.read_bytes(),
@@ -273,19 +273,19 @@ def test_fetch_exchange_forecast(adapter, session, snapshot):
     )
 
 
-def test_fetch_scheduled_exchanges_day_ahead(adapter, session, snapshot):
+def test_fetch_scheduled_exchanges_day_ahead(requests_mock, session, snapshot):
     """A09 / contract A01 — cleared day-ahead schedule. Events must be
     tagged sourceType=published per the EXCHANGE_PUBLICATION_DATA_TYPES
     contract."""
     imports = base_path_to_mock / "DK-DK2_SE-SE4_exchange_forecast_imports.xml"
     exports = base_path_to_mock / "DK-DK2_SE-SE4_exchange_forecast_exports.xml"
 
-    adapter.register_uri(
+    requests_mock.register_uri(
         GET,
         "?documentType=A09&in_Domain=10YDK-2--------M&out_Domain=10Y1001A1001A47J",
         content=imports.read_bytes(),
     )
-    adapter.register_uri(
+    requests_mock.register_uri(
         GET,
         "?documentType=A09&in_Domain=10Y1001A1001A47J&out_Domain=10YDK-2--------M",
         content=exports.read_bytes(),
@@ -302,19 +302,19 @@ def test_fetch_scheduled_exchanges_day_ahead(adapter, session, snapshot):
     assert snapshot == result
 
 
-def test_get_scheduled_exchanges_total(adapter, session, snapshot):
+def test_get_scheduled_exchanges_total(requests_mock, session, snapshot):
     """A09 / contract A05 — finalised aggregate schedule (includes intraday
     adjustments). Distinct view from day-ahead; events still tagged
     sourceType=published."""
     imports = base_path_to_mock / "DK-DK2_SE-SE4_exchange_forecast_imports.xml"
     exports = base_path_to_mock / "DK-DK2_SE-SE4_exchange_forecast_exports.xml"
 
-    adapter.register_uri(
+    requests_mock.register_uri(
         GET,
         "?documentType=A09&in_Domain=10YDK-2--------M&out_Domain=10Y1001A1001A47J",
         content=imports.read_bytes(),
     )
-    adapter.register_uri(
+    requests_mock.register_uri(
         GET,
         "?documentType=A09&in_Domain=10Y1001A1001A47J&out_Domain=10YDK-2--------M",
         content=exports.read_bytes(),
@@ -331,17 +331,17 @@ def test_get_scheduled_exchanges_total(adapter, session, snapshot):
     assert snapshot == result
 
 
-def test_fetch_exchange_forecast_15_min(adapter, session, snapshot):
+def test_fetch_exchange_forecast_15_min(requests_mock, session, snapshot):
     imports = base_path_to_mock / "BE_NL_exchange_forecast_imports.xml"
     exports = base_path_to_mock / "BE_NL_exchange_forecast_exports.xml"
 
-    adapter.register_uri(
+    requests_mock.register_uri(
         GET,
         "?documentType=A09&in_Domain=10YBE----------2&out_Domain=10YNL----------L",
         content=imports.read_bytes(),
     )
 
-    adapter.register_uri(
+    requests_mock.register_uri(
         GET,
         "?documentType=A09&in_Domain=10YNL----------L&out_Domain=10YBE----------2",
         content=exports.read_bytes(),
@@ -353,18 +353,18 @@ def test_fetch_exchange_forecast_15_min(adapter, session, snapshot):
 
 
 def test_fetch_exchange_forecast_with_longer_day_ahead_than_total(
-    adapter, session, snapshot
+    requests_mock, session, snapshot
 ):
     imports = base_path_to_mock / "EE_FI_exchange_forecast_imports.xml"
     exports = base_path_to_mock / "EE_FI_exchange_forecast_exports.xml"
 
-    adapter.register_uri(
+    requests_mock.register_uri(
         GET,
         "?documentType=A09&in_Domain=10Y1001A1001A39I&out_Domain=10YFI-1--------U",
         content=imports.read_bytes(),
     )
 
-    adapter.register_uri(
+    requests_mock.register_uri(
         GET,
         "?documentType=A09&in_Domain=10YFI-1--------U&out_Domain=10Y1001A1001A39I",
         content=exports.read_bytes(),
@@ -375,28 +375,30 @@ def test_fetch_exchange_forecast_with_longer_day_ahead_than_total(
     )
 
 
-def test_fetch_exchange_forecast_with_aggregated_exchanges(adapter, session, snapshot):
+def test_fetch_exchange_forecast_with_aggregated_exchanges(
+    requests_mock, session, snapshot
+):
     imports_AC = base_path_to_mock / "FR-COR_IT-SAR_AC_exchange_forecast_imports.xml"
     exports_AC = base_path_to_mock / "FR-COR_IT-SAR_AC_exchange_forecast_exports.xml"
     imports_DC = base_path_to_mock / "FR-COR_IT-SAR_DC_exchange_forecast_imports.xml"
     exports_DC = base_path_to_mock / "FR-COR_IT-SAR_DC_exchange_forecast_exports.xml"
 
-    adapter.register_uri(
+    requests_mock.register_uri(
         GET,
         "?documentType=A09&in_Domain=10Y1001A1001A885&out_Domain=10Y1001A1001A74G",
         content=imports_AC.read_bytes(),
     )
-    adapter.register_uri(
+    requests_mock.register_uri(
         GET,
         "?documentType=A09&in_Domain=10Y1001A1001A74G&out_Domain=10Y1001A1001A885",
         content=exports_AC.read_bytes(),
     )
-    adapter.register_uri(
+    requests_mock.register_uri(
         GET,
         "?documentType=A09&in_Domain=10Y1001A1001A893&out_Domain=10Y1001A1001A74G",
         content=imports_DC.read_bytes(),
     )
-    adapter.register_uri(
+    requests_mock.register_uri(
         GET,
         "?documentType=A09&in_Domain=10Y1001A1001A74G&out_Domain=10Y1001A1001A893",
         content=exports_DC.read_bytes(),
@@ -409,22 +411,22 @@ def test_fetch_exchange_forecast_with_aggregated_exchanges(adapter, session, sna
     )
 
 
-def test_wind_and_solar_forecasts(adapter, session, snapshot):
+def test_wind_and_solar_forecasts(requests_mock, session, snapshot):
     day_ahead = base_path_to_mock / "wind_solar_forecast_FI_DAY_AHEAD.xml"
     intraday = base_path_to_mock / "wind_solar_forecast_FI_INTRADAY.xml"
     current = base_path_to_mock / "wind_solar_forecast_FI_CURRENT.xml"
 
-    adapter.register_uri(
+    requests_mock.register_uri(
         GET,
         "?documentType=A69&processType=A01",
         content=day_ahead.read_bytes(),
     )
-    adapter.register_uri(
+    requests_mock.register_uri(
         GET,
         "?documentType=A69&processType=A40",
         content=intraday.read_bytes(),
     )
-    adapter.register_uri(
+    requests_mock.register_uri(
         GET,
         "?documentType=A69&processType=A18",
         content=current.read_bytes(),
@@ -452,21 +454,21 @@ def test_wind_and_solar_forecasts(adapter, session, snapshot):
     ids=["day_ahead", "intraday", "current"],
 )
 def test_wind_and_solar_forecasts_by_type(
-    adapter, session, snapshot, fetcher, mock_filename
+    requests_mock, session, snapshot, fetcher, mock_filename
 ):
     data = base_path_to_mock / mock_filename
-    adapter.register_uri(GET, ANY, content=data.read_bytes())
+    requests_mock.register_uri(GET, ANY, content=data.read_bytes())
     assert snapshot(extension_class=SingleFileAmberSnapshotExtension) == fetcher(
         ZoneKey("FI"), session
     )
 
 
-def test_fetch_uses_normal_url(adapter, session):
+def test_fetch_uses_normal_url(requests_mock, session):
     os.environ["ENTSOE_TOKEN"] = "proxy"
     with open(
         "electricitymap/contrib/parsers/tests/mocks/ENTSOE/FR_prices.xml", "rb"
     ) as price_fr_data:
-        adapter.register_uri(
+        requests_mock.register_uri(
             GET,
             ENTSOE.ENTSOE_URL,
             content=price_fr_data.read(),
@@ -871,16 +873,16 @@ def test_merge_exchange_capacity_forecasts_prefers_forward_zone_key():
     assert merged.events[0].source == "entsoe.eu"
 
 
-def test_fetch_exchange_capacity_forecasts_day_ahead(adapter, session, snapshot):
+def test_fetch_exchange_capacity_forecasts_day_ahead(requests_mock, session, snapshot):
     export_data = base_path_to_mock / "ES_FR_capacity_day_ahead_export.xml"
     import_data = base_path_to_mock / "ES_FR_capacity_day_ahead_import.xml"
 
-    adapter.register_uri(
+    requests_mock.register_uri(
         GET,
         "?documentType=A61&Contract_MarketAgreement.Type=A01&in_Domain=10YES-REE------0&out_Domain=10YFR-RTE------C",
         content=export_data.read_bytes(),
     )
-    adapter.register_uri(
+    requests_mock.register_uri(
         GET,
         "?documentType=A61&Contract_MarketAgreement.Type=A01&in_Domain=10YFR-RTE------C&out_Domain=10YES-REE------0",
         content=import_data.read_bytes(),
@@ -893,16 +895,16 @@ def test_fetch_exchange_capacity_forecasts_day_ahead(adapter, session, snapshot)
     )
 
 
-def test_fetch_exchange_capacity_forecasts_week_ahead(adapter, session, snapshot):
+def test_fetch_exchange_capacity_forecasts_week_ahead(requests_mock, session, snapshot):
     export_data = base_path_to_mock / "DK-DK1_DK-DK2_capacity_week_ahead_export.xml"
     import_data = base_path_to_mock / "DK-DK1_DK-DK2_capacity_week_ahead_import.xml"
 
-    adapter.register_uri(
+    requests_mock.register_uri(
         GET,
         "?documentType=A61&Contract_MarketAgreement.Type=A02&in_Domain=10YDK-1--------W&out_Domain=10YDK-2--------M",
         content=export_data.read_bytes(),
     )
-    adapter.register_uri(
+    requests_mock.register_uri(
         GET,
         "?documentType=A61&Contract_MarketAgreement.Type=A02&in_Domain=10YDK-2--------M&out_Domain=10YDK-1--------W",
         content=import_data.read_bytes(),
@@ -915,16 +917,18 @@ def test_fetch_exchange_capacity_forecasts_week_ahead(adapter, session, snapshot
     )
 
 
-def test_fetch_exchange_capacity_forecasts_month_ahead(adapter, session, snapshot):
+def test_fetch_exchange_capacity_forecasts_month_ahead(
+    requests_mock, session, snapshot
+):
     export_data = base_path_to_mock / "ES_FR_capacity_month_ahead_export.xml"
     import_data = base_path_to_mock / "ES_FR_capacity_month_ahead_import.xml"
 
-    adapter.register_uri(
+    requests_mock.register_uri(
         GET,
         "?documentType=A61&Contract_MarketAgreement.Type=A03&in_Domain=10YES-REE------0&out_Domain=10YFR-RTE------C",
         content=export_data.read_bytes(),
     )
-    adapter.register_uri(
+    requests_mock.register_uri(
         GET,
         "?documentType=A61&Contract_MarketAgreement.Type=A03&in_Domain=10YFR-RTE------C&out_Domain=10YES-REE------0",
         content=import_data.read_bytes(),

--- a/electricitymap/contrib/parsers/tests/test_ERP_PGCB.py
+++ b/electricitymap/contrib/parsers/tests/test_ERP_PGCB.py
@@ -15,12 +15,12 @@ from electricitymap.contrib.types import ZoneKey
 historical_dt = datetime.fromisoformat("2025-01-01 00:00:00 +06:00")
 
 
-def _load_mock_response(adapter, target_datetime):
+def _load_mock_response(requests_mock, target_datetime):
     mock_data_file = "latest.html"
     if target_datetime:
         mock_data_file = "historical.html"
 
-    adapter.register_uri(
+    requests_mock.register_uri(
         GET,
         ANY,
         text=resources.files("electricitymap.contrib.parsers.tests.mocks.ERP_PGCB")
@@ -30,24 +30,24 @@ def _load_mock_response(adapter, target_datetime):
 
 
 @pytest.mark.parametrize("target_datetime", [None, historical_dt])
-def test_fetch_consumption(adapter, session, snapshot, target_datetime):
-    _load_mock_response(adapter, target_datetime)
+def test_fetch_consumption(requests_mock, session, snapshot, target_datetime):
+    _load_mock_response(requests_mock, target_datetime)
     assert snapshot(
         extension_class=SingleFileAmberSnapshotExtension
     ) == fetch_consumption(session=session)
 
 
 @pytest.mark.parametrize("target_datetime", [None, historical_dt])
-def test_exchanges(adapter, session, snapshot, target_datetime):
-    _load_mock_response(adapter, target_datetime)
+def test_exchanges(requests_mock, session, snapshot, target_datetime):
+    _load_mock_response(requests_mock, target_datetime)
     assert snapshot(extension_class=SingleFileAmberSnapshotExtension) == fetch_exchange(
         ZoneKey("BD"), ZoneKey("IN-NE"), session=session
     )
 
 
 @pytest.mark.parametrize("target_datetime", [None, historical_dt])
-def test_fetch_production(adapter, session, snapshot, target_datetime):
-    _load_mock_response(adapter, target_datetime)
+def test_fetch_production(requests_mock, session, snapshot, target_datetime):
+    _load_mock_response(requests_mock, target_datetime)
     assert snapshot(
         extension_class=SingleFileAmberSnapshotExtension
     ) == fetch_production(session=session)

--- a/electricitymap/contrib/parsers/tests/test_ES.py
+++ b/electricitymap/contrib/parsers/tests/test_ES.py
@@ -20,11 +20,11 @@ ZONE_FIXTURES = [
 
 
 @pytest.fixture(autouse=True)
-def mock_response(adapter):
+def mock_response(requests_mock):
     # The upstream payloads are JSONP-wrapped, not strictly valid JSON.
     for zone_key, filename, target_date in ZONE_FIXTURES:
         with open(f"{MOCKS_DIR}/{filename}", "rb") as data:
-            adapter.register_uri(
+            requests_mock.register_uri(
                 GET,
                 ES.get_url(zone_key, target_date),
                 content=data.read(),
@@ -36,7 +36,7 @@ def mock_response(adapter):
     [(z, d) for z, _, d in ZONE_FIXTURES],
     ids=[z for z, _, _ in ZONE_FIXTURES],
 )
-def test_fetch_consumption(adapter, session, snapshot, zone_key, target_date):
+def test_fetch_consumption(requests_mock, session, snapshot, zone_key, target_date):
     assert snapshot(
         extension_class=SingleFileAmberSnapshotExtension
     ) == ES.fetch_consumption(zone_key, session, datetime.fromisoformat(target_date))
@@ -47,7 +47,7 @@ def test_fetch_consumption(adapter, session, snapshot, zone_key, target_date):
     [(z, d) for z, _, d in ZONE_FIXTURES],
     ids=[z for z, _, _ in ZONE_FIXTURES],
 )
-def test_fetch_production(adapter, session, snapshot, zone_key, target_date):
+def test_fetch_production(requests_mock, session, snapshot, zone_key, target_date):
     assert snapshot(
         extension_class=SingleFileAmberSnapshotExtension
     ) == ES.fetch_production(zone_key, session, datetime.fromisoformat(target_date))
@@ -62,7 +62,9 @@ def test_fetch_production(adapter, session, snapshot, zone_key, target_date):
     ],
     ids=["ES->PT", "ES-IB-IZ->ES-IB-MA", "ES-CN-FV->ES-CN-LZ"],
 )
-def test_fetch_exchange(adapter, session, snapshot, zone_key1, zone_key2, target_date):
+def test_fetch_exchange(
+    requests_mock, session, snapshot, zone_key1, zone_key2, target_date
+):
     assert snapshot(
         extension_class=SingleFileAmberSnapshotExtension
     ) == ES.fetch_exchange(

--- a/electricitymap/contrib/parsers/tests/test_ESIOS.py
+++ b/electricitymap/contrib/parsers/tests/test_ESIOS.py
@@ -8,8 +8,8 @@ from electricitymap.contrib.parsers import ESIOS
 from electricitymap.contrib.types import ZoneKey
 
 
-def test_fetch_exchange(adapter, session):
-    adapter.register_uri(
+def test_fetch_exchange(requests_mock, session):
+    requests_mock.register_uri(
         ANY,
         ANY,
         json=json.loads(
@@ -28,8 +28,8 @@ def test_fetch_exchange(adapter, session):
         assert data["netFlow"] is not None
 
 
-def test_exchange_with_snapshot(session, adapter, snapshot):
-    adapter.register_uri(
+def test_exchange_with_snapshot(session, requests_mock, snapshot):
+    requests_mock.register_uri(
         ANY,
         ANY,
         json=json.loads(

--- a/electricitymap/contrib/parsers/tests/test_ESKOM.py
+++ b/electricitymap/contrib/parsers/tests/test_ESKOM.py
@@ -6,11 +6,11 @@ from electricitymap.contrib.types import ZoneKey
 
 
 @freezegun.freeze_time("2023-09-22")
-def test_production(adapter, session, snapshot):
+def test_production(requests_mock, session, snapshot):
     with open(
         "electricitymap/contrib/parsers/tests/mocks/ESKOM/Station_Build_Up.csv", "rb"
     ) as mock_file:
-        adapter.register_uri(
+        requests_mock.register_uri(
             GET,
             get_url(),
             content=mock_file.read(),

--- a/electricitymap/contrib/parsers/tests/test_ESTADISTICO_UT.py
+++ b/electricitymap/contrib/parsers/tests/test_ESTADISTICO_UT.py
@@ -10,8 +10,8 @@ from electricitymap.contrib.parsers.ESTADISTICO_UT import (
 )
 
 
-def test_fetch_production_live(adapter, session, snapshot):
-    adapter.register_uri(
+def test_fetch_production_live(requests_mock, session, snapshot):
+    requests_mock.register_uri(
         GET,
         DAILY_OPERATION_URL,
         text=resources.files(
@@ -20,7 +20,7 @@ def test_fetch_production_live(adapter, session, snapshot):
         .joinpath("get_live.html")
         .read_text(),
     )
-    adapter.register_uri(
+    requests_mock.register_uri(
         POST,
         DAILY_OPERATION_URL,
         text=resources.files(
@@ -32,10 +32,10 @@ def test_fetch_production_live(adapter, session, snapshot):
     assert snapshot == fetch_production(session=session)
 
 
-def test_fetch_production_historical(adapter, session, snapshot):
+def test_fetch_production_historical(requests_mock, session, snapshot):
     dt = datetime.fromisoformat("2025-01-01").replace(tzinfo=ZONE_INFO)
 
-    adapter.register_uri(
+    requests_mock.register_uri(
         GET,
         DAILY_OPERATION_URL,
         text=resources.files(
@@ -44,7 +44,7 @@ def test_fetch_production_historical(adapter, session, snapshot):
         .joinpath("get_historical.html")
         .read_text(),
     )
-    adapter.register_uri(
+    requests_mock.register_uri(
         POST,
         DAILY_OPERATION_URL,
         text=resources.files(

--- a/electricitymap/contrib/parsers/tests/test_FO.py
+++ b/electricitymap/contrib/parsers/tests/test_FO.py
@@ -13,10 +13,10 @@ from electricitymap.contrib.types import ZoneKey
 
 @freeze_time("2024-05-16 12:04:00")
 @pytest.mark.parametrize("zone", ["FO", "FO-MI", "FO-SI"])
-def test_fetch_production_live(adapter, session, snapshot, zone):
+def test_fetch_production_live(requests_mock, session, snapshot, zone):
     """That the parser fetches expected production values."""
 
-    adapter.register_uri(
+    requests_mock.register_uri(
         GET,
         ANY,
         response_list=[
@@ -38,7 +38,9 @@ def test_fetch_production_live(adapter, session, snapshot, zone):
 
 @pytest.mark.parametrize("zone", ["FO", "FO-MI", "FO-SI"])
 @pytest.mark.parametrize("utc_offset", ["SDT", "DST"])
-def test_fetch_production_historical(adapter, session, snapshot, zone, utc_offset):
+def test_fetch_production_historical(
+    requests_mock, session, snapshot, zone, utc_offset
+):
     """That the parser fetches expected historical values.
 
     Given that API responses differ depending on whether SDT or DST apply for the target date, we also make sure
@@ -48,7 +50,7 @@ def test_fetch_production_historical(adapter, session, snapshot, zone, utc_offse
     month = 2 if utc_offset == "SDT" else 7
     target_datetime = datetime(2023, month, 16, 12, tzinfo=timezone.utc)
 
-    adapter.register_uri(
+    requests_mock.register_uri(
         GET,
         ANY,
         json=json.loads(

--- a/electricitymap/contrib/parsers/tests/test_FR.py
+++ b/electricitymap/contrib/parsers/tests/test_FR.py
@@ -6,12 +6,12 @@ from electricitymap.contrib.parsers.FR import API_ENDPOINT, fetch_production
 from electricitymap.contrib.types import ZoneKey
 
 
-def test_production(adapter, session, snapshot):
+def test_production(requests_mock, session, snapshot):
     os.environ["RESEAUX_ENERGIES_TOKEN"] = "test_token"
     with open(
         "electricitymap/contrib/parsers/tests/mocks/FR/response.json", "rb"
     ) as mock_file:
-        adapter.register_uri(
+        requests_mock.register_uri(
             GET,
             API_ENDPOINT,
             content=mock_file.read(),

--- a/electricitymap/contrib/parsers/tests/test_FR_O.py
+++ b/electricitymap/contrib/parsers/tests/test_FR_O.py
@@ -8,8 +8,8 @@ from electricitymap.contrib.parsers import FR_O
 from electricitymap.contrib.types import ZoneKey
 
 
-def test_fetch_exchange(adapter, session):
-    adapter.register_uri(
+def test_fetch_exchange(requests_mock, session):
+    requests_mock.register_uri(
         ANY,
         ANY,
         json=json.loads(
@@ -58,8 +58,8 @@ def test_fetch_exchange(adapter, session):
             assert production, expected_data[index]["production"][production_type]
 
 
-def test_fetch_price(adapter, session):
-    adapter.register_uri(
+def test_fetch_price(requests_mock, session):
+    requests_mock.register_uri(
         ANY,
         ANY,
         json=json.loads(
@@ -95,8 +95,8 @@ def test_fetch_price(adapter, session):
         assert actual["price"] == expected_data[index]["price"]
 
 
-def test_fetch_production(adapter, session):
-    adapter.register_uri(
+def test_fetch_production(requests_mock, session):
+    requests_mock.register_uri(
         ANY,
         ANY,
         json=json.loads(

--- a/electricitymap/contrib/parsers/tests/test_GB.py
+++ b/electricitymap/contrib/parsers/tests/test_GB.py
@@ -24,8 +24,8 @@ from electricitymap.contrib.types import ZoneKey
     "zone_key", ["BE", "CH", "AT", "ES", "FR", "GB", "IT", "NL", "PT"]
 )
 @freeze_time("2024-04-14 15:10:57")
-def test_fetch_price_live(adapter, session, snapshot, zone_key):
-    adapter.register_uri(
+def test_fetch_price_live(requests_mock, session, snapshot, zone_key):
+    requests_mock.register_uri(
         GET,
         ANY,
         text=resources.files("electricitymap.contrib.parsers.tests.mocks.GB")
@@ -38,8 +38,8 @@ def test_fetch_price_live(adapter, session, snapshot, zone_key):
     )
 
 
-def test_fetch_price_historical(adapter, session, snapshot):
-    adapter.register_uri(
+def test_fetch_price_historical(requests_mock, session, snapshot):
+    requests_mock.register_uri(
         GET,
         ANY,
         text=resources.files("electricitymap.contrib.parsers.tests.mocks.GB")
@@ -52,30 +52,30 @@ def test_fetch_price_historical(adapter, session, snapshot):
 
 
 @freeze_time("2024-12-16 12:00:00")
-def test_fetch_production(adapter, session, snapshot):
+def test_fetch_production(requests_mock, session, snapshot):
     neso_mock = resources.files("electricitymap.contrib.parsers.tests.mocks.GB")
     gb_mock = resources.files("electricitymap.contrib.parsers.tests.mocks.GB")
 
-    adapter.register_uri(
+    requests_mock.register_uri(
         GET,
         "https://api.neso.energy/api/3/action/datastore_search_sql",
         json=json.loads(neso_mock.joinpath("production.json").read_text()),
     )
-    adapter.register_uri(
+    requests_mock.register_uri(
         GET,
         ELEXON_BMU_UNITS,
         json=json.loads(gb_mock.joinpath("bmunits.json").read_text()),
     )
     bmvalues = json.loads(gb_mock.joinpath("bmvalues.json").read_text())
-    adapter.register_uri(GET, ELEXON_PN_STREAM, json=bmvalues)
-    adapter.register_uri(GET, ELEXON_MELS_STREAM, json=bmvalues)
-    adapter.register_uri(GET, ELEXON_MILS_STREAM, json=bmvalues)
-    adapter.register_uri(
+    requests_mock.register_uri(GET, ELEXON_PN_STREAM, json=bmvalues)
+    requests_mock.register_uri(GET, ELEXON_MELS_STREAM, json=bmvalues)
+    requests_mock.register_uri(GET, ELEXON_MILS_STREAM, json=bmvalues)
+    requests_mock.register_uri(
         GET,
         ELEXON_BOALF_STREAM,
         json=json.loads(gb_mock.joinpath("boalf.json").read_text()),
     )
-    adapter.register_uri(
+    requests_mock.register_uri(
         GET,
         ELEXON_BMU_FUEL_TYPE_URL,
         content=gb_mock.joinpath("bmu_fuel_type.xlsx").read_bytes(),

--- a/electricitymap/contrib/parsers/tests/test_GT.py
+++ b/electricitymap/contrib/parsers/tests/test_GT.py
@@ -9,8 +9,8 @@ from electricitymap.contrib.parsers.GT import fetch_consumption, fetch_productio
 
 
 @freeze_time("2024-04-10 12:28:00")
-def test_fetch_production_live(adapter, session, snapshot):
-    adapter.register_uri(
+def test_fetch_production_live(requests_mock, session, snapshot):
+    requests_mock.register_uri(
         GET,
         ANY,
         response_list=[
@@ -28,8 +28,8 @@ def test_fetch_production_live(adapter, session, snapshot):
     assert snapshot == fetch_production(session=session)
 
 
-def test_fetch_production_historical(adapter, session, snapshot):
-    adapter.register_uri(
+def test_fetch_production_historical(requests_mock, session, snapshot):
+    requests_mock.register_uri(
         GET,
         ANY,
         response_list=[
@@ -52,8 +52,8 @@ def test_fetch_production_historical(adapter, session, snapshot):
 
 
 @freeze_time("2024-04-10 12:28:00")
-def test_fetch_consumption_live(adapter, session, snapshot):
-    adapter.register_uri(
+def test_fetch_consumption_live(requests_mock, session, snapshot):
+    requests_mock.register_uri(
         GET,
         ANY,
         response_list=[
@@ -71,8 +71,8 @@ def test_fetch_consumption_live(adapter, session, snapshot):
     assert snapshot == fetch_consumption(session=session)
 
 
-def test_fetch_consumption_historical(adapter, session, snapshot):
-    adapter.register_uri(
+def test_fetch_consumption_historical(requests_mock, session, snapshot):
+    requests_mock.register_uri(
         GET,
         ANY,
         response_list=[

--- a/electricitymap/contrib/parsers/tests/test_HN.py
+++ b/electricitymap/contrib/parsers/tests/test_HN.py
@@ -10,7 +10,7 @@ from electricitymap.contrib.types import ZoneKey
 base_path_to_mock = Path("electricitymap/contrib/parsers/tests/mocks/HN")
 
 
-def test_fetch_production(adapter, session, snapshot):
+def test_fetch_production(requests_mock, session, snapshot):
     """Test production data parsing with snapshot testing."""
     # Mock all production CSV files
     production_files = [
@@ -36,7 +36,7 @@ def test_fetch_production(adapter, session, snapshot):
 
         return ""
 
-    adapter.register_uri(
+    requests_mock.register_uri(
         GET,
         ANY,
         text=mock_response,
@@ -55,11 +55,11 @@ def test_fetch_production(adapter, session, snapshot):
         ("HN", "US"),  # Test case with no matching zone
     ],
 )
-def test_fetch_exchange(adapter, session, snapshot, zone_key1, zone_key2):
+def test_fetch_exchange(requests_mock, session, snapshot, zone_key1, zone_key2):
     """Test exchange data parsing with snapshot testing."""
     exchange_file = base_path_to_mock / "exchange_index_7.csv"
 
-    adapter.register_uri(
+    requests_mock.register_uri(
         GET,
         ANY,
         text=exchange_file.read_text(encoding="utf-8"),

--- a/electricitymap/contrib/parsers/tests/test_IEMOP.py
+++ b/electricitymap/contrib/parsers/tests/test_IEMOP.py
@@ -11,7 +11,7 @@ zone_keys = [ZoneKey("PH-LU"), ZoneKey("PH-MI"), ZoneKey("PH-VI")]
 
 
 @pytest.mark.parametrize("zone_key", zone_keys)
-def test_production(adapter, session, snapshot, zone_key: ZoneKey):
+def test_production(requests_mock, session, snapshot, zone_key: ZoneKey):
     """
     Reports have been reduced to 14 September 2023 00:00 to 13 September 2023 22:00 for ease
     """
@@ -19,7 +19,7 @@ def test_production(adapter, session, snapshot, zone_key: ZoneKey):
     with open(
         "electricitymap/contrib/parsers/tests/mocks/IEMOP/list_reports_items.json", "rb"
     ) as list_reports_items:
-        adapter.register_uri(
+        requests_mock.register_uri(
             POST,
             REPORTS_ADMIN_URL,
             content=list_reports_items.read(),
@@ -28,7 +28,7 @@ def test_production(adapter, session, snapshot, zone_key: ZoneKey):
     with open(
         "electricitymap/contrib/parsers/tests/mocks/IEMOP/reports_content", "rb"
     ) as reports_byte_content:
-        adapter.register_uri(
+        requests_mock.register_uri(
             GET,
             REPORTS_LINK,
             content=reports_byte_content.read(),

--- a/electricitymap/contrib/parsers/tests/test_IL.py
+++ b/electricitymap/contrib/parsers/tests/test_IL.py
@@ -9,7 +9,7 @@ from electricitymap.contrib.parsers.IL import IEC_PRODUCTION, fetch_all
 def test_snapshot_fetch_all(snapshot):
     """Snapshot the full fetch_all output. Exercises BeautifulSoup(lxml)
     parsing of the IEC dashboard. `fetch_all` calls module-level `requests.get`
-    twice, so we patch the global adapter via `requests_mock.Mocker`.
+    twice, so we patch the global requests_mock via `requests_mock.Mocker`.
     """
     html = (
         resources.files("electricitymap.contrib.parsers.tests.mocks.IL")

--- a/electricitymap/contrib/parsers/tests/test_IN_AP.py
+++ b/electricitymap/contrib/parsers/tests/test_IN_AP.py
@@ -7,8 +7,8 @@ from electricitymap.contrib.parsers.archived import IN_AP
 
 
 @pytest.fixture(autouse=True)
-def mock_response(adapter):
-    adapter.register_uri(
+def mock_response(requests_mock):
+    requests_mock.register_uri(
         ANY,
         ANY,
         text=resources.files("electricitymap.contrib.parsers.tests.mocks")

--- a/electricitymap/contrib/parsers/tests/test_IN_EA.py
+++ b/electricitymap/contrib/parsers/tests/test_IN_EA.py
@@ -19,7 +19,7 @@ NETFLOWS = {
 
 
 @pytest.mark.parametrize("neighbour_zone_key", ZONE_NEIGHBOURS[ZoneKey("IN-EA")])
-def test_exchanges(adapter, session, neighbour_zone_key: ZoneKey):
+def test_exchanges(requests_mock, session, neighbour_zone_key: ZoneKey):
     target_date = datetime(2023, 6, 25, 0, 0, tzinfo=ZoneInfo("Asia/Kolkata"))
     sorted_zone_keys = ZoneKey("->".join(sorted([neighbour_zone_key, "IN-EA"])))
     url, _ = IN_EA.get_fetch_function(sorted_zone_keys)
@@ -31,7 +31,7 @@ def test_exchanges(adapter, session, neighbour_zone_key: ZoneKey):
     with open(
         f"electricitymap/contrib/parsers/tests/mocks/IN_EA/{filename}.json", "rb"
     ) as data:
-        adapter.register_uri(
+        requests_mock.register_uri(
             GET,
             url.format(
                 proxy=IN_EA.IN_WE_PROXY,

--- a/electricitymap/contrib/parsers/tests/test_IN_HP.py
+++ b/electricitymap/contrib/parsers/tests/test_IN_HP.py
@@ -1,3 +1,4 @@
+import logging
 from importlib import resources
 
 import pytest
@@ -8,8 +9,8 @@ from electricitymap.contrib.parsers import IN_HP
 
 
 @pytest.fixture(autouse=True)
-def mock_response(adapter):
-    adapter.register_uri(
+def mock_response(requests_mock):
+    requests_mock.register_uri(
         POST,
         IN_HP.DATA_URL,
         text=resources.files("electricitymap.contrib.parsers.tests.mocks")
@@ -19,7 +20,9 @@ def mock_response(adapter):
 
 
 def test_fetch_production(session):
-    with LogCapture() as log:
+    # level=INFO so the requests_mock fixture's DEBUG noise (HTTP method/URL
+    # echo) doesn't bleed into the parser's own warning count.
+    with LogCapture(level=logging.INFO) as log:
         data = IN_HP.fetch_production("IN-HP", session)
         assert data["zoneKey"] == "IN-HP"
         assert data["source"] == "hpsldc.com"

--- a/electricitymap/contrib/parsers/tests/test_IN_KA.py
+++ b/electricitymap/contrib/parsers/tests/test_IN_KA.py
@@ -5,8 +5,8 @@ from requests_mock import GET
 from electricitymap.contrib.parsers import IN_KA
 
 
-def test_fetch_consumption(adapter, session):
-    adapter.register_uri(
+def test_fetch_consumption(requests_mock, session):
+    requests_mock.register_uri(
         GET,
         "https://kptclsldc.in/Default.aspx",
         text=resources.files("electricitymap.contrib.parsers.tests.mocks")
@@ -23,15 +23,15 @@ def test_fetch_consumption(adapter, session):
     assert data["consumption"] == 7430.0
 
 
-def test_fetch_production(adapter, session):
-    adapter.register_uri(
+def test_fetch_production(requests_mock, session):
+    requests_mock.register_uri(
         GET,
         "https://kptclsldc.in/StateGen.aspx",
         text=resources.files("electricitymap.contrib.parsers.tests.mocks")
         .joinpath("IN_KA_StateGen.html")
         .read_text(),
     )
-    adapter.register_uri(
+    requests_mock.register_uri(
         GET,
         "https://kptclsldc.in/StateNCEP.aspx",
         text=resources.files("electricitymap.contrib.parsers.tests.mocks")

--- a/electricitymap/contrib/parsers/tests/test_JAO.py
+++ b/electricitymap/contrib/parsers/tests/test_JAO.py
@@ -40,13 +40,13 @@ CORE_EXTERNAL_TARGET_DATETIME = datetime.fromisoformat("2026-04-20T00:00:00+00:0
 APRIL_2026_TARGET_DATETIME = datetime.fromisoformat("2026-04-20T00:00:00+00:00")
 
 
-def _register_shadow_auction_atc(adapter) -> None:
+def _register_shadow_auction_atc(requests_mock) -> None:
     payload = json.loads((BASE_MOCK_PATH / "shadow_auction_atc.json").read_text())
-    adapter.register_uri(GET, SHADOW_AUCTION_ATC_URL_REGEX, json=payload)
+    requests_mock.register_uri(GET, SHADOW_AUCTION_ATC_URL_REGEX, json=payload)
 
 
-def test_fetch_shadow_auction_atc_day_ahead_de_fr(adapter, session, snapshot):
-    _register_shadow_auction_atc(adapter)
+def test_fetch_shadow_auction_atc_day_ahead_de_fr(requests_mock, session, snapshot):
+    _register_shadow_auction_atc(requests_mock)
 
     result = fetch_shadow_auction_atc_day_ahead(
         ZoneKey("DE"),
@@ -58,9 +58,9 @@ def test_fetch_shadow_auction_atc_day_ahead_de_fr(adapter, session, snapshot):
     assert snapshot(extension_class=SingleFileAmberSnapshotExtension) == result
 
 
-def test_fetch_shadow_auction_atc_day_ahead_pair_not_in_core(adapter, session):
+def test_fetch_shadow_auction_atc_day_ahead_pair_not_in_core(requests_mock, session):
     """Pairs without JAO border fields should return [] without raising."""
-    _register_shadow_auction_atc(adapter)
+    _register_shadow_auction_atc(requests_mock)
 
     result = fetch_shadow_auction_atc_day_ahead(
         ZoneKey("DE"),
@@ -72,7 +72,9 @@ def test_fetch_shadow_auction_atc_day_ahead_pair_not_in_core(adapter, session):
     assert result == []
 
 
-def test_fetch_shadow_auction_atc_day_ahead_em_to_jao_zone_remap(adapter, session):
+def test_fetch_shadow_auction_atc_day_ahead_em_to_jao_zone_remap(
+    requests_mock, session
+):
     """EM zone keys that don't match JAO's codes (e.g. IT-NO -> IT, DK-DK1 -> DK1)
     should be translated before looking up `border_XX_YY` fields."""
     remapped = {
@@ -87,7 +89,7 @@ def test_fetch_shadow_auction_atc_day_ahead_em_to_jao_zone_remap(adapter, sessio
         "rejected": False,
         "messages": None,
     }
-    adapter.register_uri(GET, SHADOW_AUCTION_ATC_URL_REGEX, json=remapped)
+    requests_mock.register_uri(GET, SHADOW_AUCTION_ATC_URL_REGEX, json=remapped)
 
     result = fetch_shadow_auction_atc_day_ahead(
         ZoneKey("FR"),
@@ -102,7 +104,7 @@ def test_fetch_shadow_auction_atc_day_ahead_em_to_jao_zone_remap(adapter, sessio
     assert result[0]["capacityImport"] == 2200
 
 
-def test_fetch_shadow_auction_atc_day_ahead_one_sided(adapter, session):
+def test_fetch_shadow_auction_atc_day_ahead_one_sided(requests_mock, session):
     """When only one direction is present in the JAO row, the event should
     still be emitted with a single populated capacity direction."""
     one_sided = {
@@ -116,7 +118,7 @@ def test_fetch_shadow_auction_atc_day_ahead_one_sided(adapter, session):
         "rejected": False,
         "messages": None,
     }
-    adapter.register_uri(GET, SHADOW_AUCTION_ATC_URL_REGEX, json=one_sided)
+    requests_mock.register_uri(GET, SHADOW_AUCTION_ATC_URL_REGEX, json=one_sided)
 
     result = fetch_shadow_auction_atc_day_ahead(
         ZoneKey("AT"),
@@ -131,11 +133,11 @@ def test_fetch_shadow_auction_atc_day_ahead_one_sided(adapter, session):
     assert result[0]["sortedZoneKeys"] == "AT->DE"
 
 
-def test_fetch_core_external_atc_day_ahead_de_dk_dk1(adapter, session, snapshot):
+def test_fetch_core_external_atc_day_ahead_de_dk_dk1(requests_mock, session, snapshot):
     """Happy path for a Core-external border that also exercises the
     DK-DK1 → DK1 zone remap. Fixture is a real 2-day, 15-min response."""
     payload = json.loads((BASE_MOCK_PATH / "core_external_atc.json").read_text())
-    adapter.register_uri(GET, CORE_EXTERNAL_ATC_URL_REGEX, json=payload)
+    requests_mock.register_uri(GET, CORE_EXTERNAL_ATC_URL_REGEX, json=payload)
 
     result = fetch_core_external_atc_day_ahead(
         ZoneKey("DE"),
@@ -147,11 +149,13 @@ def test_fetch_core_external_atc_day_ahead_de_dk_dk1(adapter, session, snapshot)
     assert snapshot(extension_class=SingleFileAmberSnapshotExtension) == result
 
 
-def test_fetch_core_external_atc_day_ahead_border_not_in_dataset(adapter, session):
+def test_fetch_core_external_atc_day_ahead_border_not_in_dataset(
+    requests_mock, session
+):
     """Core-external endpoint only lists a handful of neighbors; a pair
     that isn't in the response should return [] without raising."""
     payload = json.loads((BASE_MOCK_PATH / "core_external_atc.json").read_text())
-    adapter.register_uri(GET, CORE_EXTERNAL_ATC_URL_REGEX, json=payload)
+    requests_mock.register_uri(GET, CORE_EXTERNAL_ATC_URL_REGEX, json=payload)
 
     result = fetch_core_external_atc_day_ahead(
         ZoneKey("DE"),
@@ -163,10 +167,10 @@ def test_fetch_core_external_atc_day_ahead_border_not_in_dataset(adapter, sessio
     assert result == []
 
 
-def test_fetch_core_max_bex_day_ahead_de_fr(adapter, session, snapshot):
+def test_fetch_core_max_bex_day_ahead_de_fr(requests_mock, session, snapshot):
     """Core maxExchanges happy path (hourly, 48 rows over 2 days)."""
     payload = json.loads((BASE_MOCK_PATH / "core_max_bex.json").read_text())
-    adapter.register_uri(GET, CORE_MAX_BEX_URL_REGEX, json=payload)
+    requests_mock.register_uri(GET, CORE_MAX_BEX_URL_REGEX, json=payload)
 
     result = fetch_core_max_bex_day_ahead(
         ZoneKey("DE"),
@@ -178,11 +182,11 @@ def test_fetch_core_max_bex_day_ahead_de_fr(adapter, session, snapshot):
     assert snapshot(extension_class=SingleFileAmberSnapshotExtension) == result
 
 
-def test_fetch_nordic_max_bex_day_ahead_no1_se3(adapter, session, snapshot):
+def test_fetch_nordic_max_bex_day_ahead_no1_se3(requests_mock, session, snapshot):
     """Nordic maxExchanges happy path — exercises the NO-NO2 → NO2,
     SE-SE3 → SE3 zone remap on a real 15-min fixture."""
     payload = json.loads((BASE_MOCK_PATH / "nordic_max_bex.json").read_text())
-    adapter.register_uri(GET, NORDIC_MAX_BEX_URL_REGEX, json=payload)
+    requests_mock.register_uri(GET, NORDIC_MAX_BEX_URL_REGEX, json=payload)
 
     result = fetch_nordic_max_bex_day_ahead(
         ZoneKey("NO-NO1"),
@@ -194,10 +198,12 @@ def test_fetch_nordic_max_bex_day_ahead_no1_se3(adapter, session, snapshot):
     assert snapshot(extension_class=SingleFileAmberSnapshotExtension) == result
 
 
-def test_fetch_core_scheduled_exchanges_day_ahead_de_fr(adapter, session, snapshot):
+def test_fetch_core_scheduled_exchanges_day_ahead_de_fr(
+    requests_mock, session, snapshot
+):
     """Core scheduledExchanges happy path (cleared commercial flow, 15-min)."""
     payload = json.loads((BASE_MOCK_PATH / "core_scheduled_exchanges.json").read_text())
-    adapter.register_uri(GET, CORE_SCHEDULED_EXCHANGES_URL_REGEX, json=payload)
+    requests_mock.register_uri(GET, CORE_SCHEDULED_EXCHANGES_URL_REGEX, json=payload)
 
     result = fetch_core_scheduled_exchanges_day_ahead(
         ZoneKey("DE"),
@@ -209,10 +215,10 @@ def test_fetch_core_scheduled_exchanges_day_ahead_de_fr(adapter, session, snapsh
     assert snapshot(extension_class=SingleFileAmberSnapshotExtension) == result
 
 
-def test_fetch_nordic_max_bflow_day_ahead_no1_se3(adapter, session, snapshot):
+def test_fetch_nordic_max_bflow_day_ahead_no1_se3(requests_mock, session, snapshot):
     """Nordic maxBorderFlow happy path (physical capability ceiling, 15-min)."""
     payload = json.loads((BASE_MOCK_PATH / "nordic_max_bflow.json").read_text())
-    adapter.register_uri(GET, NORDIC_MAX_BFLOW_URL_REGEX, json=payload)
+    requests_mock.register_uri(GET, NORDIC_MAX_BFLOW_URL_REGEX, json=payload)
 
     result = fetch_nordic_max_bflow_day_ahead(
         ZoneKey("NO-NO1"),

--- a/electricitymap/contrib/parsers/tests/test_JP.py
+++ b/electricitymap/contrib/parsers/tests/test_JP.py
@@ -30,7 +30,7 @@ from electricitymap.contrib.parsers.JP import (
     ],
 )
 @freeze_time("2025-04-16")  # because the mocks are all around this date
-def test_snapshot_fetch_generation_forecast(adapter, session, snapshot, zone_key):
+def test_snapshot_fetch_generation_forecast(requests_mock, session, snapshot, zone_key):
     datestamp_today = datetime.now().strftime("%Y%m%d")
     BASE_PATH_TO_MOCK = Path("electricitymap/contrib/parsers/tests/mocks/" + zone_key)
 
@@ -60,7 +60,7 @@ def test_snapshot_fetch_generation_forecast(adapter, session, snapshot, zone_key
             today_url = "https://www.yonden.co.jp/nw/denkiyoho/supply_demand/csv/yosoku_today.csv"
             data_path = Path(BASE_PATH_TO_MOCK, "yosoku_today.csv")
 
-        adapter.register_uri(GET, today_url, body=data_path.open("rb"))
+        requests_mock.register_uri(GET, today_url, body=data_path.open("rb"))
 
         # Register tomorrow's URL (except for JP-CB which raises an exception)
         if zone_key != "JP-CB":
@@ -77,11 +77,11 @@ def test_snapshot_fetch_generation_forecast(adapter, session, snapshot, zone_key
                 tomorrow_url = "https://www.yonden.co.jp/nw/denkiyoho/supply_demand/csv/yosoku_tomorrow.csv"
                 data_path = Path(BASE_PATH_TO_MOCK, "yosoku_tomorrow.csv")
 
-            adapter.register_uri(GET, tomorrow_url, body=data_path.open("rb"))
+            requests_mock.register_uri(GET, tomorrow_url, body=data_path.open("rb"))
 
     if zone_key == "JP-HKD":
         data_path = Path(BASE_PATH_TO_MOCK, "20250415_hokkaido_yosoku.csv")
-        adapter.register_uri(
+        requests_mock.register_uri(
             GET,
             re.compile(forecast_url[zone_key]),
             body=data_path.open("rb"),
@@ -89,7 +89,7 @@ def test_snapshot_fetch_generation_forecast(adapter, session, snapshot, zone_key
 
     elif zone_key == "JP-HR":
         data_path = Path(BASE_PATH_TO_MOCK, "yosoku_05_20250415.csv")
-        adapter.register_uri(
+        requests_mock.register_uri(
             GET,
             re.compile(forecast_url[zone_key]),
             body=data_path.open("rb"),
@@ -97,7 +97,7 @@ def test_snapshot_fetch_generation_forecast(adapter, session, snapshot, zone_key
 
     elif zone_key == "JP-KN":
         data_path = Path(BASE_PATH_TO_MOCK, "20250416_yosoku.csv")
-        adapter.register_uri(
+        requests_mock.register_uri(
             GET,
             re.compile(forecast_url[zone_key]),
             body=data_path.open("rb"),
@@ -107,7 +107,7 @@ def test_snapshot_fetch_generation_forecast(adapter, session, snapshot, zone_key
         data_zip_file = Path(BASE_PATH_TO_MOCK, "202504_jyukyu2_chugoku.zip")
         with open(data_zip_file, "rb") as zip_file:
             zip_content = zip_file.read()
-        adapter.register_uri(
+        requests_mock.register_uri(
             GET,
             re.compile(forecast_url[zone_key]),
             content=zip_content,
@@ -115,7 +115,7 @@ def test_snapshot_fetch_generation_forecast(adapter, session, snapshot, zone_key
 
     elif zone_key == "JP-KY":
         data_path = Path(BASE_PATH_TO_MOCK, "21110_TSO9_0_20250407.csv")
-        adapter.register_uri(
+        requests_mock.register_uri(
             GET,
             re.compile(forecast_url[zone_key]),
             body=data_path.open("rb"),
@@ -123,7 +123,7 @@ def test_snapshot_fetch_generation_forecast(adapter, session, snapshot, zone_key
 
     elif zone_key == "JP-ON":
         data_path = Path(BASE_PATH_TO_MOCK, "jukyu_yosoku_20250415.csv")
-        adapter.register_uri(
+        requests_mock.register_uri(
             GET,
             re.compile(forecast_url[zone_key]),
             body=data_path.open("rb"),
@@ -155,7 +155,9 @@ def test_snapshot_fetch_generation_forecast(adapter, session, snapshot, zone_key
     ],
 )
 @freeze_time("2025-04-16")  # because the mocks are all around this date
-def test_snapshot_fetch_consumption_forecast(adapter, session, snapshot, zone_key):
+def test_snapshot_fetch_consumption_forecast(
+    requests_mock, session, snapshot, zone_key
+):
     datestamp_today = datetime.now().strftime("%Y%m%d")
     BASE_PATH_TO_MOCK = Path("electricitymap/contrib/parsers/tests/mocks/" + zone_key)
 
@@ -185,7 +187,7 @@ def test_snapshot_fetch_consumption_forecast(adapter, session, snapshot, zone_ke
             today_url = "https://www.yonden.co.jp/nw/denkiyoho/supply_demand/csv/yosoku_today.csv"
             data_path = Path(BASE_PATH_TO_MOCK, "yosoku_today.csv")
 
-        adapter.register_uri(GET, today_url, body=data_path.open("rb"))
+        requests_mock.register_uri(GET, today_url, body=data_path.open("rb"))
 
         # Register tomorrow's URL (except for JP-CB which raises an exception)
         if zone_key != "JP-CB":
@@ -202,11 +204,11 @@ def test_snapshot_fetch_consumption_forecast(adapter, session, snapshot, zone_ke
                 tomorrow_url = "https://www.yonden.co.jp/nw/denkiyoho/supply_demand/csv/yosoku_tomorrow.csv"
                 data_path = Path(BASE_PATH_TO_MOCK, "yosoku_tomorrow.csv")
 
-            adapter.register_uri(GET, tomorrow_url, body=data_path.open("rb"))
+            requests_mock.register_uri(GET, tomorrow_url, body=data_path.open("rb"))
 
     if zone_key == "JP-HKD":
         data_path = Path(BASE_PATH_TO_MOCK, "20250415_hokkaido_yosoku.csv")
-        adapter.register_uri(
+        requests_mock.register_uri(
             GET,
             re.compile(forecast_url[zone_key]),
             body=data_path.open("rb"),
@@ -214,7 +216,7 @@ def test_snapshot_fetch_consumption_forecast(adapter, session, snapshot, zone_ke
 
     elif zone_key == "JP-HR":
         data_path = Path(BASE_PATH_TO_MOCK, "yosoku_05_20250415.csv")
-        adapter.register_uri(
+        requests_mock.register_uri(
             GET,
             re.compile(forecast_url[zone_key]),
             body=data_path.open("rb"),
@@ -222,7 +224,7 @@ def test_snapshot_fetch_consumption_forecast(adapter, session, snapshot, zone_ke
 
     elif zone_key == "JP-KN":
         data_path = Path(BASE_PATH_TO_MOCK, "20250416_yosoku.csv")
-        adapter.register_uri(
+        requests_mock.register_uri(
             GET,
             re.compile(forecast_url[zone_key]),
             body=data_path.open("rb"),
@@ -232,7 +234,7 @@ def test_snapshot_fetch_consumption_forecast(adapter, session, snapshot, zone_ke
         data_zip_file = Path(BASE_PATH_TO_MOCK, "202504_jyukyu2_chugoku.zip")
         with open(data_zip_file, "rb") as zip_file:
             zip_content = zip_file.read()
-        adapter.register_uri(
+        requests_mock.register_uri(
             GET,
             re.compile(forecast_url[zone_key]),
             content=zip_content,
@@ -240,7 +242,7 @@ def test_snapshot_fetch_consumption_forecast(adapter, session, snapshot, zone_ke
 
     elif zone_key == "JP-KY":
         data_path = Path(BASE_PATH_TO_MOCK, "21110_TSO9_0_20250407.csv")
-        adapter.register_uri(
+        requests_mock.register_uri(
             GET,
             re.compile(forecast_url[zone_key]),
             body=data_path.open("rb"),
@@ -248,7 +250,7 @@ def test_snapshot_fetch_consumption_forecast(adapter, session, snapshot, zone_ke
 
     elif zone_key == "JP-ON":
         data_path = Path(BASE_PATH_TO_MOCK, "jukyu_yosoku_20250415.csv")
-        adapter.register_uri(
+        requests_mock.register_uri(
             GET,
             re.compile(forecast_url[zone_key]),
             body=data_path.open("rb"),

--- a/electricitymap/contrib/parsers/tests/test_JP_SK.py
+++ b/electricitymap/contrib/parsers/tests/test_JP_SK.py
@@ -11,13 +11,13 @@ from electricitymap.contrib.parsers.JP_SK import (
 )
 
 
-def test_find_nuclear_image_url(adapter, session):
+def test_find_nuclear_image_url(requests_mock, session):
     report_content = (
         resources.files("electricitymap.contrib.parsers.tests.mocks.JP-SK")
         .joinpath("jp-sk-nuclear-html-page.html")
         .read_bytes()
     )
-    adapter.register_uri(GET, NUCLEAR_REPORT_URL, content=report_content)
+    requests_mock.register_uri(GET, NUCLEAR_REPORT_URL, content=report_content)
     image_url = get_nuclear_power_image_url(session)
     pattern = r"(?P<filename>ikt721-1\.gif\?[0-9]{12})"
     pattern_matches = re.findall(pattern, image_url)
@@ -26,13 +26,13 @@ def test_find_nuclear_image_url(adapter, session):
     assert pattern_matches[0] == "ikt721-1.gif?202402060021"
 
 
-def test_fetch_nuclear_image(adapter, session):
+def test_fetch_nuclear_image(requests_mock, session):
     nuclear_prod_image = (
         resources.files("electricitymap.contrib.parsers.tests.mocks.JP-SK")
         .joinpath("image3.gif")
         .read_bytes()
     )
-    adapter.register_uri(
+    requests_mock.register_uri(
         GET,
         ANY,
         content=nuclear_prod_image,

--- a/electricitymap/contrib/parsers/tests/test_KPX.py
+++ b/electricitymap/contrib/parsers/tests/test_KPX.py
@@ -13,20 +13,20 @@ from electricitymap.contrib.types import ZoneKey
 
 
 @pytest.fixture()
-def mock_response_as_realtime(adapter):
+def mock_response_as_realtime(requests_mock):
     with open(
         "electricitymap/contrib/parsers/tests/mocks/KPX/realtime.html", "rb"
     ) as mock:
-        adapter.register_uri(GET, REAL_TIME_URL, content=mock.read())
+        requests_mock.register_uri(GET, REAL_TIME_URL, content=mock.read())
 
 
 @pytest.fixture()
-def mock_response_as_historical(adapter):
+def mock_response_as_historical(requests_mock):
     with open(
         "electricitymap/contrib/parsers/tests/mocks/KPX/historical.html", "rb"
     ) as mock:
-        adapter.register_uri(POST, HISTORICAL_PRODUCTION_URL, content=mock.read())
-        adapter.register_uri(GET, HISTORICAL_PRODUCTION_URL, content=None)
+        requests_mock.register_uri(POST, HISTORICAL_PRODUCTION_URL, content=mock.read())
+        requests_mock.register_uri(GET, HISTORICAL_PRODUCTION_URL, content=None)
 
 
 def test_fetch_consumption_realtime(session, snapshot, mock_response_as_realtime):

--- a/electricitymap/contrib/parsers/tests/test_MD.py
+++ b/electricitymap/contrib/parsers/tests/test_MD.py
@@ -24,8 +24,8 @@ historical_datetime = datetime(2021, 7, 25, 12, tzinfo=timezone.utc)
 
 
 @frozen_live_time
-def test_fetch_consumption_live(adapter, session, snapshot):
-    adapter.register_uri(
+def test_fetch_consumption_live(requests_mock, session, snapshot):
+    requests_mock.register_uri(
         GET,
         ANY,
         json=json.loads(
@@ -38,8 +38,8 @@ def test_fetch_consumption_live(adapter, session, snapshot):
     assert snapshot == fetch_consumption(session=session)
 
 
-def test_fetch_consumption_historical(adapter, session, snapshot):
-    adapter.register_uri(
+def test_fetch_consumption_historical(requests_mock, session, snapshot):
+    requests_mock.register_uri(
         GET,
         ANY,
         json=json.loads(
@@ -56,8 +56,8 @@ def test_fetch_consumption_historical(adapter, session, snapshot):
 
 @pytest.mark.parametrize("neighbor", ["RO", "UA"])
 @frozen_live_time
-def test_fetch_exchange_live(adapter, session, snapshot, neighbor):
-    adapter.register_uri(
+def test_fetch_exchange_live(requests_mock, session, snapshot, neighbor):
+    requests_mock.register_uri(
         GET,
         ANY,
         json=json.loads(
@@ -73,8 +73,8 @@ def test_fetch_exchange_live(adapter, session, snapshot, neighbor):
 
 
 @pytest.mark.parametrize("neighbor", ["RO", "UA"])
-def test_fetch_exchange_historical(adapter, session, snapshot, neighbor):
-    adapter.register_uri(
+def test_fetch_exchange_historical(requests_mock, session, snapshot, neighbor):
+    requests_mock.register_uri(
         GET,
         ANY,
         json=json.loads(
@@ -94,8 +94,8 @@ def test_fetch_exchange_historical(adapter, session, snapshot, neighbor):
 
 @pytest.mark.parametrize("neighbor", ["RO", "UA"])
 @frozen_live_time
-def test_fetch_exchange_forecast_live(adapter, session, snapshot, neighbor):
-    adapter.register_uri(
+def test_fetch_exchange_forecast_live(requests_mock, session, snapshot, neighbor):
+    requests_mock.register_uri(
         GET,
         ANY,
         json=json.loads(
@@ -111,8 +111,8 @@ def test_fetch_exchange_forecast_live(adapter, session, snapshot, neighbor):
 
 
 @pytest.mark.parametrize("neighbor", ["RO", "UA"])
-def test_fetch_exchange_forecast_historical(adapter, session, snapshot, neighbor):
-    adapter.register_uri(
+def test_fetch_exchange_forecast_historical(requests_mock, session, snapshot, neighbor):
+    requests_mock.register_uri(
         GET,
         ANY,
         json=json.loads(
@@ -160,8 +160,8 @@ def test_fetch_price_historical(snapshot, historical_datetime):
 
 
 @frozen_live_time
-def test_fetch_production_live(adapter, session, snapshot):
-    adapter.register_uri(
+def test_fetch_production_live(requests_mock, session, snapshot):
+    requests_mock.register_uri(
         GET,
         ANY,
         json=json.loads(
@@ -174,8 +174,8 @@ def test_fetch_production_live(adapter, session, snapshot):
     assert snapshot == fetch_production(session=session)
 
 
-def test_fetch_production_historical(adapter, session, snapshot):
-    adapter.register_uri(
+def test_fetch_production_historical(requests_mock, session, snapshot):
+    requests_mock.register_uri(
         GET,
         ANY,
         json=json.loads(

--- a/electricitymap/contrib/parsers/tests/test_NORDPOOL.py
+++ b/electricitymap/contrib/parsers/tests/test_NORDPOOL.py
@@ -18,22 +18,22 @@ def emaps_env():
     os.environ["EMAPS_NORDPOOL_PASSWORD"] = "password"
 
 
-def test_price_parser_se(adapter, session, snapshot):
+def test_price_parser_se(requests_mock, session, snapshot):
     mock_token = Path(base_path_to_mock, "token.json")
     mock_data_current_day = Path(base_path_to_mock, "se_current_day_price.json")
     mock_data_next_day = Path(base_path_to_mock, "se_next_day_price.json")
 
-    adapter.register_uri(
+    requests_mock.register_uri(
         POST,
         "https://sts.nordpoolgroup.com/connect/token",
         json=loads(mock_token.read_text()),
     )
-    adapter.register_uri(
+    requests_mock.register_uri(
         GET,
         "https://data-api.nordpoolgroup.com/api/v2/Auction/Prices/ByAreas?areas=SE4&currency=EUR&market=DayAhead&date=2024-07-08",
         json=loads(mock_data_current_day.read_text()),
     )
-    adapter.register_uri(
+    requests_mock.register_uri(
         GET,
         "https://data-api.nordpoolgroup.com/api/v2/Auction/Prices/ByAreas?areas=SE4&currency=EUR&market=DayAhead&date=2024-07-09",
         json=loads(mock_data_next_day.read_text()),
@@ -46,24 +46,24 @@ def test_price_parser_se(adapter, session, snapshot):
     )
 
 
-def test_exchange_parser_fi_se1(adapter, session, snapshot):
+def test_exchange_parser_fi_se1(requests_mock, session, snapshot):
     mock_token = Path(base_path_to_mock, "token.json")
     mock_data_current_day = Path(base_path_to_mock, "fi_se1_current_day_exchange.json")
     mock_data_previous_day = Path(
         base_path_to_mock, "fi_se1_previous_day_exchange.json"
     )
 
-    adapter.register_uri(
+    requests_mock.register_uri(
         POST,
         "https://sts.nordpoolgroup.com/connect/token",
         json=loads(mock_token.read_text()),
     )
-    adapter.register_uri(
+    requests_mock.register_uri(
         GET,
         "https://data-api.nordpoolgroup.com/api/v2/PowerSystem/Exchanges/ByAreas?areas=FI&date=2024-12-01",
         json=loads(mock_data_current_day.read_text()),
     )
-    adapter.register_uri(
+    requests_mock.register_uri(
         GET,
         "https://data-api.nordpoolgroup.com/api/v2/PowerSystem/Exchanges/ByAreas?areas=FI&date=2024-11-30",
         json=loads(mock_data_previous_day.read_text()),
@@ -77,7 +77,7 @@ def test_exchange_parser_fi_se1(adapter, session, snapshot):
     )
 
 
-def test_atc_parser_de_no_no2(adapter, session, snapshot):
+def test_atc_parser_de_no_no2(requests_mock, session, snapshot):
     """DE↔NO-NO2 is the NordLink cable. The parser queries from zone1's side
     (DE → Nordpool code `GER`) and filters byConnection on the counterpart
     (`NO2_NK`). From GER's perspective `exportsByConnection` is GER→NO2 =
@@ -88,17 +88,17 @@ def test_atc_parser_de_no_no2(adapter, session, snapshot):
     mock_target_day = Path(base_path_to_mock, "ger_target_day_capacity.json")
     mock_next_day = Path(base_path_to_mock, "ger_next_day_capacity.json")
 
-    adapter.register_uri(
+    requests_mock.register_uri(
         POST,
         "https://sts.nordpoolgroup.com/connect/token",
         json=loads(mock_token.read_text()),
     )
-    adapter.register_uri(
+    requests_mock.register_uri(
         GET,
         "https://data-api.nordpoolgroup.com/api/v2/Auction/Capacities/ByAreas?areas=GER&market=DayAhead&date=2025-05-10",
         json=loads(mock_target_day.read_text()),
     )
-    adapter.register_uri(
+    requests_mock.register_uri(
         GET,
         "https://data-api.nordpoolgroup.com/api/v2/Auction/Capacities/ByAreas?areas=GER&market=DayAhead&date=2025-05-11",
         json=loads(mock_next_day.read_text()),

--- a/electricitymap/contrib/parsers/tests/test_NTESMO.py
+++ b/electricitymap/contrib/parsers/tests/test_NTESMO.py
@@ -5,7 +5,7 @@ from zoneinfo import ZoneInfo
 
 import pytest
 import requests
-from requests_mock import ANY, GET, Adapter
+from requests_mock import ANY, GET
 
 from electricitymap.contrib.parsers.NTESMO import (
     fetch_consumption,
@@ -18,10 +18,7 @@ australia = ZoneInfo("Australia/Darwin")
 
 
 @pytest.fixture()
-def fixture_session_mock(adapter, session) -> tuple[requests.Session, Adapter]:
-    # do not mount mock adapter on generic https:// prefix or the parser's @retry_policy decorator will overwrite it
-    session.mount("https://ntesmo.com.au/", adapter)
-
+def fixture_session_mock(requests_mock, session) -> tuple[requests.Session, object]:
     index_page = """<div class="smp-tiles-article__item">
             <a href="https://ntesmo.com.au/__data/assets/excel_doc/0013/116113/Market-Information_System-Control-daily-trading-day_220401.xlsx">
                 <div class="smp-tiles-article__title">01 December 2022</div>
@@ -44,7 +41,7 @@ def fixture_session_mock(adapter, session) -> tuple[requests.Session, Adapter]:
     with open(
         "electricitymap/contrib/parsers/tests/mocks/AU/NTESMO.xlsx", "rb"
     ) as data:
-        adapter.register_uri(
+        requests_mock.register_uri(
             ANY,
             ANY,
             response_list=[
@@ -55,11 +52,11 @@ def fixture_session_mock(adapter, session) -> tuple[requests.Session, Adapter]:
             ],
         )
 
-    return session, adapter
+    return session, requests_mock
 
 
 def test_fetch_production(fixture_session_mock):
-    session, adapter = fixture_session_mock
+    session, requests_mock = fixture_session_mock
 
     historical_datetime = datetime(year=2022, month=12, day=1, tzinfo=timezone.utc)
     data_list = fetch_production(session=session, target_datetime=historical_datetime)
@@ -86,7 +83,7 @@ def test_fetch_production(fixture_session_mock):
 
 
 def test_fetch_price(fixture_session_mock):
-    session, adapter = fixture_session_mock
+    session, requests_mock = fixture_session_mock
 
     historical_datetime = datetime(year=2022, month=12, day=1, tzinfo=timezone.utc)
     data_list = fetch_price(session=session, target_datetime=historical_datetime)
@@ -117,7 +114,7 @@ def test_fetch_price(fixture_session_mock):
 
 
 def test_fetch_consumption(fixture_session_mock):
-    session, adapter = fixture_session_mock
+    session, requests_mock = fixture_session_mock
 
     historical_datetime = datetime(year=2022, month=12, day=1, tzinfo=timezone.utc)
     data_list = fetch_consumption(session=session, target_datetime=historical_datetime)
@@ -148,7 +145,7 @@ def test_fetch_consumption(fixture_session_mock):
 BASE_PATH_TO_MOCK = Path("electricitymap/contrib/parsers/tests/mocks/NTESMO")
 
 
-def test_snapshot_fetch_consumption_forecast(adapter, session, snapshot):
+def test_snapshot_fetch_consumption_forecast(requests_mock, session, snapshot):
     # Define mock URLs
     base_url = (
         "https://ntesmo.com.au/data/data-dashboard/2024-enhancements/demand-forecast"
@@ -166,7 +163,7 @@ def test_snapshot_fetch_consumption_forecast(adapter, session, snapshot):
         mock_data = Path(BASE_PATH_TO_MOCK, mock_file_name)
 
         # Mock request
-        adapter.register_uri(GET, endpoint, json=loads(mock_data.read_text()))
+        requests_mock.register_uri(GET, endpoint, json=loads(mock_data.read_text()))
 
     # Call the function under test
     result = fetch_consumption_forecast(zone_key="AU-NT", session=session)

--- a/electricitymap/contrib/parsers/tests/test_NZ.py
+++ b/electricitymap/contrib/parsers/tests/test_NZ.py
@@ -11,13 +11,13 @@ from electricitymap.contrib.parsers.NZ import (
 )
 
 
-def test_snapshot_production_data(adapter, session, snapshot):
+def test_snapshot_production_data(requests_mock, session, snapshot):
     with open(
         resources.files("electricitymap.contrib.parsers.tests.mocks.NZ").joinpath(
             "response_2024_04_24_17_30.html"
         )
     ) as f:
-        adapter.register_uri(
+        requests_mock.register_uri(
             GET,
             PRODUCTION_URL,
             text=f.read(),
@@ -27,7 +27,7 @@ def test_snapshot_production_data(adapter, session, snapshot):
             "response_2024_04_24_18_00.html"
         )
     ) as f:
-        adapter.register_uri(
+        requests_mock.register_uri(
             GET,
             PRODUCTION_URL,
             text=f.read(),
@@ -40,8 +40,8 @@ def test_snapshot_production_data(adapter, session, snapshot):
     assert snapshot == production
 
 
-def test_snapshot_price_data(adapter, session, snapshot):
-    adapter.register_uri(
+def test_snapshot_price_data(requests_mock, session, snapshot):
+    requests_mock.register_uri(
         GET,
         PRICE_URL,
         json=loads(
@@ -50,7 +50,7 @@ def test_snapshot_price_data(adapter, session, snapshot):
             .read_text()
         ),
     )
-    adapter.register_uri(
+    requests_mock.register_uri(
         GET,
         PRICE_URL,
         json=loads(

--- a/electricitymap/contrib/parsers/tests/test_ONS.py
+++ b/electricitymap/contrib/parsers/tests/test_ONS.py
@@ -25,12 +25,14 @@ def mock_response():
     "data_file", ["BR.json", "BR_negative_solar.json", "data.json"]
 )
 @pytest.mark.parametrize("zone_key", ["BR-NE", "BR-N", "BR-CS", "BR-S"])
-def test_snapshot_fetch_production(zone_key, data_file, adapter, session, snapshot):
+def test_snapshot_fetch_production(
+    zone_key, data_file, requests_mock, session, snapshot
+):
     """Test fetch_production with snapshot using different data files for all Brazilian subzones."""
     mock_data_path = MOCK_DATA_DIR / data_file
     mock_data = json.loads(mock_data_path.read_text())
 
-    adapter.register_uri(
+    requests_mock.register_uri(
         GET,
         "http://tr.ons.org.br/Content/GetBalancoEnergetico/null",
         json=mock_data,
@@ -60,13 +62,13 @@ def test_snapshot_fetch_production(zone_key, data_file, adapter, session, snapsh
     ],
 )
 def test_snapshot_fetch_exchange(
-    zone_key1, zone_key2, data_file, adapter, session, snapshot
+    zone_key1, zone_key2, data_file, requests_mock, session, snapshot
 ):
     """Test fetch_exchange with snapshot using different data files for all exchanges."""
     mock_data_path = MOCK_DATA_DIR / data_file
     mock_data = json.loads(mock_data_path.read_text())
 
-    adapter.register_uri(
+    requests_mock.register_uri(
         GET,
         "http://tr.ons.org.br/Content/GetBalancoEnergetico/null",
         json=mock_data,

--- a/electricitymap/contrib/parsers/tests/test_OPENNEM.py
+++ b/electricitymap/contrib/parsers/tests/test_OPENNEM.py
@@ -24,9 +24,9 @@ def openelectricity_token_env():
 @pytest.mark.parametrize(
     "zone", ["AU-NSW", "AU-QLD", "AU-SA", "AU-TAS", "AU-VIC", "AU-WA"]
 )
-def test_production(adapter, session, snapshot, zone):
+def test_production(requests_mock, session, snapshot, zone):
     mock_data = Path(base_path_to_mock, f"OPENNEM_{zone}.v4.json")
-    adapter.register_uri(
+    requests_mock.register_uri(
         ANY,
         ANY,
         json=json.loads(mock_data.read_text()),
@@ -37,9 +37,9 @@ def test_production(adapter, session, snapshot, zone):
 
 
 @pytest.mark.parametrize("zone", ["AU-SA"])
-def test_price(adapter, session, snapshot, zone):
+def test_price(requests_mock, session, snapshot, zone):
     mock_data = Path(base_path_to_mock, f"OPENNEM_price_{zone}.json")
-    adapter.register_uri(
+    requests_mock.register_uri(
         ANY,
         ANY,
         json=json.loads(mock_data.read_text()),
@@ -49,10 +49,10 @@ def test_price(adapter, session, snapshot, zone):
     )
 
 
-def test_au_nsw_au_qld_exchange(adapter, session, snapshot):
+def test_au_nsw_au_qld_exchange(requests_mock, session, snapshot):
     # Exchange tests use the old v3 stats endpoint, so use v3 mock data
     mock_data = Path(base_path_to_mock, "OPENNEM_AU-QLD.json")
-    adapter.register_uri(
+    requests_mock.register_uri(
         ANY,
         ANY,
         json=json.loads(mock_data.read_text()),
@@ -63,18 +63,18 @@ def test_au_nsw_au_qld_exchange(adapter, session, snapshot):
     )
 
 
-def test_au_nsw_au_vic_exchange(adapter, session, snapshot):
+def test_au_nsw_au_vic_exchange(requests_mock, session, snapshot):
     # Exchange tests use the old v3 stats endpoint, so use v3 mock data
     mock_data_qld = Path(base_path_to_mock, "OPENNEM_AU-QLD.json")
     mock_data_nsw = Path(base_path_to_mock, "OPENNEM_AU-NSW.json")
 
-    adapter.register_uri(
+    requests_mock.register_uri(
         ANY,
         ANY,
         json=json.loads(mock_data_qld.read_text()),
     )
 
-    adapter.register_uri(
+    requests_mock.register_uri(
         ANY,
         ANY,
         json=json.loads(mock_data_nsw.read_text()),

--- a/electricitymap/contrib/parsers/tests/test_PA.py
+++ b/electricitymap/contrib/parsers/tests/test_PA.py
@@ -8,8 +8,8 @@ from electricitymap.contrib.parsers.PA import fetch_production
 
 
 @pytest.fixture(autouse=True)
-def mock_response(adapter):
-    adapter.register_uri(
+def mock_response(requests_mock):
+    requests_mock.register_uri(
         GET,
         ANY,
         text=resources.files("electricitymap.contrib.parsers.tests.mocks")

--- a/electricitymap/contrib/parsers/tests/test_PE.py
+++ b/electricitymap/contrib/parsers/tests/test_PE.py
@@ -11,7 +11,7 @@ from electricitymap.contrib.types import ZoneKey
 MOCK_DATA_DIR = Path(__file__).parent / "mocks" / "PE"
 
 
-def test_fetch_production_with_target_datetime(adapter, session, snapshot):
+def test_fetch_production_with_target_datetime(requests_mock, session, snapshot):
     """Test production data parsing for specific target datetime 2025-09-10."""
 
     def mock_response(request, context):
@@ -40,8 +40,8 @@ def test_fetch_production_with_target_datetime(adapter, session, snapshot):
         with open(mock_file, encoding="utf-8") as f:
             return json.load(f)
 
-    # Register the mock adapter
-    adapter.register_uri(
+    # Register the mock requests_mock
+    requests_mock.register_uri(
         POST,
         API_ENDPOINT,
         json=mock_response,
@@ -59,7 +59,7 @@ def test_fetch_production_with_target_datetime(adapter, session, snapshot):
     assert snapshot == result
 
 
-def test_fetch_production_data_structure(adapter, session):
+def test_fetch_production_data_structure(requests_mock, session):
     """Test that the production data has the expected structure and values."""
 
     def mock_response(request, context):
@@ -68,7 +68,7 @@ def test_fetch_production_data_structure(adapter, session):
         with open(mock_file, encoding="utf-8") as f:
             return json.load(f)
 
-    adapter.register_uri(
+    requests_mock.register_uri(
         POST,
         API_ENDPOINT,
         json=mock_response,

--- a/electricitymap/contrib/parsers/tests/test_PF.py
+++ b/electricitymap/contrib/parsers/tests/test_PF.py
@@ -10,8 +10,8 @@ from electricitymap.contrib.parsers.PF import fetch_production
 
 
 @pytest.fixture(autouse=True)
-def mock_response(adapter):
-    adapter.register_uri(
+def mock_response(requests_mock):
+    requests_mock.register_uri(
         GET,
         ANY,
         text=resources.files("electricitymap.contrib.parsers.tests.mocks.PF")
@@ -26,9 +26,11 @@ def test_fetch_production_live(session, snapshot):
     assert snapshot == fetch_production(session=session)
 
 
-def test_fetch_production_raises_parser_exception_on_historical_data(adapter, session):
+def test_fetch_production_raises_parser_exception_on_historical_data(
+    requests_mock, session
+):
     """That a ParserException is raised if requesting historical data (not supported yet)."""
-    adapter.register_uri(GET, ANY, json=[])
+    requests_mock.register_uri(GET, ANY, json=[])
 
     with pytest.raises(
         ParserException, match="This parser is not yet able to parse historical data"

--- a/electricitymap/contrib/parsers/tests/test_RU.py
+++ b/electricitymap/contrib/parsers/tests/test_RU.py
@@ -17,7 +17,7 @@ BASE_PATH_TO_MOCK = Path("electricitymap/contrib/parsers/tests/mocks/RU")
 
 @pytest.mark.parametrize("zone_key", ["RU-1", "RU-2", "RU-AS"])
 @freeze_time("2025-07-28 12:00:00")
-def test_snapshot_fetch_production(adapter, session, snapshot, zone_key):
+def test_snapshot_fetch_production(requests_mock, session, snapshot, zone_key):
     """Test fetch_production for different Russian zones using mock data."""
     # Determine which zones need to be mocked based on the test zone
     zones_to_mock = ["RU-1", "RU-2", "RU-AS"] if zone_key == "RU" else [zone_key]
@@ -32,7 +32,7 @@ def test_snapshot_fetch_production(adapter, session, snapshot, zone_key):
         else:  # RU-AS
             url_pattern = re.compile(r".*CommonInfo/GenEquipOptions_Z2.*")
 
-        adapter.register_uri(
+        requests_mock.register_uri(
             GET,
             url_pattern,
             json=json.loads(mock_file.read_text()),
@@ -73,7 +73,7 @@ def test_snapshot_fetch_production(adapter, session, snapshot, zone_key):
 )
 @freeze_time("2025-07-28 12:00:00")
 def test_snapshot_fetch_exchange(
-    adapter, session, snapshot, zone_key1, zone_key2, hour
+    requests_mock, session, snapshot, zone_key1, zone_key2, hour
 ):
     """Test fetch_exchange for different exchange pairs using mock data."""
     # Load the appropriate mock file based on hour
@@ -81,7 +81,7 @@ def test_snapshot_fetch_exchange(
 
     # Mock the exchange API endpoint with specific pattern
     url_pattern = re.compile(r".*flowDiagramm/GetData.*")
-    adapter.register_uri(
+    requests_mock.register_uri(
         GET,
         url_pattern,
         json=json.loads(mock_file.read_text()),
@@ -99,13 +99,13 @@ def test_snapshot_fetch_exchange(
 
 
 @freeze_time("2025-07-28 12:00:00")
-def test_snapshot_fetch_exchange_live(adapter, session, snapshot):
+def test_snapshot_fetch_exchange_live(requests_mock, session, snapshot):
     """Test fetch_exchange without target_datetime (live mode) using mock data."""
     # Mock both hours 10 and 11 for live mode (last 2 hours)
     for hour in [10, 11]:
         mock_file = BASE_PATH_TO_MOCK / f"exchange_2025-07-28_{hour}.json"
         url_pattern = re.compile(r".*flowDiagramm/GetData.*")
-        adapter.register_uri(
+        requests_mock.register_uri(
             GET,
             url_pattern,
             json=json.loads(mock_file.read_text()),
@@ -120,7 +120,7 @@ def test_snapshot_fetch_exchange_live(adapter, session, snapshot):
 
 
 @freeze_time("2025-07-28 12:00:00")
-def test_snapshot_fetch_production_live(adapter, session, snapshot):
+def test_snapshot_fetch_production_live(requests_mock, session, snapshot):
     """Test fetch_production without target_datetime (live mode) using mock data."""
     # Mock all zone endpoints for live mode with specific URL patterns
     for zone in ["RU-1", "RU-2", "RU-AS"]:
@@ -133,7 +133,7 @@ def test_snapshot_fetch_production_live(adapter, session, snapshot):
         else:  # RU-AS
             url_pattern = re.compile(r".*CommonInfo/GenEquipOptions_Z2.*")
 
-        adapter.register_uri(
+        requests_mock.register_uri(
             GET,
             url_pattern,
             json=json.loads(mock_file.read_text()),

--- a/electricitymap/contrib/parsers/tests/test_SG.py
+++ b/electricitymap/contrib/parsers/tests/test_SG.py
@@ -10,8 +10,8 @@ from electricitymap.contrib.parsers import SG
 
 
 @pytest.fixture(autouse=True)
-def mock_response(adapter):
-    adapter.register_uri(
+def mock_response(requests_mock):
+    requests_mock.register_uri(
         GET,
         SG.SOLAR_URL,
         content=resources.files("electricitymap.contrib.parsers.tests.mocks")
@@ -21,8 +21,8 @@ def mock_response(adapter):
 
 
 @freeze_time("2021-12-23 03:21:00")
-def test_works_when_nonzero(adapter, session):
-    adapter.register_uri(
+def test_works_when_nonzero(requests_mock, session):
+    requests_mock.register_uri(
         GET,
         SG.SOLAR_URL,
         content=resources.files("electricitymap.contrib.parsers.tests.mocks")

--- a/electricitymap/contrib/parsers/tests/test_SMARTGRIDDASHBOARD.py
+++ b/electricitymap/contrib/parsers/tests/test_SMARTGRIDDASHBOARD.py
@@ -15,8 +15,8 @@ from electricitymap.contrib.parsers.SMARTGRIDDASHBOARD import (
 from electricitymap.contrib.types import ZoneKey
 
 
-def test_fetch_consumption(adapter, session, snapshot):
-    adapter.register_uri(
+def test_fetch_consumption(requests_mock, session, snapshot):
+    requests_mock.register_uri(
         GET,
         URL,
         json=json.loads(
@@ -33,8 +33,8 @@ def test_fetch_consumption(adapter, session, snapshot):
     )
 
 
-def test_fetch_consumption_forecast(adapter, session, snapshot):
-    adapter.register_uri(
+def test_fetch_consumption_forecast(requests_mock, session, snapshot):
+    requests_mock.register_uri(
         GET,
         URL,
         json=json.loads(
@@ -51,8 +51,8 @@ def test_fetch_consumption_forecast(adapter, session, snapshot):
     )
 
 
-def test_fetch_exchange(adapter, session, snapshot):
-    adapter.register_uri(
+def test_fetch_exchange(requests_mock, session, snapshot):
+    requests_mock.register_uri(
         GET,
         URL,
         json=json.loads(
@@ -70,8 +70,8 @@ def test_fetch_exchange(adapter, session, snapshot):
     )
 
 
-def test_fetch_generation(adapter, session, snapshot):
-    adapter.register_uri(
+def test_fetch_generation(requests_mock, session, snapshot):
+    requests_mock.register_uri(
         GET,
         URL,
         json=json.loads(
@@ -89,8 +89,8 @@ def test_fetch_generation(adapter, session, snapshot):
     )
 
 
-def test_fetch_wind_solar_forecasts(adapter, session, snapshot):
-    adapter.register_uri(
+def test_fetch_wind_solar_forecasts(requests_mock, session, snapshot):
+    requests_mock.register_uri(
         GET,
         f"{URL}?areas=windforecast",
         json=json.loads(
@@ -101,7 +101,7 @@ def test_fetch_wind_solar_forecasts(adapter, session, snapshot):
             .read_text()
         ),
     )
-    adapter.register_uri(
+    requests_mock.register_uri(
         GET,
         f"{URL}?areas=solarforecast",
         json=json.loads(
@@ -119,8 +119,8 @@ def test_fetch_wind_solar_forecasts(adapter, session, snapshot):
     )
 
 
-def test_fetch_production(adapter, session, snapshot):
-    adapter.register_uri(
+def test_fetch_production(requests_mock, session, snapshot):
+    requests_mock.register_uri(
         GET,
         f"{URL}?areas=solaractual",
         json=json.loads(
@@ -131,7 +131,7 @@ def test_fetch_production(adapter, session, snapshot):
             .read_text()
         ),
     )
-    adapter.register_uri(
+    requests_mock.register_uri(
         GET,
         f"{URL}?areas=windactual",
         json=json.loads(
@@ -142,7 +142,7 @@ def test_fetch_production(adapter, session, snapshot):
             .read_text()
         ),
     )
-    adapter.register_uri(
+    requests_mock.register_uri(
         GET,
         f"{URL}?areas=generationactual",
         json=json.loads(

--- a/electricitymap/contrib/parsers/tests/test_TAIPOWER.py
+++ b/electricitymap/contrib/parsers/tests/test_TAIPOWER.py
@@ -4,11 +4,11 @@ from electricitymap.contrib.parsers.TAIPOWER import PRODUCTION_URL, fetch_produc
 from electricitymap.contrib.types import ZoneKey
 
 
-def test_production(adapter, session, snapshot):
+def test_production(requests_mock, session, snapshot):
     with open(
         "electricitymap/contrib/parsers/tests/mocks/TAIPOWER/genary.json", "rb"
     ) as mock_file:
-        adapter.register_uri(
+        requests_mock.register_uri(
             GET,
             PRODUCTION_URL,
             content=mock_file.read(),

--- a/electricitymap/contrib/parsers/tests/test_TH.py
+++ b/electricitymap/contrib/parsers/tests/test_TH.py
@@ -17,15 +17,15 @@ from electricitymap.contrib.types import ZoneKey
 
 
 @pytest.fixture
-def mock_mea_pages(adapter):
-    adapter.register_uri(
+def mock_mea_pages(requests_mock):
+    requests_mock.register_uri(
         GET,
         MEA_BASEPRICE_URL,
         content=resources.files("electricitymap.contrib.parsers.tests.mocks.TH")
         .joinpath("mea_baseprice.html")
         .read_bytes(),
     )
-    adapter.register_uri(
+    requests_mock.register_uri(
         GET,
         MEA_FT_URL,
         content=resources.files("electricitymap.contrib.parsers.tests.mocks.TH")

--- a/electricitymap/contrib/parsers/tests/test_TR.py
+++ b/electricitymap/contrib/parsers/tests/test_TR.py
@@ -26,9 +26,9 @@ def tr_credentials_env():
         datetime(2025, 7, 28, 10, 0),
     ],
 )
-def test_fetch_production(adapter, session, snapshot, target_datetime):
+def test_fetch_production(requests_mock, session, snapshot, target_datetime):
     # Mock the TGT ticket fetch - return a simple ticket string without newlines
-    adapter.register_uri(
+    requests_mock.register_uri(
         POST,
         "https://giris.epias.com.tr/cas/v1/tickets",
         text="TGT-1234567890-abcdefghijklmnop-cas",
@@ -40,7 +40,7 @@ def test_fetch_production(adapter, session, snapshot, target_datetime):
     )
 
     # Mock the production data API response with empty items to end pagination
-    adapter.register_uri(
+    requests_mock.register_uri(
         POST,
         "https://seffaflik.epias.com.tr/electricity-service/v1/generation/data/realtime-generation",
         [

--- a/electricitymap/contrib/parsers/tests/test_US_ERCOT.py
+++ b/electricitymap/contrib/parsers/tests/test_US_ERCOT.py
@@ -16,10 +16,10 @@ HOST_PARAMETER = "host=https://www.ercot.com"
 BASE_PATH_TO_MOCK = Path("electricitymap/contrib/parsers/tests/mocks/US_ERCOT")
 
 
-def test_snapshot_fetch_consumption_forecast(adapter, session, snapshot):
+def test_snapshot_fetch_consumption_forecast(requests_mock, session, snapshot):
     # Mock load forecast request
     data = Path(BASE_PATH_TO_MOCK, "load_forecast_by_forecast_zone.json")
-    adapter.register_uri(
+    requests_mock.register_uri(
         GET,
         re.compile(
             rf"{US_PROXY}/misapp/servlets/IceDocListJsonWS\?reportTypeId={ReportTypeID.LOAD_FORECAST_REPORTID.value}&_\d+\&{HOST_PARAMETER}"
@@ -32,7 +32,7 @@ def test_snapshot_fetch_consumption_forecast(adapter, session, snapshot):
     with open(data_zip_file, "rb") as zip_file:
         zip_content = zip_file.read()
 
-    adapter.register_uri(
+    requests_mock.register_uri(
         GET,
         re.compile(
             rf"{US_PROXY}/misdownload/servlets/mirDownload\?doclookupId=\d+\&{HOST_PARAMETER}"
@@ -47,13 +47,13 @@ def test_snapshot_fetch_consumption_forecast(adapter, session, snapshot):
     )
 
 
-def test_snapshot_fetch_wind_solar_forecasts(adapter, session, snapshot):
+def test_snapshot_fetch_wind_solar_forecasts(requests_mock, session, snapshot):
     # Mock wind forecast request
     data_wind = Path(
         BASE_PATH_TO_MOCK,
         "wind_power_production_hourly_averaged_actual_and_forecasted_values_rtid.json",
     )
-    adapter.register_uri(
+    requests_mock.register_uri(
         GET,
         re.compile(
             rf"{US_PROXY}/misapp/servlets/IceDocListJsonWS\?reportTypeId={ReportTypeID.WIND_POWER_PRODUCTION_REPORTID.value}&_\d+\&{HOST_PARAMETER}"
@@ -66,7 +66,7 @@ def test_snapshot_fetch_wind_solar_forecasts(adapter, session, snapshot):
         BASE_PATH_TO_MOCK,
         "solar_power_production_hourly_averaged_actual_and_forecasted_values_rtid.json",
     )
-    adapter.register_uri(
+    requests_mock.register_uri(
         GET,
         re.compile(
             rf"{US_PROXY}/misapp/servlets/IceDocListJsonWS\?reportTypeId={ReportTypeID.SOLAR_POWER_PRODUCTION_REPORTID.value}&_\d+\&{HOST_PARAMETER}"
@@ -96,7 +96,7 @@ def test_snapshot_fetch_wind_solar_forecasts(adapter, session, snapshot):
         return None  # Fail for unexpected calls
 
     # Mock the wind or solar report request
-    adapter.register_uri(
+    requests_mock.register_uri(
         GET,
         re.compile(
             rf"{US_PROXY}/misdownload/servlets/mirDownload\?doclookupId=\d+\&{HOST_PARAMETER}"

--- a/electricitymap/contrib/parsers/tests/test_US_MISO.py
+++ b/electricitymap/contrib/parsers/tests/test_US_MISO.py
@@ -44,10 +44,10 @@ def test_fetch_production():
     assert production[0]["production"]["unknown"] >= 256
 
 
-def test_snapshot_fetch_wind_solar_forecasts(adapter, session, snapshot):
+def test_snapshot_fetch_wind_solar_forecasts(requests_mock, session, snapshot):
     # Mock wind forecast request
     data_wind = Path(base_path_to_mock, "DataBrokerServicesgetWindForecast.asmx.json")
-    adapter.register_uri(
+    requests_mock.register_uri(
         GET,
         "https://api.misoenergy.org/MISORTWDDataBroker/DataBrokerServices.asmx?messageType=getWindForecast&returnType=json",
         json=loads(data_wind.read_text()),
@@ -55,7 +55,7 @@ def test_snapshot_fetch_wind_solar_forecasts(adapter, session, snapshot):
 
     # Mock solar forecast request
     data_solar = Path(base_path_to_mock, "DataBrokerServicesgetSolarForecast.asmx.json")
-    adapter.register_uri(
+    requests_mock.register_uri(
         GET,
         "https://api.misoenergy.org/MISORTWDDataBroker/DataBrokerServices.asmx?messageType=getSolarForecast&returnType=json",
         json=loads(data_solar.read_text()),
@@ -68,10 +68,10 @@ def test_snapshot_fetch_wind_solar_forecasts(adapter, session, snapshot):
     )
 
 
-def test_snapshot_fetch_consumption_forecast(adapter, session, snapshot):
+def test_snapshot_fetch_consumption_forecast(requests_mock, session, snapshot):
     # Mock load forecast request
     data = Path(base_path_to_mock, "20250310_df_al.xls")
-    adapter.register_uri(
+    requests_mock.register_uri(
         GET,
         re.compile(r"https://docs\.misoenergy\.org/marketreports/\d+_df_al.xls"),
         content=data.read_bytes(),

--- a/electricitymap/contrib/parsers/tests/test_US_NEISO.py
+++ b/electricitymap/contrib/parsers/tests/test_US_NEISO.py
@@ -15,10 +15,10 @@ from electricitymap.contrib.types import ZoneKey
 base_path_to_mock = Path("electricitymap/contrib/parsers/tests/mocks/US_NEISO")
 
 
-def test_fetch_consumption_forecast(adapter, session, snapshot):
+def test_fetch_consumption_forecast(requests_mock, session, snapshot):
     # Mock url request
     data = Path(base_path_to_mock, "day_ahead_load_forecast_20250317.xml")
-    adapter.register_uri(
+    requests_mock.register_uri(
         POST,
         "https://www.iso-ne.com/ws/wsclient",
         text=data.read_text(),
@@ -31,15 +31,15 @@ def test_fetch_consumption_forecast(adapter, session, snapshot):
     )
 
 
-def test_fetch_wind_solar_forecasts(adapter, session, snapshot):
+def test_fetch_wind_solar_forecasts(requests_mock, session, snapshot):
     # Mock the initial page requests that set cookies
-    adapter.register_uri(
+    requests_mock.register_uri(
         GET,
         "https://www.iso-ne.com/isoexpress/web/reports/operations/-/tree/seven-day-solar-power-forecast",
         text="mock response",
     )
 
-    adapter.register_uri(
+    requests_mock.register_uri(
         GET,
         "https://www.iso-ne.com/isoexpress/web/reports/operations/-/tree/seven-day-wind-power-forecast",
         text="mock response",
@@ -47,7 +47,7 @@ def test_fetch_wind_solar_forecasts(adapter, session, snapshot):
 
     # Mock wind forecast request
     data_wind = Path(base_path_to_mock, "seven_day_wind_power_forecast_20250225.csv")
-    adapter.register_uri(
+    requests_mock.register_uri(
         GET,
         re.compile(r"https://www\.iso-ne\.com/transform/csv/wphf\?start=\d+"),
         text=data_wind.read_text(),
@@ -55,7 +55,7 @@ def test_fetch_wind_solar_forecasts(adapter, session, snapshot):
 
     # Mock solar forecast request
     data_solar = Path(base_path_to_mock, "seven_day_solar_power_forecast_20250225.csv")
-    adapter.register_uri(
+    requests_mock.register_uri(
         GET,
         re.compile(r"https://www\.iso-ne\.com/transform/csv/sphf\?start=\d+"),
         text=data_solar.read_text(),
@@ -76,9 +76,9 @@ def test_fetch_wind_solar_forecasts(adapter, session, snapshot):
         (ZoneKey("US-NE-ISNE"), ZoneKey("US-NY-NYIS")),
     ],
 )
-def test_fetch_exchange(adapter, session, snapshot, zone_key1, zone_key2):
+def test_fetch_exchange(requests_mock, session, snapshot, zone_key1, zone_key2):
     data = Path(base_path_to_mock, f"exchange_{zone_key1}_{zone_key2}.json")
-    adapter.register_uri(
+    requests_mock.register_uri(
         POST,
         ANY,
         text=data.read_text(),

--- a/electricitymap/contrib/parsers/tests/test_US_NY.py
+++ b/electricitymap/contrib/parsers/tests/test_US_NY.py
@@ -11,8 +11,8 @@ from electricitymap.contrib.parsers import US_NY
 from electricitymap.contrib.types import ZoneKey
 
 
-def test_snapshot_fetch_consumption_forecast(adapter, session, snapshot):
-    adapter.register_uri(
+def test_snapshot_fetch_consumption_forecast(requests_mock, session, snapshot):
+    requests_mock.register_uri(
         "GET",
         "http://mis.nyiso.com/public/csv/isolf/20250219isolf.csv",
         content=Path(
@@ -29,8 +29,10 @@ def test_snapshot_fetch_consumption_forecast(adapter, session, snapshot):
     assert snapshot == result
 
 
-def test_snapshot_fetch_production_more_than_9_days_in_past(adapter, session, snapshot):
-    adapter.register_uri(
+def test_snapshot_fetch_production_more_than_9_days_in_past(
+    requests_mock, session, snapshot
+):
+    requests_mock.register_uri(
         "GET",
         "http://mis.nyiso.com/public/csv/rtfuelmix/20250201rtfuelmix_csv.zip",
         content=Path(

--- a/electricitymap/contrib/parsers/tests/test_US_PJM.py
+++ b/electricitymap/contrib/parsers/tests/test_US_PJM.py
@@ -14,16 +14,16 @@ from electricitymap.contrib.types import ZoneKey
 base_path_to_mock = Path("electricitymap/contrib/parsers/tests/mocks/US_PJM")
 
 
-def test_production(adapter, session, snapshot):
+def test_production(requests_mock, session, snapshot):
     settings = Path(base_path_to_mock, "settings.json")
-    adapter.register_uri(
+    requests_mock.register_uri(
         GET,
         "https://dataminer2.pjm.com/config/settings.json",
         json=loads(settings.read_text()),
     )
 
     data = Path(base_path_to_mock, "gen_by_fuel.json")
-    adapter.register_uri(
+    requests_mock.register_uri(
         GET,
         re.compile(
             r"https://us-ca-proxy-jfnx5klx2a-uw\.a\.run\.app/api/v1/gen_by_fuel.*"
@@ -37,10 +37,10 @@ def test_production(adapter, session, snapshot):
     )
 
 
-def test_fetch_consumption_forecast(adapter, session, snapshot):
+def test_fetch_consumption_forecast(requests_mock, session, snapshot):
     # Mock the settings.json request
     settings = Path(base_path_to_mock, "settings.json")
-    adapter.register_uri(
+    requests_mock.register_uri(
         GET,
         "https://dataminer2.pjm.com/config/settings.json",
         json=loads(settings.read_text()),
@@ -48,7 +48,7 @@ def test_fetch_consumption_forecast(adapter, session, snapshot):
 
     # Mock load forecast request
     data = Path(base_path_to_mock, "compressed_pjm_load_forecast_2025-03-19.gz")
-    adapter.register_uri(
+    requests_mock.register_uri(
         GET,
         re.compile(
             r"https://us-ca-proxy-jfnx5klx2a-uw\.a\.run\.app/api/v1/load_frcstd_7_day.*"
@@ -63,10 +63,10 @@ def test_fetch_consumption_forecast(adapter, session, snapshot):
     )
 
 
-def test_fetch_wind_solar_forecasts(adapter, session, snapshot):
+def test_fetch_wind_solar_forecasts(requests_mock, session, snapshot):
     # Mock the settings.json request
     settings = Path(base_path_to_mock, "settings.json")
-    adapter.register_uri(
+    requests_mock.register_uri(
         GET,
         "https://dataminer2.pjm.com/config/settings.json",
         json=loads(settings.read_text()),
@@ -74,7 +74,7 @@ def test_fetch_wind_solar_forecasts(adapter, session, snapshot):
 
     # Mock wind forecast request
     data_wind = Path(base_path_to_mock, "pjm_wind_forecast_2025-02-24.json")
-    adapter.register_uri(
+    requests_mock.register_uri(
         GET,
         re.compile(
             r"https://us-ca-proxy-jfnx5klx2a-uw\.a\.run\.app/api/v1/hourly_wind_power_forecast.*"
@@ -84,7 +84,7 @@ def test_fetch_wind_solar_forecasts(adapter, session, snapshot):
 
     # Mock solar forecast request
     data_solar = Path(base_path_to_mock, "pjm_solar_forecast_2025-02-24.json")
-    adapter.register_uri(
+    requests_mock.register_uri(
         GET,
         re.compile(
             r"https://us-ca-proxy-jfnx5klx2a-uw\.a\.run\.app/api/v1/hourly_solar_power_forecast.*"

--- a/electricitymap/contrib/parsers/tests/test_US_SPP.py
+++ b/electricitymap/contrib/parsers/tests/test_US_SPP.py
@@ -54,7 +54,7 @@ def test_SPP_logging():
         )
 
 
-def test_fetch_realtime_locational_marginal_price(adapter, session, snapshot):
+def test_fetch_realtime_locational_marginal_price(requests_mock, session, snapshot):
     # Mock 8 consecutive 5-minute intervals of LMP data
     base_url = "https://us-ca-proxy-jfnx5klx2a-uw.a.run.app/file-browser-api/download/rtbm-lmp-by-location?host=https://portal.spp.org&path=/2025/03/By_Interval/31/RTBM-LMP-SL-{}.csv"
     times = [
@@ -71,7 +71,9 @@ def test_fetch_realtime_locational_marginal_price(adapter, session, snapshot):
         mock_csv = Path(
             f"electricitymap/contrib/parsers/tests/mocks/US_SPP/RTBM-LMP-SL-{time}.csv"
         )
-        adapter.register_uri(GET, base_url.format(time), text=mock_csv.read_text())
+        requests_mock.register_uri(
+            GET, base_url.format(time), text=mock_csv.read_text()
+        )
 
     realtime_LMP = US_SPP.fetch_realtime_locational_marginal_price(
         zone_key=ZoneKey("US-CENT-SWPP"),
@@ -84,13 +86,13 @@ def test_fetch_realtime_locational_marginal_price(adapter, session, snapshot):
     assert snapshot == realtime_LMP
 
 
-def test_fetch_dayahead_locational_marginal_price(adapter, session, snapshot):
+def test_fetch_dayahead_locational_marginal_price(requests_mock, session, snapshot):
     mock_csv = Path(
         "electricitymap/contrib/parsers/tests/mocks/US_SPP/DA-LMP-SL-202503190100.csv"
     )
     base_url = "https://us-ca-proxy-jfnx5klx2a-uw.a.run.app/file-browser-api/download/da-lmp-by-location?host=https://portal.spp.org&path=/2025/03/By_Day/DA-LMP-SL-202503190100.csv"
 
-    adapter.register_uri(GET, base_url, text=mock_csv.read_text())
+    requests_mock.register_uri(GET, base_url, text=mock_csv.read_text())
 
     dayahead_LMP = US_SPP.fetch_dayahead_locational_marginal_price(
         zone_key=ZoneKey("US-CENT-SWPP"),

--- a/electricitymap/contrib/parsers/tests/test_UY.py
+++ b/electricitymap/contrib/parsers/tests/test_UY.py
@@ -14,15 +14,15 @@ from electricitymap.contrib.types import ZoneKey
 
 
 @pytest.fixture(autouse=True)
-def register_mock_uris(adapter):
+def register_mock_uris(requests_mock):
     html = Path("electricitymap/contrib/parsers/tests/mocks/UY/html.html")
-    adapter.register_uri(
+    requests_mock.register_uri(
         GET,
         "https://pronos.adme.com.uy/gpf.php",
         text=html.read_text(),
     )
     data = Path("electricitymap/contrib/parsers/tests/mocks/UY/data.ods")
-    adapter.register_uri(
+    requests_mock.register_uri(
         GET,
         re.compile(r"https://pronos\.adme\.com\.uy.*cache.*"),
         content=data.read_bytes(),

--- a/electricitymap/contrib/parsers/tests/test_amper_landsnet.py
+++ b/electricitymap/contrib/parsers/tests/test_amper_landsnet.py
@@ -7,8 +7,8 @@ from electricitymap.contrib.parsers.amper_landsnet import SOURCE_URL, fetch_prod
 from electricitymap.contrib.types import ZoneKey
 
 
-def test_fetch_production(adapter, session, snapshot):
-    adapter.register_uri(
+def test_fetch_production(requests_mock, session, snapshot):
+    requests_mock.register_uri(
         GET,
         SOURCE_URL,
         json=json.loads(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,7 +64,7 @@ dev = [
     "ruff==0.15.4",
     "pytest>=9,<10",
     "syrupy>=5,<6",
-    "requests-mock~=1.3.0",
+    "requests-mock>=1.12,<2",
     "testfixtures>=7.0.0,<8",
     "click>=8.0.0,<9",
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -357,7 +357,7 @@ provides-extras = ["parsers"]
 dev = [
     { name = "click", specifier = ">=8.0.0,<9" },
     { name = "pytest", specifier = ">=9,<10" },
-    { name = "requests-mock", specifier = "~=1.3.0" },
+    { name = "requests-mock", specifier = ">=1.12,<2" },
     { name = "ruff", specifier = "==0.15.4" },
     { name = "syrupy", specifier = ">=5,<6" },
     { name = "testfixtures", specifier = ">=7.0.0,<8" },
@@ -1299,15 +1299,14 @@ wheels = [
 
 [[package]]
 name = "requests-mock"
-version = "1.3.0"
+version = "1.12.1"
 source = { registry = "https://pypi.org/simple/" }
 dependencies = [
     { name = "requests" },
-    { name = "six" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/8d/cb/1267d7294d97e9a3ef24bf1370791da4d2dc6abc0f67626f38f4bf25dfa3/requests-mock-1.3.0.tar.gz", hash = "sha256:bd86970d6c52cc97071f5185aa594de6a997a5ca63b3bb36aceb9bb9db49294b", size = 42399, upload-time = "2017-02-01T05:39:57.129Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/92/32/587625f91f9a0a3d84688bf9cfc4b2480a7e8ec327cefd0ff2ac891fd2cf/requests-mock-1.12.1.tar.gz", hash = "sha256:e9e12e333b525156e82a3c852f22016b9158220d2f47454de9cae8a77d371401", size = 60901, upload-time = "2024-03-29T03:54:29.446Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/1c/aa/9f820349943529551b5dc50412070a41456d37b3616e60cc0e6ccb3f7f47/requests_mock-1.3.0-py2.py3-none-any.whl", hash = "sha256:23edd6f7926aa13b88bf79cb467632ba2dd5a253034e9f41563f60ed305620c7", size = 33179, upload-time = "2017-02-01T05:39:54.875Z" },
+    { url = "https://files.pythonhosted.org/packages/97/ec/889fbc557727da0c34a33850950310240f2040f3b1955175fdb2b36a8910/requests_mock-1.12.1-py2.py3-none-any.whl", hash = "sha256:b1e37054004cdd5e56c84454cc7df12b25f90f382159087f4b6915aaeef39563", size = 27695, upload-time = "2024-03-29T03:54:27.64Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Three stacked commits — review them as a unit.

### 1. `refactor(tests): switch parser tests to requests_mock pytest fixture`

Drops the local `adapter` fixture that mounted a `requests_mock.Adapter` on the test session at `http(s)://`. Tests now use the `requests_mock` pytest fixture (auto-provided by `requests-mock`), which monkey-patches `Session.get_adapter` above the per-session adapter stack.

This removes a long-standing constraint: production parsers couldn't mount their own transport adapters on `http(s)://` without shadowing the test mock. ESIOS.py had to work around this with the `if session is None` gate that ended up being a no-op in production (the feeder always passes a session). With the new fixture, production code can freely mount adapters and tests still intercept every request.

Mechanical scope: conftest + 65 test files + pyproject bump (`requests-mock` 1.3.0 → >=1.12 for the pytest-fixture support) + one log-capture filter in `test_IN_HP` to ignore the new version's DEBUG echo.

### 2. `feat(JAO,NORDPOOL): retry on 429 and transient 5xx`

JAO and Nordpool both rate-limit aggressive callers — surfaced during the atcDayAhead backfill (40 borders × multi-year window). JAO returns a plain HTTP 429; Nordpool's data-api is Cloudflare-fronted and returns an HTML 429 page.

Adds a shared `mount_retry(session, retry=DEFAULT_RETRY)` helper in `lib/session.py` (replacing the previously-unused `LegacyHttpAdapter` content of that file). Mounts `HTTPAdapter(max_retries=urllib3.Retry(...))` with 3 retries, `backoff_factor=2` (sleeps 0, 2, 4 s), status forcelist {429, 500, 502, 503, 504}. urllib3 honours `Retry-After` for free.

- JAO: `mount_retry(session)` in `_query_jao` (single HTTP chokepoint, default policy).
- Nordpool: per-fetcher `mount_retry(session or Session(), retry=_NORDPOOL_RETRY)` where `_NORDPOOL_RETRY` extends `allowed_methods` to ["GET", "POST"] so the OAuth token endpoint also benefits.

### 3. `feat(ESIOS): mount the shared retry adapter unconditionally`

ESIOS had the original `is_new_session`-gated Retry config that the previous commit's investigation revealed to be a production no-op. Now that mounting on the caller's session doesn't break tests, the gate goes away and ESIOS uses the same `mount_retry(session or Session())` helper. Local Retry config + mount plumbing collapses from ~20 lines to one.

The application-level `try/except` loop for `ConnectTimeout`/`ConnectionError` stays — urllib3's Retry catches HTTP status codes, but connection-establishment failures propagate as exceptions before the counter engages.

## Test plan

- [x] `uv run --extra parsers pytest electricitymap/contrib/parsers/tests/` — 413/413 pass after all three commits.
- [x] uv run test_parser "DK-DK1->DK-DK2" scheduledExchangesDayAhead