### PR TITLE
Revert "Fix CA-ON parser exchange directions"

### DIFF
--- a/electricitymap/contrib/parsers/CA_ON.py
+++ b/electricitymap/contrib/parsers/CA_ON.py
@@ -269,20 +269,11 @@ def fetch_exchange(
                 except (TypeError, ValueError) as error:
                     logger.warning(error)
                     continue
-                # The IESO IntertieZone reports flows from the neighboring
-                # zone's perspective: positive = neighboring zone exporting
-                # to Ontario (i.e., flow INTO Ontario).
-                # For EM convention, positive netFlow = flow in the direction
-                # of the sorted_zone_keys arrow (zone1 -> zone2).
-                # - CA-ON->CA-QC: positive = QC exporting to ON = flow QC->ON
-                #   = opposite of arrow, so flip.
-                # - CA-MB->CA-ON: positive = MB exporting to ON = flow MB->ON
-                #   = same as arrow direction (MB is zone1), so no flip needed,
-                #   but the current sign is already handled by the else branch.
-                if (
-                    not sorted_zone_keys.startswith("CA-ON->")
-                    or sorted_zone_keys == "CA-ON->CA-QC"
-                ):
+                # In the source data, flows out of Ontario (i.e., exports) are
+                # positive. For us, positive flow follows the direction of the
+                # arrow in sorted_zone_keys, so change the sign of the flow if
+                # necessary.
+                if not sorted_zone_keys.startswith("CA-ON->"):
                     flow *= -1
                 flows[time(hour=hour, minute=minute)] += flow
 

--- a/electricitymap/contrib/parsers/CA_ON.py
+++ b/electricitymap/contrib/parsers/CA_ON.py
@@ -273,6 +273,8 @@ def fetch_exchange(
                 # positive. For us, positive flow follows the direction of the
                 # arrow in sorted_zone_keys, so change the sign of the flow if
                 # necessary.
+                # Note that this flow is inverted to the rest in the source data.
+                # Check linear GMM-1534 for more info.
                 if not sorted_zone_keys.startswith("CA-ON->"):
                     flow *= -1
                 flows[time(hour=hour, minute=minute)] += flow


### PR DESCRIPTION
Reverts electricitymaps/electricitymaps-contrib#8661

Turns out the source, not us, was wrong 🫠 

Closes: GMM-1534