### PR TITLE
fix(HU): update battery storage capacity from MAVIR (501.5 MW)

### DIFF
--- a/config/zones/HU.yaml
+++ b/config/zones/HU.yaml
@@ -5,9 +5,18 @@ bounding_box:
     - 48.56970907985509
 capacity:
   battery storage:
-    - datetime: '2024-09-01'
+    - datetime: '2023-01-01'
+      source: mavir.hu
+      value: 21.8
+    - datetime: '2024-01-01'
       source: mavir.hu
       value: 35.3
+    - datetime: '2025-01-01'
+      source: mavir.hu
+      value: 146.0
+    - datetime: '2026-05-01'
+      source: mavir.hu
+      value: 501.5
   biomass:
     - datetime: '2017-01-01'
       source: entsoe.eu


### PR DESCRIPTION
## Issue

[GMM-1931](https://linear.app/electricitymaps/issue/GMM-1931): Hungary battery storage capacity appeared outdated — the platform showed **35.3 MW**, while the latest MAVIR publication reports **501.5 MW as of 2026-05-01**.

Closes GMM-1931

## Change

Updates the `battery storage` capacity series for **HU** from the latest MAVIR installed-capacity (BT) publication. The previous single entry (35.3 MW) only reflected 2024; the source shows the metric has grown rapidly, so the full reported trajectory is now captured:

| datetime | value (MW) | MAVIR column |
|---|---|---|
| 2023-01-01 | 21.8 | 2023 |
| 2024-01-01 | 35.3 | 2024 |
| 2025-01-01 | 146.0 | 2025 |
| 2026-05-01 | 501.5 | 2026.05.01 |

Notes:
- Values were 0 for 2016–2022, so no entries are added before the first installation.
- Yearly columns are dated `YYYY-01-01`; the latest figure uses the exact `2026-05-01` snapshot date.
- The PDF also has a `2026.04.30` column (412.1 MW) one day earlier. It's deliberately **not** included: MAVIR registers capacity with an effective date of the 1st of the month, so May 1 is a batch-registration boundary (the same boundary also reclassifies ~31.7 MW gas→coal and adds 18.9 MW solar). The 04-30 point is superseded a day later and would just introduce a misleading "+89 MW/day" step.
- Gross and net MAVIR tables agree on these figures, and the `piaci+MAVIR` label confirms it is the total (market + MAVIR-owned) battery storage.

## Source

MAVIR installed-capacity report, row **"Egyéb hagyományos (akkumulátoros tárolók piaci+MAVIR)"**:
https://www.mavir.hu/documents/10258/344552830/BT_2015-20260501_ig_BR_NT_HU_v1.pdf/3c209187-14b8-1667-2d7f-a6a7cb17b2d0?t=1779096535848

> ⚠️ This metric is growing quickly month-by-month (35.3 → 146 → 501.5 MW), so it will need periodic refresh from the latest MAVIR BT PDF.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
