### PR TITLE
fix: update GB config with new solar capacity values from 2025 and 2026

### DIFF
--- a/config/zones/GB.yaml
+++ b/config/zones/GB.yaml
@@ -138,6 +138,12 @@ capacity:
     - datetime: '2024-01-01'
       source: bmreports.com
       value: 15896
+    - datetime: '2025-01-01'
+      source: DESNZ
+      value: 19001
+    - datetime: '2026-01-01'
+      source: DESNZ
+      value: 21525
   unknown:
     - datetime: '2017-01-01'
       source: Ember, Yearly electricity data


### PR DESCRIPTION
## Issue

closes electricitymaps/electricitymaps-contrib#8748

## Description

adds new solar capacity data for GB from DESNZ

### Double check

- [X] I have tested my parser changes locally with `uv run test_parser "zone_key"`
- [X] I have run `pnpx prettier@2 --write .` and `uv run format` in the top level directory to format my changes.