### PR TITLE
fix(PE): make production test mock return per-date data

### DIFF
--- a/electricitymap/contrib/parsers/tests/test_PE.py
+++ b/electricitymap/contrib/parsers/tests/test_PE.py
@@ -63,8 +63,16 @@ def test_fetch_production_data_structure(requests_mock, session):
     """Test that the production data has the expected structure and values."""
 
     def mock_response(request, context):
-        """Mock response that returns consistent data."""
-        mock_file = MOCK_DATA_DIR / "response_20250910.json"
+        """Mock response based on the requested date so the "yesterday" and
+        "today" fetches return their own data instead of duplicating one day."""
+        form_data = request.text
+        if (
+            "fechaInicial=09%2F09%2F2025" in form_data
+            or "fechaInicial=09/09/2025" in form_data
+        ):
+            mock_file = MOCK_DATA_DIR / "response_20250909.json"
+        else:
+            mock_file = MOCK_DATA_DIR / "response_20250910.json"
         with open(mock_file, encoding="utf-8") as f:
             return json.load(f)
 


### PR DESCRIPTION
## Problem

`fetch_production` fetches both the target day and the previous day. In `test_fetch_production_data_structure`, the mock returned `response_20250910.json` for **every** request regardless of the requested date, so the "yesterday" fetch got the target day's rows — producing duplicate datetimes once concatenated. The test only asserted on structure, so it passed despite the duplicated data.

## Fix

Make the mock date-aware (mirroring `test_fetch_production_with_target_datetime`) so each fetch returns its own day's fixture. No parser change; no snapshot for this test.

> [!NOTE]
> Surfaced while adding a non-overlapping-events invariant in a separate branch; splitting it out here as an independent fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)