### PR TITLE
chore(config): Start collecting production data for CH from ENTSOE

### DIFF
--- a/config/zones/CH.yaml
+++ b/config/zones/CH.yaml
@@ -389,6 +389,7 @@ parsers:
   consumptionForecast: ENTSOE.fetch_consumption_forecast
   generationForecast: ENTSOE.fetch_generation_forecast
   price: ENTSOE.fetch_price
+  production: ENTSOE.fetch_production
   productionCapacity: EMBER.fetch_production_capacity
   productionPerModeForecast: ENTSOE.fetch_wind_solar_forecasts
   productionPerModeForecastDayAhead: ENTSOE.fetch_wind_solar_forecasts_day_ahead


### PR DESCRIPTION
## Issue

We are currently estimating this zone with GPZD.

Ref: DAT-306

## Description

Let's start collecting some production data as well so we can evalutate the difference and track the evolution in time to see if there is any consolidation time we need to consider.

Since this zone is GPZD this will not switch the data to measured unless we flip the switch manually by changing the estimation method to TSA.

### Double check

- [x] I have tested my parser changes locally with `uv run test_parser "zone_key"`
- [x] I have run `pnpx prettier@2 --write .` and `uv run format` in the top level directory to format my changes.
