### PR TITLE
CA-ON: Add battery storage discharge

### DIFF
--- a/electricitymap/contrib/parsers/CA_ON.py
+++ b/electricitymap/contrib/parsers/CA_ON.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+import re
 from collections import defaultdict
 from datetime import date, datetime, time, timedelta, timezone
 from logging import Logger, getLogger
@@ -19,6 +20,7 @@ from electricitymap.contrib.lib.models.events import (
     EventSourceType,
     GridAlertType,
     ProductionMix,
+    StorageMix,
 )
 from electricitymap.contrib.types import ZoneKey
 
@@ -73,6 +75,11 @@ MODES = {
     "SOLAR": "solar",
     "WIND": "wind",
 }
+# IESO has no dedicated fuel category for battery storage; it reports the
+# battery units under FuelType "OTHER". Match the known battery units by name so
+# only they are moved into storage and any other "OTHER" plant keeps the
+# existing warn-and-skip path.
+BATTERY_NAME_PATTERN = re.compile(r"BESS|BATTERY|STORAGE", re.IGNORECASE)
 NAMESPACE = "{http://www.theIMO.com/schema}"
 PRICE_URL = (
     "http://reports.ieso.ca/public/DispUnconsHOEP/PUB_DispUnconsHOEP_{YYYYMMDD}.xml"
@@ -151,15 +158,22 @@ def fetch_production(
         if xml is None:
             continue
 
-        # Collect the source data into a dictionary keying ProductionMix objects by
-        # the time of day at which they occurred.
+        # Collect the source data into dictionaries keying ProductionMix and
+        # StorageMix objects by the time of day at which they occurred.
         mixes: defaultdict[time, ProductionMix] = defaultdict(ProductionMix)
+        storages: defaultdict[time, StorageMix] = defaultdict(StorageMix)
         for generator in xml.iter(NAMESPACE + "Generator"):
-            try:
-                mode = MODES[generator.findtext(NAMESPACE + "FuelType")]
-            except KeyError as error:
-                logger.warning(error)
-                continue
+            fuel_type = generator.findtext(NAMESPACE + "FuelType")
+            name = generator.findtext(NAMESPACE + "GeneratorName") or ""
+            is_battery = fuel_type == "OTHER" and bool(
+                BATTERY_NAME_PATTERN.search(name)
+            )
+            if not is_battery:
+                try:
+                    mode = MODES[fuel_type]
+                except KeyError as error:
+                    logger.warning(error)
+                    continue
             for output in generator.iter(NAMESPACE + "Output"):
                 try:
                     hour = _parse_hour(output)
@@ -170,14 +184,22 @@ def fetch_production(
                 # for a given plant at a given hour. In the browser, this is
                 # displayed as an "N/A" entry in the table.
                 generation = output.findtext(NAMESPACE + "EnergyMW")
-                mixes[time(hour=hour)].add_value(
-                    mode, None if generation is None else float(generation)
-                )
+                value = None if generation is None else float(generation)
+                if is_battery:
+                    # IESO only publishes battery discharge (positive MW); store
+                    # it as negative to match the storage convention, where
+                    # discharging is negative and charging is positive.
+                    storages[time(hour=hour)].add_value(
+                        "battery", None if value is None else -value
+                    )
+                else:
+                    mixes[time(hour=hour)].add_value(mode, value)
 
-        for time_, mix in mixes.items():
+        for time_ in sorted(mixes.keys() | storages.keys()):
             production_breakdowns.append(
                 datetime=datetime.combine(date_, time_, tzinfo=TIMEZONE),
-                production=mix,
+                production=mixes.get(time_),
+                storage=storages.get(time_),
                 source=SOURCE,
                 zoneKey=ZONE_KEY,
             )

--- a/electricitymap/contrib/parsers/tests/__snapshots__/test_CA_ON.ambr
+++ b/electricitymap/contrib/parsers/tests/__snapshots__/test_CA_ON.ambr
@@ -1539,6 +1539,27 @@
     }),
   ])
 # ---
+# name: test_fetch_production
+  list([
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2025, 2, 28, 0, 0, tzinfo=datetime.timezone(datetime.timedelta(days=-1, seconds=68400), 'UTC-5')),
+      'end_datetime': None,
+      'production': dict({
+        'gas': 150.0,
+        'hydro': 400.0,
+        'nuclear': 826.0,
+      }),
+      'source': 'ieso.ca',
+      'sourceType': <EventSourceType.measured: 'measured'>,
+      'storage': dict({
+        'battery': -160.0,
+      }),
+      'zoneKey': 'CA-ON',
+    }),
+  ])
+# ---
 # name: test_fetch_wind_solar_forecasts
   list([
     dict({

--- a/electricitymap/contrib/parsers/tests/mocks/CA_ON/gen_output_capability_20250228.xml
+++ b/electricitymap/contrib/parsers/tests/mocks/CA_ON/gen_output_capability_20250228.xml
@@ -1,0 +1,81 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<IMODocument xmlns="http://www.theIMO.com/schema">
+<IMODocHeader>
+<DocTitle>Generators Output and Capability Report</DocTitle>
+</IMODocHeader>
+<IMODocBody>
+<Date>2025-02-28</Date>
+<Generators>
+<Generator>
+<GeneratorName>BRUCEA-G1</GeneratorName>
+<FuelType>NUCLEAR</FuelType>
+<Outputs>
+<Output>
+<Hour>1</Hour>
+<EnergyMW>826</EnergyMW>
+</Output>
+</Outputs>
+</Generator>
+<Generator>
+<GeneratorName>LENNOX-G1</GeneratorName>
+<FuelType>GAS</FuelType>
+<Outputs>
+<Output>
+<Hour>1</Hour>
+<EnergyMW>150</EnergyMW>
+</Output>
+</Outputs>
+</Generator>
+<Generator>
+<GeneratorName>SIRADAMBECK-PGS1</GeneratorName>
+<FuelType>HYDRO</FuelType>
+<Outputs>
+<Output>
+<Hour>1</Hour>
+<EnergyMW>400</EnergyMW>
+</Output>
+</Outputs>
+</Generator>
+<Generator>
+<GeneratorName>ONEIDA ENERGY STORAGE</GeneratorName>
+<FuelType>OTHER</FuelType>
+<Outputs>
+<Output>
+<Hour>1</Hour>
+<EnergyMW>100</EnergyMW>
+</Output>
+</Outputs>
+</Generator>
+<Generator>
+<GeneratorName>TILBURY BATTERY STORAGE</GeneratorName>
+<FuelType>OTHER</FuelType>
+<Outputs>
+<Output>
+<Hour>1</Hour>
+<EnergyMW>40</EnergyMW>
+</Output>
+</Outputs>
+</Generator>
+<Generator>
+<GeneratorName>ARLEN BESS</GeneratorName>
+<FuelType>OTHER</FuelType>
+<Outputs>
+<Output>
+<Hour>1</Hour>
+<EnergyMW>20</EnergyMW>
+</Output>
+</Outputs>
+</Generator>
+<Generator>
+<GeneratorName>EXPERIMENTAL FACILITY</GeneratorName>
+<FuelType>OTHER</FuelType>
+<Outputs>
+<Output>
+<Hour>1</Hour>
+<EnergyMW>999</EnergyMW>
+</Output>
+</Outputs>
+</Generator>
+</Generators>
+</IMODocBody>
+</IMODocument>

--- a/electricitymap/contrib/parsers/tests/test_CA_ON.py
+++ b/electricitymap/contrib/parsers/tests/test_CA_ON.py
@@ -8,6 +8,7 @@ from requests_mock import GET
 from electricitymap.contrib.parsers.CA_ON import (
     TIMEZONE,
     fetch_consumption_forecast,
+    fetch_production,
     fetch_wind_solar_forecasts,
 )
 from electricitymap.contrib.types import ZoneKey
@@ -75,6 +76,31 @@ def test_fetch_consumption_forecast(requests_mock, session, snapshot):
     # snapshot is deterministic — without target_datetime the parser starts at
     # datetime.now() and the snapshot only matches on the day it was recorded.
     assert snapshot == fetch_consumption_forecast(
+        zone_key=ZoneKey("CA-ON"),
+        session=session,
+        target_datetime=datetime(2025, 2, 28, 12, 0, tzinfo=TIMEZONE),
+    )
+
+
+def test_fetch_production(requests_mock, session, snapshot):
+    # Mock the Generator Output and Capability report. The fixture holds the
+    # three battery units IESO files under FuelType "OTHER" (which the parser
+    # moves into battery storage as discharge) plus a non-battery "OTHER" unit,
+    # which must stay out of the result entirely.
+    gen_output_capability = Path(
+        base_path_to_mock, "gen_output_capability_20250228.xml"
+    )
+    requests_mock.register_uri(
+        GET,
+        re.compile(
+            r"http://reports\.ieso\.ca/public/GenOutputCapability/PUB_GenOutputCapability_\d{8}\.xml"
+        ),
+        text=gen_output_capability.read_text(),
+    )
+
+    # Anchor to a fixed date so the parser fetches a single report and the
+    # snapshot datetime is deterministic.
+    assert snapshot == fetch_production(
         zone_key=ZoneKey("CA-ON"),
         session=session,
         target_datetime=datetime(2025, 2, 28, 12, 0, tzinfo=TIMEZONE),


### PR DESCRIPTION
## Issue

Closes #8135

## Description

IESO reports Ontario's grid-scale batteries under FuelType `OTHER`, with no dedicated storage category. `OTHER` isn't in the parser's production mode map, so every battery generator hit the warn-and-skip path and its discharge never made it into the data.

This moves the named battery units into storage instead. A generator counts as battery only when its FuelType is `OTHER` and its name matches `BESS`, `BATTERY` or `STORAGE`, which right now is exactly the eight units IESO files under `OTHER`: ARLEN BESS, GOREWAY BESS, HAGERSVILLE BESS, NAPANEE BESS, ONEIDA ENERGY STORAGE, TILBURY BATTERY STORAGE, VAUGHAN 1 BESS and YORK BESS. Any `OTHER` generator that doesn't match keeps the existing warn-and-skip, so a future non-battery `OTHER` plant can't be pulled in by accident.

IESO only publishes discharge (positive MW), so it's stored as negative to match the storage convention where discharging is negative. On live data this comes through as a small negative battery value per hour.

The earlier attempt (#8142) was closed because `OTHER` can't be blanket-mapped to battery. The name gate answers that directly, and the approach was agreed on in the issue thread.

### Double check

- [x] I have tested my parser changes locally with `uv run test_parser "CA-ON"`
- [x] I have run `pnpx prettier@2 --write .` and `uv run format` in the top level directory to format my changes.
