### PR TITLE
fix(configs): clean up ENTSOE price configs

### DIFF
--- a/config/zones/BY.yaml
+++ b/config/zones/BY.yaml
@@ -110,7 +110,6 @@ parsers:
   consumption: ENTSOE.fetch_consumption
   consumptionForecast: ENTSOE.fetch_consumption_forecast
   generationForecast: ENTSOE.fetch_generation_forecast
-  price: ENTSOE.fetch_price
   production: ENTSOE.fetch_production
   productionCapacity: EMBER.fetch_production_capacity
   productionPerModeForecast: ENTSOE.fetch_wind_solar_forecasts

--- a/config/zones/RU.yaml
+++ b/config/zones/RU.yaml
@@ -298,7 +298,6 @@ parsers:
   consumption: ENTSOE.fetch_consumption
   consumptionForecast: ENTSOE.fetch_consumption_forecast
   generationForecast: ENTSOE.fetch_generation_forecast
-  price: ENTSOE.fetch_price
   production: RU.fetch_production
   productionCapacity: EMBER.fetch_production_capacity
   productionPerModeForecast: ENTSOE.fetch_wind_solar_forecasts


### PR DESCRIPTION
## Issue

RU and BY are configure to use the ENTSO-E parsers for their prices. However those two zones do not report their prices to ENTSO-E.
![Uploading image.png…]()
