### PR TITLE
feat(parsers.GB): add GB wind day ahead forecasts

### DIFF
--- a/config/zones/GB.yaml
+++ b/config/zones/GB.yaml
@@ -545,7 +545,7 @@ parsers:
   production: GB.fetch_production
   productionCapacity: GB.fetch_production_capacity
   productionPerModeForecast: ENTSOE.fetch_wind_solar_forecasts
-  productionPerModeForecastDayAhead: ENTSOE.fetch_wind_solar_forecasts_day_ahead
+  productionPerModeForecastDayAhead: GB.fetch_wind_solar_forecasts_day_ahead
   productionPerModeForecastIntraday: ENTSOE.fetch_wind_solar_forecasts_intraday
   productionPerModeForecastLatest: ENTSOE.fetch_wind_solar_forecasts_current
 region: Europe

--- a/config/zones/GB.yaml
+++ b/config/zones/GB.yaml
@@ -545,7 +545,7 @@ parsers:
   production: GB.fetch_production
   productionCapacity: GB.fetch_production_capacity
   productionPerModeForecast: ENTSOE.fetch_wind_solar_forecasts
-  productionPerModeForecastDayAhead: GB.fetch_wind_solar_forecasts_day_ahead
+  productionPerModeForecastDayAhead: GB.fetch_wind_forecasts_day_ahead
   productionPerModeForecastIntraday: ENTSOE.fetch_wind_solar_forecasts_intraday
   productionPerModeForecastLatest: ENTSOE.fetch_wind_solar_forecasts_current
 region: Europe

--- a/electricitymap/contrib/parsers/GB.py
+++ b/electricitymap/contrib/parsers/GB.py
@@ -38,6 +38,11 @@ ZONE_KEY = ZoneKey("GB")
 
 NESO_API = "https://api.neso.energy/api/3/action/datastore_search_sql"
 NESO_GENERATION_DATASET_ID = "f93d1835-75bc-43e5-84ad-12472b180a98"
+# https://www.neso.energy/data-portal/day-ahead-wind-forecast
+# "Day Ahead Wind Forecast": rolling ~24h window holding only the latest published forecast.
+NESO_WIND_DAY_AHEAD_FORECAST_DATASET_ID = "b2f03146-f05d-4824-a663-3a4f36090c71"
+# "Historic Day Ahead Wind Forecasts": archive of past forecasts, lags the live dataset by about a day.
+NESO_WIND_DAY_AHEAD_FORECAST_HISTORY_DATASET_ID = "7524ec65-f782-4258-aaf8-5b926c17b966"
 
 ELEXON_BMU_UNITS = "https://data.elexon.co.uk/bmrs/api/v1/reference/bmunits/all"
 ELEXON_PN_STREAM = "https://data.elexon.co.uk/bmrs/api/v1/datasets/PN/stream"
@@ -153,6 +158,65 @@ def fetch_price(
                 )
 
     return price_list.to_list()
+
+
+@refetch_frequency(timedelta(days=1))
+def fetch_wind_solar_forecasts_day_ahead(
+    zone_key: ZoneKey = ZONE_KEY,
+    session: Session | None = None,
+    target_datetime: datetime | None = None,
+    logger: Logger = getLogger(__name__),
+) -> list[dict]:
+    """Requests the NESO national day-ahead wind forecast.
+
+    NESO only exposes the latest published day-ahead forecast (a rolling ~24h
+    window) in the live dataset; requests for a specific target_datetime fall
+    back to NESO's historical day-ahead forecast archive, which lags the live
+    dataset by about a day.
+    NOTE: The dataset only exposes wind forecasts, not solar. Solar forecasts are not available from NESO.
+    """
+    session = session or Session()
+
+    if target_datetime is None:
+        sql_query = f"""SELECT * FROM "{NESO_WIND_DAY_AHEAD_FORECAST_DATASET_ID}" ORDER BY "Datetime_GMT" ASC"""
+    else:
+        target_datetime = target_datetime.astimezone(timezone.utc)
+        start_datetime = target_datetime - timedelta(days=1)
+        end_datetime = target_datetime + timedelta(days=1)
+        sql_query = f"""SELECT * FROM "{NESO_WIND_DAY_AHEAD_FORECAST_HISTORY_DATASET_ID}" WHERE "Datetime_GMT" >= '{start_datetime.strftime("%Y-%m-%d")}' AND "Datetime_GMT" <= '{end_datetime.strftime("%Y-%m-%d")}' ORDER BY "Datetime_GMT" ASC"""
+
+    res: Response = session.get(NESO_API, params={"sql": sql_query})
+    if not res.ok:
+        raise ParserException(
+            PARSER,
+            f"Exception when fetching wind day-ahead forecast error code: {res.status_code}: {res.text}",
+            zone_key,
+        )
+
+    records = res.json()["result"]["records"]
+    if not records:
+        raise ParserException(
+            PARSER,
+            "No wind day-ahead forecast data found",
+            zone_key,
+        )
+
+    production_list = ProductionBreakdownList(logger=logger)
+    for row in records:
+        dt = datetime.fromisoformat(row["Datetime_GMT"]).replace(tzinfo=timezone.utc)
+
+        production_mix = ProductionMix()
+        production_mix.add_value("wind", float(row["Incentive_forecast"]))
+
+        production_list.append(
+            zoneKey=zone_key,
+            datetime=dt,
+            production=production_mix,
+            source="neso.energy",
+            sourceType=EventSourceType.forecasted,
+        )
+
+    return production_list.to_list()
 
 
 @refetch_frequency(timedelta(hours=72))

--- a/electricitymap/contrib/parsers/GB.py
+++ b/electricitymap/contrib/parsers/GB.py
@@ -161,7 +161,7 @@ def fetch_price(
 
 
 @refetch_frequency(timedelta(days=1))
-def fetch_wind_solar_forecasts_day_ahead(
+def fetch_wind_forecasts_day_ahead(
     zone_key: ZoneKey = ZONE_KEY,
     session: Session | None = None,
     target_datetime: datetime | None = None,
@@ -173,7 +173,6 @@ def fetch_wind_solar_forecasts_day_ahead(
     window) in the live dataset; requests for a specific target_datetime fall
     back to NESO's historical day-ahead forecast archive, which lags the live
     dataset by about a day.
-    NOTE: The dataset only exposes wind forecasts, not solar. Solar forecasts are not available from NESO.
     """
     session = session or Session()
 

--- a/electricitymap/contrib/parsers/tests/__snapshots__/test_GB.ambr
+++ b/electricitymap/contrib/parsers/tests/__snapshots__/test_GB.ambr
@@ -485,3 +485,95 @@
     }),
   ])
 # ---
+# name: test_fetch_wind_solar_forecasts_day_ahead_historical
+  list([
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2022, 7, 15, 23, 0, tzinfo=datetime.timezone.utc),
+      'end_datetime': None,
+      'production': dict({
+        'wind': 7523.0,
+      }),
+      'source': 'neso.energy',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'GB',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2022, 7, 15, 23, 30, tzinfo=datetime.timezone.utc),
+      'end_datetime': None,
+      'production': dict({
+        'wind': 7656.0,
+      }),
+      'source': 'neso.energy',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'GB',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2022, 7, 16, 0, 0, tzinfo=datetime.timezone.utc),
+      'end_datetime': None,
+      'production': dict({
+        'wind': 7736.0,
+      }),
+      'source': 'neso.energy',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'GB',
+    }),
+  ])
+# ---
+# name: test_fetch_wind_solar_forecasts_day_ahead_live
+  list([
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': FakeDatetime(2024, 12, 16, 23, 0, tzinfo=datetime.timezone.utc),
+      'end_datetime': None,
+      'production': dict({
+        'wind': 2732.0,
+      }),
+      'source': 'neso.energy',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'GB',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': FakeDatetime(2024, 12, 16, 23, 30, tzinfo=datetime.timezone.utc),
+      'end_datetime': None,
+      'production': dict({
+        'wind': 2796.0,
+      }),
+      'source': 'neso.energy',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'GB',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': FakeDatetime(2024, 12, 17, 0, 0, tzinfo=datetime.timezone.utc),
+      'end_datetime': None,
+      'production': dict({
+        'wind': 2882.0,
+      }),
+      'source': 'neso.energy',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'GB',
+    }),
+  ])
+# ---

--- a/electricitymap/contrib/parsers/tests/__snapshots__/test_GB.ambr
+++ b/electricitymap/contrib/parsers/tests/__snapshots__/test_GB.ambr
@@ -485,6 +485,52 @@
     }),
   ])
 # ---
+# name: test_fetch_wind_forecasts_day_ahead_historical
+  list([
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2022, 7, 15, 23, 0, tzinfo=datetime.timezone.utc),
+      'end_datetime': None,
+      'production': dict({
+        'wind': 7523.0,
+      }),
+      'source': 'neso.energy',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'GB',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2022, 7, 15, 23, 30, tzinfo=datetime.timezone.utc),
+      'end_datetime': None,
+      'production': dict({
+        'wind': 7656.0,
+      }),
+      'source': 'neso.energy',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'GB',
+    }),
+    dict({
+      'correctedModes': list([
+      ]),
+      'datetime': datetime.datetime(2022, 7, 16, 0, 0, tzinfo=datetime.timezone.utc),
+      'end_datetime': None,
+      'production': dict({
+        'wind': 7736.0,
+      }),
+      'source': 'neso.energy',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'storage': dict({
+      }),
+      'zoneKey': 'GB',
+    }),
+  ])
+# ---
 # name: test_fetch_wind_solar_forecasts_day_ahead_historical
   list([
     dict({

--- a/electricitymap/contrib/parsers/tests/__snapshots__/test_GB.ambr
+++ b/electricitymap/contrib/parsers/tests/__snapshots__/test_GB.ambr
@@ -531,52 +531,6 @@
     }),
   ])
 # ---
-# name: test_fetch_wind_solar_forecasts_day_ahead_historical
-  list([
-    dict({
-      'correctedModes': list([
-      ]),
-      'datetime': datetime.datetime(2022, 7, 15, 23, 0, tzinfo=datetime.timezone.utc),
-      'end_datetime': None,
-      'production': dict({
-        'wind': 7523.0,
-      }),
-      'source': 'neso.energy',
-      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
-      'storage': dict({
-      }),
-      'zoneKey': 'GB',
-    }),
-    dict({
-      'correctedModes': list([
-      ]),
-      'datetime': datetime.datetime(2022, 7, 15, 23, 30, tzinfo=datetime.timezone.utc),
-      'end_datetime': None,
-      'production': dict({
-        'wind': 7656.0,
-      }),
-      'source': 'neso.energy',
-      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
-      'storage': dict({
-      }),
-      'zoneKey': 'GB',
-    }),
-    dict({
-      'correctedModes': list([
-      ]),
-      'datetime': datetime.datetime(2022, 7, 16, 0, 0, tzinfo=datetime.timezone.utc),
-      'end_datetime': None,
-      'production': dict({
-        'wind': 7736.0,
-      }),
-      'source': 'neso.energy',
-      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
-      'storage': dict({
-      }),
-      'zoneKey': 'GB',
-    }),
-  ])
-# ---
 # name: test_fetch_wind_solar_forecasts_day_ahead_live
   list([
     dict({

--- a/electricitymap/contrib/parsers/tests/mocks/GB/wind_day_ahead_forecast_historical.json
+++ b/electricitymap/contrib/parsers/tests/mocks/GB/wind_day_ahead_forecast_historical.json
@@ -1,0 +1,35 @@
+{
+  "help": "Mock NESO historic day-ahead wind forecast data",
+  "success": true,
+  "result": {
+    "records": [
+      {
+        "_id": 100,
+        "Datetime_GMT": "2022-07-15T23:00:00",
+        "Date": "2022-07-16",
+        "Settlement_period": 1,
+        "Capacity": 15594,
+        "Incentive_forecast": 7523,
+        "Forecast_Timestamp": "2022-07-16T08:45:00"
+      },
+      {
+        "_id": 101,
+        "Datetime_GMT": "2022-07-15T23:30:00",
+        "Date": "2022-07-16",
+        "Settlement_period": 2,
+        "Capacity": 15594,
+        "Incentive_forecast": 7656,
+        "Forecast_Timestamp": "2022-07-16T08:45:00"
+      },
+      {
+        "_id": 102,
+        "Datetime_GMT": "2022-07-16T00:00:00",
+        "Date": "2022-07-16",
+        "Settlement_period": 3,
+        "Capacity": 15594,
+        "Incentive_forecast": 7736,
+        "Forecast_Timestamp": "2022-07-16T08:45:00"
+      }
+    ]
+  }
+}

--- a/electricitymap/contrib/parsers/tests/mocks/GB/wind_day_ahead_forecast_live.json
+++ b/electricitymap/contrib/parsers/tests/mocks/GB/wind_day_ahead_forecast_live.json
@@ -1,0 +1,32 @@
+{
+  "help": "Mock NESO live day-ahead wind forecast data",
+  "success": true,
+  "result": {
+    "records": [
+      {
+        "_id": 1,
+        "Datetime_GMT": "2024-12-16T23:00:00",
+        "Date": "2024-12-17",
+        "Settlement_period": 1,
+        "Capacity": 24472,
+        "Incentive_forecast": 2732
+      },
+      {
+        "_id": 2,
+        "Datetime_GMT": "2024-12-16T23:30:00",
+        "Date": "2024-12-17",
+        "Settlement_period": 2,
+        "Capacity": 24472,
+        "Incentive_forecast": 2796
+      },
+      {
+        "_id": 3,
+        "Datetime_GMT": "2024-12-17T00:00:00",
+        "Date": "2024-12-17",
+        "Settlement_period": 3,
+        "Capacity": 24472,
+        "Incentive_forecast": 2882
+      }
+    ]
+  }
+}

--- a/electricitymap/contrib/parsers/tests/test_GB.py
+++ b/electricitymap/contrib/parsers/tests/test_GB.py
@@ -106,9 +106,7 @@ def test_fetch_wind_solar_forecasts_day_ahead_live(requests_mock, session, snaps
     )
 
 
-def test_fetch_wind_forecasts_day_ahead_historical(
-    requests_mock, session, snapshot
-):
+def test_fetch_wind_forecasts_day_ahead_historical(requests_mock, session, snapshot):
     gb_mock = resources.files("electricitymap.contrib.parsers.tests.mocks.GB")
     requests_mock.register_uri(
         GET,

--- a/electricitymap/contrib/parsers/tests/test_GB.py
+++ b/electricitymap/contrib/parsers/tests/test_GB.py
@@ -17,7 +17,7 @@ from electricitymap.contrib.parsers.GB import (
     NESO_API,
     fetch_price,
     fetch_production,
-    fetch_wind_solar_forecasts_day_ahead,
+    fetch_wind_forecasts_day_ahead,
 )
 from electricitymap.contrib.types import ZoneKey
 
@@ -100,13 +100,13 @@ def test_fetch_wind_solar_forecasts_day_ahead_live(requests_mock, session, snaps
         ),
     )
 
-    assert snapshot == fetch_wind_solar_forecasts_day_ahead(
+    assert snapshot == fetch_wind_forecasts_day_ahead(
         zone_key=ZoneKey("GB"),
         session=session,
     )
 
 
-def test_fetch_wind_solar_forecasts_day_ahead_historical(
+def test_fetch_wind_forecasts_day_ahead_historical(
     requests_mock, session, snapshot
 ):
     gb_mock = resources.files("electricitymap.contrib.parsers.tests.mocks.GB")
@@ -119,7 +119,7 @@ def test_fetch_wind_solar_forecasts_day_ahead_historical(
     )
 
     historical_datetime = datetime(2022, 7, 16, 12, tzinfo=timezone.utc)
-    assert snapshot == fetch_wind_solar_forecasts_day_ahead(
+    assert snapshot == fetch_wind_forecasts_day_ahead(
         zone_key=ZoneKey("GB"),
         session=session,
         target_datetime=historical_datetime,

--- a/electricitymap/contrib/parsers/tests/test_GB.py
+++ b/electricitymap/contrib/parsers/tests/test_GB.py
@@ -14,8 +14,10 @@ from electricitymap.contrib.parsers.GB import (
     ELEXON_MELS_STREAM,
     ELEXON_MILS_STREAM,
     ELEXON_PN_STREAM,
+    NESO_API,
     fetch_price,
     fetch_production,
+    fetch_wind_solar_forecasts_day_ahead,
 )
 from electricitymap.contrib.types import ZoneKey
 
@@ -84,4 +86,41 @@ def test_fetch_production(requests_mock, session, snapshot):
     assert snapshot == fetch_production(
         zone_key=ZoneKey("GB"),
         session=session,
+    )
+
+
+@freeze_time("2024-12-16 12:00:00")
+def test_fetch_wind_solar_forecasts_day_ahead_live(requests_mock, session, snapshot):
+    gb_mock = resources.files("electricitymap.contrib.parsers.tests.mocks.GB")
+    requests_mock.register_uri(
+        GET,
+        NESO_API,
+        json=json.loads(
+            gb_mock.joinpath("wind_day_ahead_forecast_live.json").read_text()
+        ),
+    )
+
+    assert snapshot == fetch_wind_solar_forecasts_day_ahead(
+        zone_key=ZoneKey("GB"),
+        session=session,
+    )
+
+
+def test_fetch_wind_solar_forecasts_day_ahead_historical(
+    requests_mock, session, snapshot
+):
+    gb_mock = resources.files("electricitymap.contrib.parsers.tests.mocks.GB")
+    requests_mock.register_uri(
+        GET,
+        NESO_API,
+        json=json.loads(
+            gb_mock.joinpath("wind_day_ahead_forecast_historical.json").read_text()
+        ),
+    )
+
+    historical_datetime = datetime(2022, 7, 16, 12, tzinfo=timezone.utc)
+    assert snapshot == fetch_wind_solar_forecasts_day_ahead(
+        zone_key=ZoneKey("GB"),
+        session=session,
+        target_datetime=historical_datetime,
     )


### PR DESCRIPTION
## Issue

Parsing GB day ahead forecasts for wind. Unfortunately solar cannot be parsed from this source.

### Double check

- [ ] I have tested my parser changes locally with `uv run test_parser "zone_key"`
- [ ] I have run `pnpx prettier@2 --write .` and `uv run format` in the top level directory to format my changes.