### PR TITLE
feat(GB): parse consumption forecasts

### DIFF
--- a/config/zones/GB.yaml
+++ b/config/zones/GB.yaml
@@ -539,7 +539,7 @@ isRenewable:
       value: 0.5929
 parsers:
   consumption: ELEXON.fetch_consumption
-  consumptionForecast: ENTSOE.fetch_consumption_forecast
+  consumptionForecast: GB.fetch_consumption_forecast
   generationForecast: ENTSOE.fetch_generation_forecast
   price: NORDPOOL.fetch_price
   production: GB.fetch_production

--- a/electricitymap/contrib/parsers/GB.py
+++ b/electricitymap/contrib/parsers/GB.py
@@ -22,6 +22,7 @@ from requests import Response, Session
 from electricitymap.contrib.lib.models.event_lists import (
     PriceList,
     ProductionBreakdownList,
+    TotalConsumptionList,
 )
 from electricitymap.contrib.lib.models.events import (
     EventSourceType,
@@ -43,6 +44,17 @@ NESO_GENERATION_DATASET_ID = "f93d1835-75bc-43e5-84ad-12472b180a98"
 NESO_WIND_DAY_AHEAD_FORECAST_DATASET_ID = "b2f03146-f05d-4824-a663-3a4f36090c71"
 # "Historic Day Ahead Wind Forecasts": archive of past forecasts, lags the live dataset by about a day.
 NESO_WIND_DAY_AHEAD_FORECAST_HISTORY_DATASET_ID = "7524ec65-f782-4258-aaf8-5b926c17b966"
+# https://www.neso.energy/data-portal/2-14-days-ahead-national-demand-forecast
+# "2-14 Days Ahead Half Hourly Forecast": rolling ~14-day-ahead window holding only the
+# latest published forecast, at half-hourly granularity.
+NESO_DEMAND_HALF_HOURLY_FORECAST_DATASET_ID = "7c0411cd-2714-4bb5-a408-adb065edf34d"
+# https://www.neso.energy/data-portal/day-ahead-half-hourly-demand-forecast-performance
+# "Day Ahead Half Hourly Demand Forecast Performance": historic half-hourly day-ahead (D+1)
+# forecasts (alongside outturn/error metrics we don't use) since April 2021. Used as the
+# historical fallback since the 2-14 day forecast has no matching half-hourly archive.
+NESO_DEMAND_DAY_AHEAD_HALF_HOURLY_PERFORMANCE_DATASET_ID = (
+    "08e41551-80f8-4e28-a416-ea473a695db9"
+)
 
 ELEXON_BMU_UNITS = "https://data.elexon.co.uk/bmrs/api/v1/reference/bmunits/all"
 ELEXON_PN_STREAM = "https://data.elexon.co.uk/bmrs/api/v1/datasets/PN/stream"
@@ -216,6 +228,68 @@ def fetch_wind_forecasts_day_ahead(
         )
 
     return production_list.to_list()
+
+
+@refetch_frequency(timedelta(days=1))
+def fetch_consumption_forecast(
+    zone_key: ZoneKey = ZONE_KEY,
+    session: Session | None = None,
+    target_datetime: datetime | None = None,
+    logger: Logger = getLogger(__name__),
+) -> list[dict]:
+    """Requests the NESO national demand forecast at half-hourly granularity.
+
+    Uses the live "2-14 Days Ahead Half Hourly Forecast" dataset, which only
+    exposes the latest published forecast (a rolling ~14-day-ahead window).
+    Requests for a specific target_datetime instead use NESO's "Day Ahead
+    Half Hourly Demand Forecast Performance" archive: it only covers the
+    1-day-ahead horizon, but keeps the same half-hourly granularity as the
+    live dataset (the 2-14 day forecast has no matching half-hourly archive).
+    """
+    session = session or Session()
+
+    if target_datetime is None:
+        sql_query = f"""SELECT * FROM "{NESO_DEMAND_HALF_HOURLY_FORECAST_DATASET_ID}" ORDER BY "GDATETIME" ASC"""
+    else:
+        target_date = target_datetime.astimezone(TIMEZONE).date()
+        start_date = target_date - timedelta(days=1)
+        end_date = target_date + timedelta(days=1)
+        sql_query = f"""SELECT * FROM "{NESO_DEMAND_DAY_AHEAD_HALF_HOURLY_PERFORMANCE_DATASET_ID}" WHERE "Datetime" >= '{start_date.strftime("%Y-%m-%d")}' AND "Datetime" <= '{end_date.strftime("%Y-%m-%d")}' ORDER BY "Datetime" ASC"""
+
+    res: Response = session.get(NESO_API, params={"sql": sql_query})
+    if not res.ok:
+        raise ParserException(
+            PARSER,
+            f"Exception when fetching consumption forecast error code: {res.status_code}: {res.text}",
+            zone_key,
+        )
+
+    records = res.json()["result"]["records"]
+    if not records:
+        raise ParserException(
+            PARSER,
+            "No consumption forecast data found",
+            zone_key,
+        )
+
+    consumption_list = TotalConsumptionList(logger)
+    for row in records:
+        if target_datetime is None:
+            dt = datetime.fromisoformat(row["GDATETIME"]).replace(tzinfo=timezone.utc)
+            value = row["NATIONALDEMAND"]
+        else:
+            dt = datetime.fromisoformat(row["Datetime"]).replace(tzinfo=TIMEZONE)
+            value = row["Demand_Forecast"]
+
+        consumption_list.append(
+            zoneKey=zone_key,
+            datetime=dt,
+            source="neso.energy",
+            consumption=float(value),
+            sourceType=EventSourceType.forecasted,
+        )
+
+    return consumption_list.to_list()
 
 
 @refetch_frequency(timedelta(hours=72))

--- a/electricitymap/contrib/parsers/tests/__snapshots__/test_GB.ambr
+++ b/electricitymap/contrib/parsers/tests/__snapshots__/test_GB.ambr
@@ -1,4 +1,108 @@
 # serializer version: 1
+# name: test_fetch_consumption_forecast_historical
+  list([
+    dict({
+      'consumption': 20902.0,
+      'datetime': datetime.datetime(2026, 7, 17, 5, 30, tzinfo=zoneinfo.ZoneInfo(key='Europe/London')),
+      'end_datetime': None,
+      'source': 'neso.energy',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'zoneKey': 'GB',
+    }),
+    dict({
+      'consumption': 20951.0,
+      'datetime': datetime.datetime(2026, 7, 17, 6, 0, tzinfo=zoneinfo.ZoneInfo(key='Europe/London')),
+      'end_datetime': None,
+      'source': 'neso.energy',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'zoneKey': 'GB',
+    }),
+    dict({
+      'consumption': 22373.0,
+      'datetime': datetime.datetime(2026, 7, 17, 6, 30, tzinfo=zoneinfo.ZoneInfo(key='Europe/London')),
+      'end_datetime': None,
+      'source': 'neso.energy',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'zoneKey': 'GB',
+    }),
+    dict({
+      'consumption': 23098.0,
+      'datetime': datetime.datetime(2026, 7, 17, 7, 0, tzinfo=zoneinfo.ZoneInfo(key='Europe/London')),
+      'end_datetime': None,
+      'source': 'neso.energy',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'zoneKey': 'GB',
+    }),
+    dict({
+      'consumption': 24147.0,
+      'datetime': datetime.datetime(2026, 7, 17, 7, 30, tzinfo=zoneinfo.ZoneInfo(key='Europe/London')),
+      'end_datetime': None,
+      'source': 'neso.energy',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'zoneKey': 'GB',
+    }),
+    dict({
+      'consumption': 24310.0,
+      'datetime': datetime.datetime(2026, 7, 17, 8, 0, tzinfo=zoneinfo.ZoneInfo(key='Europe/London')),
+      'end_datetime': None,
+      'source': 'neso.energy',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'zoneKey': 'GB',
+    }),
+  ])
+# ---
+# name: test_fetch_consumption_forecast_live
+  list([
+    dict({
+      'consumption': 20289.0,
+      'datetime': FakeDatetime(2026, 7, 31, 13, 30, tzinfo=datetime.timezone.utc),
+      'end_datetime': None,
+      'source': 'neso.energy',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'zoneKey': 'GB',
+    }),
+    dict({
+      'consumption': 20099.0,
+      'datetime': FakeDatetime(2026, 7, 31, 14, 0, tzinfo=datetime.timezone.utc),
+      'end_datetime': None,
+      'source': 'neso.energy',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'zoneKey': 'GB',
+    }),
+    dict({
+      'consumption': 20663.0,
+      'datetime': FakeDatetime(2026, 7, 31, 14, 30, tzinfo=datetime.timezone.utc),
+      'end_datetime': None,
+      'source': 'neso.energy',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'zoneKey': 'GB',
+    }),
+    dict({
+      'consumption': 20747.0,
+      'datetime': FakeDatetime(2026, 7, 31, 15, 0, tzinfo=datetime.timezone.utc),
+      'end_datetime': None,
+      'source': 'neso.energy',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'zoneKey': 'GB',
+    }),
+    dict({
+      'consumption': 21203.0,
+      'datetime': FakeDatetime(2026, 7, 31, 15, 30, tzinfo=datetime.timezone.utc),
+      'end_datetime': None,
+      'source': 'neso.energy',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'zoneKey': 'GB',
+    }),
+    dict({
+      'consumption': 22465.0,
+      'datetime': FakeDatetime(2026, 7, 31, 16, 0, tzinfo=datetime.timezone.utc),
+      'end_datetime': None,
+      'source': 'neso.energy',
+      'sourceType': <EventSourceType.forecasted: 'forecasted'>,
+      'zoneKey': 'GB',
+    }),
+  ])
+# ---
 # name: test_fetch_price_historical
   list([
     dict({

--- a/electricitymap/contrib/parsers/tests/mocks/GB/consumption_forecast_historical.json
+++ b/electricitymap/contrib/parsers/tests/mocks/GB/consumption_forecast_historical.json
@@ -1,0 +1,92 @@
+{
+  "help": "Mock NESO day ahead half hourly demand forecast performance data",
+  "success": true,
+  "result": {
+    "records": [
+      {
+        "_id": 92793,
+        "Month": "Jul",
+        "Date": "2026-07-17",
+        "Datetime": "2026-07-17T05:30:00",
+        "Settlement_Period": 11,
+        "Demand_Forecast": 20902,
+        "Demand_Outturn": 20415,
+        "TRIAD_Avoidance_Estimate": 0,
+        "TRIAD_Avoidance_Corrected_Demand_Outturn": 20415,
+        "APE": 2.385500857,
+        "Absolute_Error": 487,
+        "Publish_Datetime": "2026-07-16T08:33:00"
+      },
+      {
+        "_id": 92794,
+        "Month": "Jul",
+        "Date": "2026-07-17",
+        "Datetime": "2026-07-17T06:00:00",
+        "Settlement_Period": 12,
+        "Demand_Forecast": 20951,
+        "Demand_Outturn": 20640,
+        "TRIAD_Avoidance_Estimate": 0,
+        "TRIAD_Avoidance_Corrected_Demand_Outturn": 20640,
+        "APE": 1.506782945,
+        "Absolute_Error": 311,
+        "Publish_Datetime": "2026-07-16T08:33:00"
+      },
+      {
+        "_id": 92795,
+        "Month": "Jul",
+        "Date": "2026-07-17",
+        "Datetime": "2026-07-17T06:30:00",
+        "Settlement_Period": 13,
+        "Demand_Forecast": 22373,
+        "Demand_Outturn": 22096,
+        "TRIAD_Avoidance_Estimate": 0,
+        "TRIAD_Avoidance_Corrected_Demand_Outturn": 22096,
+        "APE": 1.253620564,
+        "Absolute_Error": 277,
+        "Publish_Datetime": "2026-07-16T08:33:00"
+      },
+      {
+        "_id": 92796,
+        "Month": "Jul",
+        "Date": "2026-07-17",
+        "Datetime": "2026-07-17T07:00:00",
+        "Settlement_Period": 14,
+        "Demand_Forecast": 23098,
+        "Demand_Outturn": 22845,
+        "TRIAD_Avoidance_Estimate": 0,
+        "TRIAD_Avoidance_Corrected_Demand_Outturn": 22845,
+        "APE": 1.107463339,
+        "Absolute_Error": 253,
+        "Publish_Datetime": "2026-07-16T08:33:00"
+      },
+      {
+        "_id": 92797,
+        "Month": "Jul",
+        "Date": "2026-07-17",
+        "Datetime": "2026-07-17T07:30:00",
+        "Settlement_Period": 15,
+        "Demand_Forecast": 24147,
+        "Demand_Outturn": 24606,
+        "TRIAD_Avoidance_Estimate": 0,
+        "TRIAD_Avoidance_Corrected_Demand_Outturn": 24606,
+        "APE": 1.865398683,
+        "Absolute_Error": 459,
+        "Publish_Datetime": "2026-07-16T08:33:00"
+      },
+      {
+        "_id": 92798,
+        "Month": "Jul",
+        "Date": "2026-07-17",
+        "Datetime": "2026-07-17T08:00:00",
+        "Settlement_Period": 16,
+        "Demand_Forecast": 24310,
+        "Demand_Outturn": 24915,
+        "TRIAD_Avoidance_Estimate": 0,
+        "TRIAD_Avoidance_Corrected_Demand_Outturn": 24915,
+        "APE": 2.42825607,
+        "Absolute_Error": 605,
+        "Publish_Datetime": "2026-07-16T08:33:00"
+      }
+    ]
+  }
+}

--- a/electricitymap/contrib/parsers/tests/mocks/GB/consumption_forecast_live.json
+++ b/electricitymap/contrib/parsers/tests/mocks/GB/consumption_forecast_live.json
@@ -1,0 +1,50 @@
+{
+  "help": "Mock NESO live 2-14 days ahead half hourly demand forecast data",
+  "success": true,
+  "result": {
+    "records": [
+      {
+        "_id": 605,
+        "DATE": "2026-07-31",
+        "CTIME": 1430,
+        "GDATETIME": "2026-07-31T13:30:00",
+        "NATIONALDEMAND": 20289
+      },
+      {
+        "_id": 606,
+        "DATE": "2026-07-31",
+        "CTIME": 1500,
+        "GDATETIME": "2026-07-31T14:00:00",
+        "NATIONALDEMAND": 20099
+      },
+      {
+        "_id": 607,
+        "DATE": "2026-07-31",
+        "CTIME": 1530,
+        "GDATETIME": "2026-07-31T14:30:00",
+        "NATIONALDEMAND": 20663
+      },
+      {
+        "_id": 608,
+        "DATE": "2026-07-31",
+        "CTIME": 1600,
+        "GDATETIME": "2026-07-31T15:00:00",
+        "NATIONALDEMAND": 20747
+      },
+      {
+        "_id": 609,
+        "DATE": "2026-07-31",
+        "CTIME": 1630,
+        "GDATETIME": "2026-07-31T15:30:00",
+        "NATIONALDEMAND": 21203
+      },
+      {
+        "_id": 610,
+        "DATE": "2026-07-31",
+        "CTIME": 1700,
+        "GDATETIME": "2026-07-31T16:00:00",
+        "NATIONALDEMAND": 22465
+      }
+    ]
+  }
+}

--- a/electricitymap/contrib/parsers/tests/test_GB.py
+++ b/electricitymap/contrib/parsers/tests/test_GB.py
@@ -131,9 +131,7 @@ def test_fetch_consumption_forecast_live(requests_mock, session, snapshot):
     requests_mock.register_uri(
         GET,
         NESO_API,
-        json=json.loads(
-            gb_mock.joinpath("consumption_forecast_live.json").read_text()
-        ),
+        json=json.loads(gb_mock.joinpath("consumption_forecast_live.json").read_text()),
     )
 
     assert snapshot == fetch_consumption_forecast(

--- a/electricitymap/contrib/parsers/tests/test_GB.py
+++ b/electricitymap/contrib/parsers/tests/test_GB.py
@@ -15,6 +15,7 @@ from electricitymap.contrib.parsers.GB import (
     ELEXON_MILS_STREAM,
     ELEXON_PN_STREAM,
     NESO_API,
+    fetch_consumption_forecast,
     fetch_price,
     fetch_production,
     fetch_wind_forecasts_day_ahead,
@@ -118,6 +119,41 @@ def test_fetch_wind_forecasts_day_ahead_historical(requests_mock, session, snaps
 
     historical_datetime = datetime(2022, 7, 16, 12, tzinfo=timezone.utc)
     assert snapshot == fetch_wind_forecasts_day_ahead(
+        zone_key=ZoneKey("GB"),
+        session=session,
+        target_datetime=historical_datetime,
+    )
+
+
+@freeze_time("2024-12-16 12:00:00")
+def test_fetch_consumption_forecast_live(requests_mock, session, snapshot):
+    gb_mock = resources.files("electricitymap.contrib.parsers.tests.mocks.GB")
+    requests_mock.register_uri(
+        GET,
+        NESO_API,
+        json=json.loads(
+            gb_mock.joinpath("consumption_forecast_live.json").read_text()
+        ),
+    )
+
+    assert snapshot == fetch_consumption_forecast(
+        zone_key=ZoneKey("GB"),
+        session=session,
+    )
+
+
+def test_fetch_consumption_forecast_historical(requests_mock, session, snapshot):
+    gb_mock = resources.files("electricitymap.contrib.parsers.tests.mocks.GB")
+    requests_mock.register_uri(
+        GET,
+        NESO_API,
+        json=json.loads(
+            gb_mock.joinpath("consumption_forecast_historical.json").read_text()
+        ),
+    )
+
+    historical_datetime = datetime(2026, 7, 17, 12, tzinfo=timezone.utc)
+    assert snapshot == fetch_consumption_forecast(
         zone_key=ZoneKey("GB"),
         session=session,
         target_datetime=historical_datetime,


### PR DESCRIPTION
## Description

Parse GB consumption forecasts from NESO.
For historical lookback we need to parse it from another dataset which limits the forecast to day ahead horizon. Unfortunately at the moment there isn't a historical overview of the forecasts that were made.

### Preview

<!-- Please add screenshots and/or gif that shows visual changes (if applicable) -->

### Double check

- [ ] I have tested my parser changes locally with `uv run test_parser "zone_key"`
- [ ] I have run `pnpx prettier@2 --write .` and `uv run format` in the top level directory to format my changes.
