### PR TITLE
Add GB↔GB-ZET exchange config for Shetland HVDC link

### DIFF
--- a/config/exchanges/GB_GB-ZET.yaml
+++ b/config/exchanges/GB_GB-ZET.yaml
@@ -1,0 +1,8 @@
+_comment: 600MW Shetland HVDC Link (SSEN Transmission) https://www.ofgem.gov.uk/sites/default/files/2021-11/Shetland%20Link%20Project%20Assessment%20Decision%20FINAL.pdf
+capacity:
+  - -600
+  - 600
+lonlat:
+  - -2.2
+  - 59.35
+rotation: 45


### PR DESCRIPTION
## Summary

* Adds `config/exchanges/GB_GB-ZET.yaml` for the Shetland HVDC Link between mainland Great Britain (`GB`) and the Shetland Islands (`GB-ZET`).
* Sets bidirectional capacity to **600 MW**, matching the SSEN Transmission / Ofgem-approved Shetland HVDC Link rating.
* Addresses the filename feedback from [#7534](<https://github.com/electricitymaps/electricitymaps-contrib/issues/7534>) (`GB_GB-ZET.yaml`, not `GB_ZET.yaml`).

## Capacity source

* Ofgem Shetland HVDC Link Project Assessment Decision (2021): +/-320kV **600MW** HVDC single circuit between Upper Kergord/Weisdale Voe (Shetland) and Noss Head (Caithness)
  * [https://www.ofgem.gov.uk/sites/default/files/2021-11/Shetland%20Link%20Project%20Assessment%20Decision%20FINAL.pdf](<https://www.ofgem.gov.uk/sites/default/files/2021-11/Shetland%20Link%20Project%20Assessment%20Decision%20FINAL.pdf>)
* SSEN Transmission project page: [https://www.ssen-transmission.co.uk/projects/project-map/shetland/](<https://www.ssen-transmission.co.uk/projects/project-map/shetland/>)

## Notes

* No live exchange parser is included: Elexon/BMRS interconnector feeds cover international links (FR, BE, NL, NO, IE), not this domestic SSEN transmission asset. This matches other capacity-only exchange configs in the repo (e.g. `FR_JE`, `AX_SE`, `IT_MT`).
* Lonlat is placed roughly midway on the subsea route; rotation points toward `GB-ZET` for positive `GB→GB-ZET` flow.

Fixes electricitymaps/electricitymaps-contrib#7269

## Test plan

- [X] Config loads as `GB->GB-ZET` via `EXCHANGES_CONFIG` / `CONFIG_MODEL`
- [X] `uv run python -m unittest tests.test_exchanges_json -v`
- [ ] Visual check of exchange arrow on map (staging / local web if available)


### AI/LLM disclosure

* AI coding tools (including Cursor agent-assisted editing) were used to help draft or modify code and this PR description.
* I reviewed the complete change, understand the reasoning, and ran the reported local tests before submitting.
* This submission is original work of authorship under the project CLA / contributor terms; AI output was not pasted unreviewed.
