### PR TITLE
fix(ENTSOE): resolve FTC domains via override table, enable 11 borders

### DIFF
--- a/config/exchanges/AT_CZ.yaml
+++ b/config/exchanges/AT_CZ.yaml
@@ -3,6 +3,8 @@ lonlat:
   - 48.909846
 parsers:
   exchange: CZ.fetch_exchange
+  exchangeCapacityForecastWeekAhead: ENTSOE.fetch_exchange_capacity_forecasts_week_ahead
+  exchangeCapacityForecastMonthAhead: ENTSOE.fetch_exchange_capacity_forecasts_month_ahead
   atcDayAhead: JAO.fetch_shadow_auction_atc_day_ahead
   maxBexDayAhead: JAO.fetch_core_max_bex_day_ahead
   scheduledExchangesDayAhead: JAO.fetch_core_scheduled_exchanges_day_ahead

--- a/config/exchanges/CZ_PL.yaml
+++ b/config/exchanges/CZ_PL.yaml
@@ -3,6 +3,7 @@ lonlat:
   - 50.269487
 parsers:
   exchange: CZ.fetch_exchange
+  exchangeCapacityForecastMonthAhead: ENTSOE.fetch_exchange_capacity_forecasts_month_ahead
   atcDayAhead: JAO.fetch_shadow_auction_atc_day_ahead
   maxBexDayAhead: JAO.fetch_core_max_bex_day_ahead
   scheduledExchangesDayAhead: JAO.fetch_core_scheduled_exchanges_day_ahead

--- a/config/exchanges/CZ_SK.yaml
+++ b/config/exchanges/CZ_SK.yaml
@@ -3,6 +3,7 @@ lonlat:
   - 49.089498
 parsers:
   exchange: CZ.fetch_exchange
+  exchangeCapacityForecastMonthAhead: ENTSOE.fetch_exchange_capacity_forecasts_month_ahead
   atcDayAhead: JAO.fetch_shadow_auction_atc_day_ahead
   maxBexDayAhead: JAO.fetch_core_max_bex_day_ahead
   scheduledExchangesDayAhead: JAO.fetch_core_scheduled_exchanges_day_ahead

--- a/config/exchanges/DE_DK-DK1.yaml
+++ b/config/exchanges/DE_DK-DK1.yaml
@@ -3,6 +3,9 @@ lonlat:
   - 54.9
 parsers:
   exchange: DK.fetch_exchange
+  exchangeCapacityForecastDayAhead: ENTSOE.fetch_exchange_capacity_forecasts_day_ahead
+  exchangeCapacityForecastWeekAhead: ENTSOE.fetch_exchange_capacity_forecasts_week_ahead
+  exchangeCapacityForecastMonthAhead: ENTSOE.fetch_exchange_capacity_forecasts_month_ahead
   atcDayAhead: JAO.fetch_core_external_atc_day_ahead
   maxBexDayAhead: JAO.fetch_nordic_max_bex_day_ahead
   scheduledExchangesDayAhead: JAO.fetch_core_scheduled_exchanges_day_ahead

--- a/config/exchanges/DE_DK-DK2.yaml
+++ b/config/exchanges/DE_DK-DK2.yaml
@@ -6,6 +6,8 @@ lonlat:
   - 54.486043
 parsers:
   exchange: DK.fetch_exchange
+  exchangeCapacityForecastWeekAhead: ENTSOE.fetch_exchange_capacity_forecasts_week_ahead
+  exchangeCapacityForecastMonthAhead: ENTSOE.fetch_exchange_capacity_forecasts_month_ahead
   atcDayAhead: NORDPOOL.fetch_exchange_available_transfer_capacity
   maxBexDayAhead: JAO.fetch_nordic_max_bex_day_ahead
   scheduledExchangesDayAhead: JAO.fetch_core_scheduled_exchanges_day_ahead

--- a/config/exchanges/DK-DK1_NL.yaml
+++ b/config/exchanges/DK-DK1_NL.yaml
@@ -7,6 +7,9 @@ lonlat:
   - 54.5
 parsers:
   exchange: DK.fetch_exchange
+  exchangeCapacityForecastDayAhead: ENTSOE.fetch_exchange_capacity_forecasts_day_ahead
+  exchangeCapacityForecastWeekAhead: ENTSOE.fetch_exchange_capacity_forecasts_week_ahead
+  exchangeCapacityForecastMonthAhead: ENTSOE.fetch_exchange_capacity_forecasts_month_ahead
   atcDayAhead: JAO.fetch_core_external_atc_day_ahead
   maxBexDayAhead: JAO.fetch_nordic_max_bex_day_ahead
   scheduledExchangesDayAhead: JAO.fetch_core_scheduled_exchanges_day_ahead

--- a/config/exchanges/DK-DK1_NO-NO2.yaml
+++ b/config/exchanges/DK-DK1_NO-NO2.yaml
@@ -6,6 +6,8 @@ lonlat:
   - 57.7
 parsers:
   exchange: DK.fetch_exchange
+  exchangeCapacityForecastWeekAhead: ENTSOE.fetch_exchange_capacity_forecasts_week_ahead
+  exchangeCapacityForecastMonthAhead: ENTSOE.fetch_exchange_capacity_forecasts_month_ahead
   atcDayAhead: NORDPOOL.fetch_exchange_available_transfer_capacity
   maxBexDayAhead: JAO.fetch_nordic_max_bex_day_ahead
   scheduledExchangesDayAhead: ENTSOE.fetch_scheduled_exchanges_day_ahead

--- a/config/exchanges/FR_GB.yaml
+++ b/config/exchanges/FR_GB.yaml
@@ -6,6 +6,9 @@ lonlat:
   - 50.4
 parsers:
   exchange: ELEXON.fetch_exchange
+  exchangeCapacityForecastDayAhead: ENTSOE.fetch_exchange_capacity_forecasts_day_ahead
+  exchangeCapacityForecastWeekAhead: ENTSOE.fetch_exchange_capacity_forecasts_week_ahead
+  exchangeCapacityForecastMonthAhead: ENTSOE.fetch_exchange_capacity_forecasts_month_ahead
   atcDayAhead: JAO_Auctions.fetch_auction_atc_day_ahead
   scheduledExchangesDayAhead: ENTSOE.fetch_scheduled_exchanges_day_ahead
   scheduledExchangesTotal: ENTSOE.fetch_scheduled_exchanges_total

--- a/config/exchanges/GB_GB-NIR.yaml
+++ b/config/exchanges/GB_GB-NIR.yaml
@@ -6,4 +6,5 @@ lonlat:
   - 54.87826
 parsers:
   exchange: SMARTGRIDDASHBOARD.fetch_exchange
+  exchangeCapacityForecastDayAhead: ENTSOE.fetch_exchange_capacity_forecasts_day_ahead
 rotation: -110

--- a/config/exchanges/GB_IE.yaml
+++ b/config/exchanges/GB_IE.yaml
@@ -6,6 +6,7 @@ lonlat:
   - 53
 parsers:
   exchange: ELEXON.fetch_exchange
+  exchangeCapacityForecastDayAhead: ENTSOE.fetch_exchange_capacity_forecasts_day_ahead
   scheduledExchangesDayAhead: ENTSOE.fetch_scheduled_exchanges_day_ahead
   scheduledExchangesTotal: ENTSOE.fetch_scheduled_exchanges_total
   exchangeForecast: ENTSOE.fetch_exchange_forecast

--- a/config/exchanges/GB_NL.yaml
+++ b/config/exchanges/GB_NL.yaml
@@ -6,6 +6,9 @@ lonlat:
   - 52.4
 parsers:
   exchange: ELEXON.fetch_exchange
+  exchangeCapacityForecastDayAhead: ENTSOE.fetch_exchange_capacity_forecasts_day_ahead
+  exchangeCapacityForecastWeekAhead: ENTSOE.fetch_exchange_capacity_forecasts_week_ahead
+  exchangeCapacityForecastMonthAhead: ENTSOE.fetch_exchange_capacity_forecasts_month_ahead
   scheduledExchangesDayAhead: ENTSOE.fetch_scheduled_exchanges_day_ahead
   scheduledExchangesTotal: ENTSOE.fetch_scheduled_exchanges_total
   exchangeForecast: ENTSOE.fetch_exchange_forecast

--- a/electricitymap/contrib/parsers/ENTSOE.py
+++ b/electricitymap/contrib/parsers/ENTSOE.py
@@ -1810,19 +1810,20 @@ def fetch_wind_solar_forecasts_current(
     ).to_list()
 
 
-def _fetch_forecast_transfer_capacity(
-    zone_key1: ZoneKey,
-    zone_key2: ZoneKey,
+def _query_forecast_transfer_capacity_both_directions(
+    domain_a: str,
+    domain_b: str,
     forecast_type: EntsoeTypeEnum,
     session: Session,
     target_datetime: datetime | None,
+    sorted_zone_keys: ZoneKey,
     logger: Logger,
-) -> list[dict]:
-    """Shared logic for all 3 type-specific fetch functions."""
-    sorted_zone_keys = ZoneKey("->".join(sorted([zone_key1, zone_key2])))
-    domain_1 = ENTSOE_DOMAIN_MAPPINGS[zone_key1]
-    domain_2 = ENTSOE_DOMAIN_MAPPINGS[zone_key2]
+) -> tuple[str, str]:
+    """Query A61 for both directions of one domain pair, retrying on failure.
 
+    Returns `(raw_export, raw_import)` where "export" is the `domain_a` →
+    `domain_b` flow, i.e. the first-to-second direction of `sorted_zone_keys`.
+    """
     raw_export: str | None = None
     raw_import: str | None = None
     max_retries = 5
@@ -1830,8 +1831,8 @@ def _fetch_forecast_transfer_capacity(
     for attempt in range(1, max_retries + 1):
         if raw_export is None:
             raw_export = query_forecast_transfer_capacity(
-                domain_2,
-                domain_1,
+                domain_b,
+                domain_a,
                 session,
                 forecast_type,
                 target_datetime=target_datetime,
@@ -1839,8 +1840,8 @@ def _fetch_forecast_transfer_capacity(
             )
         if raw_import is None:
             raw_import = query_forecast_transfer_capacity(
-                domain_1,
-                domain_2,
+                domain_a,
+                domain_b,
                 session,
                 forecast_type,
                 target_datetime=target_datetime,
@@ -1862,12 +1863,86 @@ def _fetch_forecast_transfer_capacity(
             parser="ENTSOE.py",
             message=(
                 f"Failed to get both export and import exchange capacity forecast "
-                f"data for {sorted_zone_keys} after {max_retries} attempts. "
+                f"data for {sorted_zone_keys} ({domain_a} <-> {domain_b}) after "
+                f"{max_retries} attempts. "
                 f"export={'OK' if raw_export else 'MISSING'}, "
                 f"import={'OK' if raw_import else 'MISSING'}"
             ),
             zone_key=sorted_zone_keys,
         )
+
+    return raw_export, raw_import
+
+
+def _sum_forecast_transfer_capacities(
+    per_pair: list[ForecastTransferCapacityList],
+    sorted_zone_keys: ZoneKey,
+    market_agreement_type: MarketAgreementType,
+    logger: Logger,
+) -> ForecastTransferCapacityList:
+    """Sum capacities across the domain pairs of an aggregated border.
+
+    Borders served by several interconnectors (e.g. FR-COR↔IT-SAR via the
+    SACOAC and SACODC links) are published as one A61 document per link; the
+    border's capacity is their total. Mirrors `ExchangeList.merge_exchanges`,
+    which sums net flows for the same aggregated borders.
+    """
+    totals: dict[datetime, tuple[datetime | None, str, float | None, float | None]] = {}
+    for capacities in per_pair:
+        for event in capacities.events:
+            end_datetime, source, export_cap, import_cap = totals.get(
+                event.datetime, (event.end_datetime, event.source, None, None)
+            )
+            totals[event.datetime] = (
+                end_datetime,
+                source,
+                _add_optional(export_cap, event.capacityExport),
+                _add_optional(import_cap, event.capacityImport),
+            )
+
+    summed = ForecastTransferCapacityList(logger)
+    for dt in sorted(totals):
+        end_datetime, source, export_cap, import_cap = totals[dt]
+        summed.append(
+            zoneKey=sorted_zone_keys,
+            datetime=dt,
+            end_datetime=end_datetime,
+            source=source,
+            capacityExport=export_cap,
+            capacityImport=import_cap,
+            marketAgreementType=market_agreement_type,
+        )
+    return summed
+
+
+def _add_optional(a: float | None, b: float | None) -> float | None:
+    """Sum two capacities, treating a missing value as absent rather than zero."""
+    if a is None:
+        return b
+    if b is None:
+        return a
+    return a + b
+
+
+def _fetch_forecast_transfer_capacity(
+    zone_key1: ZoneKey,
+    zone_key2: ZoneKey,
+    forecast_type: EntsoeTypeEnum,
+    session: Session,
+    target_datetime: datetime | None,
+    logger: Logger,
+) -> list[dict]:
+    """Shared logic for all 3 type-specific fetch functions."""
+    zone_a, zone_b = sorted([zone_key1, zone_key2])
+    sorted_zone_keys = ZoneKey(f"{zone_a}->{zone_b}")
+    # A61 is published per bidding zone, so a number of borders are only
+    # available under a domain that differs from the zone's own EIC code — e.g.
+    # DE->DK-DK1 is published on DE-LU (10Y1001A1001A82H), not on the DE
+    # country domain (10Y1001A1001A83F). Resolve through the shared lookup
+    # chain instead of indexing ENTSOE_DOMAIN_MAPPINGS directly. Passing the
+    # sorted zones keeps the returned pairs ordered (zone_a, zone_b), which the
+    # export/import direction below depends on.
+    domain_pairs = _resolve_exchange_domain_pairs(zone_a, zone_b)
 
     # `EntsoeTypeEnum` values are ENTSOE wire codes (A01, A02) used in URL
     # params; `MarketAgreementType` values are the DB-friendly discriminator
@@ -1875,23 +1950,42 @@ def _fetch_forecast_transfer_capacity(
     # does. Raises KeyError loudly if an unsupported forecast_type ever reaches
     # here (e.g. INTRADAY, which is not a transfer-capacity contract type).
     market_agreement_type = MarketAgreementType[forecast_type.name]
-    export_list = parse_forecast_transfer_capacity(
-        raw_export,
-        sorted_zone_keys=sorted_zone_keys,
-        market_agreement_type=market_agreement_type,
-        logger=logger,
-        direction="export",
-    )
-    import_list = parse_forecast_transfer_capacity(
-        raw_import,
-        sorted_zone_keys=sorted_zone_keys,
-        market_agreement_type=market_agreement_type,
-        logger=logger,
-        direction="import",
-    )
 
-    return _merge_forecast_transfer_capacities(
-        export_list, import_list, market_agreement_type, logger
+    per_pair: list[ForecastTransferCapacityList] = []
+    for domain_a, domain_b in domain_pairs:
+        raw_export, raw_import = _query_forecast_transfer_capacity_both_directions(
+            domain_a,
+            domain_b,
+            forecast_type,
+            session,
+            target_datetime,
+            sorted_zone_keys,
+            logger,
+        )
+        export_list = parse_forecast_transfer_capacity(
+            raw_export,
+            sorted_zone_keys=sorted_zone_keys,
+            market_agreement_type=market_agreement_type,
+            logger=logger,
+            direction="export",
+        )
+        import_list = parse_forecast_transfer_capacity(
+            raw_import,
+            sorted_zone_keys=sorted_zone_keys,
+            market_agreement_type=market_agreement_type,
+            logger=logger,
+            direction="import",
+        )
+        per_pair.append(
+            _merge_forecast_transfer_capacities(
+                export_list, import_list, market_agreement_type, logger
+            )
+        )
+
+    if len(per_pair) == 1:
+        return per_pair[0].to_list()
+    return _sum_forecast_transfer_capacities(
+        per_pair, sorted_zone_keys, market_agreement_type, logger
     ).to_list()
 
 

--- a/electricitymap/contrib/parsers/ENTSOE.py
+++ b/electricitymap/contrib/parsers/ENTSOE.py
@@ -1894,7 +1894,10 @@ def _sum_forecast_transfer_capacities(
                 event.datetime, (event.end_datetime, event.source, None, None)
             )
             totals[event.datetime] = (
-                end_datetime,
+                # Keep the earliest end when links disagree on resolution, as
+                # `ExchangeList.merge_exchanges` does: it is deterministic and
+                # the finest resolution cannot overlap the next merged point.
+                _min_optional(end_datetime, event.end_datetime),
                 source,
                 _add_optional(export_cap, event.capacityExport),
                 _add_optional(import_cap, event.capacityImport),
@@ -1922,6 +1925,15 @@ def _add_optional(a: float | None, b: float | None) -> float | None:
     if b is None:
         return a
     return a + b
+
+
+def _min_optional(a: datetime | None, b: datetime | None) -> datetime | None:
+    """Earliest of two end datetimes, ignoring missing values."""
+    if a is None:
+        return b
+    if b is None:
+        return a
+    return min(a, b)
 
 
 def _fetch_forecast_transfer_capacity(

--- a/electricitymap/contrib/parsers/tests/test_ENTSOE.py
+++ b/electricitymap/contrib/parsers/tests/test_ENTSOE.py
@@ -862,6 +862,132 @@ def test_merge_forecast_transfer_capacities_both_directions():
     assert events[1].capacityImport == 350.0
 
 
+# ─── _fetch_forecast_transfer_capacity domain resolution ─────────────────────
+
+DE_LU_DOMAIN = "10Y1001A1001A82H"
+DE_COUNTRY_DOMAIN = "10Y1001A1001A83F"
+DK_DK1_DOMAIN = "10YDK-1--------W"
+
+
+def _register_de_dk1_week_ahead(requests_mock):
+    """Serve A61 week-ahead only on the DE-LU domain, as ENTSO-E does."""
+    export = base_path_to_mock / "DK-DK1_DK-DK2_capacity_week_ahead_export.xml"
+    imprt = base_path_to_mock / "DK-DK1_DK-DK2_capacity_week_ahead_import.xml"
+    requests_mock.register_uri(
+        GET,
+        f"?documentType=A61&Contract_MarketAgreement.Type=A02"
+        f"&in_Domain={DK_DK1_DOMAIN}&out_Domain={DE_LU_DOMAIN}",
+        content=export.read_bytes(),
+    )
+    requests_mock.register_uri(
+        GET,
+        f"?documentType=A61&Contract_MarketAgreement.Type=A02"
+        f"&in_Domain={DE_LU_DOMAIN}&out_Domain={DK_DK1_DOMAIN}",
+        content=imprt.read_bytes(),
+    )
+
+
+def test_fetch_forecast_transfer_capacity_uses_domain_override(requests_mock, session):
+    """DE->DK-DK1 must be queried on the DE-LU bidding zone, not the DE country
+    domain. ENTSO-E publishes A61 per bidding zone, so resolving `DE` straight
+    through ENTSOE_DOMAIN_MAPPINGS yields "No matching data found" and the
+    border silently reports nothing.
+    """
+    _register_de_dk1_week_ahead(requests_mock)
+
+    result = ENTSOE.fetch_exchange_capacity_forecasts_week_ahead(
+        zone_key1=ZoneKey("DE"),
+        zone_key2=ZoneKey("DK-DK1"),
+        session=session,
+    )
+
+    assert result, "expected capacity forecasts for DE->DK-DK1"
+    assert all(e["sortedZoneKeys"] == "DE->DK-DK1" for e in result)
+    queried = [r.qs for r in requests_mock.request_history]
+    assert queried, "no request was made"
+    for qs in queried:
+        domains = set(qs["in_domain"]) | set(qs["out_domain"])
+        assert DE_COUNTRY_DOMAIN.lower() not in domains
+        assert DE_LU_DOMAIN.lower() in domains
+
+
+def test_fetch_forecast_transfer_capacity_is_argument_order_independent(
+    requests_mock, session
+):
+    """Swapping the two zones must not flip export/import.
+
+    The domain pair is resolved from the *sorted* zones, so ("DK-DK1", "DE")
+    has to produce byte-identical events to ("DE", "DK-DK1").
+    """
+    _register_de_dk1_week_ahead(requests_mock)
+
+    forward = ENTSOE.fetch_exchange_capacity_forecasts_week_ahead(
+        zone_key1=ZoneKey("DE"), zone_key2=ZoneKey("DK-DK1"), session=session
+    )
+    reversed_args = ENTSOE.fetch_exchange_capacity_forecasts_week_ahead(
+        zone_key1=ZoneKey("DK-DK1"), zone_key2=ZoneKey("DE"), session=session
+    )
+
+    assert forward == reversed_args
+
+
+def test_fetch_forecast_transfer_capacity_sums_aggregated_border(
+    requests_mock, session
+):
+    """FR-COR->IT-SAR is served by two links (SACOAC + SACODC), each published
+    as its own A61 document. The border's capacity is their sum.
+    """
+    export = base_path_to_mock / "DK-DK1_DK-DK2_capacity_week_ahead_export.xml"
+    imprt = base_path_to_mock / "DK-DK1_DK-DK2_capacity_week_ahead_import.xml"
+    # Same payload on both links, so the summed result must be exactly doubled.
+    # FR-COR is the first sorted zone and is represented by the converter
+    # domains, so `in_Domain=IT-SAR` is the FR-COR->IT-SAR (export) direction.
+    for ac_dc in ("10Y1001A1001A885", "10Y1001A1001A893"):
+        requests_mock.register_uri(
+            GET,
+            f"?documentType=A61&Contract_MarketAgreement.Type=A02"
+            f"&in_Domain=10Y1001A1001A74G&out_Domain={ac_dc}",
+            content=export.read_bytes(),
+        )
+        requests_mock.register_uri(
+            GET,
+            f"?documentType=A61&Contract_MarketAgreement.Type=A02"
+            f"&in_Domain={ac_dc}&out_Domain=10Y1001A1001A74G",
+            content=imprt.read_bytes(),
+        )
+
+    # DE->DK-DK1 resolves to a single domain pair fed the same payload, giving
+    # the un-summed baseline to compare against.
+    _register_de_dk1_week_ahead(requests_mock)
+
+    single = ENTSOE.fetch_exchange_capacity_forecasts_week_ahead(
+        zone_key1=ZoneKey("DE"), zone_key2=ZoneKey("DK-DK1"), session=session
+    )
+    aggregated = ENTSOE.fetch_exchange_capacity_forecasts_week_ahead(
+        zone_key1=ZoneKey("FR-COR"), zone_key2=ZoneKey("IT-SAR"), session=session
+    )
+
+    assert len(aggregated) == len(single)
+    for agg, one in zip(aggregated, single, strict=True):
+        assert agg["capacityExport"] == pytest.approx(one["capacityExport"] * 2)
+        assert agg["capacityImport"] == pytest.approx(one["capacityImport"] * 2)
+
+
+def test_fetch_forecast_transfer_capacity_resolves_zones_absent_from_mappings(
+    requests_mock, session
+):
+    """Zones that only exist in the override table (RU-1, FR-COR) must resolve.
+
+    Indexing ENTSOE_DOMAIN_MAPPINGS directly raised KeyError for these.
+    """
+    requests_mock.register_uri(GET, ANY, content=b"<empty/>")
+
+    for zone_1, zone_2 in (("EE", "RU-1"), ("FR-COR", "IT-CNO")):
+        ENTSOE.fetch_exchange_capacity_forecasts_week_ahead(
+            zone_key1=ZoneKey(zone_1), zone_key2=ZoneKey(zone_2), session=session
+        )
+
+
 def test_merge_forecast_transfer_capacities_only_forward():
     """Only forward data → merged events have capacityImport=None."""
     logger = logging.getLogger("test")


### PR DESCRIPTION
## Problem

`DE->DK-DK1` had no exchange-capacity-forecast (FTC) data even though ENTSO-E publishes it for the DE-LU↔DK1 border.

The mapping was already there — `ENTSOE_EXCHANGE_DOMAIN_OVERRIDE` has had `"DE->DK-DK1": [DE-LU, DK-DK1]` all along. The problem is that `_fetch_forecast_transfer_capacity` never consulted it:

```python
domain_1 = ENTSOE_DOMAIN_MAPPINGS[zone_key1]   # bare lookup
domain_2 = ENTSOE_DOMAIN_MAPPINGS[zone_key2]
```

Every other exchange fetcher resolves via `_resolve_exchange_domain_pairs`, which walks `EXCHANGE_AGGREGATES` → `ENTSOE_EXCHANGE_DOMAIN_OVERRIDE` → `ENTSOE_DOMAIN_MAPPINGS`. The FTC path was the only one that skipped it.

ENTSO-E publishes A61 per **bidding zone**, so `DE` resolved to the country/CTA domain `10Y1001A1001A83F` instead of the DE-LU bidding zone `10Y1001A1001A82H`:

```
in=DK1, out=10Y1001A1001A83F (DE)     → Acknowledgement, Reason 999
   "No matching data found for Data item FORECASTED_TRANSFER_CAPACITIES_EXPLICIT [11.1]"
in=DK1, out=10Y1001A1001A82H (DE-LU)  → Publication_MarketDocument with TimeSeries ✅
```

### Why it failed silently

For A61, ENTSO-E returns "no matching data" with **HTTP 200** plus an `Acknowledgement_MarketDocument`, not a 4xx. `query_ENTSOE` only inspects the body when `not response.ok`, so the acknowledgement was passed along as if it were data; no `<timeseries>` were found and the border reported a clean `[]` with no warning.

Separately, zones that exist **only** in the override/aggregate tables (`RU-1`, `FR-COR`) raised `KeyError` outright — 6 borders were hard-crashing.

## Fix

Route the FTC path through `_resolve_exchange_domain_pairs`. Three things follow:

- **Sorted-key resolution.** Domains now come from `sorted([zone_key1, zone_key2])`, so argument order can no longer invert export/import. Previously `sorted_zone_keys` was sorted but the domain lookups used the raw order — a latent sign-flip.
- **Aggregated borders work.** `FR-COR->IT-SAR` fans out to SACOAC + SACODC; `_sum_forecast_transfer_capacities` totals the per-link documents, mirroring `ExchangeList.merge_exchanges` which already sums net flows on the same borders.
- Per-pair query/retry logic extracted to `_query_forecast_transfer_capacity_both_directions`, since it now runs once per domain pair.

## Borders fixed by the parser change

Live probe, row counts before → after:

| border | day | week | month | before |
|---|---|---|---|---|
| `DE->DK-DK1` | 324 | 17 | 38 | empty |
| `DE->NL` | 81 | 17 | 38 | empty |
| `CH->DE` | 81 | 0 | 38 | empty |
| `DE->NO-NO2` | 0 | 17 | 38 | empty |
| `IT-SIC->IT-SO` | 81 | 17 | 38 | empty |
| `RO/HU/PL/SK/MD->UA` | 57–81 | 0–38 | 38 | empty |
| `FR-COR->IT-CNO`, `FR-COR->IT-SAR` | 81 | 17 | 38 | **KeyError** |
| `GE->RU-1`, `FI->RU-1` | 0–127 | 17 | 38 | **KeyError** |
| `EE->RU-1`, `LV->RU-1` | 0 | 0 | 0 | **KeyError** (Baltics desynced, ENTSO-E publishes nothing) |

## Borders newly enabled in config

I swept all 381 exchange configs for A61 data with correctly-resolved domains and found 11 real borders publishing data with no `exchangeCapacityForecast*` config. All 11 are now wired up:

| border | day | week | month |
|---|---|---|---|
| `AT->CZ` | | ✅ | ✅ |
| `CZ->PL` | | | ✅ |
| `CZ->SK` | | | ✅ |
| `DE->DK-DK1` | ✅ | ✅ | ✅ |
| `DE->DK-DK2` | | ✅ | ✅ |
| `DK-DK1->NL` | ✅ | ✅ | ✅ |
| `DK-DK1->NO-NO2` | | ✅ | ✅ |
| `FR->GB` | ✅ | ✅ | ✅ |
| `GB->GB-NIR` | ✅ | | |
| `GB->IE` | ✅ | | |
| `GB->NL` | ✅ | ✅ | ✅ |

**Only horizons with confirmed data are configured**, verified across 4 time windows × both directions (every result was unambiguous — 0/2 or 2/2). ENTSO-E genuinely doesn't publish some combinations: `DE->DK-DK2` and `DK-DK1->NO-NO2` have no day-ahead NTC because that capacity is allocated implicitly, and `GB->IE`/`GB->GB-NIR` are day-ahead only. Partial config is schema-legal (each key is independently `str | None`) but new to this repo — happy to fill in all three everywhere instead if you'd rather trade always-empty fetches for uniformity.

Deliberately left alone: 10 further hits (`AT->IT`, `CH->IT`, `FI->SE`, `FR->IT`, `GR->IT`, `IT->SI`, `LT->SE`, `NL->NO`, `NO->SE`, `PL->SE`) are country-aggregate config stubs with no parsers at all, where we model the sub-zones (`IT-NO`, `SE-SE1..4`, `NO-NO1..5`) and the real sub-zone borders already have FTC.

## Tests

4 regression tests covering exactly what was untested — existing coverage only exercised `parse_forecast_transfer_capacity` and `_merge_...` in isolation, never the domain resolution:

- `DE->DK-DK1` queries the DE-LU EIC and **never** the DE country EIC
- swapping the two zone arguments produces identical events
- aggregated borders sum their per-link capacities
- override-only zones (`RU-1`, `FR-COR`) resolve without `KeyError`

123 tests pass, ruff clean. Every newly configured horizon verified to return data against the live API.

## Follow-ups (not in this PR)

1. **`query_ENTSOE` should detect `Acknowledgement_MarketDocument` / Reason 999 on HTTP 200.** This is why the bug stayed invisible — "no data" is currently indistinguishable from "data". Fixing it turns this whole class of failure from silent to loud.
2. **The `entsoe-proxy` Cloud Run service intermittently returns 401 `Authentication failed`.** Measured with the same URL and a valid token, 40 sequential requests each: **proxy 9/40 (~22%) vs direct `web-api.tp.entsoe.eu` 0/40**. The proxy does forward the token correctly (a garbage token 401s 100% of the time), so the likely mechanism is ENTSO-E throttling the proxy's shared egress and surfacing it as 401 rather than 429. Two things amplify it on our side: `lib/session.py`'s `DEFAULT_RETRY` has `status_forcelist=[429, 500, 502, 503, 504]` — **401 is absent**, so urllib3's backoff never engages — and the FTC retry loop has no `sleep`, so it re-fires instantly into a throttle. Worth adding 401 + backoff, and investigating the proxy itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)