### PR TITLE
feat(ES): map the "bio" key to biomass

### DIFF
--- a/electricitymap/contrib/parsers/ES.py
+++ b/electricitymap/contrib/parsers/ES.py
@@ -52,6 +52,7 @@ PRODUCTION_PARSE_MAPPING = {
     "car": "coal",  # Coal
     "resid": "biomass",  # Wastes
     "termRenov": "unknown",  # Thermal renewable
+    "bio": "biomass",  # Biomass (Peninsula; replaces "termRenov" in that system)
     "cogenResto": "unknown",  # Cogeneration and waste
     "tnr": "unknown",  # Other special regime
     "trn": "unknown",  # Thermal renewable


### PR DESCRIPTION
## Issue

Found while verifying the sign of the Tenerife–La Gomera link in #8821.

## Description

REE renamed the Peninsula system's renewable-thermal key from `termRenov` to `bio`. The new name was in neither `PRODUCTION_PARSE_MAPPING` nor `PRODUCTION_IGNORE_KEYS`, so `check_known_key` logs `Key "bio" could not be parsed!` **once per record** on every Peninsula fetch, and the generation is dropped.

This still matters even though `ES` production comes from ENTSO-E: the Peninsula payload is fetched for the `ES->PT`, `ES->FR`, `ES->MA` and `AD->ES` exchanges, so the warning fires in production today.

### Evidence it's a rename, not a new category

| Payload | `termRenov` | `bio` |
|---|---|---|
| `mocks/ES/demandaGeneracionPeninsula.json` (recorded 2024-10-26) | present | absent |
| live Peninsula feed (2026-08-18) | absent | present |

REE's API serves the *current* schema even for historical dates, so `bio` comes back for every date I sampled going back to 2019. `termRenov` is left mapped so the recorded fixture — and any other stored payload — still parses.

### Why `biomass`

Live values average **440 MW** (min 331, max 516 over 210 events). ENTSO-E reports 587–725 MW of biomass for `ES` over the same window in `avg_1h.time_aligned_production_breakdown`; same magnitude and same daily shape, with ENTSO-E's category being slightly broader. `resid` and `residRen` already map to `biomass`, so this is consistent with the rest of the table.

### Sweep for other missing keys

Every zone in `ZONE_MAPPING` (15) was fetched across 16 distinct dates spanning 2019–2026 and diffed against the parser's own `KNOWN_KEY`. **`bio` on the Peninsula is the only unmapped key** — no gaps in the Canary, Balearic, Ceuta or Melilla systems.

### Live verification

`fetch_production` for all 15 zones and `fetch_exchange` for all 10 configured pairs run clean against the live API, with no `could not be parsed` warnings. Before/after on the same live payload:

| | `biomass` in last event | warnings |
|---|---|---|
| before | `None` | 1 per record |
| after | `340` | none |

No snapshot changes — the recorded fixture predates the rename. All 14 existing tests pass.

### Double check

- [x] I have tested my parser changes locally with `uv run test_parser "zone_key"`
- [x] I have run `pnpx prettier@2 --write .` and `uv run format` in the top level directory to format my changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
