### PR TITLE
fix(JAO): resolve Core-external borders renamed to interconnector endpoints

### DIFF
--- a/electricitymap/contrib/parsers/JAO.py
+++ b/electricitymap/contrib/parsers/JAO.py
@@ -123,6 +123,76 @@ def _em_to_jao_zone(em_zone: str) -> str:
     return EM_TO_JAO_ZONE.get(em_zone, em_zone)
 
 
+# Most border fields are `border_{zone_a}_{zone_b}`, but JAO names some borders
+# after the *interconnector endpoints* rather than the bidding zones, so the
+# field cannot be derived from the zone codes alone:
+#
+#   BG->RO      border_BG_RO_BG_VH            (endpoints BG / RO_BG_VH)
+#   DE->DK-DK1  border_DE_DK1_VH_DK1_DE       (Vejle hub)
+#   DK-DK1->NL  border_DK1_CO_NL_DK1_COBRA    (COBRAcable)
+#
+# Keyed by the sorted EM exchange key; the tuple is (endpoint for zone_a,
+# endpoint for zone_b), so export is `{prefix}_{a}_{b}` and import the reverse,
+# exactly as for the derived names.
+#
+# The payload carries further qualified borders we do not consume here
+# (`border_ALBE_ALDE` for ALEGrO, `border_DE_NO2_BigHub_NO2_NK` for NordLink);
+# add them only alongside wiring the matching exchange to this parser, to avoid
+# double-sourcing borders already served by NORDPOOL.
+JAO_BORDER_ENDPOINTS: dict[str, tuple[str, str]] = {
+    "BG->RO": ("BG", "RO_BG_VH"),
+    "DE->DK-DK1": ("DE_DK1_VH", "DK1_DE"),
+    "DK-DK1->NL": ("DK1_CO", "NL_DK1_COBRA"),
+}
+
+
+def _resolve_border_fields(
+    sorted_zone_keys: ZoneKey,
+    rows: list[dict],
+    field_prefix: str,
+    logger: Logger,
+) -> tuple[str, str]:
+    """Resolve the (export, import) field names for a border.
+
+    Picks whichever naming the payload actually carries: the interconnector
+    endpoints from `JAO_BORDER_ENDPOINTS` if present, otherwise the names
+    derived from the zone codes. Selecting on the payload rather than switching
+    outright matters because the convention varies *per dataset* - shadowAuctionATC
+    still publishes plain `border_DE_FR`, while coreExternal moved to qualified
+    names - and the same EM border can appear in more than one dataset.
+
+    Warns when neither naming is present. Both extractors skip rows where the
+    two fields are absent, so without this a renamed field is indistinguishable
+    from "no capacity published": the parser returns zero events, raises
+    nothing, and writes nothing. That is how the Core-external borders above
+    went unnoticed for ~3 months after JAO renamed them.
+    """
+    zone_a, zone_b = sorted_zone_keys.split("->")
+    derived = (_em_to_jao_zone(zone_a), _em_to_jao_zone(zone_b))
+    qualified = JAO_BORDER_ENDPOINTS.get(sorted_zone_keys)
+
+    candidates = [qualified, derived] if qualified else [derived]
+    for endpoint_a, endpoint_b in candidates:
+        export_field = f"{field_prefix}_{endpoint_a}_{endpoint_b}"
+        import_field = f"{field_prefix}_{endpoint_b}_{endpoint_a}"
+        if not rows or export_field in rows[0] or import_field in rows[0]:
+            return export_field, import_field
+
+    # Nothing matched: fall back to the derived names so behaviour is unchanged,
+    # but say so loudly - this is the signal that a border has been renamed.
+    export_field = f"{field_prefix}_{derived[0]}_{derived[1]}"
+    import_field = f"{field_prefix}_{derived[1]}_{derived[0]}"
+    available = sorted(k for k in rows[0] if k.startswith(f"{field_prefix}_"))
+    logger.warning(
+        f"JAO: no field found for {sorted_zone_keys} - tried "
+        f"{[f'{field_prefix}_{a}_{b}' for a, b in candidates]}. The border may "
+        f"have been renamed; available fields: {available}",
+        extra={"key": sorted_zone_keys},
+    )
+
+    return export_field, import_field
+
+
 def _format_utc(dt: datetime) -> str:
     """Format a tz-aware datetime as the ISO-8601 string JAO expects."""
     return dt.astimezone(timezone.utc).strftime("%Y-%m-%dT%H:%M:%S.000Z")
@@ -221,11 +291,9 @@ def _extract_border_capacity(
     (MaxBeX, MaxBflow). ATC datasets use `_extract_border_atc` instead so the
     `atcType` discriminator can be attached.
     """
-    zone_a, zone_b = sorted_zone_keys.split("->")
-    jao_a = _em_to_jao_zone(zone_a)
-    jao_b = _em_to_jao_zone(zone_b)
-    export_field = f"{field_prefix}_{jao_a}_{jao_b}"
-    import_field = f"{field_prefix}_{jao_b}_{jao_a}"
+    export_field, import_field = _resolve_border_fields(
+        sorted_zone_keys, rows, field_prefix, logger
+    )
 
     capacities = ExchangeCapacityList(logger)
     for row in rows:
@@ -256,11 +324,9 @@ def _extract_border_atc(
     Same `border_XX_YY` row shape as `_extract_border_capacity` but emits the
     ATC-specific event class (carries the `atcType` discriminator).
     """
-    zone_a, zone_b = sorted_zone_keys.split("->")
-    jao_a = _em_to_jao_zone(zone_a)
-    jao_b = _em_to_jao_zone(zone_b)
-    export_field = f"{field_prefix}_{jao_a}_{jao_b}"
-    import_field = f"{field_prefix}_{jao_b}_{jao_a}"
+    export_field, import_field = _resolve_border_fields(
+        sorted_zone_keys, rows, field_prefix, logger
+    )
 
     capacities = ExchangeAtcList(logger)
     for row in rows:
@@ -299,11 +365,9 @@ def _extract_border_scheduled_exchanges(
     Emitted with sourceType=published since the values are TSO-published
     ex-ante schedules, not statistical forecasts.
     """
-    zone_a, zone_b = sorted_zone_keys.split("->")
-    jao_a = _em_to_jao_zone(zone_a)
-    jao_b = _em_to_jao_zone(zone_b)
-    export_field = f"{field_prefix}_{jao_a}_{jao_b}"
-    import_field = f"{field_prefix}_{jao_b}_{jao_a}"
+    export_field, import_field = _resolve_border_fields(
+        sorted_zone_keys, rows, field_prefix, logger
+    )
 
     exchanges: list[ScheduledExchange] = []
     for row in rows:

--- a/electricitymap/contrib/parsers/tests/test_JAO.py
+++ b/electricitymap/contrib/parsers/tests/test_JAO.py
@@ -1,6 +1,7 @@
 import json
 import re
 from datetime import datetime
+from logging import WARNING, getLogger
 from pathlib import Path
 
 from requests_mock import GET
@@ -8,6 +9,7 @@ from syrupy.extensions.single_file import SingleFileAmberSnapshotExtension
 
 from electricitymap.contrib.config import ZoneKey
 from electricitymap.contrib.parsers.JAO import (
+    _extract_border_atc,
     fetch_core_external_atc_day_ahead,
     fetch_core_max_bex_day_ahead,
     fetch_core_scheduled_exchanges_day_ahead,
@@ -15,6 +17,7 @@ from electricitymap.contrib.parsers.JAO import (
     fetch_nordic_max_bflow_day_ahead,
     fetch_shadow_auction_atc_day_ahead,
 )
+from electricitymap.contrib.types import AtcType
 
 BASE_MOCK_PATH = Path("electricitymap/contrib/parsers/tests/mocks/JAO")
 SHADOW_AUCTION_ATC_URL_REGEX = re.compile(
@@ -228,3 +231,63 @@ def test_fetch_nordic_max_bflow_day_ahead_no1_se3(requests_mock, session, snapsh
     )
 
     assert snapshot(extension_class=SingleFileAmberSnapshotExtension) == result
+
+
+# ---------------------------------------------------------------------------
+# Border field-name resolution.
+#
+# JAO names some borders after the interconnector endpoints rather than the
+# bidding zones (`border_DE_DK1_VH_DK1_DE` instead of `border_DE_DK1`), and the
+# convention differs per dataset. The extractors skip rows whose fields are
+# absent, so an unrecognised name yields zero events with no error - these pin
+# both namings and the warning that makes the silent case visible.
+# ---------------------------------------------------------------------------
+
+_ROW_DT = "2026-08-24T00:00:00Z"
+
+
+def _atc_for(rows: list[dict], logger) -> list[dict]:
+    return _extract_border_atc(
+        rows, ZoneKey("DE->DK-DK1"), "jao.eu", logger, AtcType.COORDINATED_NTC
+    ).to_list()
+
+
+def test_border_fields_resolve_qualified_interconnector_names():
+    """Current Core-external naming: endpoints, not bidding zones."""
+    rows = [
+        {
+            "dateTimeUtc": _ROW_DT,
+            "border_DE_DK1_VH_DK1_DE": 700.0,
+            "border_DK1_DE_DE_DK1_VH": 500.0,
+        }
+    ]
+
+    result = _atc_for(rows, getLogger("test"))
+
+    assert len(result) == 1
+    assert result[0]["capacityExport"] == 700.0
+    assert result[0]["capacityImport"] == 500.0
+
+
+def test_border_fields_fall_back_to_plain_zone_names():
+    """shadowAuctionATC still publishes plain names, and older captured
+    responses use them too - the qualified mapping must not break those."""
+    rows = [{"dateTimeUtc": _ROW_DT, "border_DE_DK1": 700.0, "border_DK1_DE": 500.0}]
+
+    result = _atc_for(rows, getLogger("test"))
+
+    assert len(result) == 1
+    assert result[0]["capacityExport"] == 700.0
+    assert result[0]["capacityImport"] == 500.0
+
+
+def test_border_fields_warn_when_no_naming_matches(caplog):
+    """The regression guard: an unrecognised border must not fail silently."""
+    rows = [{"dateTimeUtc": _ROW_DT, "border_ES_FR": 1000.0}]
+
+    with caplog.at_level(WARNING):
+        result = _atc_for(rows, getLogger("test"))
+
+    assert result == []
+    assert "no field found for DE->DK-DK1" in caplog.text
+    assert "border_ES_FR" in caplog.text


### PR DESCRIPTION
## Issue

Core-external ATC silently stopped ingesting for 3 of 6 borders on **2026-06-10**, unnoticed for ~3 months.

## Description

JAO renamed some Core-external border fields from bidding zones to **interconnector endpoints**, and restated their history under the new names:

| border | old field | current field |
| --- | --- | --- |
| `BG->RO` | `border_BG_RO` | `border_BG_RO_BG_VH` |
| `DE->DK-DK1` | `border_DE_DK1` | `border_DE_DK1_VH_DK1_DE` (Vejle hub) |
| `DK-DK1->NL` | `border_DK1_NL` | `border_NL_DK1_COBRA_DK1_CO` (COBRAcable) |

`_extract_border_atc` builds the field name from the zone codes and reads it with `row.get(...)`:

```python
export_value = row.get(export_field)     # -> None once renamed
import_value = row.get(import_field)     # -> None
if export_value is None and import_value is None:
    continue                             # row skipped
```

So an unrecognised name yields **zero events, no exception, no log line** — indistinguishable from "no capacity published for this border". `ES->FR` kept working because its field was left unqualified, which is exactly why 5 of the 6 Core-external borders went quiet while one stayed healthy — and why the outage looked like an upstream problem rather than ours.

> [!NOTE]
> The restatement is what made this so hard to spot: querying a *past* date today returns the *new* names, so the breakage is invisible in any historical probe. The only observable symptom was the row count going flat.

### Changes

- **`JAO_BORDER_ENDPOINTS`** — the qualified endpoint pairs for the three affected borders.
- **`_resolve_border_fields`** — shared by the ATC, capacity and scheduled-exchange extractors, which each built the same two field names inline.
- **A warning when no naming matches**, listing the border, what was tried, and the fields actually present.

Resolution **selects whichever naming the payload carries** rather than switching outright. That matters because the convention differs *per dataset* — `shadowAuctionATC` still publishes plain `border_DE_FR` — and the same EM border can appear in more than one dataset. It also means the captured `core_external_atc.json` fixture, which predates the rename and uses plain names, passes unchanged.

The warning is the part that generalises: it turns this failure mode from months of silent loss into a log line on day one.

### Preview

Against the live API, target `2026-08-24`:

```
                 before      after
BG->RO           0 events    192 events   2026-08-24 00:00 .. 2026-08-25 23:45
DE->DK-DK1       0 events    192 events
DK-DK1->NL       0 events    192 events
ES->FR (control) 192 events  192 events
```

Test suite: **13 passed** (10 existing + 3 new). The new tests were checked against the unfixed parser and genuinely fail there:

```
FAILED test_border_fields_resolve_qualified_interconnector_names - assert 0 == 1
FAILED test_border_fields_warn_when_no_naming_matches - assert 'no field found for DE->DK-DK1' in ''
```

### Not addressed here

`AT->IT-NO` and `FR->IT-NO` appear under **no** name in the payload and have only ever had 4 and 6 days of data. They look mis-wired to this parser rather than renamed, and want a separate look.

The payload also carries qualified borders we don't consume (`border_ALBE_ALDE` for ALEGrO, `border_DE_NO2_BigHub_NO2_NK` for NordLink). I left them out deliberately — adding them should come with wiring the matching exchange, to avoid double-sourcing borders already served by NORDPOOL.

## AI Disclosure

Written with Claude Code (Opus 4.8). Claude diagnosed the root cause by comparing expected against actual payload field names, made the change, and verified it against the live API and the test suite. The payload-driven resolution replaced an initial hard-switch design after the existing fixture revealed that the naming convention varies per dataset.
