### PR TITLE
refactor(event lists): collapse duplicate datetimes and unify the matching-datetimes merge option

### DIFF
--- a/electricitymap/contrib/lib/models/event_lists.py
+++ b/electricitymap/contrib/lib/models/event_lists.py
@@ -125,6 +125,31 @@ class AggregatableEventList(EventList[EventType], ABC, Generic[EventType]):
         )
 
     @classmethod
+    def _matching_datetimes(
+        cls, ungrouped_events: Sequence["AggregatableEventList"], logger: Logger
+    ) -> set[datetime]:
+        """
+        The datetimes every input covers, warning about the ones only some cover.
+
+        Used by the merges when their inputs are parts of one total rather than
+        separate sources of the same series: summing a datetime an input does not
+        cover understates the total instead of leaving it missing. An input
+        covering nothing therefore leaves nothing matching - the same rule, not a
+        special case.
+        """
+        covered = [{event.datetime for event in single} for single in ungrouped_events]
+        if not covered:
+            return set()
+        matching = set.intersection(*covered)
+        non_matching = set.union(*covered) - matching
+        if non_matching:
+            logger.warning(
+                f"Dropping {len(non_matching)} datetime(s) that only some of the "
+                f"{len(covered)} merged {cls.__name__}s cover."
+            )
+        return matching
+
+    @classmethod
     def _get_unique_zone(cls, events: pd.DataFrame) -> ZoneKey:
         """
         Given a concatenated dataframe of events, return the unique zone.
@@ -288,16 +313,7 @@ class ExchangeList(NonOverlappingEventList[Exchange], AggregatableEventList[Exch
         zone_key, sources, source_type = ExchangeList.get_zone_source_type(exchange_df)
 
         if drop_non_matching_datetimes:
-            covered = [
-                {event.datetime for event in single} for single in ungrouped_exchanges
-            ]
-            matching = set.intersection(*covered)
-            non_matching = set.union(*covered) - matching
-            if non_matching:
-                logger.warning(
-                    f"Dropping {len(non_matching)} datetime(s) that only some of the "
-                    f"{len(covered)} merged {ExchangeList.__name__}s cover."
-                )
+            matching = ExchangeList._matching_datetimes(ungrouped_exchanges, logger)
             exchange_df = exchange_df[exchange_df.index.isin(matching)]
 
         end_datetimes = None
@@ -470,21 +486,23 @@ class ProductionBreakdownList(
     def merge_production_breakdowns(
         ungrouped_production_breakdowns: list["ProductionBreakdownList"],
         logger: Logger,
-        matching_timestamps_only: bool = False,
+        drop_non_matching_datetimes: bool = False,
     ) -> "ProductionBreakdownList":
         """
         Given multiple parser outputs, sum the production and storage
         of corresponding datetimes to create a unique production breakdown list.
         Sources will be aggregated in a comma-separated string. Ex: "entsoe, eia".
         There should be only one zone in the list of production breakdowns.
-        Matching timestamps only will only keep the timestamps where all the production breakdowns have data.
+
+        By default a datetime only some of the inputs cover is summed from those
+        that do. Set `drop_non_matching_datetimes` when the inputs are parts of
+        one total instead, and only the datetimes they disagree on are dropped.
         """
         production_breakdowns = ProductionBreakdownList(logger)
         if ProductionBreakdownList.is_completely_empty(
             ungrouped_production_breakdowns, logger
         ):
             return production_breakdowns
-        len_ungrouped_production_breakdowns = len(ungrouped_production_breakdowns)
         df = pd.concat(
             [
                 production_breakdowns.dataframe
@@ -496,14 +514,11 @@ class ProductionBreakdownList(
 
         df = df.drop(columns=["source", "sourceType", "zoneKey"])
         df = df.groupby(level=0, dropna=False)["data"].apply(list)
-        if matching_timestamps_only:
-            logger.info(
-                f"Filtering production breakdowns to keep \
-                only the timestamps where all the production breakdowns \
-                have data, {len(df[df.apply(lambda x: len(x) != len_ungrouped_production_breakdowns)])}\
-                points where discarded."
+        if drop_non_matching_datetimes:
+            matching = ProductionBreakdownList._matching_datetimes(
+                ungrouped_production_breakdowns, logger
             )
-            df = df[df.apply(lambda x: len(x) == len_ungrouped_production_breakdowns)]
+            df = df[df.index.isin(matching)]
         for row in df:
             prod = ProductionBreakdown.aggregate(row)
             production_breakdowns.events.append(prod)
@@ -514,7 +529,7 @@ class ProductionBreakdownList(
         production_breakdowns: "ProductionBreakdownList",
         new_production_breakdowns: "ProductionBreakdownList",
         logger: Logger,
-        matching_timestamps_only: bool = False,
+        drop_non_matching_datetimes: bool = False,
     ) -> "ProductionBreakdownList":
         """
         Given a new batch of production breakdowns, update the existing ones.
@@ -523,7 +538,7 @@ class ProductionBreakdownList(
         - production_breakdowns: The existing production breakdowns to be updated.
         - new_production_breakdowns: The new batch of production breakdowns.
         - logger: The logger object used for logging information.
-        - matching_timestamps_only: Flag indicating whether to update only the events with matching timestamps from both the production breakdowns.
+        - drop_non_matching_datetimes: Flag indicating whether to update only the events with matching timestamps from both the production breakdowns.
         """
 
         if len(new_production_breakdowns) == 0:
@@ -533,7 +548,7 @@ class ProductionBreakdownList(
 
         updated_production_breakdowns = ProductionBreakdownList(logger)
 
-        if matching_timestamps_only:
+        if drop_non_matching_datetimes:
             diff = abs(len(new_production_breakdowns) - len(production_breakdowns))
             logger.info(
                 f"Filtering production breakdowns to keep only the events where both the production breakdowns have matching datetimes, {diff} events where discarded."
@@ -552,7 +567,7 @@ class ProductionBreakdownList(
                     storage=updated_event.storage,
                     sourceType=updated_event.sourceType,
                 )
-            elif matching_timestamps_only is False:
+            elif drop_non_matching_datetimes is False:
                 updated_production_breakdowns.append(
                     new_event.zoneKey,
                     new_event.datetime,
@@ -563,7 +578,7 @@ class ProductionBreakdownList(
                     sourceType=new_event.sourceType,
                 )
 
-        if matching_timestamps_only is False:
+        if drop_non_matching_datetimes is False:
             for existing_event in production_breakdowns.events:
                 if existing_event.datetime not in new_production_breakdowns:
                     updated_production_breakdowns.append(

--- a/electricitymap/contrib/lib/models/event_lists.py
+++ b/electricitymap/contrib/lib/models/event_lists.py
@@ -129,13 +129,9 @@ class AggregatableEventList(EventList[EventType], ABC, Generic[EventType]):
         cls, ungrouped_events: Sequence["AggregatableEventList"], logger: Logger
     ) -> set[datetime]:
         """
-        The datetimes every input covers, warning about the ones only some cover.
+        Returns the datetimes every input covers, and warns about the rest.
 
-        Used by the merges when their inputs are parts of one total rather than
-        separate sources of the same series: summing a datetime an input does not
-        cover understates the total instead of leaving it missing. An input
-        covering nothing therefore leaves nothing matching - the same rule, not a
-        special case.
+        An input covering nothing leaves nothing matching.
         """
         covered = [{event.datetime for event in single} for single in ungrouped_events]
         if not covered:
@@ -196,13 +192,12 @@ class NonOverlappingEventList(EventList[EventType], ABC, Generic[EventType]):
 
     Mixed into list types whose events must not overlap (exchanges, production,
     consumption, prices, exchange capacity). `to_list()` enforces that in two
-    steps: events sharing the exact same `datetime` collapse to the last one
-    appended, then events whose `[datetime, end_datetime)` intervals intersect
-    are clamped, the earlier event's end moved to the later event's start. Both
-    log a warning — a data imperfection should degrade the output, not crash the
-    whole fetch. Lists that legitimately hold several events per datetime —
-    e.g. locational marginal prices keyed by node, or grid alerts — do NOT use
-    this mixin.
+    steps, warning on each: events sharing the exact same `datetime` collapse to
+    the last one appended, then events whose `[datetime, end_datetime)` intervals
+    intersect are clamped, the earlier event's end moved to the later event's
+    start. Lists that legitimately hold several events per datetime — e.g.
+    locational marginal prices keyed by node, or grid alerts — do NOT use this
+    mixin.
     """
 
     def to_list(self) -> list[dict[str, Any]]:
@@ -211,18 +206,10 @@ class NonOverlappingEventList(EventList[EventType], ABC, Generic[EventType]):
     def _collapse_duplicates(
         self, events: list[dict[str, Any]]
     ) -> list[dict[str, Any]]:
-        """Keeps one event per `datetime`: the last one appended.
+        """Keeps one event per `datetime`, the last one appended, and warns.
 
-        A source that republishes an interval — a revision, or an archive
-        overlapping the live feed — otherwise leaves two events on the same
-        instant, which downstream sums (`merge_exchanges`,
-        `merge_production_breakdowns`) would add together and double. Keeping
-        the last means the newest value wins, matching how `update_*` treats a
-        newer batch of events.
-
-        `events` arrives sorted by `datetime` from a stable sort, so within a
-        group of equal datetimes the append order survives and the last entry is
-        the most recently added one.
+        `events` is sorted by `datetime` from a stable sort, so the last entry of
+        a group of equal datetimes is the most recently appended one.
         """
         collapsed: dict[datetime, dict[str, Any]] = {}
         for event in events:
@@ -242,10 +229,7 @@ class NonOverlappingEventList(EventList[EventType], ABC, Generic[EventType]):
         datetime, duplicates having already been collapsed; a pair overlaps when
         the earlier event's `end_datetime` is strictly after the later event's
         `datetime`. Events without an `end_datetime` are treated as
-        instantaneous points at `datetime`. Because the events are
-        start-sorted, checking consecutive pairs is enough to catch any
-        overlap. Clamping always leaves a positive duration, as the earlier
-        event starts strictly before the later one.
+        instantaneous points at `datetime`.
         """
         for previous, current in pairwise(events):
             previous_end = previous["end_datetime"]
@@ -287,15 +271,10 @@ class ExchangeList(NonOverlappingEventList[Exchange], AggregatableEventList[Exch
         to create a unique exchange list. Sources will be aggregated in a
         comma-separated string. Ex: "entsoe, eia".
 
-        By default a datetime only some of the inputs reported is summed from
-        those that did, which is what merging two sources of the same flow wants.
-        Set `drop_non_matching_datetimes` when the inputs are instead parts of
-        one total — the interconnectors making up a border, or the two directions
-        of one exchange — where a partial sum understates the flow rather than
-        showing up as missing. Only the datetimes the inputs disagree on are
-        dropped, the rest are summed as usual; an input covering nothing at all
-        therefore drops every datetime, as there is none left that all inputs
-        cover.
+        A datetime only some of the inputs cover is summed from those that do,
+        unless `drop_non_matching_datetimes` is set, which drops it instead. Use
+        it when the inputs are parts of one total, such as the interconnectors of
+        a border or the two directions of one exchange.
         """
         exchanges = ExchangeList(logger)
         if ExchangeList.is_completely_empty(ungrouped_exchanges, logger):
@@ -494,9 +473,8 @@ class ProductionBreakdownList(
         Sources will be aggregated in a comma-separated string. Ex: "entsoe, eia".
         There should be only one zone in the list of production breakdowns.
 
-        By default a datetime only some of the inputs cover is summed from those
-        that do. Set `drop_non_matching_datetimes` when the inputs are parts of
-        one total instead, and only the datetimes they disagree on are dropped.
+        A datetime only some of the inputs cover is summed from those that do,
+        unless `drop_non_matching_datetimes` is set, which drops it instead.
         """
         production_breakdowns = ProductionBreakdownList(logger)
         if ProductionBreakdownList.is_completely_empty(

--- a/electricitymap/contrib/lib/models/event_lists.py
+++ b/electricitymap/contrib/lib/models/event_lists.py
@@ -170,24 +170,52 @@ class NonOverlappingEventList(EventList[EventType], ABC, Generic[EventType]):
     should cover any given instant.
 
     Mixed into list types whose events must not overlap (exchanges, production,
-    consumption, prices, exchange capacity). `to_list()` resolves events whose
-    `[datetime, end_datetime)` intervals intersect by clamping the earlier
-    event's end to the later event's start. Events sharing the exact same
-    `datetime` cannot be clamped, so they are kept as-is; both cases log a
-    warning — a data imperfection should degrade the output, not crash the
+    consumption, prices, exchange capacity). `to_list()` enforces that in two
+    steps: events sharing the exact same `datetime` collapse to the last one
+    appended, then events whose `[datetime, end_datetime)` intervals intersect
+    are clamped, the earlier event's end moved to the later event's start. Both
+    log a warning — a data imperfection should degrade the output, not crash the
     whole fetch. Lists that legitimately hold several events per datetime —
     e.g. locational marginal prices keyed by node, or grid alerts — do NOT use
     this mixin.
     """
 
     def to_list(self) -> list[dict[str, Any]]:
-        return self._resolve_overlaps(super().to_list())
+        return self._resolve_overlaps(self._collapse_duplicates(super().to_list()))
+
+    def _collapse_duplicates(
+        self, events: list[dict[str, Any]]
+    ) -> list[dict[str, Any]]:
+        """Keeps one event per `datetime`: the last one appended.
+
+        A source that republishes an interval — a revision, or an archive
+        overlapping the live feed — otherwise leaves two events on the same
+        instant, which downstream sums (`merge_exchanges`,
+        `merge_production_breakdowns`) would add together and double. Keeping
+        the last means the newest value wins, matching how `update_*` treats a
+        newer batch of events.
+
+        `events` arrives sorted by `datetime` from a stable sort, so within a
+        group of equal datetimes the append order survives and the last entry is
+        the most recently added one.
+        """
+        collapsed: dict[datetime, dict[str, Any]] = {}
+        for event in events:
+            collapsed[event["datetime"]] = event
+        dropped = len(events) - len(collapsed)
+        if dropped:
+            self.logger.warning(
+                f"{type(self).__name__} has {dropped} event(s) sharing a datetime "
+                "with another; keeping the last of each."
+            )
+        return list(collapsed.values())
 
     def _resolve_overlaps(self, events: list[dict[str, Any]]) -> list[dict[str, Any]]:
         """Clamps overlapping `[datetime, end_datetime)` intervals in place.
 
-        `events` is sorted by start (`datetime`); a pair overlaps when the
-        earlier event's `end_datetime` is strictly after the later event's
+        `events` is sorted by start (`datetime`) and carries one event per
+        datetime, duplicates having already been collapsed; a pair overlaps when
+        the earlier event's `end_datetime` is strictly after the later event's
         `datetime`. Events without an `end_datetime` are treated as
         instantaneous points at `datetime`. Because the events are
         start-sorted, checking consecutive pairs is enough to catch any
@@ -195,12 +223,6 @@ class NonOverlappingEventList(EventList[EventType], ABC, Generic[EventType]):
         event starts strictly before the later one.
         """
         for previous, current in pairwise(events):
-            if previous["datetime"] == current["datetime"]:
-                self.logger.warning(
-                    f"{type(self).__name__} has two events sharing datetime "
-                    f"{current['datetime']}; keeping both."
-                )
-                continue
             previous_end = previous["end_datetime"]
             if previous_end is not None and previous_end > current["datetime"]:
                 self.logger.warning(
@@ -231,12 +253,24 @@ class ExchangeList(NonOverlappingEventList[Exchange], AggregatableEventList[Exch
 
     @staticmethod
     def merge_exchanges(
-        ungrouped_exchanges: list["ExchangeList"], logger: Logger
+        ungrouped_exchanges: list["ExchangeList"],
+        logger: Logger,
+        drop_non_matching_datetimes: bool = False,
     ) -> "ExchangeList":
         """
         Given multiple parser outputs, sum the netflows of corresponding datetimes
         to create a unique exchange list. Sources will be aggregated in a
         comma-separated string. Ex: "entsoe, eia".
+
+        By default a datetime only some of the inputs reported is summed from
+        those that did, which is what merging two sources of the same flow wants.
+        Set `drop_non_matching_datetimes` when the inputs are instead parts of
+        one total — the interconnectors making up a border, or the two directions
+        of one exchange — where a partial sum understates the flow rather than
+        showing up as missing. Only the datetimes the inputs disagree on are
+        dropped, the rest are summed as usual; an input covering nothing at all
+        therefore drops every datetime, as there is none left that all inputs
+        cover.
         """
         exchanges = ExchangeList(logger)
         if ExchangeList.is_completely_empty(ungrouped_exchanges, logger):
@@ -252,6 +286,19 @@ class ExchangeList(NonOverlappingEventList[Exchange], AggregatableEventList[Exch
         exchange_df = pd.concat(exchange_dfs)
         exchange_df = exchange_df.rename(columns={"sortedZoneKeys": "zoneKey"})
         zone_key, sources, source_type = ExchangeList.get_zone_source_type(exchange_df)
+
+        if drop_non_matching_datetimes:
+            covered = [
+                {event.datetime for event in single} for single in ungrouped_exchanges
+            ]
+            matching = set.intersection(*covered)
+            non_matching = set.union(*covered) - matching
+            if non_matching:
+                logger.warning(
+                    f"Dropping {len(non_matching)} datetime(s) that only some of the "
+                    f"{len(covered)} merged {ExchangeList.__name__}s cover."
+                )
+            exchange_df = exchange_df[exchange_df.index.isin(matching)]
 
         end_datetimes = None
         if "end_datetime" in exchange_df.columns:

--- a/electricitymap/contrib/lib/models/event_lists.py
+++ b/electricitymap/contrib/lib/models/event_lists.py
@@ -192,41 +192,39 @@ class NonOverlappingEventList(EventList[EventType], ABC, Generic[EventType]):
 
     Mixed into list types whose events must not overlap (exchanges, production,
     consumption, prices, exchange capacity). `to_list()` enforces that in two
-    steps, warning on each: events sharing the exact same `datetime` collapse to
-    the last one appended, then events whose `[datetime, end_datetime)` intervals
-    intersect are clamped, the earlier event's end moved to the later event's
-    start. Lists that legitimately hold several events per datetime — e.g.
-    locational marginal prices keyed by node, or grid alerts — do NOT use this
-    mixin.
+    steps, warning on each: events sharing the exact same `datetime` are
+    deduplicated to the last one appended, then events whose
+    `[datetime, end_datetime)` intervals intersect are clamped, the earlier
+    event's end moved to the later event's start. Lists that legitimately hold
+    several events per datetime — e.g. locational marginal prices keyed by node,
+    or grid alerts — do NOT use this mixin.
     """
 
     def to_list(self) -> list[dict[str, Any]]:
-        return self._resolve_overlaps(self._collapse_duplicates(super().to_list()))
+        return self._resolve_overlaps(self._deduplicate(super().to_list()))
 
-    def _collapse_duplicates(
-        self, events: list[dict[str, Any]]
-    ) -> list[dict[str, Any]]:
+    def _deduplicate(self, events: list[dict[str, Any]]) -> list[dict[str, Any]]:
         """Keeps one event per `datetime`, the last one appended, and warns.
 
         `events` is sorted by `datetime` from a stable sort, so the last entry of
         a group of equal datetimes is the most recently appended one.
         """
-        collapsed: dict[datetime, dict[str, Any]] = {}
+        deduplicated: dict[datetime, dict[str, Any]] = {}
         for event in events:
-            collapsed[event["datetime"]] = event
-        dropped = len(events) - len(collapsed)
+            deduplicated[event["datetime"]] = event
+        dropped = len(events) - len(deduplicated)
         if dropped:
             self.logger.warning(
                 f"{type(self).__name__} has {dropped} event(s) sharing a datetime "
                 "with another; keeping the last of each."
             )
-        return list(collapsed.values())
+        return list(deduplicated.values())
 
     def _resolve_overlaps(self, events: list[dict[str, Any]]) -> list[dict[str, Any]]:
         """Clamps overlapping `[datetime, end_datetime)` intervals in place.
 
         `events` is sorted by start (`datetime`) and carries one event per
-        datetime, duplicates having already been collapsed; a pair overlaps when
+        datetime, duplicates having already been removed; a pair overlaps when
         the earlier event's `end_datetime` is strictly after the later event's
         `datetime`. Events without an `end_datetime` are treated as
         instantaneous points at `datetime`.

--- a/electricitymap/contrib/lib/tests/test_event_lists.py
+++ b/electricitymap/contrib/lib/tests/test_event_lists.py
@@ -1252,6 +1252,68 @@ def test_merge_exchanges_sums_partially_reported_datetimes_by_default():
     assert [event["netFlow"] for event in merged] == [15, 20]
 
 
+def _production_list_at(logger, offsets_and_wind, source="trust.me"):
+    dt = datetime(2023, 1, 1, tzinfo=timezone.utc)
+    breakdowns = ProductionBreakdownList(logger)
+    for offset, wind in offsets_and_wind:
+        breakdowns.append(
+            zoneKey=ZoneKey("DE"),
+            datetime=dt + timedelta(hours=offset),
+            production=ProductionMix(wind=wind),
+            source=source,
+        )
+    return breakdowns
+
+
+def test_merge_production_breakdowns_can_drop_non_matching_datetimes():
+    # Same rule as merge_exchanges, sharing one implementation: parts of one
+    # total, so an hour an input does not cover is dropped rather than summed
+    # short. Previously this counted events per datetime instead.
+    logger = logging.Logger("test")
+    with patch.object(logger, "warning") as mock_warning:
+        merged = ProductionBreakdownList.merge_production_breakdowns(
+            [
+                _production_list_at(logger, [(0, 10), (1, 20)], source="a.com"),
+                _production_list_at(logger, [(0, 5)], source="b.com"),
+            ],
+            logger,
+            drop_non_matching_datetimes=True,
+        ).to_list()
+
+    assert [event["datetime"] for event in merged] == [
+        datetime(2023, 1, 1, tzinfo=timezone.utc)
+    ]
+    assert merged[0]["production"]["wind"] == 15
+    mock_warning.assert_called_once()
+
+
+def test_merge_production_breakdowns_sums_partially_covered_datetimes_by_default():
+    logger = logging.Logger("test")
+    merged = ProductionBreakdownList.merge_production_breakdowns(
+        [
+            _production_list_at(logger, [(0, 10), (1, 20)], source="a.com"),
+            _production_list_at(logger, [(0, 5)], source="b.com"),
+        ],
+        logger,
+    ).to_list()
+
+    assert [event["production"]["wind"] for event in merged] == [15, 20]
+
+
+def test_merge_production_breakdowns_dropping_non_matching_drops_all_when_one_input_is_empty():
+    logger = logging.Logger("test")
+    merged = ProductionBreakdownList.merge_production_breakdowns(
+        [
+            _production_list_at(logger, [(0, 10), (1, 20)]),
+            ProductionBreakdownList(logger),
+        ],
+        logger,
+        drop_non_matching_datetimes=True,
+    ).to_list()
+
+    assert merged == []
+
+
 def test_merge_exchanges_can_drop_non_matching_datetimes():
     # Parts of one total: an hour missing a part would be summed short, so it is
     # dropped instead.

--- a/electricitymap/contrib/lib/tests/test_event_lists.py
+++ b/electricitymap/contrib/lib/tests/test_event_lists.py
@@ -1268,7 +1268,7 @@ def _production_list_at(logger, offsets_and_wind, source="trust.me"):
 def test_merge_production_breakdowns_can_drop_non_matching_datetimes():
     # Same rule as merge_exchanges, sharing one implementation: parts of one
     # total, so an hour an input does not cover is dropped rather than summed
-    # short. Previously this counted events per datetime instead.
+    # short.
     logger = logging.Logger("test")
     with patch.object(logger, "warning") as mock_warning:
         merged = ProductionBreakdownList.merge_production_breakdowns(

--- a/electricitymap/contrib/lib/tests/test_event_lists.py
+++ b/electricitymap/contrib/lib/tests/test_event_lists.py
@@ -1224,23 +1224,149 @@ def test_non_overlapping_list_clamps_overlapping_intervals():
     mock_warning.assert_called_once()
 
 
-def test_non_overlapping_list_keeps_and_warns_on_duplicate_datetimes():
+def _exchange_list_at(logger, offsets_and_flows, source="trust.me"):
+    dt = datetime(2023, 1, 1, tzinfo=timezone.utc)
+    exchanges = ExchangeList(logger)
+    for offset, net_flow in offsets_and_flows:
+        exchanges.append(
+            zoneKey=ZoneKey("AT->DE"),
+            datetime=dt + timedelta(hours=offset),
+            netFlow=net_flow,
+            source=source,
+        )
+    return exchanges
+
+
+def test_merge_exchanges_sums_partially_reported_datetimes_by_default():
+    # Two sources of the same flow: an hour only one of them covers is still
+    # worth reporting from that one.
+    logger = logging.Logger("test")
+    merged = ExchangeList.merge_exchanges(
+        [
+            _exchange_list_at(logger, [(0, 10), (1, 20)], source="a.com"),
+            _exchange_list_at(logger, [(0, 5)], source="b.com"),
+        ],
+        logger,
+    ).to_list()
+
+    assert [event["netFlow"] for event in merged] == [15, 20]
+
+
+def test_merge_exchanges_can_drop_non_matching_datetimes():
+    # Parts of one total: an hour missing a part would be summed short, so it is
+    # dropped instead.
+    logger = logging.Logger("test")
+    with patch.object(logger, "warning") as mock_warning:
+        merged = ExchangeList.merge_exchanges(
+            [
+                _exchange_list_at(logger, [(0, 10), (1, 20)]),
+                _exchange_list_at(logger, [(0, 5)]),
+            ],
+            logger,
+            drop_non_matching_datetimes=True,
+        ).to_list()
+
+    assert [event["netFlow"] for event in merged] == [15]
+    assert [event["datetime"] for event in merged] == [
+        datetime(2023, 1, 1, tzinfo=timezone.utc)
+    ]
+    mock_warning.assert_called_once()
+
+
+def test_merge_exchanges_dropping_non_matching_drops_all_when_one_input_is_empty():
+    # An input that reported nothing leaves no datetime complete.
+    logger = logging.Logger("test")
+    merged = ExchangeList.merge_exchanges(
+        [_exchange_list_at(logger, [(0, 10), (1, 20)]), ExchangeList(logger)],
+        logger,
+        drop_non_matching_datetimes=True,
+    ).to_list()
+
+    assert merged == []
+
+
+def test_merge_exchanges_dropping_non_matching_keeps_end_datetimes():
+    logger = logging.Logger("test")
+    dt = datetime(2023, 1, 1, tzinfo=timezone.utc)
+    inputs = []
+    for net_flow in (10, 5):
+        exchanges = ExchangeList(logger)
+        exchanges.append(
+            zoneKey=ZoneKey("AT->DE"),
+            datetime=dt,
+            end_datetime=dt + timedelta(minutes=5),
+            netFlow=net_flow,
+            source="trust.me",
+        )
+        inputs.append(exchanges)
+
+    merged = ExchangeList.merge_exchanges(
+        inputs, logger, drop_non_matching_datetimes=True
+    ).to_list()
+
+    assert len(merged) == 1
+    assert merged[0]["netFlow"] == 15
+    assert merged[0]["end_datetime"] == dt + timedelta(minutes=5)
+
+
+def test_non_overlapping_list_collapses_duplicate_datetimes():
     logger = logging.Logger("test")
     production_list = ProductionBreakdownList(logger)
     dt = datetime(2023, 1, 1, tzinfo=timezone.utc)
-    for _ in range(2):
+    for wind in (10, 12):
         production_list.append(
             zoneKey=ZoneKey("DE"),
             datetime=dt,
-            production=ProductionMix(wind=10),
+            production=ProductionMix(wind=wind),
             source="trust.me",
         )
     with patch.object(logger, "warning") as mock_warning:
         result = production_list.to_list()
-    # Duplicate starts cannot be clamped: both events are kept and a warning is
-    # emitted so the parser can be fixed upstream.
-    assert len(result) == 2
+    # One event per instant: the last append wins, so a republished interval
+    # revises the value instead of being summed on top of it downstream.
+    assert len(result) == 1
+    assert result[0]["production"]["wind"] == 12
     mock_warning.assert_called_once()
+
+
+def test_non_overlapping_list_keeps_collapsed_events_in_datetime_order():
+    logger = logging.Logger("test")
+    exchange_list = ExchangeList(logger)
+    dt = datetime(2023, 1, 1, tzinfo=timezone.utc)
+    for offset, net_flow in ((1, 1), (0, 2), (1, 3), (2, 4)):
+        exchange_list.append(
+            zoneKey=ZoneKey("AT->DE"),
+            datetime=dt + timedelta(hours=offset),
+            netFlow=net_flow,
+            source="trust.me",
+        )
+    with patch.object(logger, "warning"):
+        result = exchange_list.to_list()
+
+    assert [event["datetime"] for event in result] == [
+        dt,
+        dt + timedelta(hours=1),
+        dt + timedelta(hours=2),
+    ]
+    assert [event["netFlow"] for event in result] == [2, 3, 4]
+
+
+def test_non_overlapping_list_leaves_distinct_datetimes_alone():
+    logger = logging.Logger("test")
+    consumption_list = TotalConsumptionList(logger)
+    dt = datetime(2023, 1, 1, tzinfo=timezone.utc)
+    for hour in range(3):
+        consumption_list.append(
+            zoneKey=ZoneKey("DE"),
+            datetime=dt + timedelta(hours=hour),
+            consumption=100 + hour,
+            source="trust.me",
+        )
+    with patch.object(logger, "warning") as mock_warning:
+        result = consumption_list.to_list()
+
+    assert len(result) == 3
+    mock_warning.assert_not_called()
 
 
 def test_non_overlapping_list_allows_adjacent_intervals():
@@ -1301,10 +1427,10 @@ def test_non_overlapping_list_clamps_merged_mixed_resolution_gap():
     mock_warning.assert_called_once()
 
 
-def test_price_list_keeps_and_warns_on_duplicate_datetimes():
-    # PriceList represents a single series with one price per MTU. Duplicates
-    # (the ENTSO-E intraday parser collapses auction sessions upstream) are kept
-    # with a warning rather than failing the fetch.
+def test_price_list_collapses_duplicate_datetimes():
+    # PriceList represents a single series with one price per MTU, so a second
+    # price on the same MTU collapses onto the last one with a warning rather
+    # than failing the fetch or leaving two prices on one instant.
     logger = logging.Logger("test")
     price_list = PriceList(logger)
     dt = datetime(2023, 1, 1, tzinfo=timezone.utc)
@@ -1318,5 +1444,28 @@ def test_price_list_keeps_and_warns_on_duplicate_datetimes():
         )
     with patch.object(logger, "warning") as mock_warning:
         result = price_list.to_list()
-    assert len(result) == 2
+    assert len(result) == 1
+    assert result[0]["price"] == 77.77
     mock_warning.assert_called_once()
+
+
+def test_list_holding_several_events_per_datetime_is_untouched():
+    # LocationalMarginalPriceList is keyed by node, so several events share a
+    # datetime legitimately. It does not use the non-overlapping mixin.
+    logger = logging.Logger("test")
+    prices = LocationalMarginalPriceList(logger)
+    dt = datetime(2023, 1, 1, tzinfo=timezone.utc)
+    for node in ("NODE_A", "NODE_B"):
+        prices.append(
+            zoneKey=ZoneKey("US-CENT-SWPP"),
+            datetime=dt,
+            price=20.0,
+            currency="USD",
+            node=node,
+            source="trust.me",
+        )
+    with patch.object(logger, "warning") as mock_warning:
+        result = prices.to_list()
+
+    assert len(result) == 2
+    mock_warning.assert_not_called()

--- a/electricitymap/contrib/lib/tests/test_event_lists.py
+++ b/electricitymap/contrib/lib/tests/test_event_lists.py
@@ -1371,7 +1371,7 @@ def test_merge_exchanges_dropping_non_matching_keeps_end_datetimes():
     assert merged[0]["end_datetime"] == dt + timedelta(minutes=5)
 
 
-def test_non_overlapping_list_collapses_duplicate_datetimes():
+def test_non_overlapping_list_deduplicates_datetimes():
     logger = logging.Logger("test")
     production_list = ProductionBreakdownList(logger)
     dt = datetime(2023, 1, 1, tzinfo=timezone.utc)
@@ -1391,7 +1391,7 @@ def test_non_overlapping_list_collapses_duplicate_datetimes():
     mock_warning.assert_called_once()
 
 
-def test_non_overlapping_list_keeps_collapsed_events_in_datetime_order():
+def test_non_overlapping_list_keeps_deduplicated_events_in_datetime_order():
     logger = logging.Logger("test")
     exchange_list = ExchangeList(logger)
     dt = datetime(2023, 1, 1, tzinfo=timezone.utc)
@@ -1489,10 +1489,10 @@ def test_non_overlapping_list_clamps_merged_mixed_resolution_gap():
     mock_warning.assert_called_once()
 
 
-def test_price_list_collapses_duplicate_datetimes():
+def test_price_list_deduplicates_datetimes():
     # PriceList represents a single series with one price per MTU, so a second
-    # price on the same MTU collapses onto the last one with a warning rather
-    # than failing the fetch or leaving two prices on one instant.
+    # price on the same MTU is deduplicated onto the last one with a warning
+    # rather than failing the fetch or leaving two prices on one instant.
     logger = logging.Logger("test")
     price_list = PriceList(logger)
     dt = datetime(2023, 1, 1, tzinfo=timezone.utc)

--- a/electricitymap/contrib/parsers/AEMO.py
+++ b/electricitymap/contrib/parsers/AEMO.py
@@ -2,7 +2,6 @@ import csv
 import io
 import re
 import zipfile
-from collections import Counter
 from collections.abc import Iterable, Iterator
 from datetime import datetime, timedelta
 from logging import Logger, getLogger
@@ -327,13 +326,13 @@ def fetch_exchange(
         window = (end - REFETCH_FREQUENCY, end)
         rows = _fetch_archived_rows(session, *window, logger)
 
+    # AEMO republishes an interval under a new sequence number when it is
+    # revised, and the archives overlap around midnight, so the same flow can
+    # arrive twice. ExchangeList collapses those onto the last one appended,
+    # which is the newest revision since the sources are read oldest first.
     contributions = {
         interconnector: ExchangeList(logger) for interconnector in interconnectors
     }
-    # AEMO republishes an interval under a new sequence number when it is
-    # revised, and the archives overlap around midnight, so the same flow can
-    # arrive twice. Merging sums whatever it is given, so drop repeats here.
-    seen: set[tuple[str, datetime]] = set()
     unmapped: set[str] = set()
     published = False
     for row in rows:
@@ -353,9 +352,6 @@ def fetch_exchange(
         ).replace(tzinfo=MARKET_TIMEZONE)
         if window and not window[0] < settlement <= window[1]:
             continue
-        if (interconnector, settlement) in seen:
-            continue
-        seen.add((interconnector, settlement))
         contributions[interconnector].append(
             zoneKey=exchange_key,
             datetime=settlement - DISPATCH_INTERVAL,
@@ -380,24 +376,11 @@ def fetch_exchange(
             f"AEMO dispatched interconnectors this parser does not map: {sorted(unmapped)}"
         )
 
-    merged = ExchangeList.merge_exchanges(
-        list(contributions.values()), logger
+    # The lines of a border are parts of one flow, so an interval one of them is
+    # missing from is dropped rather than summed short.
+    return ExchangeList.merge_exchanges(
+        list(contributions.values()), logger, drop_non_matching_datetimes=True
     ).to_list()
-
-    # Merging sums the lines it is given, so an interval one line did not report
-    # would come out understated rather than missing. Drop those.
-    reported = Counter(settlement for _, settlement in seen)
-    events = [
-        event
-        for event in merged
-        if reported[event["end_datetime"]] == len(interconnectors)
-    ]
-    if len(events) < len(merged):
-        logger.warning(
-            f"Skipping {len(merged) - len(events)} interval(s) of {exchange_key} where "
-            f"not all of {sorted(interconnectors)} reported a flow"
-        )
-    return events
 
 
 if __name__ == "__main__":

--- a/electricitymap/contrib/parsers/AEMO.py
+++ b/electricitymap/contrib/parsers/AEMO.py
@@ -328,7 +328,7 @@ def fetch_exchange(
 
     # AEMO republishes an interval under a new sequence number when it is
     # revised, and the archives overlap around midnight, so the same flow can
-    # arrive twice. ExchangeList collapses those onto the last one appended,
+    # arrive twice. ExchangeList deduplicates those onto the last one appended,
     # which is the newest revision since the sources are read oldest first.
     contributions = {
         interconnector: ExchangeList(logger) for interconnector in interconnectors

--- a/electricitymap/contrib/parsers/CAMMESA.py
+++ b/electricitymap/contrib/parsers/CAMMESA.py
@@ -89,7 +89,7 @@ def fetch_production(
     return ProductionBreakdownList.merge_production_breakdowns(
         [conventional_production, renewables_production],
         logger,
-        matching_timestamps_only=True,
+        drop_non_matching_datetimes=True,
     ).to_list()
 
 

--- a/electricitymap/contrib/parsers/ELEXON.py
+++ b/electricitymap/contrib/parsers/ELEXON.py
@@ -365,7 +365,9 @@ def query_and_merge_production_fuelhh_and_eso(
     parsed_events_eso = parse_eso_production(events_eso, logger)
 
     merged_events = ProductionBreakdownList.merge_production_breakdowns(
-        [parsed_events_fuelhh, parsed_events_eso], logger, matching_timestamps_only=True
+        [parsed_events_fuelhh, parsed_events_eso],
+        logger,
+        drop_non_matching_datetimes=True,
     )
     return merged_events
 
@@ -534,7 +536,7 @@ def fetch_production(
     return ProductionBreakdownList.merge_production_breakdowns(
         [data, parsed_hydro_storage_data],
         logger,
-        matching_timestamps_only=True,
+        drop_non_matching_datetimes=True,
     ).to_list()
 
 

--- a/electricitymap/contrib/parsers/ENTSOE.py
+++ b/electricitymap/contrib/parsers/ENTSOE.py
@@ -1253,6 +1253,12 @@ def get_physical_flows(
 
     raw_exchange_lists: list[ExchangeList] = []
     for domain_pair in domain_pairs:
+        # The two directions are the halves of one net flow, so an MTU only one
+        # of them covers is dropped rather than reported one-sided. Whole domain
+        # pairs are then added up as they come: a border can map to a pair
+        # ENTSO-E publishes nothing for (FR-COR->IT-SAR), and the pairs that do
+        # publish still describe the border.
+        directions: list[ExchangeList] = []
         for is_import in (True, False):
             domain1, domain2 = domain_pair if is_import else domain_pair[::-1]
             try:
@@ -1275,7 +1281,7 @@ def get_physical_flows(
                     message=f"No exchange data found for {domain1} -> {domain2}",
                     zone_key=sorted_zone_keys,
                 )
-            raw_exchange_lists.append(
+            directions.append(
                 parse_exchange(
                     raw_exchange,
                     is_import=is_import,
@@ -1283,6 +1289,11 @@ def get_physical_flows(
                     logger=logger,
                 )
             )
+        raw_exchange_lists.append(
+            ExchangeList.merge_exchanges(
+                directions, logger, drop_non_matching_datetimes=True
+            )
+        )
     return ExchangeList.merge_exchanges(raw_exchange_lists, logger)
 
 

--- a/electricitymap/contrib/parsers/NED.py
+++ b/electricitymap/contrib/parsers/NED.py
@@ -295,7 +295,7 @@ def fetch_production(
             zone_key, session, target_datetime, logger
         )
         combined_data = ProductionBreakdownList.update_production_breakdowns(
-            ENTSOE_data, NED_data, logger, matching_timestamps_only=True
+            ENTSOE_data, NED_data, logger, drop_non_matching_datetimes=True
         )
         return combined_data.to_list()
 


### PR DESCRIPTION
## Issue

Follow-up to electricitymaps/electricitymaps-contrib#8830 (stacked on it — **review that one first**). It found that `ExchangeList` keeps both events of a shared datetime while `merge_exchanges` sums them, so the AEMO parser had to guard for itself.

## Description

Two jobs parsers were doing for themselves, moved into the list classes where every parser benefits.

### 1. Duplicate datetimes now collapse

`NonOverlappingEventList` documents that "at most one event should cover any given instant", but events sharing an *exact* datetime were kept with a warning — they can't be clamped the way overlapping intervals can. Downstream sums then double them:

```
one list, two identical -100 MW events at the same instant
  -> to_list()          : 2 events
  -> merge_exchanges()  : 1 event, netFlow = -200 MW
```

`to_list()` now keeps the **last event appended**, matching how `update_*` treats a newer batch: a republished interval revises the value instead of being added on top of it. The warning stays, so a parser producing duplicates is still visible.

### 2. `drop_non_matching_datetimes`, one implementation for both merges

By default, a datetime only some inputs cover is summed from those that do — correct when merging two *sources of the same flow*. The flag is for inputs that are *parts of one total*, where a partial sum understates the flow rather than showing as missing. Only the datetimes the inputs disagree on are dropped; an input covering nothing therefore drops every datetime, since none is left that all inputs cover.

`merge_production_breakdowns` already had this feature under a different name, `matching_timestamps_only`, with its own implementation. Both merges now call one `AggregatableEventList._matching_datetimes`, and the production parameter is renamed to match (`ELEXON` ×2, `NED`, `CAMMESA` call sites updated).

That also fixes a latent bug on the production side: it counted events per datetime and compared against the number of inputs, which passed when one input held two events on a datetime and another held none. Unreachable now that duplicates collapse, but an intersection cannot get it wrong in the first place. Its log moves from `info` to `warning`, matching the exchange side.

Both parsers that sum parts of one total now use it:

- **AEMO** — the interconnectors making up a border. Drops both the dedupe and the completeness filter the parser owned; `fetch_exchange` now ends in a single `return`. It also keeps the *revision* of a republished interval rather than the first copy, which is the point of AEMO republishing it.
- **ENTSOE** — the two directions of one domain pair, so an MTU only one direction covers is no longer reported one-sided.

> [!IMPORTANT]
> ENTSO-E needed the flag applied **per domain pair, not across them**. `FR-COR->IT-SAR` maps to two domain pairs and ENTSO-E publishes nothing for one of them — live counts per input are `[288, 288, 0, 0]`. Requiring agreement across all four inputs would have dropped all 288 intervals and killed that border. Pairs are therefore still summed as they come, and only the two directions within a pair must agree. Verified the border still returns 279 events.

## Verification

**Nothing else in the repo relied on the old behaviour.** A tripwire raising on any collapse ran the parser and capacity-parser suites — **546 tests, 323 snapshots — and fired exactly once**, in the AEMO test written for it. No snapshot changed.

**Real ENTSO-E data backs the per-direction flag**: six borders queried live (DE→DK-DK1, ES→FR, AT→DE, DK-DK2→SE-SE4, FR→GB, BE→NL) all cover identical MTUs in both directions, so the flag drops nothing today — it is insurance against a short document.

**Existing parser dedupe logic was audited and none of it can be removed**: `NL`, `IEMOP` and `US_NEISO` all dedupe *source rows before events exist* — NL before averaging 5-minute flows into hours (so the dedupe changes the mean), IEMOP per resource, US_NEISO on raw CSV rows. Handing those to the event layer would change results, so they stay. AEMO's was the only event-level guard, and it's gone.

Also checked: `NED`'s duplicate-related comment is about API pagination, and it appends one event per datetime; `US_SPP`'s locational marginal prices legitimately share datetimes and use plain `EventList`, not the non-overlapping mixin — covered by a new test.

The production path previously had only parser-level coverage; it now has direct tests for dropping non-matching datetimes, the default summing them, and an empty input leaving nothing matching.

Tests: 704 pass across the parser, capacity-parser and lib suites. Live spot checks — AEMO still matches OPENNEM exactly on all borders, `DE->DK-DK1` returns 288 events, `FR-COR->IT-SAR` 279.

### Double check

- [x] Tested locally — live `AEMO.fetch_exchange`, `ENTSOE.fetch_exchange` for a normal border and for the multi-pair `FR-COR->IT-SAR`
- [x] I have run `pnpx prettier@2 --write .` and `uv run format` in the top level directory to format my changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
