### PR TITLE
chore: start collecting AL production data from ENTSO-E

### DIFF
--- a/config/zones/AL.yaml
+++ b/config/zones/AL.yaml
@@ -70,6 +70,7 @@ contributors:
   - corradio
   - nessie2013
   - autipial
+  - VIKTORVAV99
 country: AL
 country_name: Albania
 currency: ALL
@@ -90,6 +91,7 @@ parsers:
   consumptionForecast: ENTSOE.fetch_consumption_forecast
   generationForecast: ENTSOE.fetch_generation_forecast
   price: ENTSOE.fetch_price
+  production: ENTSOE.fetch_production
   productionCapacity: ENTSOE.fetch_production_capacity
   productionPerModeForecast: ENTSOE.fetch_wind_solar_forecasts
   productionPerModeForecastDayAhead: ENTSOE.fetch_wind_solar_forecasts_day_ahead


### PR DESCRIPTION
## Issue

Closes #4180
## Description

Adds ENTSO-E as a production parser for Albania so we start collecting data for it.

> [!IMPORTANT]
> This does not mean it will use measured data on the map yet. We still need to flip the switch internally.

### Double check

- [x] I have tested my parser changes locally with `uv run test_parser "zone_key"`
- [x] I have run `pnpx prettier@2 --write .` and `uv run format` in the top level directory to format my changes.
