### PR TITLE
fix: remove doubled words in comments and an error message

### DIFF
--- a/electricitymap/contrib/config/emission_factors_lookup.py
+++ b/electricitymap/contrib/config/emission_factors_lookup.py
@@ -77,7 +77,7 @@ def _get_zone_specific_co2eq_parameter_no_metadata(
 
     if isinstance(res, list):
         # `n` dates are sorted in ascending order (d1, d2, ..., dn)
-        # d1 is valid from from (epoch to d2)
+        # d1 is valid from (epoch to d2)
         # d2 is valid from (d2 to d3)
         # dn is valid from (dn to end_of_time)
 
@@ -136,7 +136,7 @@ def _get_zone_specific_co2eq_parameter_with_metadata(
 
     if isinstance(res, list):
         # `n` dates are sorted in ascending order (d1, d2, ..., dn)
-        # d1 is valid from from (epoch to d2)
+        # d1 is valid from (epoch to d2)
         # d2 is valid from (d2 to d3)
         # dn is valid from (dn to end_of_time)
 

--- a/electricitymap/contrib/parsers/AX.py
+++ b/electricitymap/contrib/parsers/AX.py
@@ -45,7 +45,7 @@ def fetch_data(session: Session, logger: Logger):
         if len(raw.split(",")) != len(time_series):
             raise ParserException(
                 "AX.py",
-                "The raw data did not match the length of the the time series. Check if the website has changed.",
+                "The raw data did not match the length of the time series. Check if the website has changed.",
             )
     data_list = []
     for time, sweden, alink, fossil, gustavs, wind, consumption in zip(

--- a/electricitymap/contrib/parsers/IN.py
+++ b/electricitymap/contrib/parsers/IN.py
@@ -380,7 +380,7 @@ def fetch_grid_india_report(
     Rely on grid-india.in backend API to fetch data report.
     First query the backend to get the list of files available for a given date.
     Reports can be found here : https://grid-india.in/en/reports/daily-psp-report
-    And also here here : https://report.grid-india.in/index.php?p=
+    And also here : https://report.grid-india.in/index.php?p=
 
     """
 


### PR DESCRIPTION
## Issue

None - noticed while reading the code.

## Description

Four doubled words:

- `config/emission_factors_lookup.py`: "d1 is valid from from (epoch to d2)" in both of the twin lookup helpers
- `parsers/AX.py`: "the length of the the time series" in the `ParserException` message
- `parsers/IN.py`: "And also here here :" in the module docstring

Comments, a docstring and one exception message; no parser logic changed
and the message is not asserted on in the tests.

### Double check

- [ ] I have tested my parser changes locally with `uv run test_parser "zone_key"` - no parser logic changed, so there is nothing new to exercise.
- [ ] I have run `pnpx prettier@2 --write .` and `uv run format` - not run locally, but only text inside existing lines changed, so formatting is unaffected.
