### PR TITLE
feat(XK): collect day-ahead prices from ENTSO-E

### DIFF
--- a/config/zones/XK.yaml
+++ b/config/zones/XK.yaml
@@ -158,6 +158,7 @@ parsers:
   consumption: ENTSOE.fetch_consumption
   consumptionForecast: ENTSOE.fetch_consumption_forecast
   generationForecast: ENTSOE.fetch_generation_forecast
+  price: ENTSOE.fetch_price
   production: ENTSOE.fetch_production
   productionCapacity: ENTSOE.fetch_production_capacity
   productionPerModeForecast: ENTSOE.fetch_wind_solar_forecasts


### PR DESCRIPTION
## Issue

None

## Description

Adds day-ahead price collection for Kosovo (`XK`) using the existing `ENTSOE.fetch_price` parser. XK already had its ENTSO-E domain (`10Y1001C--00100H`) in the parser mapping, so this is a config-only change.

Kosovo's day-ahead market is run by ALPEX (the Albanian Power Exchange), which also runs the Albanian market we already collect prices for.

### Verification

`uv run test_parser XK price` returns 96 hourly EUR points (2026-09-03 22:00 → 2026-09-07 21:00 UTC), no gaps, duplicates or nulls. Cross-checked against `AL` for the same window: 90 of 96 hours are identical, mean |diff| 3.47 EUR/MWh, as expected for two ALPEX-coupled markets.

### History available on ENTSO-E

| Zone | First delivery day | Resolution | Gaps > 1h |
|---|---|---|---|
| XK | 2024-02-01 | hourly | none |
| AL | 2023-04-12 | hourly | none |

> [!NOTE]
> Follow-up after deploy: backfill XK price from 2024-02-01. AL price in the DB currently starts 2024-12-31, so AL can be backfilled from 2023-04-12 as well.

### Double check

- [x] I have tested my parser changes locally with `uv run test_parser "zone_key"`
- [x] I have run `pnpx prettier@2 --write .` and `uv run format` in the top level directory to format my changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
