### PR TITLE
Reject negative scheduled exchange directions

### DIFF
--- a/electricitymap/contrib/lib/models/events.py
+++ b/electricitymap/contrib/lib/models/events.py
@@ -600,6 +600,8 @@ class ScheduledExchange(Event):
             raise ValueError(f"Scheduled exchange direction cannot be None: {v}")
         if math.isnan(v):
             raise ValueError(f"Scheduled exchange direction cannot be NaN: {v}")
+        if v < 0:
+            raise ValueError(f"Scheduled exchange direction cannot be negative: {v}")
         # TODO in the future those checks should be performed in the data quality layer.
         if abs(v) > 100000:
             raise ValueError(

--- a/electricitymap/contrib/lib/tests/test_events.py
+++ b/electricitymap/contrib/lib/tests/test_events.py
@@ -1409,3 +1409,23 @@ def test_exchange_capacity_forecast_to_dict():
     assert d["capacityImport"] == 900.0
     assert d["source"] == "trust.me"
     assert d["sourceType"] == EventSourceType.published
+
+
+def test_scheduled_exchange_rejects_negative_directions():
+    # Both gross directions are magnitudes, so a negative value is not a
+    # smaller flow but a flow the other way: a negative import would otherwise
+    # be derived into a positive netFlow and invert the arrow.
+    for export, imp in ((-250.0, 0.0), (0.0, -250.0), (-100.0, -80.0)):
+        assert (
+            ScheduledExchange.create(
+                logger=logging.getLogger(),
+                zoneKey=ZoneKey("AT->DE"),
+                datetime=datetime(2023, 1, 1, tzinfo=timezone.utc),
+                end_datetime=None,
+                source="trust.me",
+                scheduledExport=export,
+                scheduledImport=imp,
+                marketAgreementType=MarketAgreementType.DAY_AHEAD,
+            )
+            is None
+        )


### PR DESCRIPTION
`ScheduledExchange` documents both gross directions as **always >= 0**:

> - `scheduledExport`: scheduled flow zone1 -> zone2 (the sorted-first zone exporting), always >= 0.
> - `scheduledImport`: scheduled flow zone2 -> zone1 (the sorted-first zone importing), always >= 0.

`_validate_directional_flow` already rejects `None`, `NaN` and anything above 100 GW but not a negative value.

Because `netFlow` is derived as `scheduledExport - scheduledImport`, a negative does not read as a smaller flow, it reads as a flow the other way. Constructing the event on `master` today:

```
export=250,  import=0      -> accepted, netFlow=250
export=-250, import=0      -> accepted, netFlow=-250
export=0,    import=-250   -> accepted, netFlow=+250
export=-100, import=-80    -> accepted, netFlow=-20
export=200000, import=0    -> rejected  (the 100 GW check works)
```

The third line is the one that matters: **a negative import is derived into a positive export**, so the arrow points the opposite way, and nothing in the logs says so.

Neither producer would catch it first, `JAO` passes `row.get(export_field)` straight through, and `ENTSOE` accumulates `quantity` values parsed from the XML.

## The change

```python
if v < 0:
    raise ValueError(f"Scheduled exchange direction cannot be negative: {v}")
```

Two lines, in the validator, alongside the existing `None` / `NaN` / magnitude checks.

## Tests

One case added to `electricitymap/contrib/lib/tests/test_events.py`, covering all three negative combinations.

```
without the change:  1 failed
with the change:     149 passed   (electricitymap/contrib/lib/tests/)
```
